### PR TITLE
Fix devcontainer docker-in-docker build on Debian trixie base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,11 @@
     },
 
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        // The base image (pulumi/pulumi) is on Debian "trixie", which doesn't ship the
+        // Moby packages this feature installs by default. Use Docker CE instead.
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
+        },
         "ghcr.io/devcontainers/features/common-utils:2": {
             "installZsh": false,
             "installOhMyZsh": false,


### PR DESCRIPTION
### Problem

Building the dev container (e.g. via VS Code / Cursor "Reopen in Container") currently fails during feature installation:

```
(!) The 'moby' option is not supported on debian 'trixie' because 'moby-cli' and related system packages are not available in that distribution.
(!) To continue, either set the feature option '"moby": false' or use a different base image.
ERROR: Feature "Docker (Docker-in-Docker)" failed to install!
```

The `pulumi/pulumi` base image moved to Debian 13 "trixie", which does not ship the `moby-engine` / `moby-cli` packages that the `docker-in-docker` feature installs by default (`moby: true`).

### Fix

Set `"moby": false` on the `docker-in-docker` feature so it installs Docker CE from Docker's official repo, which supports trixie. The resulting `docker` CLI behaves the same.

### Testing

Verified locally with `@devcontainers/cli build` — the build now completes with `{"outcome":"success"}` (it failed before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)