### PR TITLE
fix(nodejs/npm): use quoted bracket notation for pnpm >= 11 scoped packages

### DIFF
--- a/changelog/pending/20260630--sdk-nodejs--fix-pnpm11-scoped-package-link.yaml
+++ b/changelog/pending/20260630--sdk-nodejs--fix-pnpm11-scoped-package-link.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: fix
+body: Fix `pulumi install` failing with pnpm >= 11 for scoped packages by using quoted bracket notation in `pkg set` property paths
+time: 2026-06-30T20:33:00.000000+02:00
+custom:
+  PR: 23748

--- a/sdk/nodejs/npm/manager.go
+++ b/sdk/nodejs/npm/manager.go
@@ -282,3 +282,11 @@ func preferYarn() bool {
 func getLinkPackageProperty(packageName, path string) string {
 	return fmt.Sprintf("dependencies[%s]=file:%s", packageName, path)
 }
+
+// getPnpmLinkPackageProperty returns the property specifier for pnpm's `pkg set` command.
+// pnpm >= 11 requires quoted keys inside brackets (e.g. dependencies["@pulumi/aap"]=file:sdks/aap),
+// otherwise it rejects special characters like '@' and '-' in property paths.
+// npm/bun/yarn interpret quotes literally, so this format is pnpm-specific.
+func getPnpmLinkPackageProperty(packageName, path string) string {
+	return fmt.Sprintf(`dependencies["%s"]=file:%s`, packageName, path)
+}

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha1" //nolint:gosec // this is what NPM wants
 	"encoding/hex"
 	"fmt"
@@ -63,6 +64,36 @@ func TestGetLinkPackageProperty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := getLinkPackageProperty(tt.packageName, tt.path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetPnpmLinkPackageProperty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		packageName string
+		path        string
+		want        string
+	}{
+		{
+			name:        "scoped package",
+			packageName: "@pulumi/aap",
+			path:        "sdks/aap",
+			want:        `dependencies["@pulumi/aap"]=file:sdks/aap`,
+		},
+		{
+			name:        "unscoped package",
+			packageName: "pulumi-aap",
+			path:        "sdks/aap",
+			want:        `dependencies["pulumi-aap"]=file:sdks/aap`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := getPnpmLinkPackageProperty(tt.packageName, tt.path)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -573,4 +604,48 @@ func writeFile(t testing.TB, path, contents string) {
 
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
 	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+}
+
+func TestLinkScopedPackage(t *testing.T) {
+	t.Parallel()
+
+	// Tests that Link correctly adds scoped packages (with @) to package.json
+	// for each supported package manager that is available locally.
+	managers := []struct {
+		name       string
+		pmType     PackageManagerType
+		executable string
+	}{
+		{"npm", NpmPackageManager, "npm"},
+		{"pnpm", PnpmPackageManager, "pnpm"},
+		{"bun", BunPackageManager, "bun"},
+	}
+
+	for _, mgr := range managers {
+		mgr := mgr
+		t.Run(mgr.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Skip if the package manager is not installed.
+			if _, err := exec.LookPath(mgr.executable); err != nil {
+				t.Skipf("%s not found on PATH, skipping", mgr.executable)
+			}
+
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "package.json"), `{"name":"test","version":"1.0.0"}`)
+
+			pm, err := ResolvePackageManager(mgr.pmType, dir)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			err = pm.Link(ctx, dir, "@pulumi/authentik", "sdks/authentik")
+			require.NoError(t, err, "%s Link failed for scoped package", mgr.name)
+
+			// Verify package.json was updated correctly.
+			data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+			require.NoError(t, err)
+			assert.Contains(t, string(data), `"@pulumi/authentik"`)
+			assert.Contains(t, string(data), `file:sdks/authentik`)
+		})
+	}
 }

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -94,7 +94,7 @@ func (pnpm *pnpmManager) installCmd(ctx context.Context, production bool) *exec.
 }
 
 func (pnpm *pnpmManager) Link(ctx context.Context, dir, packageName, path string) error {
-	packageSpecifier := getLinkPackageProperty(packageName, path)
+	packageSpecifier := getPnpmLinkPackageProperty(packageName, path)
 	cmd := exec.CommandContext(ctx, "pnpm", "pkg", "set", packageSpecifier)
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary

Follow-up to #23365. pnpm >= 11 changed its property path tokenizer and now rejects `@` and `-` even inside bracket notation (`dependencies[@pulumi/aap]=file:...`), producing `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH`.

Fixed by adding `getPnpmLinkPackageProperty` that wraps the package name in quotes inside brackets (`dependencies["@pulumi/aap"]=file:sdks/aap`). npm/bun/yarn keep using unquoted brackets since npm interprets inner quotes literally (would corrupt the key name).

## Test plan

- [x] Unit test `TestGetPnpmLinkPackageProperty` — covers scoped and unscoped packages
- [x] Integration test `TestLinkScopedPackage` — exercises actual `pnpm pkg set`, `npm pkg set`, and `bun pm pkg set` with scoped packages
- [x] Manual validation with `pulumi install` on a real project using pnpm 11.9.0

## Changelog

- [x] `changelog/pending/20260630--sdk-nodejs--fix-pnpm11-scoped-package-link.yaml`

## Risk

Low. Surgical change: pnpm's `Link()` now calls a pnpm-specific format function. npm/bun/yarn paths unchanged.
