### PR TITLE
do: load partial package spec

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -529,7 +529,7 @@ func (pc *packageCommand) newCommand() (*cobra.Command, error) {
 
 	if len(pc.args) == 0 || strings.Count(pc.args[0], ":") == 0 {
 		// No token (or just a package name), so this is just the package command.
-		return pc.newPackageCommand()
+		return pc.newPackageCommand(), nil
 	}
 
 	// Try and look it up, it's either a module, resource, or function.
@@ -543,42 +543,51 @@ func (pc *packageCommand) newCommand() (*cobra.Command, error) {
 	} else if ok {
 		return pc.newResourceCommand(res), nil
 	}
-	if known, err := pc.isKnownModule(pc.args[0]); err != nil {
-		return nil, err
-	} else if known {
-		return pc.newModuleCommand()
+	if pc.isKnownModule(pc.args[0]) {
+		return pc.newModuleCommand(), nil
 	}
 
 	return nil, pc.unknownTokenError(pc.args[0])
 }
 
+// memberTokens returns the resource and function tokens defined in the schema, excluding method
+// functions, without binding any package members.
+func (pc *packageCommand) memberTokens() (resources, functions []string) {
+	for it := pc.spec.Resources().Range(); it.Next(); {
+		resources = append(resources, it.Token())
+	}
+	for it := pc.spec.Functions().Range(); it.Next(); {
+		if !it.IsMethod() {
+			functions = append(functions, it.Token())
+		}
+	}
+	return resources, functions
+}
+
 // isKnownModule checks whether `typed` (e.g. "aws:s3" or "pkg:mod1/mod2") matches a module in the schema.
-func (pc *packageCommand) isKnownModule(typed string) (bool, error) {
+func (pc *packageCommand) isKnownModule(typed string) bool {
 	// inModule reports whether the token lives in module `typed` or a descendant of it. Modules nest
 	// on "/", so a parent like "pkg:mod1" matches a token in "pkg:mod1/mod2".
 	_, name, _ := strings.Cut(typed, ":")
 	if name == "" {
-		return false, nil
-	}
-	def, err := pc.spec.Definition()
-	if err != nil {
-		return false, err
+		return false
 	}
 	inModule := func(token string) bool {
 		mod := pc.spec.TokenToModule(token)
 		return mod == name || strings.HasPrefix(mod, name+"/")
 	}
-	for _, fn := range def.Functions {
-		if !fn.IsMethod && inModule(fn.Token) {
-			return true, nil
+	resources, functions := pc.memberTokens()
+	for _, tok := range functions {
+		if inModule(tok) {
+			return true
 		}
 	}
-	for _, res := range def.Resources {
-		if inModule(res.Token) {
-			return true, nil
+	for _, tok := range resources {
+		if inModule(tok) {
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
 func (pc *packageCommand) moduleToken(token string) string {
@@ -611,10 +620,7 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 	if diags.HasErrors() {
 		return nil
 	}
-	def, err := pc.spec.Definition()
-	if err != nil {
-		return nil
-	}
+	resources, functions := pc.memberTokens()
 
 	op := levenshtein.DefaultOptionsWithSub
 	op.Matches = func(r1, r2 rune) bool {
@@ -659,14 +665,11 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 		seen[display] = struct{}{}
 		suggestions = append(suggestions, display)
 	}
-	for _, fn := range def.Functions {
-		if fn.IsMethod {
-			continue
-		}
-		consider(fn.Token)
+	for _, tok := range functions {
+		consider(tok)
 	}
-	for _, res := range def.Resources {
-		consider(res.Token)
+	for _, tok := range resources {
+		consider(tok)
 	}
 
 	// If the user typed a 2-segment value (pkg:something), the second segment may have been intended as a module name,
@@ -684,13 +687,11 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 			seen[display] = struct{}{}
 			suggestions = append(suggestions, display)
 		}
-		for _, fn := range def.Functions {
-			if !fn.IsMethod {
-				considerModule(fn.Token)
-			}
+		for _, tok := range functions {
+			considerModule(tok)
 		}
-		for _, res := range def.Resources {
-			considerModule(res.Token)
+		for _, tok := range resources {
+			considerModule(tok)
 		}
 	}
 
@@ -698,12 +699,7 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 	return suggestions
 }
 
-func (pc *packageCommand) newPackageCommand() (*cobra.Command, error) {
-	def, err := pc.spec.Definition()
-	if err != nil {
-		return nil, err
-	}
-
+func (pc *packageCommand) newPackageCommand() *cobra.Command {
 	shorthelp := fmt.Sprintf("Interact with %s resources and functions", pc.spec.Name())
 	longhelp := shorthelp + "."
 	if pc.spec.Description() != "" {
@@ -725,27 +721,25 @@ func (pc *packageCommand) newPackageCommand() (*cobra.Command, error) {
 		"%s\n\nRun 'pulumi do%s <module/resource/function> --help' for more details on usage.",
 		longhelp, flag)
 
+	resTokens, fnTokens := pc.memberTokens()
 	modules := map[string]struct{}{}
-	functions := map[string]*schema.Function{}
-	resources := map[string]*schema.Resource{}
-	for _, fn := range def.Functions {
-		if fn.IsMethod {
-			continue
-		}
-
-		if mod := pc.moduleToken(fn.Token); mod == "" {
-			functions[fn.Token] = fn
+	var functions, resources []string
+	for _, tok := range fnTokens {
+		if mod := pc.moduleToken(tok); mod == "" {
+			functions = append(functions, tok)
 		} else {
 			modules[mod] = struct{}{}
 		}
 	}
-	for _, res := range def.Resources {
-		if mod := pc.moduleToken(res.Token); mod == "" {
-			resources[res.Token] = res
+	for _, tok := range resTokens {
+		if mod := pc.moduleToken(tok); mod == "" {
+			resources = append(resources, tok)
 		} else {
 			modules[mod] = struct{}{}
 		}
 	}
+	slices.Sort(functions)
+	slices.Sort(resources)
 
 	var help strings.Builder
 	if len(modules) > 0 {
@@ -757,17 +751,15 @@ func (pc *packageCommand) newPackageCommand() (*cobra.Command, error) {
 	}
 	if len(functions) > 0 {
 		fmt.Fprintln(&help, "Functions:")
-		for _, fn := range maps.Sorted(functions) {
-			tok := pc.spec.CanonicalizeToken(fn.Token)
-			fmt.Fprintf(&help, "  %s\n", tok)
+		for _, tok := range functions {
+			fmt.Fprintf(&help, "  %s\n", pc.spec.CanonicalizeToken(tok))
 		}
 		fmt.Fprintln(&help, "")
 	}
 	if len(resources) > 0 {
 		fmt.Fprintln(&help, "Resources:")
-		for _, res := range maps.Sorted(resources) {
-			tok := pc.spec.CanonicalizeToken(res.Token)
-			fmt.Fprintf(&help, "  %s\n", tok)
+		for _, tok := range resources {
+			fmt.Fprintf(&help, "  %s\n", pc.spec.CanonicalizeToken(tok))
 		}
 		fmt.Fprintln(&help, "")
 	}
@@ -779,22 +771,15 @@ func (pc *packageCommand) newPackageCommand() (*cobra.Command, error) {
 		use = pc.args[0]
 	}
 
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   use,
 		Short: shorthelp,
 		Long:  longhelp,
 		Args:  cobra.NoArgs,
 	}
-
-	return cmd, nil
 }
 
-func (pc *packageCommand) newModuleCommand() (*cobra.Command, error) {
-	def, err := pc.spec.Definition()
-	if err != nil {
-		return nil, err
-	}
-
+func (pc *packageCommand) newModuleCommand() *cobra.Command {
 	_, name, _ := strings.Cut(pc.args[0], ":")
 
 	shorthelp := fmt.Sprintf("Functions and resources for the %s module", name)
@@ -815,29 +800,27 @@ func (pc *packageCommand) newModuleCommand() (*cobra.Command, error) {
 		"%s\n\nRun 'pulumi do%s <module/resource/function> --help' for more details on usage.",
 		longhelp, flag)
 
+	resTokens, fnTokens := pc.memberTokens()
 	modules := map[string]struct{}{}
-	functions := map[string]*schema.Function{}
-	resources := map[string]*schema.Resource{}
-	for _, fn := range def.Functions {
-		if fn.IsMethod {
-			continue
-		}
-
-		mod := pc.spec.TokenToModule(fn.Token)
+	var functions, resources []string
+	for _, tok := range fnTokens {
+		mod := pc.spec.TokenToModule(tok)
 		if mod == name {
-			functions[pc.spec.CanonicalizeToken(fn.Token)] = fn
+			functions = append(functions, pc.spec.CanonicalizeToken(tok))
 		} else if strings.HasPrefix(mod, name+"/") {
-			modules[pc.moduleToken(fn.Token)] = struct{}{}
+			modules[pc.moduleToken(tok)] = struct{}{}
 		}
 	}
-	for _, res := range def.Resources {
-		mod := pc.spec.TokenToModule(res.Token)
+	for _, tok := range resTokens {
+		mod := pc.spec.TokenToModule(tok)
 		if mod == name {
-			resources[res.Token] = res
+			resources = append(resources, tok)
 		} else if strings.HasPrefix(mod, name+"/") {
-			modules[pc.moduleToken(res.Token)] = struct{}{}
+			modules[pc.moduleToken(tok)] = struct{}{}
 		}
 	}
+	slices.Sort(functions)
+	slices.Sort(resources)
 
 	var help strings.Builder
 	if len(modules) > 0 {
@@ -849,17 +832,15 @@ func (pc *packageCommand) newModuleCommand() (*cobra.Command, error) {
 	}
 	if len(functions) > 0 {
 		fmt.Fprintln(&help, "Functions:")
-		for _, fn := range maps.Sorted(functions) {
-			tok := pc.spec.CanonicalizeToken(fn.Token)
+		for _, tok := range functions {
 			fmt.Fprintf(&help, "  %s\n", tok)
 		}
 		fmt.Fprintln(&help, "")
 	}
 	if len(resources) > 0 {
 		fmt.Fprintln(&help, "Resources:")
-		for _, res := range maps.Sorted(resources) {
-			tok := pc.spec.CanonicalizeToken(res.Token)
-			fmt.Fprintf(&help, "  %s\n", tok)
+		for _, tok := range resources {
+			fmt.Fprintf(&help, "  %s\n", pc.spec.CanonicalizeToken(tok))
 		}
 		fmt.Fprintln(&help, "")
 	}
@@ -871,12 +852,10 @@ func (pc *packageCommand) newModuleCommand() (*cobra.Command, error) {
 		use = pc.args[0]
 	}
 
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   use,
 		Short: shorthelp,
 		Long:  longhelp,
 		Args:  cobra.NoArgs,
 	}
-
-	return cmd, nil
 }

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -16,7 +16,6 @@ package do
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -27,6 +26,7 @@ import (
 	"github.com/google/shlex"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pgavlin/fx/v2/maps"
+	json "github.com/segmentio/encoding/json"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/texttheater/golang-levenshtein/levenshtein"
@@ -218,8 +218,8 @@ func NewDoCmd(
 			return nil, nil, fmt.Errorf("get schema: %w", err)
 		}
 		_, unmarshalSpan := tracer.Start(ctx, "pulumi-do.unmarshal-schema")
-		var spec schema.PackageSpec
-		err = json.Unmarshal(getSchema.Schema, &spec)
+		var spec schema.PartialPackageSpec
+		_, err = json.Parse(getSchema.Schema, &spec, json.ZeroCopy)
 		unmarshalSpan.End()
 		if err != nil {
 			cleanup()
@@ -234,10 +234,17 @@ func NewDoCmd(
 			packageDescriptor.Parameterization.Value = spec.Parameterization.Parameter
 		}
 
-		boundpkg, err := packages.BindSpecWithContext(ctx, spec, schema.NewPluginLoader(pctx))
+		boundpkg, err := schema.ImportPartialSpecWithContext(ctx, spec, nil, schema.NewPluginLoader(pctx))
 		if err != nil {
 			cleanup()
-			return nil, nil, fmt.Errorf("bind schema: %w", err)
+			return nil, nil, fmt.Errorf("import schema: %w", err)
+		}
+
+		// This is needed in every subcommand, so bind it now.
+		providerDef, err := boundpkg.Provider()
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("bind provider schema: %w", err)
 		}
 
 		loadConverter := func(name string) (plugin.Converter, error) {
@@ -255,6 +262,7 @@ func NewDoCmd(
 			packageDescriptor: packageDescriptor,
 			provider:          p,
 			spec:              boundpkg,
+			providerDef:       providerDef,
 			dryrun:            dryrun,
 			showSecrets:       showSecrets,
 			stateless:         stateless,
@@ -479,7 +487,8 @@ type packageCommand struct {
 	providerFile      string
 	providerURN       string
 	format            string
-	spec              *schema.Package
+	spec              schema.PackageReference
+	providerDef       *schema.Resource
 	dryrun            bool
 	showSecrets       bool
 	stateless         bool
@@ -520,46 +529,56 @@ func (pc *packageCommand) newCommand() (*cobra.Command, error) {
 
 	if len(pc.args) == 0 || strings.Count(pc.args[0], ":") == 0 {
 		// No token (or just a package name), so this is just the package command.
-		return pc.newPackageCommand(), nil
+		return pc.newPackageCommand()
 	}
 
 	// Try and look it up, it's either a module, resource, or function.
-	if fun, ok := pc.spec.GetFunction(pc.args[0]); ok {
+	if fun, ok, err := pc.spec.Functions().Get(pc.args[0]); err != nil {
+		return nil, err
+	} else if ok {
 		return pc.newFunctionCommand(fun), nil
 	}
-	if res, ok := pc.spec.GetResource(pc.args[0]); ok {
+	if res, ok, err := pc.spec.Resources().Get(pc.args[0]); err != nil {
+		return nil, err
+	} else if ok {
 		return pc.newResourceCommand(res), nil
 	}
-	if pc.isKnownModule(pc.args[0]) {
-		return pc.newModuleCommand(), nil
+	if known, err := pc.isKnownModule(pc.args[0]); err != nil {
+		return nil, err
+	} else if known {
+		return pc.newModuleCommand()
 	}
 
 	return nil, pc.unknownTokenError(pc.args[0])
 }
 
 // isKnownModule checks whether `typed` (e.g. "aws:s3" or "pkg:mod1/mod2") matches a module in the schema.
-func (pc *packageCommand) isKnownModule(typed string) bool {
+func (pc *packageCommand) isKnownModule(typed string) (bool, error) {
 	// inModule reports whether the token lives in module `typed` or a descendant of it. Modules nest
 	// on "/", so a parent like "pkg:mod1" matches a token in "pkg:mod1/mod2".
 	_, name, _ := strings.Cut(typed, ":")
 	if name == "" {
-		return false
+		return false, nil
+	}
+	def, err := pc.spec.Definition()
+	if err != nil {
+		return false, err
 	}
 	inModule := func(token string) bool {
 		mod := pc.spec.TokenToModule(token)
 		return mod == name || strings.HasPrefix(mod, name+"/")
 	}
-	for _, fn := range pc.spec.Functions {
+	for _, fn := range def.Functions {
 		if !fn.IsMethod && inModule(fn.Token) {
-			return true
+			return true, nil
 		}
 	}
-	for _, res := range pc.spec.Resources {
+	for _, res := range def.Resources {
 		if inModule(res.Token) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func (pc *packageCommand) moduleToken(token string) string {
@@ -571,7 +590,7 @@ func (pc *packageCommand) moduleToken(token string) string {
 }
 
 func (pc *packageCommand) unknownTokenError(typed string) error {
-	msg := fmt.Sprintf("unknown function, resource, or module %q in package %q", typed, pc.spec.Name)
+	msg := fmt.Sprintf("unknown function, resource, or module %q in package %q", typed, pc.spec.Name())
 	suggestions := pc.suggestTokens(typed)
 	if len(suggestions) == 0 {
 		return cmdCmd.ConfigurationError{Message: msg}
@@ -590,6 +609,10 @@ func (pc *packageCommand) unknownTokenError(typed string) error {
 func (pc *packageCommand) suggestTokens(typed string) []string {
 	_, typedMod, typedName, diags := pcl.DecomposeToken(typed, hcl.Range{})
 	if diags.HasErrors() {
+		return nil
+	}
+	def, err := pc.spec.Definition()
+	if err != nil {
 		return nil
 	}
 
@@ -636,13 +659,13 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 		seen[display] = struct{}{}
 		suggestions = append(suggestions, display)
 	}
-	for _, fn := range pc.spec.Functions {
+	for _, fn := range def.Functions {
 		if fn.IsMethod {
 			continue
 		}
 		consider(fn.Token)
 	}
-	for _, res := range pc.spec.Resources {
+	for _, res := range def.Resources {
 		consider(res.Token)
 	}
 
@@ -661,12 +684,12 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 			seen[display] = struct{}{}
 			suggestions = append(suggestions, display)
 		}
-		for _, fn := range pc.spec.Functions {
+		for _, fn := range def.Functions {
 			if !fn.IsMethod {
 				considerModule(fn.Token)
 			}
 		}
-		for _, res := range pc.spec.Resources {
+		for _, res := range def.Resources {
 			considerModule(res.Token)
 		}
 	}
@@ -675,11 +698,16 @@ func (pc *packageCommand) suggestTokens(typed string) []string {
 	return suggestions
 }
 
-func (pc *packageCommand) newPackageCommand() *cobra.Command {
-	shorthelp := fmt.Sprintf("Interact with %s resources and functions", pc.spec.Name)
+func (pc *packageCommand) newPackageCommand() (*cobra.Command, error) {
+	def, err := pc.spec.Definition()
+	if err != nil {
+		return nil, err
+	}
+
+	shorthelp := fmt.Sprintf("Interact with %s resources and functions", pc.spec.Name())
 	longhelp := shorthelp + "."
-	if pc.spec.Description != "" {
-		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, pc.spec.Description)
+	if pc.spec.Description() != "" {
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, pc.spec.Description())
 	}
 
 	// If the package can't be inferred from the token then add --package to the help text.
@@ -700,7 +728,7 @@ func (pc *packageCommand) newPackageCommand() *cobra.Command {
 	modules := map[string]struct{}{}
 	functions := map[string]*schema.Function{}
 	resources := map[string]*schema.Resource{}
-	for _, fn := range pc.spec.Functions {
+	for _, fn := range def.Functions {
 		if fn.IsMethod {
 			continue
 		}
@@ -711,7 +739,7 @@ func (pc *packageCommand) newPackageCommand() *cobra.Command {
 			modules[mod] = struct{}{}
 		}
 	}
-	for _, res := range pc.spec.Resources {
+	for _, res := range def.Resources {
 		if mod := pc.moduleToken(res.Token); mod == "" {
 			resources[res.Token] = res
 		} else {
@@ -746,7 +774,7 @@ func (pc *packageCommand) newPackageCommand() *cobra.Command {
 
 	longhelp = fmt.Sprintf("%s\n\n%s", longhelp, help.String())
 
-	use := pc.spec.Name
+	use := pc.spec.Name()
 	if len(pc.args) > 0 {
 		use = pc.args[0]
 	}
@@ -758,10 +786,15 @@ func (pc *packageCommand) newPackageCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	return cmd
+	return cmd, nil
 }
 
-func (pc *packageCommand) newModuleCommand() *cobra.Command {
+func (pc *packageCommand) newModuleCommand() (*cobra.Command, error) {
+	def, err := pc.spec.Definition()
+	if err != nil {
+		return nil, err
+	}
+
 	_, name, _ := strings.Cut(pc.args[0], ":")
 
 	shorthelp := fmt.Sprintf("Functions and resources for the %s module", name)
@@ -785,7 +818,7 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 	modules := map[string]struct{}{}
 	functions := map[string]*schema.Function{}
 	resources := map[string]*schema.Resource{}
-	for _, fn := range pc.spec.Functions {
+	for _, fn := range def.Functions {
 		if fn.IsMethod {
 			continue
 		}
@@ -797,7 +830,7 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 			modules[pc.moduleToken(fn.Token)] = struct{}{}
 		}
 	}
-	for _, res := range pc.spec.Resources {
+	for _, res := range def.Resources {
 		mod := pc.spec.TokenToModule(res.Token)
 		if mod == name {
 			resources[res.Token] = res
@@ -833,7 +866,7 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 
 	longhelp = fmt.Sprintf("%s\n\n%s", longhelp, help.String())
 
-	use := pc.spec.Name
+	use := pc.spec.Name()
 	if len(pc.args) > 0 {
 		use = pc.args[0]
 	}
@@ -845,5 +878,5 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	return cmd
+	return cmd, nil
 }

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -156,7 +156,7 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
 			"base of the provider configuration (requires a stack context)")
 
-	addInputFlags(cmd, pc.spec.Name, pc.spec.Provider.InputProperties)
+	addInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties)
 	if fn.Inputs != nil {
 		addInputFlags(cmd, "input", fn.Inputs.Properties)
 	}

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -107,7 +107,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 	cmd.PersistentFlags().StringVar(&pc.providerURN, "provider", "",
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
 			"base of the provider configuration (requires a stack context)")
-	addPersistentInputFlags(cmd, pc.spec.Name, pc.spec.Provider.InputProperties)
+	addPersistentInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties)
 	cmd.AddCommand(pc.newResourceCreateCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -619,8 +619,8 @@ func (pc *packageCommand) configureProvider(cmd *cobra.Command, ctx context.Cont
 
 	config, err := evaluateResourceFile(
 		ctx, pc.providerFile, "provider", pc.format,
-		pc.spec.Provider, ec, pc.converter, pc.loaderTarget, pc.packageDescriptor,
-		collectInputFlags(cmd, pc.spec.Name, pc.spec.Provider.InputProperties))
+		pc.providerDef, ec, pc.converter, pc.loaderTarget, pc.packageDescriptor,
+		collectInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties))
 	if err != nil {
 		return fmt.Errorf("parse provider file: %w", err)
 	}
@@ -633,7 +633,7 @@ func (pc *packageCommand) configureProvider(cmd *cobra.Command, ctx context.Cont
 		config = merged
 	}
 
-	urn := resource.NewURN("dev", "default", "", tokens.Type("pulumi:providers:"+pc.spec.Name), "")
+	urn := resource.NewURN("dev", "default", "", tokens.Type("pulumi:providers:"+pc.spec.Name()), "")
 	name := urn.Name()
 	typ := urn.Type()
 	uuid, err := uuid.NewV4()
@@ -693,7 +693,7 @@ func (pc *packageCommand) loadProviderInputsFromStack(
 		// The provider package must also match: AWS provider inputs handed to an Azure
 		// Configure call would either fail with a confusing schema mismatch or — worse — silently
 		// authenticate against the wrong cloud. Reject early with a clear message.
-		expectedType := tokens.Type("pulumi:providers:" + pc.spec.Name)
+		expectedType := tokens.Type("pulumi:providers:" + pc.spec.Name())
 		if res.Type != expectedType {
 			return nil, fmt.Errorf(
 				"resource %s is a provider for a different package (type=%s); --provider must name a %s resource",

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -182,6 +182,7 @@ type PackageFunctions interface {
 type FunctionsIter interface {
 	Token() string
 	Function() (*Function, error)
+	IsMethod() bool
 	Next() bool
 }
 
@@ -373,6 +374,10 @@ func (i *packageDefFunctionsIter) Function() (*Function, error) {
 	return i.f, nil
 }
 
+func (i *packageDefFunctionsIter) IsMethod() bool {
+	return i.f.IsMethod
+}
+
 func (i *packageDefFunctionsIter) Next() bool {
 	if len(i.functions) == 0 {
 		return false
@@ -407,6 +412,13 @@ type PartialPackage struct {
 		types     map[string]string
 		resources map[string]string
 		functions map[string]string
+	}
+
+	// methodTokens is the set of function tokens that implement resource methods, read straight
+	// out of the spec's `methods` maps. Built lazily on first use of FunctionsIter.IsMethod.
+	methodTokens struct {
+		once   sync.Once
+		tokens map[string]struct{}
 	}
 }
 
@@ -668,6 +680,32 @@ func (p *PartialPackage) resourceAliases() map[string]string {
 func (p *PartialPackage) functionAliases() map[string]string {
 	p.specAliases.once.Do(p.buildSpecAliases)
 	return p.specAliases.functions
+}
+
+// methodTokenSet returns the set of function tokens that implement resource methods, without
+// binding any package members. Malformed member specs are skipped; they fail with a proper error
+// when the member is bound.
+func (p *PartialPackage) methodTokenSet() map[string]struct{} {
+	p.methodTokens.once.Do(func() {
+		tokens := map[string]struct{}{}
+		collect := func(raw json.RawMessage) {
+			var res struct {
+				Methods map[string]string `json:"methods"`
+			}
+			if err := parseJSONPropertyValue(raw, &res); err != nil {
+				return
+			}
+			for _, tok := range res.Methods {
+				tokens[tok] = struct{}{}
+			}
+		}
+		collect(p.spec.Provider)
+		for _, raw := range p.spec.Resources {
+			collect(raw)
+		}
+		p.methodTokens.tokens = tokens
+	})
+	return p.methodTokens.tokens
 }
 
 // buildSpecAliases builds normalized→source-form alias maps over the spec's token keys.
@@ -1017,6 +1055,11 @@ func (i *partialPackageFunctionsIter) Token() string {
 func (i *partialPackageFunctionsIter) Function() (*Function, error) {
 	fn, _, err := i.functions.Get(i.Token())
 	return fn, err
+}
+
+func (i *partialPackageFunctionsIter) IsMethod() bool {
+	_, ok := i.functions.methodTokenSet()[i.Token()]
+	return ok
 }
 
 func (i *partialPackageFunctionsIter) Next() bool {


### PR DESCRIPTION
Currently we bind the schema in `pulumi do` using
`BindSchema`. However we rarely need the whole schema here, so we can make use of the `PartialPackageSpec`, which doesn't force us to parse the whole schema upfront, but allows us to pick the pieces we need.

This saves about 4 seconds when loading running `pulumi do aws:lambda:Function create --help`.  Using the `segmentio/encoding` package for json parsing saves another 500ms loading the JSON.

This brings the whole command from taking about 7s down to 2.5s. Which still feels long for a `--help` command, but much better than before.
