### PR TITLE
Show a `retain` marker for retain-on-delete resources in `--diff` output

### DIFF
--- a/changelog/pending/cli-fix-diff-retain-marker.yaml
+++ b/changelog/pending/cli-fix-diff-retain-marker.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Show a `retain` marker for retain-on-delete resources in `--diff` output
+time: 2026-07-01T09:13:57.126160+02:00

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -74,11 +74,29 @@ func printStepHeader(b io.StringWriter, step engine.StepEventMetadata, showURNs 
 		// show a locked symbol, since we are either newly protecting this resource, or retaining protection.
 		extra = " 🔒"
 	}
+	op := addRetainStatusFlag(string(step.Op), step)
 	if showURNs {
-		writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.URN), step.Op, extra))
+		writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.URN), op, extra))
 	} else {
-		writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.Type), step.Op, extra))
+		writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.Type), op, extra))
 	}
+}
+
+// addRetainStatusFlag adds a "[retain]" suffix to the input string if the resource is marked as
+// RetainOnDelete and the step will discard the resource.
+func addRetainStatusFlag(status string, step engine.StepEventMetadata) string {
+	if step.Old == nil || !step.Old.RetainOnDelete {
+		return status
+	}
+
+	switch step.Op {
+	// Deletes and Replacements should indicate retain on delete behavior as they can leave
+	// untracked resources in the environment.
+	case deploy.OpDelete, deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced:
+		status += "[retain]"
+	}
+
+	return status
 }
 
 func getIndentationString(indent int, op display.StepOp, prefix bool) string {

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -374,23 +374,6 @@ func (data *resourceRowData) ColorizedColumns() []string {
 	return columns
 }
 
-// addRetainStatusFlag adds a "[retain]" suffix to the input string if the resource is marked as
-// RetainOnDelete and the step will discard the resource.
-func addRetainStatusFlag(status string, step engine.StepEventMetadata) string {
-	if step.Old == nil || !step.Old.RetainOnDelete {
-		return status
-	}
-
-	switch step.Op {
-	// Deletes and Replacements should indicate retain on delete behavior as they can leave
-	// untracked resources in the environment.
-	case deploy.OpDelete, deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced:
-		status += "[retain]"
-	}
-
-	return status
-}
-
 func (data *resourceRowData) getInfoColumn() string {
 	step := data.step
 	switch step.Op {

--- a/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/1/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/1/diff.stdout.txt
@@ -1,12 +1,12 @@
-<{%fg 10%}>++pkgA:m:typA: (create-replacement)
+<{%fg 10%}>++pkgA:m:typA: (create-replacement[retain])
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
 <{%reset%}><{%fg 3%}>  ~ foo: <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 1%}>r<{%reset%}><{%fg 3%}>"<{%reset%}><{%fg 3%}> => <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 2%}>z<{%reset%}><{%fg 3%}>"
-<{%reset%}><{%reset%}><{%fg 13%}>+-pkgA:m:typA: (replace)
+<{%reset%}><{%reset%}><{%fg 13%}>+-pkgA:m:typA: (replace[retain])
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
 <{%reset%}><{%fg 3%}>  ~ foo: <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 1%}>r<{%reset%}><{%fg 3%}>"<{%reset%}><{%fg 3%}> => <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 2%}>z<{%reset%}><{%fg 3%}>"
-<{%reset%}><{%reset%}><{%fg 9%}>--pkgA:m:typA: (delete-replaced)
+<{%reset%}><{%reset%}><{%fg 9%}>--pkgA:m:typA: (delete-replaced[retain])
 <{%fg 9%}>    [id=3]
 <{%reset%}><{%fg 9%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
 <{%reset%}><{%fg 9%}>    foo: <{%reset%}><{%fg 9%}>"bar"<{%reset%}><{%fg 9%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/1/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/1/urns-diff.stdout.txt
@@ -1,10 +1,10 @@
-<{%fg 10%}>++urn:pulumi:test::test::pkgA:m:typA::resA: (create-replacement)
+<{%fg 10%}>++urn:pulumi:test::test::pkgA:m:typA::resA: (create-replacement[retain])
 <{%reset%}>    [id=3]
 <{%reset%}><{%fg 3%}>  ~ foo: <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 1%}>r<{%reset%}><{%fg 3%}>"<{%reset%}><{%fg 3%}> => <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 2%}>z<{%reset%}><{%fg 3%}>"
-<{%reset%}><{%reset%}><{%fg 13%}>+-urn:pulumi:test::test::pkgA:m:typA::resA: (replace)
+<{%reset%}><{%reset%}><{%fg 13%}>+-urn:pulumi:test::test::pkgA:m:typA::resA: (replace[retain])
 <{%reset%}>    [id=3]
 <{%reset%}><{%fg 3%}>  ~ foo: <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 1%}>r<{%reset%}><{%fg 3%}>"<{%reset%}><{%fg 3%}> => <{%reset%}><{%fg 3%}>"<{%reset%}><{%reset%}>ba<{%reset%}><{%fg 2%}>z<{%reset%}><{%fg 3%}>"
-<{%reset%}><{%reset%}><{%fg 9%}>--urn:pulumi:test::test::pkgA:m:typA::resA: (delete-replaced)
+<{%reset%}><{%reset%}><{%fg 9%}>--urn:pulumi:test::test::pkgA:m:typA::resA: (delete-replaced[retain])
 <{%fg 9%}>    [id=3]
 <{%reset%}><{%fg 9%}>    foo: <{%reset%}><{%fg 9%}>"bar"<{%reset%}><{%fg 9%}>
 <{%reset%}><{%reset%}><{%fg 9%}>    --outputs:--<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/2/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/2/diff.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 1%}>- pkgA:m:typA: (delete)
+<{%fg 1%}>- pkgA:m:typA: (delete[retain])
 <{%fg 1%}>    [id=1]
 <{%reset%}><{%fg 1%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
 <{%reset%}><{%fg 1%}>    foo: <{%reset%}><{%fg 1%}>"baz"<{%reset%}><{%fg 1%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/2/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestRetainOnDelete/2/urns-diff.stdout.txt
@@ -1,4 +1,4 @@
-<{%fg 1%}>- urn:pulumi:test::test::pkgA:m:typA::resA: (delete)
+<{%fg 1%}>- urn:pulumi:test::test::pkgA:m:typA::resA: (delete[retain])
 <{%fg 1%}>    [id=1]
 <{%reset%}><{%fg 1%}>    foo: <{%reset%}><{%fg 1%}>"baz"<{%reset%}><{%fg 1%}>
 <{%reset%}><{%reset%}><{%fg 1%}>    --outputs:--<{%reset%}>


### PR DESCRIPTION
We added this for the progress display in https://github.com/pulumi/pulumi/pull/12157, but forgot to do so for the diff display.

```
$ pulumi destroy --diff
Previewing destroy (dev)

- random:index/randomString:RandomString: (delete[retain])
    [id=!wCBROb>H{wx&q0!]
    [urn=urn:pulumi:dev::pulumi-retain-on-delete::random:index/randomString:RandomString::retained]
    length: 16
- pulumi:pulumi:Stack: (delete)
    [urn=urn:pulumi:dev::pulumi-retain-on-delete::pulumi:pulumi:Stack::pulumi-retain-on-delete-dev]
    --outputs:--
  - value: "!wCBROb>H{wx&q0!"
Resources:
    - 2 to delete
info: This update will leave 1 resource(s) untracked in your environment:
    - random:index:RandomString retained
```

Fixes https://github.com/pulumi/pulumi/issues/23751
