### PR TITLE
Don't include the version in module paths when serializing functions when using pnpm

### DIFF
--- a/changelog/pending/sdkgen-nodejs-fix-20260701-151843.yaml
+++ b/changelog/pending/sdkgen-nodejs-fix-20260701-151843.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: fix
+body: Don't include the version in module paths when serializing functions when using pnpm
+time: 2026-07-01T15:18:43.430936+02:00

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1389,7 +1389,15 @@ async function getOrCreateEntryAsync(
         const moduleParts = normalizedModuleName.split("/");
 
         const nodeModulesSegment = "node_modules";
-        const nodeModulesSegmentIndex = moduleParts.findIndex((v) => v === nodeModulesSegment);
+        // pnpm installs packages into a store keyed with version numbers
+        // `node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg>/...`, and adds a symlink to this in
+        // `node_modules/<pkg>` so Node.js can resolve the package. We see the real path here, not the symlink. In that
+        // layout the real package name follows the *last* `node_modules` segment. For npm/yarn (and pnpm's hoisted
+        // node-linker) the package name follows the *first* `node_modules` segment.
+        const isPnpmStore = moduleParts.includes(".pnpm");
+        const nodeModulesSegmentIndex = isPnpmStore
+            ? moduleParts.lastIndexOf(nodeModulesSegment)
+            : moduleParts.indexOf(nodeModulesSegment);
         const isInNodeModules = nodeModulesSegmentIndex >= 0;
 
         const isLocalModule = normalizedModuleName.startsWith(".") && !isInNodeModules;

--- a/sdk/nodejs/runtime/closure/package.ts
+++ b/sdk/nodejs/runtime/closure/package.ts
@@ -46,7 +46,26 @@ function getPackageDefinition(path: string): PackageDefinition | undefined {
         if (last === undefined || lastFullPath === undefined) {
             throw new Error(`no package.json found for ${path}`);
         }
-        const packageDefinitionAbsPath = lastFullPath.slice(0, lastFullPath.indexOf(last)) + last + "/package.json";
+        // Locate the package's directory within the resolved path so we can read its package.json. `last` is the bare
+        // package specifier (e.g. "lodash" or "@scope/pkg") and its installed directory is `node_modules/<last>`.
+        //
+        // We anchor on `node_modules/<last>` rather than the first occurrence of `last` because:
+        //
+        //   - under pnpm the path is
+        //     `.../node_modules/.pnpm/<name>@<version>/node_modules/<name>/...`,
+        //   - some packages have a main file whose name repeats the package name
+        //     (e.g. lodash resolves to `.../node_modules/lodash/lodash.js`).
+        // The last occurrence of the `node_modules/<last>` marker is the package's real directory.
+        const resolvedPath = upath.normalize(lastFullPath);
+        const marker = `node_modules/${last}`;
+        const markerIndex = resolvedPath.lastIndexOf(marker);
+        const packageDefinitionAbsPath =
+            markerIndex >= 0
+                ? resolvedPath.slice(0, markerIndex + marker.length) + "/package.json"
+                : // For packages resolved outside of node_modules (e.g. `yarn link`ed or workspace
+                  // packages) there is no marker to anchor on, so fall back to the first occurrence of
+                  // the name in the resolved path.
+                  resolvedPath.slice(0, resolvedPath.indexOf(last)) + last + "/package.json";
         return require(packageDefinitionAbsPath);
     } catch (err) {
         return undefined;

--- a/sdk/nodejs/tests/runtime/closure-integration-tests.ts
+++ b/sdk/nodejs/tests/runtime/closure-integration-tests.ts
@@ -37,6 +37,7 @@ async function writePackageJSON(
             "@types/mocha": "^10.0.0",
             "@types/node": nodeTypesVersion,
             "@types/semver": "^7.5.6",
+            execa: "^5.1.0",
             mocha: "^11.0.0",
             "mocha-suppress-logs": "^0.5.1",
             mockpackage: "file:mockpackage-src",
@@ -46,6 +47,11 @@ async function writePackageJSON(
         },
         overrides: {
             typescript: typescriptVersion,
+        },
+        pnpm: {
+            overrides: {
+                typescript: typescriptVersion,
+            },
         },
     };
 
@@ -70,7 +76,29 @@ async function copyDir(src: string, dest: string) {
     }
 }
 
-async function run(typescriptVersion: string, nodeTypesVersion: string) {
+// The package managers we run the closure tests against. npm and pnpm lay out
+// node_modules differently (pnpm uses a symlinked virtual store under
+// node_modules/.pnpm), so we exercise both to ensure function serialization
+// resolves module names correctly regardless of the on-disk layout.
+type PackageManager = "npm" | "pnpm";
+
+async function install(packageManager: PackageManager, dir: string) {
+    if (packageManager === "pnpm") {
+        // Force the isolated node-linker so we actually exercise the
+        // node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg> layout, even if
+        // the environment defaults to a hoisted layout.
+        await fs.writeFile(path.join(dir, ".npmrc"), "node-linker=isolated\n");
+        // Use pnpm 10, we don't support 11 yet https://github.com/pulumi/pulumi/issues/22893
+        await execa("corepack", ["use", "pnpm@^10.0.0"], {
+            cwd: dir,
+            env: { COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+        });
+    } else {
+        await execa("npm", ["install", "--install-links"], { cwd: dir });
+    }
+}
+
+async function run(packageManager: PackageManager, typescriptVersion: string, nodeTypesVersion: string) {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "closure-test-"));
     const sdkRoot = path.join(__dirname, "..", "..", "..");
     const sdkRootBin = path.join(sdkRoot, "bin");
@@ -81,13 +109,14 @@ async function run(typescriptVersion: string, nodeTypesVersion: string) {
     await writePackageJSON(tmpDir, pulumiPackagePath, typescriptVersion, nodeTypesVersion);
     await copyDir(path.join(sdkRoot, "tests", "runtime", "testdata", "closure-tests"), tmpDir);
 
-    await execa("npm", ["install", "--install-links"], { cwd: tmpDir });
+    await install(packageManager, tmpDir);
 
     await execa("npx", ["--no-install", "tsc"], { cwd: tmpDir });
 
     await execa("npx", ["--no-install", "mocha", "--timeout", "30000", "test.js"], {
         cwd: tmpDir,
         stdio: "inherit",
+        env: { CLOSURE_TEST_PACKAGE_MANAGER: packageManager, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
     });
 
     await fs.rm(tmpDir, { recursive: true, force: true });
@@ -101,8 +130,13 @@ async function main() {
         ["<5.2.0", "ts5.1"], // Awaiter changed slightly in 5.2.0 https://github.com/microsoft/TypeScript/pull/56296
         ["^5.2.0", "latest"], // Latest 5.x.x
     ]) {
-        await run(ts, typesNode);
+        await run("npm", ts, typesNode);
     }
+
+    // Also run the suite under pnpm for the default TypeScript version. The module-resolution logic that pnpm exercises
+    // is independent of the TypeScript version, so a single run is enough to guard against regressions in pnpm's
+    // symlinked node_modules layout.
+    await run("pnpm", "~3.8.3", "ts3.8");
 }
 
 main().catch((error) => {

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/test.ts
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/test.ts
@@ -45,14 +45,28 @@ async function getSnapshot(testCase: string, typescriptVersion: string): Promise
     return fs.readFile(path.join("cases", testCase, "snapshot.txt"), "utf-8");
 }
 
+// Returns the typescript version resolved within the @pulumi/pulumi package, as reported by the package manager.
+async function resolvedTypescriptVersion(packageManager: string): Promise<string> {
+    if (packageManager === "pnpm") {
+        const { stdout } = await execa("pnpm", ["ls", "typescript", "--json", "--depth", "Infinity"], {
+            cwd: __dirname,
+            reject: false,
+        });
+        const projects = JSON.parse(stdout);
+        return projects[0].dependencies["@pulumi/pulumi"].dependencies.typescript.version;
+    }
+    const { stdout } = await execa("npm", ["ls", "typescript", "--json"], { cwd: __dirname, reject: false });
+    const deps = JSON.parse(stdout);
+    return deps.dependencies["@pulumi/pulumi"].dependencies.typescript.version;
+}
+
 // This test validates that the typescript version used by the closure tests
 // is the same as the one used by the pulumi package and that we are testing
 // what we think we are testing ...
 it(`resolve to the correct typescript version within the pulumi package`,
     async function () {
-        const { stdout } = await execa("npm", ["ls", "typescript", "--json"], { cwd: __dirname, reject: false });
-        const deps = JSON.parse(stdout);
-        const version = deps.dependencies["@pulumi/pulumi"].dependencies.typescript.version;
+        const packageManager = process.env.CLOSURE_TEST_PACKAGE_MANAGER ?? "npm";
+        const version = await resolvedTypescriptVersion(packageManager);
         assert.strictEqual(version, typescript.version);
     });
 


### PR DESCRIPTION
pnpm installs packages into a store keyed by version numbers `node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg>/...`, and adds a symlink to this in `node_modules/<pkg>` so Node.js can resolve the package.

The closure serializer sees the real path, not the symlink, and so would write out code like

```javascript
cosnt ms = require(".pnpm/ms@2.1.3/node_modules/ms/index.js”)
```

Since this includes the version number, when the package is updated, we ended up with a diff on the serialized code. Even worse, if a package is updated, and you run a pulumi operation that doesn’t run the program (refresh, destroy), you could end up with an error because a dynamic provider would fail to load some of its dependencies.

To fix this, we detect these paths and capture for example `require("ms/index.js”)`, the same as under npm or yarn.

When updating the `@pulumi/pulumi` SDK to a version with this fix, users will see one final diff that changes the `require` calls.

Fixes https://github.com/pulumi/pulumi/issues/10009
Fixes https://github.com/pulumi/pulumi/issues/9085
Partial fix for https://github.com/pulumi/pulumi/issues/18976 (pnpm, not the for packages in the `.aspect_rules_js` folder, which I think is Bazel?)
