### PR TITLE
clean up help for flags

### DIFF
--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -54,7 +54,7 @@ func functionSchemaHelp(fn *schema.Function) string {
 			}
 			b.WriteString(")")
 			if property.Comment != "" {
-				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(property.Comment, "\n", " "))
+				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(cleanComment(property.Comment), "\n", " "))
 			}
 			b.WriteString("\n")
 		}
@@ -81,7 +81,7 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 	shorthelp := fmt.Sprintf("Invoke the %s function", name)
 	longhelp := shorthelp + "."
 	if fn.Comment != "" {
-		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, fn.Comment)
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, cleanComment(fn.Comment))
 	}
 	if schemaHelp := functionSchemaHelp(fn); schemaHelp != "" {
 		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, schemaHelp)

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -63,7 +63,7 @@ func resourceSchemaHelp(res *schema.Resource) string {
 			}
 			b.WriteString(")")
 			if property.Comment != "" {
-				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(property.Comment, "\n", " "))
+				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(cleanComment(property.Comment), "\n", " "))
 			}
 			b.WriteString("\n")
 		}
@@ -84,7 +84,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 	shorthelp := fmt.Sprintf("Operate on the %s resource", name)
 	longhelp := shorthelp + "."
 	if res.Comment != "" {
-		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, res.Comment)
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, cleanComment(res.Comment))
 	}
 	if schemaHelp := resourceSchemaHelp(res); schemaHelp != "" {
 		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, schemaHelp)

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -508,25 +509,26 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		var flagFunc func(string, string)
 
 		typ := unwrapType(input.Type)
+		comment := flagUsage(input.Comment)
 
 		if typ == schema.StringType {
 			flagFunc = func(name, extraHelp string) {
-				flags.String(name, "", input.Comment+extraHelp)
+				flags.String(name, "", comment+extraHelp)
 			}
 		}
 		if typ == schema.BoolType {
 			flagFunc = func(name, extraHelp string) {
-				flags.Bool(name, false, input.Comment+extraHelp)
+				flags.Bool(name, false, comment+extraHelp)
 			}
 		}
 		if typ == schema.IntType {
 			flagFunc = func(name, extraHelp string) {
-				flags.Int(name, 0, input.Comment+extraHelp)
+				flags.Int(name, 0, comment+extraHelp)
 			}
 		}
 		if typ == schema.NumberType {
 			flagFunc = func(name, extraHelp string) {
-				flags.Float64(name, 0, input.Comment+extraHelp)
+				flags.Float64(name, 0, comment+extraHelp)
 			}
 		}
 
@@ -542,6 +544,19 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 			}
 		}
 	}
+}
+
+var langChoiceSpanRegexp = regexp.MustCompile(`(?s)<span\b[^>]*>(.*?)</span>`)
+
+var envVarChoiceRegexp = regexp.MustCompile("(?s)(`[A-Z][A-Z0-9_]*`) or <span\\b[^>]*>.*?</span> environment variables")
+
+func cleanComment(comment string) string {
+	comment = envVarChoiceRegexp.ReplaceAllString(comment, "$1 environment variable")
+	return langChoiceSpanRegexp.ReplaceAllString(comment, "$1")
+}
+
+func flagUsage(comment string) string {
+	return strings.ReplaceAll(cleanComment(comment), "`", "")
 }
 
 func inputFlagName(name string) string {

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -1080,3 +1080,109 @@ func TestDoCmdFunctionInvokeWithoutStackContext(t *testing.T) {
 		require.ErrorContains(t, err, "organization is not supported")
 	})
 }
+
+func TestCleanComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no markup",
+			input:    "Function entry point in your code.",
+			expected: "Function entry point in your code.",
+		},
+		{
+			name: "language-choice span renders the canonical camelCase choice",
+			input: "Required if <span pulumi-lang-nodejs=\"`packageType`\" " +
+				"pulumi-lang-python=\"`package_type`\">`packageType`</span> is `Zip`.",
+			expected: "Required if `packageType` is `Zip`.",
+		},
+		{
+			name: "multiple spans on one line are handled independently",
+			input: "Conflicts with <span pulumi-lang-go=\"`imageUri`\">`imageUri`</span> " +
+				"and <span pulumi-lang-go=\"`s3Bucket`\">`s3Bucket`</span>.",
+			expected: "Conflicts with `imageUri` and `s3Bucket`.",
+		},
+		{
+			name:     "span nested in backticks",
+			input:    "Valid values are `[<span pulumi-lang-python=\"x86_64\">\"x8664\"</span>]` and `[\"arm64\"]`.",
+			expected: "Valid values are `[\"x8664\"]` and `[\"arm64\"]`.",
+		},
+		{
+			name:     "literal angle-bracket placeholders are left untouched",
+			input:    "Use the form arn:aws:s3:::<bucket>/<key>.",
+			expected: "Use the form arn:aws:s3:::<bucket>/<key>.",
+		},
+		{
+			name: "a paired env var collapses to the uppercase name",
+			input: "Can also be set using the `HTTP_PROXY` or " +
+				"<span pulumi-lang-nodejs=\"`httpProxy`\" " +
+				"pulumi-lang-python=\"`http_proxy`\">`httpProxy`</span> environment variables.",
+			expected: "Can also be set using the `HTTP_PROXY` environment variable.",
+		},
+		{
+			name:     "a lone env var is left untouched",
+			input:    "Can also be configured using the `AWS_RETRY_MODE` environment variable.",
+			expected: "Can also be configured using the `AWS_RETRY_MODE` environment variable.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, cleanComment(tt.input))
+		})
+	}
+}
+
+func TestFlagUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "spans are resolved to canonical text and backticks stripped",
+			input: "Conflicts with <span pulumi-lang-nodejs=\"`imageUri`\">`imageUri`</span> " +
+				"and <span pulumi-lang-go=\"`s3Bucket`\">`s3Bucket`</span>.",
+			expected: "Conflicts with imageUri and s3Bucket.",
+		},
+		{
+			name: "span for a literal value keeps the inner text",
+			input: "Defaults to <span pulumi-lang-nodejs=\"`false`\" " +
+				"pulumi-lang-dotnet=\"`False`\">`false`</span>.",
+			expected: "Defaults to false.",
+		},
+		{
+			name: "a paired env var collapses to the uppercase name",
+			input: "Can also be set using the `HTTP_PROXY` or " +
+				"<span pulumi-lang-nodejs=\"`httpProxy`\" " +
+				"pulumi-lang-python=\"`http_proxy`\">`httpProxy`</span> environment variables.",
+			expected: "Can also be set using the HTTP_PROXY environment variable.",
+		},
+		{
+			name:     "inline-code backticks are stripped so pflag does not hijack the placeholder",
+			input:    "...using the `AWS_CA_BUNDLE` environment variable.",
+			expected: "...using the AWS_CA_BUNDLE environment variable.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := flagUsage(tt.input)
+			assert.Equal(t, tt.expected, got)
+			assert.NotContains(t, got, "`", "usage strings must not contain backticks")
+		})
+	}
+}


### PR DESCRIPTION
In the help for these flags, we currently have a few issues, that this PR addresses.

- Language choosers using `<span ...>` tags for various languages. These are not really useful for the user as is, we only keep the default value here.
- Environment variables that can be set per language. E.g. `HTTP_PROXY` can be set as `httpProxy` env variable in NodeJS. It's not really useful to have multiple options here, so we just keep the uppercase one when we can parse it out.
- Backticks in the help text are interpreted by the pflags library. We just drop them, to have plain text output in the terminal.
