### PR TITLE
(Temporarily) forbid `convert --from terraform --language hcl`

### DIFF
--- a/changelog/pending/cli-convert-improvement-20260630-173824.yaml
+++ b/changelog/pending/cli-convert-improvement-20260630-173824.yaml
@@ -2,3 +2,5 @@ component: cli/convert
 kind: improvement
 body: Error when converting a Terraform program to the `hcl` language
 time: 2026-06-30T17:38:24.603534+02:00
+custom:
+    PR: "23742"

--- a/changelog/pending/cli-convert-improvement-20260630-173824.yaml
+++ b/changelog/pending/cli-convert-improvement-20260630-173824.yaml
@@ -1,0 +1,4 @@
+component: cli/convert
+kind: improvement
+body: Error when converting a Terraform program to the `hcl` language
+time: 2026-06-30T17:38:24.603534+02:00

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -239,6 +239,12 @@ func runConvert(
 
 	language = cmdCmd.NormalizeRuntimeName(language)
 
+	if from == "terraform" && language == "hcl" {
+		return errors.New("cannot convert a Terraform program to the \"hcl\" language: " +
+			"pulumi-hcl runs Terraform directly, so no conversion is needed; converting would re-home " +
+			"every resource onto a different provider and show a delete and create for each one on the next preview")
+	}
+
 	var projectGenerator projectGeneratorFunction
 	switch language {
 	case "pulumi", "pcl":

--- a/pkg/cmd/pulumi/convert/convert_test.go
+++ b/pkg/cmd/pulumi/convert/convert_test.go
@@ -92,6 +92,23 @@ output result {
 	assert.Equal(t, expectedPclCode, pclCode)
 }
 
+// Tests that converting a Terraform program to the "hcl" language is rejected,
+// since pulumi-hcl runs Terraform directly and converting would re-home every
+// resource onto a different provider.
+func TestConvertTerraformToHclErrors(t *testing.T) {
+	t.Parallel()
+
+	cwd, err := filepath.Abs("testdata")
+	require.NoError(t, err)
+
+	result := runConvert(
+		t.Context(), io.Discard, io.Discard, &cmdBackend.MockLoginManager{}, pkgWorkspace.Instance,
+		env.Global(), []string{}, cwd, []string{},
+		"terraform", "hcl", t.TempDir(), true, true, "")
+	require.Error(t, result)
+	assert.Contains(t, result.Error(), "pulumi-hcl runs Terraform directly")
+}
+
 // Tests that project names default to the directory of the source project.
 func TestProjectNameDefaults(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Let's imagine that we start with a Terraform program that creates resource `aws:A`.

Internally, we see `aws` in a Terraform program, and handle it dynamically via `pulumi-terraform-bridge`, and thus the provider becomes (let's imagine, for the sake of illustration) `pulumi-terraform-bridge-aws`.

When we convert a program, we look for mentions of these dynamic providers, and if a specific "static" bridge provider exists for the backend (here `aws`), we'll convert the program to use them, and thus we end up with (let's imagine, for the sake of illustration) `pulumi-static-bridge-aws`.

When we `preview` this program after converting, we'll see that we are going to delete `pulumi-terraform-bridge-aws:A` and create `pulumi-static-bridge-aws:A`, despite the fact that these are two interfaces to the same resource. In reality, nothing has changed, and no update is needed.

We have some future plans to make this process smoother, but for now, we can simply say that if someone is trying to convert from Terraform to HCL, this is almost certainly a mistake: you're not going to convert any actual code (because it's already HCL), you're just going to force a replace of every resource.