### PR TITLE
Fix npm cache in ci-run-test

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -229,18 +229,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ fromJson(inputs.version-set).nodejs }}
-      - name: Get npm cache directory
-        id: npm-cache
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
-      - name: Cache npm
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ${{ steps.npm-cache.outputs.dir }}
-          key: npm-${{ runner.os }}-${{ fromJson(inputs.version-set).nodejs }}-${{ hashFiles('sdk/nodejs/package-lock.json') }}
-          restore-keys: |
-            npm-${{ runner.os }}-${{ fromJson(inputs.version-set).nodejs }}-
-            npm-${{ runner.os }}-
+          cache: npm
+          cache-dependency-path: sdk/nodejs/package-lock.json
       - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
I missed this in https://github.com/pulumi/pulumi/pull/23655. We can let the `Set up Node` action do the caching for npm, since that’s our package manager now, we don’t need separate steps to do this for us.
