### PR TITLE
Forbid `import --from terraform` in an `hcl` project

### DIFF
--- a/changelog/pending/cli-import-improvement-20260630-174433.yaml
+++ b/changelog/pending/cli-import-improvement-20260630-174433.yaml
@@ -1,0 +1,4 @@
+component: cli/import
+kind: improvement
+body: Error when running `pulumi import --from terraform` in a Pulumi HCL project
+time: 2026-06-30T17:44:33.25819+02:00

--- a/changelog/pending/cli-import-improvement-20260630-174433.yaml
+++ b/changelog/pending/cli-import-improvement-20260630-174433.yaml
@@ -2,3 +2,5 @@ component: cli/import
 kind: improvement
 body: Error when running `pulumi import --from terraform` in a Pulumi HCL project
 time: 2026-06-30T17:44:33.25819+02:00
+custom:
+    PR: "23744"

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -878,6 +878,13 @@ func NewImportCmd() *cobra.Command {
 				return err
 			}
 
+			if from == "terraform" && importFilePath == "" && proj.Runtime.Name() == "hcl" {
+				return errors.New("cannot run `pulumi import --from terraform` in a Pulumi HCL project: " +
+					"it would import resources under statically bridged providers, but pulumi-hcl runs them " +
+					"through the dynamic Terraform bridge, so the next preview would show a delete and create " +
+					"for every resource")
+			}
+
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 			cwd, err := os.Getwd()

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -879,10 +879,9 @@ func NewImportCmd() *cobra.Command {
 			}
 
 			if from == "terraform" && importFilePath == "" && proj.Runtime.Name() == "hcl" {
-				return errors.New("cannot run `pulumi import --from terraform` in a Pulumi HCL project: " +
-					"it would import resources under statically bridged providers, but pulumi-hcl runs them " +
-					"through the dynamic Terraform bridge, so the next preview would show a delete and create " +
-					"for every resource")
+				return errors.New("`pulumi import --from terraform` will produce "+`
+state that doesn't line up with Pulumi's HCL runtime. You should run `+
+"\n`pulumi import --from hcl` instead.")
 			}
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -879,9 +879,8 @@ func NewImportCmd() *cobra.Command {
 			}
 
 			if from == "terraform" && importFilePath == "" && proj.Runtime.Name() == "hcl" {
-				return errors.New("`pulumi import --from terraform` will produce "+`
-state that doesn't line up with Pulumi's HCL runtime. You should run `+
-"\n`pulumi import --from hcl` instead.")
+				return errors.New("`pulumi import --from terraform` will produce state that doesn't line up " +
+					"with Pulumi's HCL runtime.\nYou should run `pulumi import --from hcl` instead.")
 			}
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/blang/semver"
@@ -931,4 +933,27 @@ func TestImportCmd_OutputAndJSONMutuallyExclusive(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "none of the others can be",
 		"expected cobra's mutually-exclusive error, got: %v", err)
+}
+
+// TestImportCmd_TerraformConverterRejectedInHclProject verifies that
+// `pulumi import --from terraform` is rejected in a Pulumi HCL project. The
+// Terraform converter writes statically bridged providers into state, but
+// pulumi-hcl runs resources through the dynamic Terraform bridge, so the next
+// preview would show a delete and create for every resource.
+//
+//nolint:paralleltest // changes process working directory
+func TestImportCmd_TerraformConverterRejectedInHclProject(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: test\nruntime: hcl\n"), 0o600)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	cmd := NewImportCmd()
+	cmd.SetArgs([]string{"--from", "terraform", "--yes"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Pulumi HCL project")
 }

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -955,5 +955,5 @@ func TestImportCmd_TerraformConverterRejectedInHclProject(t *testing.T) {
 
 	err = cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Pulumi HCL project")
+	assert.Contains(t, err.Error(), "pulumi import --from hcl")
 }


### PR DESCRIPTION
The second part after #23742.