### PR TITLE
Add `plugin.NewPackageResolverClient`

### DIFF
--- a/pkg/cmd/pulumi/packageworkspace/resolver.go
+++ b/pkg/cmd/pulumi/packageworkspace/resolver.go
@@ -32,7 +32,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
+
+// resolverTracer instruments the package-resolution steps so the cost of
+// installing a plugin versus generating its schema is visible in traces.
+var resolverTracer = otel.Tracer("pulumi-cli")
 
 // NewResolverServer returns a [plugin.NewResolverFunc] that builds a package resolver service bound
 // to a context's workspace view. The resolver runs a spec through the standard package installation
@@ -68,8 +74,18 @@ func (s *resolverServer) ResolvePackage(
 		PluginDownloadURL: req.Server,
 	}
 
+	ctx, span := resolverTracer.Start(ctx, "ResolvePackage")
+	span.SetAttributes(
+		attribute.String("source", req.Source),
+		attribute.String("version", req.Version),
+		attribute.String("server", req.Server),
+		attribute.StringSlice("parameters", req.Parameters),
+	)
+	defer span.End()
+
 	s.m.Lock()
-	run, resolved, state, err := packageinstallation.InstallPlugin(ctx, spec, nil, "", packageinstallation.Options{
+	installCtx, installSpan := resolverTracer.Start(ctx, "InstallPlugin")
+	run, resolved, state, err := packageinstallation.InstallPlugin(installCtx, spec, nil, "", packageinstallation.Options{
 		PriorState: s.state,
 		Options: packageresolution.Options{
 			ResolveWithRegistry:                        true,
@@ -77,6 +93,7 @@ func (s *resolverServer) ResolvePackage(
 			AllowNonInvertableLocalWorkspaceResolution: true,
 		},
 	}, s.reg, s.w)
+	installSpan.End()
 	if err != nil {
 		s.m.Unlock()
 		return nil, fmt.Errorf("resolving package %q: %w", spec.Source, err)
@@ -84,13 +101,17 @@ func (s *resolverServer) ResolvePackage(
 	s.state = state
 	s.m.Unlock()
 
-	prov, err := run(ctx, s.w.pctx.Pwd)
+	runCtx, runSpan := resolverTracer.Start(ctx, "run-plugin")
+	prov, err := run(runCtx, s.w.pctx.Pwd)
+	runSpan.End()
 	if err != nil {
 		return nil, err
 	}
 	defer contract.IgnoreClose(prov)
 
-	resp, err := prov.GetSchema(ctx, plugin.GetSchemaRequest{})
+	schemaCtx, schemaSpan := resolverTracer.Start(ctx, "GetSchema")
+	resp, err := prov.GetSchema(schemaCtx, plugin.GetSchemaRequest{})
+	schemaSpan.End()
 	if err != nil {
 		return nil, fmt.Errorf("getting schema: %w", err)
 	}

--- a/sdk/go/common/resource/plugin/resolver_client.go
+++ b/sdk/go/common/resource/plugin/resolver_client.go
@@ -1,0 +1,39 @@
+// Copyright 2016, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func NewPackageResolverClient(target string) (pulumirpc.PackageResolverClient, error) {
+	contract.Assertf(target != "", "unexpected empty target for package resolver")
+
+	dialOpts := append(
+		rpcutil.TracingInterceptorDialOptions(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		rpcutil.GrpcChannelOptions(),
+	)
+	conn, err := grpc.NewClient(target, dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return pulumirpc.NewPackageResolverClient(conn), nil
+}


### PR DESCRIPTION
This matches how other clients are constructed.

This PR also adds some OTEL spans around package installation. This was motivated by better profiling to track down a slow paramaterize call. 