### PR TITLE
[neo] CLI: render Neo usage-limit errors (org + per-member)

### DIFF
--- a/changelog/pending/cli-neo-usage-limit-errors.yaml
+++ b/changelog/pending/cli-neo-usage-limit-errors.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: feat
+body: Render a clear, actionable message when a Neo usage limit is reached, pointing the user at their org admin to raise the org-level or per-member limit
+time: 2026-06-30T00:00:00.000000+00:00
+custom:
+    PR: "23752"

--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -215,6 +215,31 @@ func (err LoginRequiredError) Error() string {
 	return "this command requires logging in; try running `pulumi login` first"
 }
 
+// NeoCapExhaustedError represents a 402 from the Pulumi Service indicating
+// the organization has reached its admin-configured monthly Neo usage cap.
+// The CLI renders a "raise the limit" pointer when this error surfaces; the
+// `pulumi/pulumi-service` decode in pkg/backend/httpstate/client/api.go
+// constructs it from an ErrorResponse carrying ErrorType
+// "neo_org_cap_exhausted".
+type NeoCapExhaustedError struct {
+	// OrgLogin is the organization whose cap was exhausted, if the
+	// service-side response carried it on RequestError.Attribute.
+	OrgLogin string
+	// Message is the human-readable text from ErrorResponse.Message —
+	// includes the consumed-vs-cap numbers and reset window when relevant.
+	Message string
+}
+
+func (e NeoCapExhaustedError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.OrgLogin != "" {
+		return fmt.Sprintf("Neo usage limit reached for %s; ask the org admin to raise the limit", e.OrgLogin)
+	}
+	return "Neo usage limit reached for this organization; ask the org admin to raise the limit"
+}
+
 // CancelledError represents a user-initiated cancellation of an operation
 // such as an update or destroy.
 type CancelledError struct {

--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -215,13 +215,28 @@ func (err LoginRequiredError) Error() string {
 	return "this command requires logging in; try running `pulumi login` first"
 }
 
-// NeoCapExhaustedError represents a 402 from the Pulumi Service indicating
-// the organization has reached its admin-configured monthly Neo usage cap.
-// The CLI renders a "raise the limit" pointer when this error surfaces; the
-// `pulumi/pulumi-service` decode in pkg/backend/httpstate/client/api.go
-// constructs it from an ErrorResponse carrying ErrorType
-// "neo_org_cap_exhausted".
+// NeoCapScope identifies which Neo usage cap was exhausted — the
+// organization-wide cap or an individual member's per-member cap.
+type NeoCapScope int
+
+const (
+	// NeoCapScopeOrg is the organization-wide Neo usage cap. It is the zero
+	// value so a NeoCapExhaustedError constructed without an explicit scope
+	// defaults to org, matching the original org-only decode.
+	NeoCapScopeOrg NeoCapScope = iota
+	// NeoCapScopeMember is an individual member's per-member Neo usage cap.
+	NeoCapScopeMember
+)
+
+// NeoCapExhaustedError represents a 402 from the Pulumi Service indicating a
+// Neo usage cap has been reached — either the organization-wide cap or a
+// member's per-member cap, distinguished by Scope. The CLI renders a "raise
+// the limit" pointer when this error surfaces; the decode in
+// pkg/backend/httpstate/client/api.go constructs it from an ErrorResponse
+// carrying ErrorType "neo_org_cap_exhausted" or "neo_member_cap_exhausted".
 type NeoCapExhaustedError struct {
+	// Scope is which cap was exhausted (org-wide vs per-member).
+	Scope NeoCapScope
 	// OrgLogin is the organization whose cap was exhausted, if the
 	// service-side response carried it on RequestError.Attribute.
 	OrgLogin string
@@ -233,6 +248,9 @@ type NeoCapExhaustedError struct {
 func (e NeoCapExhaustedError) Error() string {
 	if e.Message != "" {
 		return e.Message
+	}
+	if e.Scope == NeoCapScopeMember {
+		return "Neo usage limit reached for you; ask the org admin to raise your per-member limit"
 	}
 	if e.OrgLogin != "" {
 		return fmt.Sprintf("Neo usage limit reached for %s; ask the org admin to raise the limit", e.OrgLogin)

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -594,6 +594,21 @@ func pulumiAPICall(ctx context.Context,
 			return "", nil, loginErr
 		}
 
+		if resp.StatusCode == 402 {
+			var errResp *apitype.ErrorResponse
+			if errors.As(err, &errResp) {
+				for _, e := range errResp.Errors {
+					if e.ErrorType == apitype.NeoOrgCapExhaustedErrorType {
+						capErr := backenderr.NeoCapExhaustedError{Message: errResp.Message}
+						if e.Attribute != nil {
+							capErr.OrgLogin = *e.Attribute
+						}
+						return "", nil, capErr
+					}
+				}
+			}
+		}
+
 		return "", nil, err
 	}
 

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -605,6 +605,16 @@ func pulumiAPICall(ctx context.Context,
 						}
 						return "", nil, capErr
 					}
+					if e.ErrorType == apitype.NeoMemberCapExhaustedErrorType {
+						capErr := backenderr.NeoCapExhaustedError{
+							Scope:   backenderr.NeoCapScopeMember,
+							Message: errResp.Message,
+						}
+						if e.Attribute != nil {
+							capErr.OrgLogin = *e.Attribute
+						}
+						return "", nil, capErr
+					}
 				}
 			}
 		}

--- a/sdk/go/common/apitype/errors.go
+++ b/sdk/go/common/apitype/errors.go
@@ -36,6 +36,13 @@ const (
 	// CustomErrorType is used to describe any ErrorType not found in this file, and must be paired with
 	// a custom error message.
 	CustomErrorType ErrorType = "custom"
+
+	// NeoOrgCapExhaustedErrorType accompanies the 402 the Pulumi Service returns when an
+	// organization has reached its admin-configured monthly Neo usage cap. New-enough Pulumi
+	// CLIs decode this into the "ask your org admin to raise the cap" pointer in
+	// pkg/backend/backenderr; older clients fall through to displaying the top-level
+	// ErrorResponse.Message field, so the wire shape is additive.
+	NeoOrgCapExhaustedErrorType ErrorType = "neo_org_cap_exhausted"
 )
 
 // RequestError describes a request error in more detail, such the specific validation

--- a/sdk/go/common/apitype/errors.go
+++ b/sdk/go/common/apitype/errors.go
@@ -39,10 +39,15 @@ const (
 
 	// NeoOrgCapExhaustedErrorType accompanies the 402 the Pulumi Service returns when an
 	// organization has reached its admin-configured monthly Neo usage cap. New-enough Pulumi
-	// CLIs decode this into the "ask your org admin to raise the cap" pointer in
+	// CLIs decode this into the "ask your org admin to raise the limit" pointer in
 	// pkg/backend/backenderr; older clients fall through to displaying the top-level
 	// ErrorResponse.Message field, so the wire shape is additive.
 	NeoOrgCapExhaustedErrorType ErrorType = "neo_org_cap_exhausted"
+	// NeoMemberCapExhaustedErrorType accompanies the 402 the Pulumi Service returns when an
+	// individual member has reached their admin-configured per-member Neo usage cap. Decoded
+	// like NeoOrgCapExhaustedErrorType, but into a member-scoped pointer; older clients fall
+	// through to the top-level ErrorResponse.Message field, so the wire shape is additive.
+	NeoMemberCapExhaustedErrorType ErrorType = "neo_member_cap_exhausted"
 )
 
 // RequestError describes a request error in more detail, such the specific validation


### PR DESCRIPTION
Decodes the 402 structured errors the Pulumi Service returns when a Neo usage limit is reached and renders a clear, actionable CLI message instead of raw HTTP status text.

- `neo_org_cap_exhausted` → org-scoped `NeoCapExhaustedError` ("Neo usage limit reached for <org>; ask the org admin to raise the limit").
- `neo_member_cap_exhausted` → member-scoped `NeoCapExhaustedError` ("Neo usage limit reached for you; ask the org admin to raise your per-member limit").

Both point the user at their org admin to raise the limit. The decode is additive: older clients / services that don't emit these error types fall through to the top-level `ErrorResponse.Message`.

Customer-facing wording is "limit" (not "cap"); the wire error-type strings and Go identifiers are unchanged.

The service side that emits these 402s ships in the pulumi-service Neo usage limits PR stack.

## Test plan
- [x] `go test ./backend/backenderr/...` and `./backend/httpstate/...` pass