### PR TITLE
Fix FileArchive producing backslash zip/tar entries on Windows (#16273)

### DIFF
--- a/changelog/pending/sdk-go-fix-archive-backslash-windows.yaml
+++ b/changelog/pending/sdk-go-fix-archive-backslash-windows.yaml
@@ -1,0 +1,6 @@
+component: sdk/go
+kind: fix
+body: Fix FileArchive nested in an AssetArchive producing zip/tar entries with backslashes on Windows
+time: 2026-06-13T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/changelog/pending/sdk-go-fix-archive-backslash-windows.yaml
+++ b/changelog/pending/sdk-go-fix-archive-backslash-windows.yaml
@@ -3,4 +3,4 @@ kind: fix
 body: Fix FileArchive nested in an AssetArchive producing zip/tar entries with backslashes on Windows
 time: 2026-06-13T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23750"

--- a/sdk/go/common/resource/archive/archive.go
+++ b/sdk/go/common/resource/archive/archive.go
@@ -373,8 +373,9 @@ func (r *assetsArchiveReader) Next() (string, *asset.Blob, error) {
 				// The subarchive produced a legitimate error; return it.
 				return "", nil, err
 			default:
-				// The subarchive produced a valid blob. Return it.
-				return filepath.Join(r.archiveRoot, name), blob, nil
+				// The subarchive produced a valid blob. Return it. Use ToSlash to ensure archive member
+				// names always use forward slashes, even on Windows (filepath.Join would use backslashes).
+				return filepath.ToSlash(filepath.Join(r.archiveRoot, name)), blob, nil
 			}
 		}
 

--- a/sdk/go/common/resource/archive/archive.go
+++ b/sdk/go/common/resource/archive/archive.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -373,9 +374,8 @@ func (r *assetsArchiveReader) Next() (string, *asset.Blob, error) {
 				// The subarchive produced a legitimate error; return it.
 				return "", nil, err
 			default:
-				// The subarchive produced a valid blob. Return it. Use ToSlash to ensure archive member
-				// names always use forward slashes, even on Windows (filepath.Join would use backslashes).
-				return filepath.ToSlash(filepath.Join(r.archiveRoot, name)), blob, nil
+				// The subarchive produced a valid blob. Return it.
+				return path.Join(r.archiveRoot, name), blob, nil
 			}
 		}
 

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -595,9 +595,11 @@ func TestNestedArchive(t *testing.T) {
 	files := zipReader.File
 	require.Len(t, files, 3)
 
-	assert.Equal(t, "foo/a.txt", filepath.ToSlash(files[0].Name))
-	assert.Equal(t, "foo/bar/b.txt", filepath.ToSlash(files[1].Name))
-	assert.Equal(t, "fake.txt", filepath.ToSlash(files[2].Name))
+	// Archive member names must always use forward slashes, even on Windows (do not normalize
+	// the actual value with ToSlash here, otherwise the assertion would mask backslashes).
+	assert.Equal(t, "foo/a.txt", files[0].Name)
+	assert.Equal(t, "foo/bar/b.txt", files[1].Name)
+	assert.Equal(t, "fake.txt", files[2].Name)
 }
 
 //nolint:gosec
@@ -634,7 +636,9 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	require.NoError(t, err)
 	files := zipReader.File
 	require.Len(t, files, 1)
-	assert.Equal(t, "foo/bar/b.txt", filepath.ToSlash(files[0].Name))
+	// Archive member names must always use forward slashes, even on Windows (do not normalize
+	// the actual value with ToSlash here, otherwise the assertion would mask backslashes).
+	assert.Equal(t, "foo/bar/b.txt", files[0].Name)
 }
 
 func TestEmptyArchiveRoundTrip(t *testing.T) {

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -595,8 +595,7 @@ func TestNestedArchive(t *testing.T) {
 	files := zipReader.File
 	require.Len(t, files, 3)
 
-	// Archive member names must always use forward slashes, even on Windows (do not normalize
-	// the actual value with ToSlash here, otherwise the assertion would mask backslashes).
+	// Archive member names must always use forward slashes, even on Windows
 	assert.Equal(t, "foo/a.txt", files[0].Name)
 	assert.Equal(t, "foo/bar/b.txt", files[1].Name)
 	assert.Equal(t, "fake.txt", files[2].Name)
@@ -636,8 +635,7 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	require.NoError(t, err)
 	files := zipReader.File
 	require.Len(t, files, 1)
-	// Archive member names must always use forward slashes, even on Windows (do not normalize
-	// the actual value with ToSlash here, otherwise the assertion would mask backslashes).
+	// Archive member names must always use forward slashes, even on Windows
 	assert.Equal(t, "foo/bar/b.txt", files[0].Name)
 }
 


### PR DESCRIPTION
## Summary

Nested FileArchives in an AssetArchive produced archive member names with OS-native separators, yielding backslashes in zip/tar entries on Windows. Wrap the joined name in filepath.ToSlash so members always use forward slashes.

Fixes #16273

## Test plan
<!-- How did you test this change? -->
- [X] Added appropriate unit tests - Amended existing tests
- [ ] Added a test in `pkg/engine/lifecycletest` - N/A
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - N/A
- [ ] Added a golden test in `pkg/backend/display` - N/A

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [X] `make lint` — clean
- [ ] `make test_fast` — Ran ; 54 failures, all pre-existing/flaky in unrelated pkg/ packages (S3, httpstate, ESC config TTY prompts, codegen example-coverage). The changed package's own tests pass.
- [X] `make tidy_fix` — clean
- [X] `make format` — clean
- [X] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [X] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

* Hash churn for existing Windows stacks: Nested-archive member names change foo\bar.txt → foo/bar.txt, so the archive's content hash changes on Windows. Windows users with an AssetArchive-of-FileArchive will see a one-time update/diff (and a re-upload) on their next pulumi up.
* State/serialization adjacency: This touches sdk/go/common/resource/ and alters archive naming, which feeds content hashes. Low blast radius (one line, behavior-preserving on non-Windows), but per the repo's escalation rules please review appropriately.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
