### PR TITLE
do: improve input/output formatting 

### DIFF
--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schemainfo"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
@@ -31,45 +32,25 @@ import (
 
 func functionSchemaHelp(fn *schema.Function) string {
 	var b strings.Builder
-	writeProperties := func(title string, properties []*schema.Property, includeRequired bool) {
-		if len(properties) == 0 {
-			return
-		}
+	writeSection := func(title string, properties []*schema.Property, kind schemainfo.Kind) {
 		if b.Len() > 0 {
-			trimmed := strings.TrimSuffix(b.String(), "\n")
-			b.Reset()
-			b.WriteString(trimmed)
-			b.WriteString("\n\n")
+			b.WriteByte('\n')
 		}
-		b.WriteString(title)
-		b.WriteString(":\n")
-		for _, property := range properties {
-			fmt.Fprintf(&b, "  %s (%s", property.Name, unwrapType(property.Type))
-			if includeRequired {
-				if property.IsRequired() {
-					b.WriteString(", required")
-				} else {
-					b.WriteString(", optional")
-				}
-			}
-			b.WriteString(")")
-			if property.Comment != "" {
-				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(cleanComment(property.Comment), "\n", " "))
-			}
-			b.WriteString("\n")
-		}
+		schemainfo.WriteProperties(&b, title, schemainfo.BoundProperties(properties), kind)
 	}
 
+	var inputs []*schema.Property
 	if fn.Inputs != nil {
-		writeProperties("Inputs", fn.Inputs.Properties, true)
+		inputs = fn.Inputs.Properties
 	}
+	writeSection("Inputs", inputs, schemainfo.Inputs)
+
 	if fn.Outputs != nil {
-		writeProperties("Outputs", fn.Outputs.Properties, true)
+		writeSection("Outputs", fn.Outputs.Properties, schemainfo.Outputs)
 	} else if fn.ReturnType != nil {
-		if b.Len() > 0 {
-			b.WriteString("\n\n")
-		}
-		fmt.Fprintf(&b, "Outputs:\n  result (%s)\n", unwrapType(fn.ReturnType))
+		b.WriteByte('\n')
+		fmt.Fprintf(&b, "%s: %s\n",
+			schemainfo.Bold("Outputs"), schemainfo.Underline(schemainfo.TypeString(fn.ReturnType)))
 	}
 	return strings.TrimSuffix(b.String(), "\n")
 }

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -27,16 +27,18 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func functionSchemaHelp(fn *schema.Function) string {
+	color := cmdutil.GetGlobalColorization()
 	var b strings.Builder
 	writeSection := func(title string, properties []*schema.Property, kind schemainfo.Kind) {
 		if b.Len() > 0 {
 			b.WriteByte('\n')
 		}
-		schemainfo.WriteProperties(&b, title, schemainfo.BoundProperties(properties), kind)
+		schemainfo.WriteProperties(&b, color, title, schemainfo.BoundProperties(properties), kind)
 	}
 
 	var inputs []*schema.Property
@@ -50,7 +52,7 @@ func functionSchemaHelp(fn *schema.Function) string {
 	} else if fn.ReturnType != nil {
 		b.WriteByte('\n')
 		fmt.Fprintf(&b, "%s: %s\n",
-			schemainfo.Bold("Outputs"), schemainfo.Underline(schemainfo.TypeString(fn.ReturnType)))
+			schemainfo.Bold(color, "Outputs"), schemainfo.Underline(color, schemainfo.TypeString(fn.ReturnType)))
 	}
 	return strings.TrimSuffix(b.String(), "\n")
 }

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -117,13 +117,15 @@ func TestDoCmdWithFunctionHelpArgPrintsHelp(t *testing.T) {
 This is the other function in this package.
 
 Inputs:
-  param1 (string, required) - To set param1 things
-  param2 (Array<number>, optional) - Optional values.
+ - param1 (string*): To set param1 things
+ - param2 (Array<number>): Optional values.
+Inputs marked with '*' are required
 
 Outputs:
-  output1 (string, required) - The first output.
-  output2 (number, optional) - The second output.
-  output3 (boolean, required) - Whether it worked.
+ - output1 (string*): The first output.
+ - output2 (number): The second output.
+ - output3 (boolean*): Whether it worked.
+Outputs marked with '*' are always present
 
 Usage:
   do azure:myModule:myOtherFunction [flags]
@@ -141,7 +143,7 @@ Flags:
       --show-secrets           Show secret values in output
       --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so create/patch/delete error out unless --stateless is set.
 `
-	assert.Equal(t, expected, stdout.String())
+	assert.Equal(t, expected, stripANSI(stdout.String()))
 }
 
 func TestDoCmdFunctionInvoke(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -143,7 +143,7 @@ Flags:
       --show-secrets           Show secret values in output
       --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so create/patch/delete error out unless --stateless is set.
 `
-	assert.Equal(t, expected, stripANSI(stdout.String()))
+	assert.Equal(t, expected, stdout.String())
 }
 
 func TestDoCmdFunctionInvoke(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schemainfo"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
@@ -41,39 +42,18 @@ import (
 
 func resourceSchemaHelp(res *schema.Resource) string {
 	var b strings.Builder
-	writeProperties := func(title string, properties []*schema.Property, includeRequired bool) {
-		if len(properties) == 0 {
-			return
-		}
+	writeSection := func(title string, properties []*schema.Property, kind schemainfo.Kind) {
 		if b.Len() > 0 {
-			trimmed := strings.TrimSuffix(b.String(), "\n")
-			b.Reset()
-			b.WriteString(trimmed)
-			b.WriteString("\n\n")
+			// WriteProperties output ends in a newline; add one more to separate sections.
+			b.WriteByte('\n')
 		}
-		b.WriteString(title)
-		b.WriteString(":\n")
-		for _, property := range properties {
-			fmt.Fprintf(&b, "  %s (%s", property.Name, unwrapType(property.Type))
-			if includeRequired {
-				if property.IsRequired() {
-					b.WriteString(", required")
-				} else {
-					b.WriteString(", optional")
-				}
-			}
-			b.WriteString(")")
-			if property.Comment != "" {
-				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(cleanComment(property.Comment), "\n", " "))
-			}
-			b.WriteString("\n")
-		}
+		schemainfo.WriteProperties(&b, title, schemainfo.BoundProperties(properties), kind)
 	}
 
-	writeProperties("Inputs", res.InputProperties, true)
-	writeProperties("Outputs", res.Properties, false)
-	if res.ListInputs != nil {
-		writeProperties("List Inputs", res.ListInputs.Properties, true)
+	writeSection("Inputs", res.InputProperties, schemainfo.Inputs)
+	writeSection("Outputs", res.Properties, schemainfo.Outputs)
+	if res.ListInputs != nil && len(res.ListInputs.Properties) > 0 {
+		writeSection("List Inputs", res.ListInputs.Properties, schemainfo.ListInputs)
 	}
 	return strings.TrimSuffix(b.String(), "\n")
 }

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -41,13 +41,14 @@ import (
 )
 
 func resourceSchemaHelp(res *schema.Resource) string {
+	color := cmdutil.GetGlobalColorization()
 	var b strings.Builder
 	writeSection := func(title string, properties []*schema.Property, kind schemainfo.Kind) {
 		if b.Len() > 0 {
 			// WriteProperties output ends in a newline; add one more to separate sections.
 			b.WriteByte('\n')
 		}
-		schemainfo.WriteProperties(&b, title, schemainfo.BoundProperties(properties), kind)
+		schemainfo.WriteProperties(&b, color, title, schemainfo.BoundProperties(properties), kind)
 	}
 
 	writeSection("Inputs", res.InputProperties, schemainfo.Inputs)

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -149,7 +149,7 @@ Flags:
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
-	assert.Equal(t, expected, stripANSI(stdout.String()))
+	assert.Equal(t, expected, stdout.String())
 }
 
 func TestDoCmdResourceHelpOmitsListWithoutListInputs(t *testing.T) {
@@ -199,7 +199,7 @@ Flags:
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
-	assert.Equal(t, expected, stripANSI(stdout.String()))
+	assert.Equal(t, expected, stdout.String())
 }
 
 func TestDoCmdResourceCreate(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -112,18 +112,19 @@ func TestDoCmdResourceHelpListsOperations(t *testing.T) {
 A test resource.
 
 Inputs:
-  enabled (boolean, optional)
-  name (string, required) - The resource name.
-  size (integer, optional)
+ - enabled (boolean)
+ - name (string*): The resource name.
+ - size (integer)
+Inputs marked with '*' are required
 
 Outputs:
-  enabled (boolean)
-  extra (string)
-  name (string)
-  size (integer)
+ - enabled (boolean)
+ - extra (string)
+ - name (string)
+ - size (integer)
 
 List Inputs:
-  prefix (string, optional)
+ - prefix (string)
 
 Usage:
   do azure:index:myResource [command]
@@ -148,7 +149,7 @@ Flags:
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
-	assert.Equal(t, expected, stdout.String())
+	assert.Equal(t, expected, stripANSI(stdout.String()))
 }
 
 func TestDoCmdResourceHelpOmitsListWithoutListInputs(t *testing.T) {
@@ -165,15 +166,16 @@ func TestDoCmdResourceHelpOmitsListWithoutListInputs(t *testing.T) {
 A test resource.
 
 Inputs:
-  enabled (boolean, optional)
-  name (string, required) - The resource name.
-  size (integer, optional)
+ - enabled (boolean)
+ - name (string*): The resource name.
+ - size (integer)
+Inputs marked with '*' are required
 
 Outputs:
-  enabled (boolean)
-  extra (string)
-  name (string)
-  size (integer)
+ - enabled (boolean)
+ - extra (string)
+ - name (string)
+ - size (integer)
 
 Usage:
   do azure:index:myResource [command]
@@ -197,7 +199,7 @@ Flags:
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
-	assert.Equal(t, expected, stdout.String())
+	assert.Equal(t, expected, stripANSI(stdout.String()))
 }
 
 func TestDoCmdResourceCreate(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/blang/semver"
@@ -1287,11 +1286,4 @@ options {
 			assert.Equal(t, tt.want, string(got))
 		})
 	}
-}
-
-var ansiEscapeRegexp = regexp.MustCompile("\x1b\\[[0-9;]*m")
-
-// stripANSI removes ANSI color escapes so help output can be compared as plain text.
-func stripANSI(s string) string {
-	return ansiEscapeRegexp.ReplaceAllString(s, "")
 }

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/blang/semver"
@@ -1286,4 +1287,11 @@ options {
 			assert.Equal(t, tt.want, string(got))
 		})
 	}
+}
+
+var ansiEscapeRegexp = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// stripANSI removes ANSI color escapes so help output can be compared as plain text.
+func stripANSI(s string) string {
+	return ansiEscapeRegexp.ReplaceAllString(s, "")
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageworkspace"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schemainfo"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
@@ -83,22 +84,36 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
+			stdout := cmd.OutOrStdout()
+
+			loadPartial := func() (*schema.PartialPackage, error) {
+				return packages.PartialPackageFromSchemaSource(cmd.Context(), pkgWorkspace.Instance, pctx, args[0],
+					parameters, registry, env.Global(), 0 /* unbounded concurrency */)
+			}
+
+			if function != "" {
+				pp, err := loadPartial()
+				if err != nil {
+					return err
+				}
+				return showFunctionInfo(pp, module, function, stdout)
+			} else if resource != "" {
+				pp, err := loadPartial()
+				if err != nil {
+					return err
+				}
+				return showResourceInfo(pp, module, resource, stdout)
+			}
+
 			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, args[0], parameters,
 				registry, env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err
 			}
-
-			stdout := cmd.OutOrStdout()
-
-			if function != "" {
-				return showFunctionInfo(spec, module, function, stdout)
-			} else if resource != "" {
-				return showResourceInfo(spec, module, resource, stdout)
-			} else if module != "" {
+			if module != "" {
 				return showModuleInfo(spec, module, stdout)
 			}
-			return showProviderInfo(spec, args, stdout)
+			return showProviderInfo(spec, loadPartial, args, stdout)
 		},
 	}
 
@@ -122,7 +137,9 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 	return cmd
 }
 
-func showProviderInfo(spec *schema.PackageSpec, args []string, stdout io.Writer) error {
+func showProviderInfo(
+	spec *schema.PackageSpec, loadPartial func() (*schema.PartialPackage, error), args []string, stdout io.Writer,
+) error {
 	contract.Requiref(len(args) > 0, "args", "should be non-empty")
 
 	modules := make(map[string]struct{})
@@ -145,7 +162,11 @@ func showProviderInfo(spec *schema.PackageSpec, args []string, stdout io.Writer)
 			if len(nameSplit) < 3 {
 				return fmt.Errorf("invalid function name %q", name)
 			}
-			return showFunctionInfo(spec, "", nameSplit[2], stdout)
+			pp, err := loadPartial()
+			if err != nil {
+				return err
+			}
+			return showFunctionInfo(pp, "", nameSplit[2], stdout)
 		}
 	}
 
@@ -155,7 +176,11 @@ func showProviderInfo(spec *schema.PackageSpec, args []string, stdout io.Writer)
 			if len(nameSplit) < 3 {
 				return fmt.Errorf("invalid resource name %q", name)
 			}
-			return showResourceInfo(spec, "", nameSplit[2], stdout)
+			pp, err := loadPartial()
+			if err != nil {
+				return err
+			}
+			return showResourceInfo(pp, "", nameSplit[2], stdout)
 		}
 	}
 
@@ -287,277 +312,112 @@ func underline(s string) string {
 	return colors.Always.Colorize(colors.Underline + s + colors.Reset)
 }
 
-func showFunctionInfo(spec *schema.PackageSpec, moduleName, functionName string, stdout io.Writer) error {
-	var fun schema.FunctionSpec
-	var specFunName string
-	if moduleName != "" {
-		fullFunctionName := fmt.Sprintf("%s:%s:%s", spec.Name, moduleName, functionName)
-		var ok bool
-		fun, ok = spec.Functions[fullFunctionName]
-		specFunName = fullFunctionName
-		if !ok {
-			for name, f := range spec.Functions {
-				simplifiedName, err := simplifyModuleName("function", name)
-				if err != nil {
-					return err
-				}
-
-				if fullFunctionName == simplifiedName {
-					fun = f
-					ok = true
-					specFunName = name
-					break
-				}
-			}
-		}
-		if !ok {
-			return fmt.Errorf("function %q not found", fullFunctionName)
-		}
-	} else {
-		found := false
-		for name, f := range spec.Functions {
-			split := strings.Split(name, ":")
-			if len(split) < 3 {
-				return fmt.Errorf("invalid function name %q", name)
-			}
-			resName := split[2]
-			if resName == functionName {
-				if found {
-					return fmt.Errorf("ambiguous resource name %q, please use --module <module> to disambiguate", functionName)
-				}
-				fun = f
-				found = true
-				specFunName = name
-			}
-		}
-		if !found {
-			return fmt.Errorf("function %q not found", functionName)
-		}
+func showFunctionInfo(pp *schema.PartialPackage, moduleName, functionName string, stdout io.Writer) error {
+	var tokens []string
+	for it := pp.Functions().Range(); it.Next(); {
+		tokens = append(tokens, it.Token())
+	}
+	token, err := findMemberToken(tokens, "function", moduleName, functionName)
+	if err != nil {
+		return err
+	}
+	fun, ok, err := pp.Functions().Get(token)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("function %q not found", functionName)
 	}
 
-	fmt.Fprintf(stdout, bold("Function")+": %s\n", specFunName)
-	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(fun.Description))
+	fmt.Fprintf(stdout, bold("Function")+": %s\n", fun.Token)
+	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(fun.Comment))
 
 	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, bold("Inputs")+":")
-	hasRequired := false
-	for _, name := range maputil.SortedKeys(fun.Inputs.Properties) {
-		prop := fun.Inputs.Properties[name]
-		requiredStr := ""
-		if slices.Contains(fun.Inputs.Required, name) {
-			hasRequired = true
-			requiredStr = "*"
-		}
-		typ, err := getType(spec, prop.TypeSpec)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(stdout, " - %s (%s%s): %s\n",
-			bold(name), underline(typ), underline(requiredStr),
-			summaryFromDescription(prop.Description))
+	var inputProperties []*schema.Property
+	if fun.Inputs != nil {
+		inputProperties = fun.Inputs.Properties
 	}
-	if hasRequired {
-		fmt.Fprintf(stdout, "Inputs marked with '*' are required\n")
-	}
+	schemainfo.WriteProperties(stdout, "Inputs", schemainfo.BoundProperties(inputProperties), schemainfo.Inputs)
 
-	var returnType *schema.ReturnTypeSpec
-	if fun.ReturnType != nil {
-		returnType = fun.ReturnType
-	} else if fun.Outputs != nil {
-		returnType = &schema.ReturnTypeSpec{
-			ObjectTypeSpec: fun.Outputs,
-		}
-	}
-	if returnType != nil {
+	// A bound function's object outputs live in Outputs; a single non-object return value lives in
+	// ReturnType and renders inline.
+	if fun.Outputs != nil {
 		fmt.Fprintln(stdout)
-		fmt.Fprint(stdout, bold("Outputs")+":")
-		if returnType.ObjectTypeSpec != nil {
-			fmt.Fprintln(stdout)
-			obj := returnType.ObjectTypeSpec
-			hasPresent := false
-			for _, name := range maputil.SortedKeys(obj.Properties) {
-				prop := obj.Properties[name]
-				presentStr := ""
-				if slices.Contains(obj.Required, name) {
-					hasPresent = true
-					presentStr = "*"
-				}
-				typ, err := getType(spec, prop.TypeSpec)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(stdout, " - %s (%s%s): %s\n",
-					bold(name), underline(typ), underline(presentStr),
-					summaryFromDescription(prop.Description))
-			}
-			if hasPresent {
-				fmt.Fprintf(stdout, "Outputs marked with '*' are always present\n")
-			}
-		} else if returnType.TypeSpec != nil {
-			typ, err := getType(spec, *returnType.TypeSpec)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(stdout, " %s\n", underline(typ))
-		}
+		outputs := schemainfo.BoundProperties(fun.Outputs.Properties)
+		schemainfo.WriteProperties(stdout, "Outputs", outputs, schemainfo.Outputs)
+	} else if fun.ReturnType != nil {
+		fmt.Fprintln(stdout)
+		fmt.Fprintf(stdout, bold("Outputs")+": %s\n", underline(schemainfo.TypeString(fun.ReturnType)))
 	}
 
 	return nil
 }
 
-func showResourceInfo(spec *schema.PackageSpec, moduleName, resourceName string, stdout io.Writer) error {
-	var res schema.ResourceSpec
-	var specResName string
-	if moduleName != "" {
-		fullResourceName := fmt.Sprintf("%s:%s:%s", spec.Name, moduleName, resourceName)
-		var ok bool
-		res, ok = spec.Resources[fullResourceName]
-		specResName = fullResourceName
-		if !ok {
-			for name, r := range spec.Resources {
-				simplifiedName, err := simplifyModuleName("resource", name)
-				if err != nil {
-					return err
-				}
-
-				if fullResourceName == simplifiedName {
-					res = r
-					ok = true
-					specResName = name
-					break
-				}
-			}
-		}
-		if !ok {
-			return fmt.Errorf("resource %q not found", fullResourceName)
-		}
-	} else {
-		found := false
-		for name, r := range spec.Resources {
-			split := strings.Split(name, ":")
-			if len(split) < 3 {
-				return fmt.Errorf("invalid resource name %q", name)
-			}
-			resName := split[2]
-			if resName == resourceName {
-				if found {
-					return fmt.Errorf("ambiguous resource name %q, please use --module <module> to disambiguate", resourceName)
-				}
-				res = r
-				found = true
-				specResName = name
-			}
-		}
-		if !found {
-			return fmt.Errorf("resource %q not found", resourceName)
-		}
+func showResourceInfo(pp *schema.PartialPackage, moduleName, resourceName string, stdout io.Writer) error {
+	var tokens []string
+	for it := pp.Resources().Range(); it.Next(); {
+		tokens = append(tokens, it.Token())
+	}
+	token, err := findMemberToken(tokens, "resource", moduleName, resourceName)
+	if err != nil {
+		return err
+	}
+	res, ok, err := pp.Resources().Get(token)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("resource %q not found", resourceName)
 	}
 
-	fmt.Fprintf(stdout, bold("Resource")+": %s\n", specResName)
-	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(res.Description))
+	fmt.Fprintf(stdout, bold("Resource")+": %s\n", res.Token)
+	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(res.Comment))
 
 	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, bold("Inputs")+":")
-	hasRequired := false
-	for _, name := range maputil.SortedKeys(res.InputProperties) {
-		prop := res.InputProperties[name]
-		requiredStr := ""
-		if slices.Contains(res.RequiredInputs, name) {
-			hasRequired = true
-			requiredStr = "*"
-		}
-		typ, err := getType(spec, prop.TypeSpec)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(stdout, " - %s (%s%s): %s\n",
-			bold(name), underline(typ), underline(requiredStr),
-			summaryFromDescription(prop.Description))
-	}
-	if hasRequired {
-		fmt.Fprintf(stdout, "Inputs marked with '*' are required\n")
-	}
+	schemainfo.WriteProperties(stdout, "Inputs", schemainfo.BoundProperties(res.InputProperties), schemainfo.Inputs)
 
 	fmt.Fprintln(stdout)
-
-	fmt.Fprintln(stdout, bold("Outputs")+":")
-	hasPresent := false
-	for _, name := range maputil.SortedKeys(res.Properties) {
-		prop := res.Properties[name]
-		presentStr := ""
-		if slices.Contains(res.Required, name) {
-			hasPresent = true
-			presentStr = "*"
-		}
-		typ, err := getType(spec, prop.TypeSpec)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(stdout, " - %s (%s%s): %s\n",
-			bold(name), underline(typ), underline(presentStr),
-			summaryFromDescription(prop.Description))
-	}
-	if hasPresent {
-		fmt.Fprintf(stdout, "Outputs marked with '*' are always present\n")
-	}
+	schemainfo.WriteProperties(stdout, "Outputs", schemainfo.BoundProperties(res.Properties), schemainfo.Outputs)
 	return nil
 }
 
-func getType(spec *schema.PackageSpec, prop schema.TypeSpec) (string, error) {
-	typ := prop.Type
-	if typ != "" && typ != "object" && typ != "array" && prop.Ref == "" {
-		return typ, nil
-	}
-	if prop.Type == "array" {
-		if prop.Items == nil {
-			return "[]unknown", nil
+// findMemberToken resolves the full token of a resource or function from its unqualified name,
+// optionally disambiguated by module.
+func findMemberToken(tokens []string, kind, moduleName, name string) (string, error) {
+	var found string
+	for _, token := range tokens {
+		if memberName(token) != name {
+			continue
 		}
-		typ, err := getType(spec, *prop.Items)
-		if err != nil {
-			return "", err
-		}
-		return "[]" + typ, nil
-	}
-	if prop.Type == "object" {
-		if prop.AdditionalProperties == nil {
-			return "object", nil
-		}
-		typ, err := getType(spec, *prop.AdditionalProperties)
-		if err != nil {
-			return "", err
-		}
-		return "map[string]" + typ, nil
-	}
-	if prop.Ref != "" {
-		if strings.HasPrefix(prop.Ref, "#/types/") {
-			ref := strings.TrimPrefix(prop.Ref, "#/types/")
-			ref = strings.ReplaceAll(ref, "%2F", "/")
-			if typeSpec, ok := spec.Types[ref]; ok {
-				if len(typeSpec.Enum) > 0 {
-					return fmt.Sprintf("enum(%s){%s}",
-						typeSpec.Type, formatEnumValues(typeSpec.Enum)), nil
-				}
-				simplifiedName, err := simplifyModuleName("type", ref)
-				if err != nil {
-					return "", err
-				}
-				split := strings.Split(simplifiedName, ":")
-				return split[2], nil
+		if moduleName != "" {
+			if tokenModule(token) == moduleName {
+				return token, nil
 			}
+			continue
 		}
-		return prop.Ref, nil
+		if found != "" {
+			return "", fmt.Errorf("ambiguous %s name %q, please use --module <module> to disambiguate", kind, name)
+		}
+		found = token
 	}
-	return "unknown", nil
+	if found == "" {
+		return "", fmt.Errorf("%s %q not found", kind, name)
+	}
+	return found, nil
 }
 
-func formatEnumValues(enum []schema.EnumValueSpec) string {
-	var values []string
-	for _, v := range enum {
-		if v.Name != "" {
-			values = append(values, v.Name)
-		} else if v.Value != nil {
-			values = append(values, fmt.Sprintf("%v", v.Value))
-		}
+// memberName returns the type-name segment of a Pulumi token (e.g. "aws:s3/bucket:Bucket" ->
+// "Bucket").
+func memberName(token string) string {
+	parts := strings.Split(token, ":")
+	return parts[len(parts)-1]
+}
+
+// tokenModule returns the simplified module of a Pulumi token (e.g. "aws:s3/bucket:Bucket" -> "s3").
+func tokenModule(token string) string {
+	parts := strings.Split(token, ":")
+	if len(parts) < 3 {
+		return ""
 	}
-	return strings.Join(values, ", ")
+	return strings.Split(parts[1], "/")[0]
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -85,6 +85,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			stdout := cmd.OutOrStdout()
+			color := cmdutil.GetGlobalColorization()
 
 			loadPartial := func() (*schema.PartialPackage, error) {
 				return packages.PartialPackageFromSchemaSource(cmd.Context(), pkgWorkspace.Instance, pctx, args[0],
@@ -96,13 +97,13 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				if err != nil {
 					return err
 				}
-				return showFunctionInfo(pp, module, function, stdout)
+				return showFunctionInfo(pp, module, function, stdout, color)
 			} else if resource != "" {
 				pp, err := loadPartial()
 				if err != nil {
 					return err
 				}
-				return showResourceInfo(pp, module, resource, stdout)
+				return showResourceInfo(pp, module, resource, stdout, color)
 			}
 
 			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, args[0], parameters,
@@ -111,9 +112,9 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				return err
 			}
 			if module != "" {
-				return showModuleInfo(spec, module, stdout)
+				return showModuleInfo(spec, module, stdout, color)
 			}
-			return showProviderInfo(spec, loadPartial, args, stdout)
+			return showProviderInfo(spec, loadPartial, args, stdout, color)
 		},
 	}
 
@@ -139,6 +140,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 
 func showProviderInfo(
 	spec *schema.PackageSpec, loadPartial func() (*schema.PartialPackage, error), args []string, stdout io.Writer,
+	color colors.Colorization,
 ) error {
 	contract.Requiref(len(args) > 0, "args", "should be non-empty")
 
@@ -166,7 +168,7 @@ func showProviderInfo(
 			if err != nil {
 				return err
 			}
-			return showFunctionInfo(pp, "", nameSplit[2], stdout)
+			return showFunctionInfo(pp, "", nameSplit[2], stdout, color)
 		}
 	}
 
@@ -180,16 +182,17 @@ func showProviderInfo(
 			if err != nil {
 				return err
 			}
-			return showResourceInfo(pp, "", nameSplit[2], stdout)
+			return showResourceInfo(pp, "", nameSplit[2], stdout, color)
 		}
 	}
 
 	if len(modules) == 1 {
 		for name := range modules {
-			return showModuleInfo(spec, name, stdout)
+			return showModuleInfo(spec, name, stdout, color)
 		}
 	}
 
+	bold := func(s string) string { return schemainfo.Bold(color, s) }
 	fmt.Fprintf(stdout, bold("Name")+": %s\n", spec.Name)
 	fmt.Fprintf(stdout, bold("Version")+": %s\n", spec.Version)
 	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(spec.Description))
@@ -244,7 +247,8 @@ func simplifyModuleName(typ string, name string) (string, error) {
 	return split[0] + ":" + moduleSplit[0] + ":" + split[2], nil
 }
 
-func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Writer) error {
+func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Writer, color colors.Colorization) error {
+	bold := func(s string) string { return schemainfo.Bold(color, s) }
 	fmt.Fprintf(stdout, bold("Name")+": %s\n", spec.Name)
 	fmt.Fprintf(stdout, bold("Module")+": %s\n", moduleName)
 	fmt.Fprintf(stdout, bold("Version")+": %s\n", spec.Version)
@@ -304,15 +308,9 @@ func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Write
 	return nil
 }
 
-func bold(s string) string {
-	return colors.Always.Colorize(colors.Bold + s + colors.Reset)
-}
-
-func underline(s string) string {
-	return colors.Always.Colorize(colors.Underline + s + colors.Reset)
-}
-
-func showFunctionInfo(pp *schema.PartialPackage, moduleName, functionName string, stdout io.Writer) error {
+func showFunctionInfo(
+	pp *schema.PartialPackage, moduleName, functionName string, stdout io.Writer, color colors.Colorization,
+) error {
 	var tokens []string
 	for it := pp.Functions().Range(); it.Next(); {
 		tokens = append(tokens, it.Token())
@@ -329,6 +327,7 @@ func showFunctionInfo(pp *schema.PartialPackage, moduleName, functionName string
 		return fmt.Errorf("function %q not found", functionName)
 	}
 
+	bold := func(s string) string { return schemainfo.Bold(color, s) }
 	fmt.Fprintf(stdout, bold("Function")+": %s\n", fun.Token)
 	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(fun.Comment))
 
@@ -337,23 +336,26 @@ func showFunctionInfo(pp *schema.PartialPackage, moduleName, functionName string
 	if fun.Inputs != nil {
 		inputProperties = fun.Inputs.Properties
 	}
-	schemainfo.WriteProperties(stdout, "Inputs", schemainfo.BoundProperties(inputProperties), schemainfo.Inputs)
+	schemainfo.WriteProperties(stdout, color, "Inputs", schemainfo.BoundProperties(inputProperties), schemainfo.Inputs)
 
 	// A bound function's object outputs live in Outputs; a single non-object return value lives in
 	// ReturnType and renders inline.
 	if fun.Outputs != nil {
 		fmt.Fprintln(stdout)
 		outputs := schemainfo.BoundProperties(fun.Outputs.Properties)
-		schemainfo.WriteProperties(stdout, "Outputs", outputs, schemainfo.Outputs)
+		schemainfo.WriteProperties(stdout, color, "Outputs", outputs, schemainfo.Outputs)
 	} else if fun.ReturnType != nil {
 		fmt.Fprintln(stdout)
-		fmt.Fprintf(stdout, bold("Outputs")+": %s\n", underline(schemainfo.TypeString(fun.ReturnType)))
+		fmt.Fprintf(stdout, bold("Outputs")+": %s\n",
+			schemainfo.Underline(color, schemainfo.TypeString(fun.ReturnType)))
 	}
 
 	return nil
 }
 
-func showResourceInfo(pp *schema.PartialPackage, moduleName, resourceName string, stdout io.Writer) error {
+func showResourceInfo(
+	pp *schema.PartialPackage, moduleName, resourceName string, stdout io.Writer, color colors.Colorization,
+) error {
 	var tokens []string
 	for it := pp.Resources().Range(); it.Next(); {
 		tokens = append(tokens, it.Token())
@@ -370,14 +372,16 @@ func showResourceInfo(pp *schema.PartialPackage, moduleName, resourceName string
 		return fmt.Errorf("resource %q not found", resourceName)
 	}
 
+	bold := func(s string) string { return schemainfo.Bold(color, s) }
 	fmt.Fprintf(stdout, bold("Resource")+": %s\n", res.Token)
 	fmt.Fprintf(stdout, bold("Description")+": %s\n", summaryFromDescription(res.Comment))
 
 	fmt.Fprintln(stdout)
-	schemainfo.WriteProperties(stdout, "Inputs", schemainfo.BoundProperties(res.InputProperties), schemainfo.Inputs)
+	schemainfo.WriteProperties(
+		stdout, color, "Inputs", schemainfo.BoundProperties(res.InputProperties), schemainfo.Inputs)
 
 	fmt.Fprintln(stdout)
-	schemainfo.WriteProperties(stdout, "Outputs", schemainfo.BoundProperties(res.Properties), schemainfo.Outputs)
+	schemainfo.WriteProperties(stdout, color, "Outputs", schemainfo.BoundProperties(res.Properties), schemainfo.Outputs)
 	return nil
 }
 

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -37,6 +37,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/maputil"
@@ -311,11 +312,11 @@ func showModuleInfo(spec *schema.PackageSpec, moduleName string, stdout io.Write
 func showFunctionInfo(
 	pp *schema.PartialPackage, moduleName, functionName string, stdout io.Writer, color colors.Colorization,
 ) error {
-	var tokens []string
+	var memberTokens []string
 	for it := pp.Functions().Range(); it.Next(); {
-		tokens = append(tokens, it.Token())
+		memberTokens = append(memberTokens, it.Token())
 	}
-	token, err := findMemberToken(tokens, "function", moduleName, functionName)
+	token, err := findMemberToken(pp, memberTokens, "function", moduleName, functionName)
 	if err != nil {
 		return err
 	}
@@ -356,11 +357,11 @@ func showFunctionInfo(
 func showResourceInfo(
 	pp *schema.PartialPackage, moduleName, resourceName string, stdout io.Writer, color colors.Colorization,
 ) error {
-	var tokens []string
+	var memberTokens []string
 	for it := pp.Resources().Range(); it.Next(); {
-		tokens = append(tokens, it.Token())
+		memberTokens = append(memberTokens, it.Token())
 	}
-	token, err := findMemberToken(tokens, "resource", moduleName, resourceName)
+	token, err := findMemberToken(pp, memberTokens, "resource", moduleName, resourceName)
 	if err != nil {
 		return err
 	}
@@ -387,14 +388,14 @@ func showResourceInfo(
 
 // findMemberToken resolves the full token of a resource or function from its unqualified name,
 // optionally disambiguated by module.
-func findMemberToken(tokens []string, kind, moduleName, name string) (string, error) {
+func findMemberToken(pp *schema.PartialPackage, memberTokens []string, kind, moduleName, name string) (string, error) {
 	var found string
-	for _, token := range tokens {
-		if memberName(token) != name {
+	for _, token := range memberTokens {
+		if !tokens.Token(token).HasModuleMember() || string(tokens.Type(token).Name()) != name {
 			continue
 		}
 		if moduleName != "" {
-			if tokenModule(token) == moduleName {
+			if tokenModule(pp, token) == moduleName {
 				return token, nil
 			}
 			continue
@@ -410,18 +411,11 @@ func findMemberToken(tokens []string, kind, moduleName, name string) (string, er
 	return found, nil
 }
 
-// memberName returns the type-name segment of a Pulumi token (e.g. "aws:s3/bucket:Bucket" ->
-// "Bucket").
-func memberName(token string) string {
-	parts := strings.Split(token, ":")
-	return parts[len(parts)-1]
-}
-
-// tokenModule returns the simplified module of a Pulumi token (e.g. "aws:s3/bucket:Bucket" -> "s3").
-func tokenModule(token string) string {
-	parts := strings.Split(token, ":")
-	if len(parts) < 3 {
-		return ""
+// tokenModule returns the module of a Pulumi token per the package's module format, mapping the
+// root module back to its "index" spelling so it can be matched against --module index.
+func tokenModule(pp *schema.PartialPackage, token string) string {
+	if module := pp.TokenToModule(token); module != "" {
+		return module
 	}
-	return strings.Split(parts[1], "/")[0]
+	return "index"
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -190,18 +189,18 @@ func TestPackageInfo(t *testing.T) {
 	cmd.SetErr(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(`\x1b[1mName\x1b[0m: test
-\x1b[1mVersion\x1b[0m: 0.0.1
-\x1b[1mDescription\x1b[0m: test description markdown formatted
-\x1b[1mTotal resources\x1b[0m 3
-\x1b[1mTotal functions\x1b[0m 2
-\x1b[1mTotal modules\x1b[0m: 3
+	require.Equal(t, fmt.Sprintf(`Name: test
+Version: 0.0.1
+Description: test description markdown formatted
+Total resources 3
+Total functions 2
+Total modules: 3
 
-\x1b[1mModules\x1b[0m: another, funs, index
+Modules: another, funs, index
 
 Use 'pulumi package info %[1]s --module <module>' to list resources in a module
 Use 'pulumi package info %[1]s --module <module> --resource <resource>' for detailed resource info
-`, schemaPath), strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+`, schemaPath), output.String())
 }
 
 func TestModuleInfo(t *testing.T) {
@@ -221,18 +220,18 @@ func TestModuleInfo(t *testing.T) {
 	cmd.SetErr(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `\x1b[1mName\x1b[0m: test
-\x1b[1mModule\x1b[0m: index
-\x1b[1mVersion\x1b[0m: 0.0.1
-\x1b[1mDescription\x1b[0m: test description markdown formatted
-\x1b[1mResources\x1b[0m: 2
+	require.Equal(t, `Name: test
+Module: index
+Version: 0.0.1
+Description: test description markdown formatted
+Resources: 2
 
- - \x1b[1mTest\x1b[0m: test resource description
- - \x1b[1mTest2\x1b[0m: this is another test resource
+ - Test: test resource description
+ - Test2: this is another test resource
 
-\x1b[1mFunctions\x1b[0m: 0
+Functions: 0
 
-`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+`, output.String())
 }
 
 func TestResourceInfo(t *testing.T) {
@@ -251,19 +250,19 @@ func TestResourceInfo(t *testing.T) {
 	cmd.SetErr(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `\x1b[1mResource\x1b[0m: test:index:Test
-\x1b[1mDescription\x1b[0m: test resource description
+	require.Equal(t, `Resource: test:index:Test
+Description: test resource description
 
-\x1b[1mInputs\x1b[0m:
- - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m\x1b[0m): this is a string property
+Inputs:
+ - prop1 (string): this is a string property
 
-\x1b[1mOutputs\x1b[0m:
- - \x1b[1marrayProp\x1b[0m (\x1b[4mArray<test:index:TestType>\x1b[0m\x1b[4m\x1b[0m): this is an array property
- - \x1b[1menumProp\x1b[0m (\x1b[4mtest:index:EnumType\x1b[0m\x1b[4m\x1b[0m): this is an enum property
- - \x1b[1mmapProp\x1b[0m (\x1b[4mMap<string>\x1b[0m\x1b[4m\x1b[0m): this is a map property
- - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is a string property
+Outputs:
+ - arrayProp (Array<test:index:TestType>): this is an array property
+ - enumProp (test:index:EnumType): this is an enum property
+ - mapProp (Map<string>): this is a map property
+ - prop1 (string*): this is a string property
 Outputs marked with '*' are always present
-`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+`, output.String())
 
 	cmd.SetArgs([]string{"--module", "index", "--resource", "Test2", schemaPath})
 	output.Reset()
@@ -271,15 +270,15 @@ Outputs marked with '*' are always present
 	cmd.SetErr(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `\x1b[1mResource\x1b[0m: test:index:Test2
-\x1b[1mDescription\x1b[0m: this is another test resource
+	require.Equal(t, `Resource: test:index:Test2
+Description: this is another test resource
 
-\x1b[1mInputs\x1b[0m:
- - \x1b[1mpropA\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is propA
+Inputs:
+ - propA (string*): this is propA
 Inputs marked with '*' are required
 
-\x1b[1mOutputs\x1b[0m:
-`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+Outputs:
+`, output.String())
 }
 
 func TestFunctionInfo(t *testing.T) {
@@ -299,14 +298,14 @@ func TestFunctionInfo(t *testing.T) {
 	cmd.SetErr(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `\x1b[1mFunction\x1b[0m: test:funs:TestFunction
-\x1b[1mDescription\x1b[0m: this is a test function
+	require.Equal(t, `Function: test:funs:TestFunction
+Description: this is a test function
 
-\x1b[1mInputs\x1b[0m:
- - \x1b[1minput1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m\x1b[0m): the first and only input
+Inputs:
+ - input1 (string): the first and only input
 
-\x1b[1mOutputs\x1b[0m: \x1b[4mstring\x1b[0m
-`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+Outputs: string
+`, output.String())
 
 	cmd.SetArgs([]string{"--function", "TestFunction2", schemaPath})
 	output = bytes.Buffer{}
@@ -314,14 +313,13 @@ func TestFunctionInfo(t *testing.T) {
 	cmd.SetErr(&output)
 	err = cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, `\x1b[1mFunction\x1b[0m: test:funs:TestFunction2
-\x1b[1mDescription\x1b[0m: 
-
-\x1b[1mInputs\x1b[0m:
- - \x1b[1minput1\x1b[0m (\x1b[4mboolean\x1b[0m\x1b[4m*\x1b[0m): a flag input
-Inputs marked with '*' are required
-
-\x1b[1mOutputs\x1b[0m:
- - \x1b[1moutput1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m\x1b[0m): the first and only output
-`, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))
+	require.Equal(t, "Function: test:funs:TestFunction2\n"+
+		"Description: \n"+
+		"\n"+
+		"Inputs:\n"+
+		" - input1 (boolean*): a flag input\n"+
+		"Inputs marked with '*' are required\n"+
+		"\n"+
+		"Outputs:\n"+
+		" - output1 (string): the first and only output\n", output.String())
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info_test.go
@@ -258,9 +258,9 @@ func TestResourceInfo(t *testing.T) {
  - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m\x1b[0m): this is a string property
 
 \x1b[1mOutputs\x1b[0m:
- - \x1b[1marrayProp\x1b[0m (\x1b[4m[]TestType\x1b[0m\x1b[4m\x1b[0m): this is an array property
- - \x1b[1menumProp\x1b[0m (\x1b[4menum(string){EnumValue1, value2}\x1b[0m\x1b[4m\x1b[0m): this is an enum property
- - \x1b[1mmapProp\x1b[0m (\x1b[4mmap[string]string\x1b[0m\x1b[4m\x1b[0m): this is a map property
+ - \x1b[1marrayProp\x1b[0m (\x1b[4mArray<test:index:TestType>\x1b[0m\x1b[4m\x1b[0m): this is an array property
+ - \x1b[1menumProp\x1b[0m (\x1b[4mtest:index:EnumType\x1b[0m\x1b[4m\x1b[0m): this is an enum property
+ - \x1b[1mmapProp\x1b[0m (\x1b[4mMap<string>\x1b[0m\x1b[4m\x1b[0m): this is a map property
  - \x1b[1mprop1\x1b[0m (\x1b[4mstring\x1b[0m\x1b[4m*\x1b[0m): this is a string property
 Outputs marked with '*' are always present
 `, strings.ReplaceAll(output.String(), "\x1b", "\\x1b"))

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	segmentiojson "github.com/segmentio/encoding/json"
+
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageinstallation"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageresolution"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageworkspace"
@@ -455,6 +457,74 @@ func SchemaFromSchemaSource(
 	}
 	setSpecNamespace(&spec, pluginSpec)
 	return &spec, &packageSpec, nil
+}
+
+// PartialPackageFromSchemaSource loads a schema source into a lazily-bound *schema.PartialPackage.
+// Unlike SchemaFromSchemaSource it does not parse or bind the whole schema up front, so commands
+// that only need a few members (e.g. `pulumi package info --resource`) avoid the cost of binding
+// the entire package.
+func PartialPackageFromSchemaSource(
+	ctx context.Context,
+	ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string,
+	parameters plugin.ParameterizeParameters, reg registry.Registry, env env.Env, concurrency int,
+) (*schema.PartialPackage, error) {
+	raw, err := schemaJSONBytes(ws, pctx, packageSource, parameters, reg, env, concurrency)
+	if err != nil {
+		return nil, err
+	}
+	var spec schema.PartialPackageSpec
+	if _, err := segmentiojson.Parse(raw, &spec, segmentiojson.ZeroCopy); err != nil {
+		return nil, fmt.Errorf("unmarshal schema: %w", err)
+	}
+	return schema.ImportPartialSpecWithContext(ctx, spec, nil, schema.NewPluginLoader(pctx))
+}
+
+// schemaJSONBytes returns the raw JSON bytes of a schema source (a YAML or JSON file, or a
+// provider's schema).
+func schemaJSONBytes(
+	ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string,
+	parameters plugin.ParameterizeParameters, reg registry.Registry, env env.Env, concurrency int,
+) ([]byte, error) {
+	switch filepath.Ext(packageSource) {
+	case ".yaml", ".yml":
+		if !parameters.Empty() {
+			return nil, errors.New("parameterization arguments are not supported for yaml files")
+		}
+		f, err := os.ReadFile(packageSource)
+		if err != nil {
+			return nil, err
+		}
+		var spec schema.PackageSpec
+		if err := yaml.Unmarshal(f, &spec); err != nil {
+			return nil, err
+		}
+		return json.Marshal(spec)
+	case ".json":
+		if !parameters.Empty() {
+			return nil, errors.New("parameterization arguments are not supported for json files")
+		}
+		return os.ReadFile(packageSource)
+	}
+
+	p, _, err := ProviderFromSource(ws, pctx, packageSource, reg, env, concurrency)
+	if err != nil {
+		return nil, err
+	}
+	defer contract.IgnoreClose(p)
+
+	var request plugin.GetSchemaRequest
+	if !parameters.Empty() {
+		resp, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{Parameters: parameters})
+		if err != nil {
+			return nil, fmt.Errorf("parameterize: %w", err)
+		}
+		request = plugin.GetSchemaRequest{SubpackageName: resp.Name, SubpackageVersion: &resp.Version}
+	}
+	getSchema, err := p.GetSchema(pctx.Request(), request)
+	if err != nil {
+		return nil, err
+	}
+	return getSchema.Schema, nil
 }
 
 // ProviderFromSource takes a plugin name or path.

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -385,68 +385,17 @@ func SchemaFromSchemaSource(
 	pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters, registry registry.Registry,
 	env env.Env, concurrency int,
 ) (*schema.PackageSpec, *workspace.PackageSpec, error) {
+	raw, packageSpec, err := schemaJSONBytes(ws, pctx, packageSource, parameters, registry, env, concurrency)
+	if err != nil {
+		return nil, nil, err
+	}
 	var spec schema.PackageSpec
-	if ext := filepath.Ext(packageSource); ext == ".yaml" || ext == ".yml" {
-		if !parameters.Empty() {
-			return nil, nil, errors.New("parameterization arguments are not supported for yaml files")
-		}
-		f, err := os.ReadFile(packageSource)
-		if err != nil {
-			return nil, nil, err
-		}
-		err = yaml.Unmarshal(f, &spec)
-		if err != nil {
-			return nil, nil, err
-		}
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return nil, nil, err
+	}
+	if packageSpec == nil {
+		// The schema came from a file, so there is no plugin to describe.
 		return &spec, nil, nil
-	} else if ext == ".json" {
-		if !parameters.Empty() {
-			return nil, nil, errors.New("parameterization arguments are not supported for json files")
-		}
-
-		f, err := os.ReadFile(packageSource)
-		if err != nil {
-			return nil, nil, err
-		}
-		err = json.Unmarshal(f, &spec)
-		if err != nil {
-			return nil, nil, err
-		}
-		return &spec, nil, nil
-	}
-
-	p, packageSpec, err := ProviderFromSource(ws, pctx, packageSource, registry, env, concurrency)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer contract.IgnoreClose(p)
-
-	var request plugin.GetSchemaRequest
-	if !parameters.Empty() {
-		resp, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{
-			Parameters: parameters,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("parameterize: %w", err)
-		}
-
-		request = plugin.GetSchemaRequest{
-			SubpackageName:    resp.Name,
-			SubpackageVersion: &resp.Version,
-		}
-	}
-
-	tracer := otel.Tracer("pulumi-cli")
-	_, schemaSpan := cmdutil.StartSpan(pctx.Request(), tracer, "get-schema",
-		trace.WithAttributes(attribute.String("source", packageSource)))
-	schema, err := p.GetSchema(pctx.Request(), request)
-	schemaSpan.End()
-	if err != nil {
-		return nil, nil, err
-	}
-	err = json.Unmarshal(schema.Schema, &spec)
-	if err != nil {
-		return nil, nil, err
 	}
 	pluginSpec, err := workspace.NewPluginDescriptor(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
@@ -456,7 +405,7 @@ func SchemaFromSchemaSource(
 		spec.PluginDownloadURL = pluginSpec.PluginDownloadURL
 	}
 	setSpecNamespace(&spec, pluginSpec)
-	return &spec, &packageSpec, nil
+	return &spec, packageSpec, nil
 }
 
 // PartialPackageFromSchemaSource loads a schema source into a lazily-bound *schema.PartialPackage.
@@ -468,7 +417,7 @@ func PartialPackageFromSchemaSource(
 	ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string,
 	parameters plugin.ParameterizeParameters, reg registry.Registry, env env.Env, concurrency int,
 ) (*schema.PartialPackage, error) {
-	raw, err := schemaJSONBytes(ws, pctx, packageSource, parameters, reg, env, concurrency)
+	raw, _, err := schemaJSONBytes(ws, pctx, packageSource, parameters, reg, env, concurrency)
 	if err != nil {
 		return nil, err
 	}
@@ -480,35 +429,38 @@ func PartialPackageFromSchemaSource(
 }
 
 // schemaJSONBytes returns the raw JSON bytes of a schema source (a YAML or JSON file, or a
-// provider's schema).
+// provider's schema). The returned workspace.PackageSpec is non-nil if and only if the schema is
+// sourced from a plugin.
 func schemaJSONBytes(
 	ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string,
 	parameters plugin.ParameterizeParameters, reg registry.Registry, env env.Env, concurrency int,
-) ([]byte, error) {
+) ([]byte, *workspace.PackageSpec, error) {
 	switch filepath.Ext(packageSource) {
 	case ".yaml", ".yml":
 		if !parameters.Empty() {
-			return nil, errors.New("parameterization arguments are not supported for yaml files")
+			return nil, nil, errors.New("parameterization arguments are not supported for yaml files")
 		}
 		f, err := os.ReadFile(packageSource)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		var spec schema.PackageSpec
 		if err := yaml.Unmarshal(f, &spec); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return json.Marshal(spec)
+		raw, err := json.Marshal(spec)
+		return raw, nil, err
 	case ".json":
 		if !parameters.Empty() {
-			return nil, errors.New("parameterization arguments are not supported for json files")
+			return nil, nil, errors.New("parameterization arguments are not supported for json files")
 		}
-		return os.ReadFile(packageSource)
+		raw, err := os.ReadFile(packageSource)
+		return raw, nil, err
 	}
 
-	p, _, err := ProviderFromSource(ws, pctx, packageSource, reg, env, concurrency)
+	p, packageSpec, err := ProviderFromSource(ws, pctx, packageSource, reg, env, concurrency)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer contract.IgnoreClose(p)
 
@@ -516,15 +468,19 @@ func schemaJSONBytes(
 	if !parameters.Empty() {
 		resp, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{Parameters: parameters})
 		if err != nil {
-			return nil, fmt.Errorf("parameterize: %w", err)
+			return nil, nil, fmt.Errorf("parameterize: %w", err)
 		}
 		request = plugin.GetSchemaRequest{SubpackageName: resp.Name, SubpackageVersion: &resp.Version}
 	}
+	tracer := otel.Tracer("pulumi-cli")
+	_, schemaSpan := cmdutil.StartSpan(pctx.Request(), tracer, "get-schema",
+		trace.WithAttributes(attribute.String("source", packageSource)))
 	getSchema, err := p.GetSchema(pctx.Request(), request)
+	schemaSpan.End()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return getSchema.Schema, nil
+	return getSchema.Schema, &packageSpec, nil
 }
 
 // ProviderFromSource takes a plugin name or path.

--- a/pkg/cmd/pulumi/schemainfo/schemainfo.go
+++ b/pkg/cmd/pulumi/schemainfo/schemainfo.go
@@ -80,15 +80,14 @@ func TypeString(typ schema.Type) string {
 	}
 }
 
-// Bold renders s in bold. Colorization is always enabled so the output is consistent regardless of
-// whether it is written to a terminal.
-func Bold(s string) string {
-	return colors.Always.Colorize(colors.Bold + s + colors.Reset)
+// Bold renders s in bold when c enables colorization.
+func Bold(c colors.Colorization, s string) string {
+	return c.Colorize(colors.Bold + s + colors.Reset)
 }
 
-// Underline renders s underlined.
-func Underline(s string) string {
-	return colors.Always.Colorize(colors.Underline + s + colors.Reset)
+// Underline renders s underlined when c enables colorization.
+func Underline(c colors.Colorization, s string) string {
+	return c.Colorize(colors.Underline + s + colors.Reset)
 }
 
 var langChoiceSpanRegexp = regexp.MustCompile(`(?s)<span\b[^>]*>(.*?)</span>`)
@@ -122,8 +121,8 @@ func Summarize(description string) string {
 //
 // and, when any property is marked, a footnote explaining the '*' is appended. The section title is
 // always written, even when there are no properties.
-func WriteProperties(w io.Writer, title string, props []Property, kind Kind) {
-	fmt.Fprintln(w, Bold(title)+":")
+func WriteProperties(w io.Writer, c colors.Colorization, title string, props []Property, kind Kind) {
+	fmt.Fprintln(w, Bold(c, title)+":")
 
 	sorted := make([]Property, len(props))
 	copy(sorted, props)
@@ -136,7 +135,7 @@ func WriteProperties(w io.Writer, title string, props []Property, kind Kind) {
 			marker = "*"
 			marked = true
 		}
-		fmt.Fprintf(w, " - %s (%s%s)", Bold(prop.Name), Underline(prop.Type), Underline(marker))
+		fmt.Fprintf(w, " - %s (%s%s)", Bold(c, prop.Name), Underline(c, prop.Type), Underline(c, marker))
 		if summary := Summarize(prop.Description); summary != "" {
 			fmt.Fprintf(w, ": %s", summary)
 		}

--- a/pkg/cmd/pulumi/schemainfo/schemainfo.go
+++ b/pkg/cmd/pulumi/schemainfo/schemainfo.go
@@ -1,0 +1,156 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package schemainfo renders schema resource and function inputs/outputs for CLI help. It is shared
+// by `pulumi package info` and `pulumi do` so both display property information the same way.
+package schemainfo
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+// Kind distinguishes an inputs section from an outputs section, which changes the footnote wording.
+type Kind int
+
+const (
+	// Inputs is a section of input properties; required members are annotated with '*'.
+	Inputs Kind = iota
+	// Outputs is a section of output properties; always-present members are annotated with '*'.
+	Outputs
+	// ListInputs is a section of list-operation input properties; required members are annotated
+	// with '*'.
+	ListInputs
+)
+
+// Property is a single input or output row to render. Type is the already-rendered type string;
+// Description is the raw schema description, which is summarized on render.
+type Property struct {
+	Name        string
+	Type        string
+	Required    bool
+	Description string
+}
+
+// BoundProperties adapts bound schema properties to the rendering model, rendering each type with
+// TypeString.
+func BoundProperties(properties []*schema.Property) []Property {
+	result := make([]Property, 0, len(properties))
+	for _, prop := range properties {
+		result = append(result, Property{
+			Name:        prop.Name,
+			Type:        TypeString(prop.Type),
+			Required:    prop.IsRequired(),
+			Description: prop.Comment,
+		})
+	}
+	return result
+}
+
+// TypeString renders a bound schema.Type for display, eliding the outer Optional and Input wrappers
+// (the property's own optionality is conveyed by the '*' marker) and otherwise using the type's
+// canonical String form, e.g. "Array<Input<string>>" or "pkg:mod:Foo•Input".
+func TypeString(typ schema.Type) string {
+	for {
+		switch t := typ.(type) {
+		case *schema.OptionalType:
+			typ = t.ElementType
+		case *schema.InputType:
+			typ = t.ElementType
+		default:
+			return typ.String()
+		}
+	}
+}
+
+// Bold renders s in bold. Colorization is always enabled so the output is consistent regardless of
+// whether it is written to a terminal.
+func Bold(s string) string {
+	return colors.Always.Colorize(colors.Bold + s + colors.Reset)
+}
+
+// Underline renders s underlined.
+func Underline(s string) string {
+	return colors.Always.Colorize(colors.Underline + s + colors.Reset)
+}
+
+var langChoiceSpanRegexp = regexp.MustCompile(`(?s)<span\b[^>]*>(.*?)</span>`)
+
+// Summarize returns the first paragraph of a schema description for use as a one-line summary. It
+// resolves the language-choice `<span>` markup that bridged-provider descriptions embed to its
+// canonical text and collapses the paragraph's internal newlines into spaces.
+func Summarize(description string) string {
+	description = langChoiceSpanRegexp.ReplaceAllString(description, "$1")
+
+	var summary strings.Builder
+	started := false
+	for _, line := range strings.Split(description, "\n") {
+		if strings.TrimSpace(line) == "" {
+			if started {
+				// A blank line ends the first paragraph.
+				break
+			}
+			// Skip leading blank lines.
+			continue
+		}
+		started = true
+		summary.WriteString(line + " ")
+	}
+	return strings.TrimSpace(summary.String())
+}
+
+// WriteProperties writes a titled, alphabetically-sorted property section. Each property renders as
+//
+//   - <bold name> (<underline type>[<underline *>]): <summary>
+//
+// and, when any property is marked, a footnote explaining the '*' is appended. The section title is
+// always written, even when there are no properties.
+func WriteProperties(w io.Writer, title string, props []Property, kind Kind) {
+	fmt.Fprintln(w, Bold(title)+":")
+
+	sorted := make([]Property, len(props))
+	copy(sorted, props)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	marked := false
+	for _, prop := range sorted {
+		marker := ""
+		if prop.Required {
+			marker = "*"
+			marked = true
+		}
+		fmt.Fprintf(w, " - %s (%s%s)", Bold(prop.Name), Underline(prop.Type), Underline(marker))
+		if summary := Summarize(prop.Description); summary != "" {
+			fmt.Fprintf(w, ": %s", summary)
+		}
+		fmt.Fprintln(w)
+	}
+
+	if marked {
+		switch kind {
+		case Inputs:
+			fmt.Fprintln(w, "Inputs marked with '*' are required")
+		case ListInputs:
+			fmt.Fprintln(w, "List inputs marked with '*' are required")
+		case Outputs:
+			fmt.Fprintln(w, "Outputs marked with '*' are always present")
+		}
+	}
+}

--- a/pkg/cmd/pulumi/schemainfo/schemainfo.go
+++ b/pkg/cmd/pulumi/schemainfo/schemainfo.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -99,23 +98,18 @@ func Summarize(description string) string {
 	description = langChoiceSpanRegexp.ReplaceAllString(description, "$1")
 
 	var summary strings.Builder
-	started := false
-	for _, line := range strings.Split(description, "\n") {
+	for _, line := range strings.Split(strings.TrimSpace(description), "\n") {
 		if strings.TrimSpace(line) == "" {
-			if started {
-				// A blank line ends the first paragraph.
-				break
-			}
-			// Skip leading blank lines.
-			continue
+			// A blank line ends the first paragraph.
+			break
 		}
-		started = true
 		summary.WriteString(line + " ")
 	}
 	return strings.TrimSpace(summary.String())
 }
 
-// WriteProperties writes a titled, alphabetically-sorted property section. Each property renders as
+// WriteProperties writes a titled property section in the order given; sorting is the caller's
+// responsibility. Each property renders as
 //
 //   - <bold name> (<underline type>[<underline *>]): <summary>
 //
@@ -124,12 +118,8 @@ func Summarize(description string) string {
 func WriteProperties(w io.Writer, c colors.Colorization, title string, props []Property, kind Kind) {
 	fmt.Fprintln(w, Bold(c, title)+":")
 
-	sorted := make([]Property, len(props))
-	copy(sorted, props)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
-
 	marked := false
-	for _, prop := range sorted {
+	for _, prop := range props {
 		marker := ""
 		if prop.Required {
 			marker = "*"

--- a/pkg/cmd/pulumi/schemainfo/schemainfo_test.go
+++ b/pkg/cmd/pulumi/schemainfo/schemainfo_test.go
@@ -108,7 +108,7 @@ func TestBoundProperties(t *testing.T) {
 func TestWriteProperties(t *testing.T) {
 	t.Parallel()
 
-	t.Run("sorts, marks required, and adds the inputs footnote", func(t *testing.T) {
+	t.Run("writes in the given order, marks required, and adds the inputs footnote", func(t *testing.T) {
 		t.Parallel()
 		var b strings.Builder
 		WriteProperties(&b, colors.Never, "Inputs", []Property{
@@ -117,8 +117,8 @@ func TestWriteProperties(t *testing.T) {
 			{Name: "tags", Type: "[]string"},
 		}, Inputs)
 		assert.Equal(t, "Inputs:\n"+
-			" - name (string*): The name.\n"+
 			" - size (integer)\n"+
+			" - name (string*): The name.\n"+
 			" - tags ([]string)\n"+
 			"Inputs marked with '*' are required\n", b.String())
 	})

--- a/pkg/cmd/pulumi/schemainfo/schemainfo_test.go
+++ b/pkg/cmd/pulumi/schemainfo/schemainfo_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemainfo
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+var ansiEscapeRegexp = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string {
+	return ansiEscapeRegexp.ReplaceAllString(s, "")
+}
+
+func TestSummarize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "single line", input: "A short description.", expected: "A short description."},
+		{
+			name:     "collapses newlines within the first paragraph",
+			input:    "The first\nparagraph continues.\n\nA second paragraph is dropped.",
+			expected: "The first paragraph continues.",
+		},
+		{
+			name:     "resolves language-choice spans",
+			input:    "Conflicts with <span pulumi-lang-nodejs=\"`imageUri`\">`imageUri`</span>.",
+			expected: "Conflicts with `imageUri`.",
+		},
+		{
+			name:     "skips leading blank lines",
+			input:    "\n\nThe actual content.\n\nDropped.",
+			expected: "The actual content.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, Summarize(tt.input))
+		})
+	}
+}
+
+func TestTypeString(t *testing.T) {
+	t.Parallel()
+
+	input := func(t schema.Type) schema.Type { return &schema.InputType{ElementType: t} }
+	optional := func(t schema.Type) schema.Type { return &schema.OptionalType{ElementType: t} }
+
+	tests := []struct {
+		name     string
+		typ      schema.Type
+		expected string
+	}{
+		{name: "primitive", typ: schema.StringType, expected: "string"},
+		{name: "outer optional and input are elided", typ: optional(input(schema.BoolType)), expected: "boolean"},
+		{
+			name:     "inner input wrappers are preserved",
+			typ:      input(&schema.ArrayType{ElementType: input(schema.StringType)}),
+			expected: "Array<Input<string>>",
+		},
+		{name: "map", typ: &schema.MapType{ElementType: schema.StringType}, expected: "Map<string>"},
+		{
+			name:     "object reference keeps its full token",
+			typ:      &schema.ObjectType{Token: "aws:lambda/function:FunctionConfig"},
+			expected: "aws:lambda/function:FunctionConfig",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, TypeString(tt.typ))
+		})
+	}
+}
+
+func TestBoundProperties(t *testing.T) {
+	t.Parallel()
+
+	props := []*schema.Property{
+		{Name: "name", Type: schema.StringType, Comment: "The name."},
+		{Name: "size", Type: &schema.OptionalType{ElementType: schema.IntType}},
+	}
+	got := BoundProperties(props)
+	assert.Equal(t, []Property{
+		{Name: "name", Type: "string", Required: true, Description: "The name."},
+		{Name: "size", Type: "integer", Required: false},
+	}, got)
+}
+
+func TestWriteProperties(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sorts, marks required, and adds the inputs footnote", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		WriteProperties(&b, "Inputs", []Property{
+			{Name: "size", Type: "integer"},
+			{Name: "name", Type: "string", Required: true, Description: "The name.\n\nMore detail."},
+			{Name: "tags", Type: "[]string"},
+		}, Inputs)
+		assert.Equal(t, "Inputs:\n"+
+			" - name (string*): The name.\n"+
+			" - size (integer)\n"+
+			" - tags ([]string)\n"+
+			"Inputs marked with '*' are required\n", stripANSI(b.String()))
+	})
+
+	t.Run("uses the outputs footnote wording", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		WriteProperties(&b, "Outputs", []Property{
+			{Name: "id", Type: "string", Required: true, Description: "The id."},
+		}, Outputs)
+		assert.Equal(t, "Outputs:\n"+
+			" - id (string*): The id.\n"+
+			"Outputs marked with '*' are always present\n", stripANSI(b.String()))
+	})
+
+	t.Run("uses the list-inputs footnote wording", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		WriteProperties(&b, "List Inputs", []Property{
+			{Name: "prefix", Type: "string", Required: true, Description: "The prefix."},
+		}, ListInputs)
+		assert.Equal(t, "List Inputs:\n"+
+			" - prefix (string*): The prefix.\n"+
+			"List inputs marked with '*' are required\n", stripANSI(b.String()))
+	})
+
+	t.Run("writes the title with no footnote for an empty or unmarked section", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		WriteProperties(&b, "Outputs", nil, Outputs)
+		assert.Equal(t, "Outputs:\n", stripANSI(b.String()))
+	})
+
+	t.Run("styles names bold and types underlined", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		WriteProperties(&b, "Inputs", []Property{{Name: "name", Type: "string"}}, Inputs)
+		assert.Contains(t, b.String(), Bold("name"))
+		assert.Contains(t, b.String(), Underline("string"))
+	})
+}

--- a/pkg/cmd/pulumi/schemainfo/schemainfo_test.go
+++ b/pkg/cmd/pulumi/schemainfo/schemainfo_test.go
@@ -15,20 +15,14 @@
 package schemainfo
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
-
-var ansiEscapeRegexp = regexp.MustCompile("\x1b\\[[0-9;]*m")
-
-func stripANSI(s string) string {
-	return ansiEscapeRegexp.ReplaceAllString(s, "")
-}
 
 func TestSummarize(t *testing.T) {
 	t.Parallel()
@@ -117,7 +111,7 @@ func TestWriteProperties(t *testing.T) {
 	t.Run("sorts, marks required, and adds the inputs footnote", func(t *testing.T) {
 		t.Parallel()
 		var b strings.Builder
-		WriteProperties(&b, "Inputs", []Property{
+		WriteProperties(&b, colors.Never, "Inputs", []Property{
 			{Name: "size", Type: "integer"},
 			{Name: "name", Type: "string", Required: true, Description: "The name.\n\nMore detail."},
 			{Name: "tags", Type: "[]string"},
@@ -126,43 +120,43 @@ func TestWriteProperties(t *testing.T) {
 			" - name (string*): The name.\n"+
 			" - size (integer)\n"+
 			" - tags ([]string)\n"+
-			"Inputs marked with '*' are required\n", stripANSI(b.String()))
+			"Inputs marked with '*' are required\n", b.String())
 	})
 
 	t.Run("uses the outputs footnote wording", func(t *testing.T) {
 		t.Parallel()
 		var b strings.Builder
-		WriteProperties(&b, "Outputs", []Property{
+		WriteProperties(&b, colors.Never, "Outputs", []Property{
 			{Name: "id", Type: "string", Required: true, Description: "The id."},
 		}, Outputs)
 		assert.Equal(t, "Outputs:\n"+
 			" - id (string*): The id.\n"+
-			"Outputs marked with '*' are always present\n", stripANSI(b.String()))
+			"Outputs marked with '*' are always present\n", b.String())
 	})
 
 	t.Run("uses the list-inputs footnote wording", func(t *testing.T) {
 		t.Parallel()
 		var b strings.Builder
-		WriteProperties(&b, "List Inputs", []Property{
+		WriteProperties(&b, colors.Never, "List Inputs", []Property{
 			{Name: "prefix", Type: "string", Required: true, Description: "The prefix."},
 		}, ListInputs)
 		assert.Equal(t, "List Inputs:\n"+
 			" - prefix (string*): The prefix.\n"+
-			"List inputs marked with '*' are required\n", stripANSI(b.String()))
+			"List inputs marked with '*' are required\n", b.String())
 	})
 
 	t.Run("writes the title with no footnote for an empty or unmarked section", func(t *testing.T) {
 		t.Parallel()
 		var b strings.Builder
-		WriteProperties(&b, "Outputs", nil, Outputs)
-		assert.Equal(t, "Outputs:\n", stripANSI(b.String()))
+		WriteProperties(&b, colors.Never, "Outputs", nil, Outputs)
+		assert.Equal(t, "Outputs:\n", b.String())
 	})
 
-	t.Run("styles names bold and types underlined", func(t *testing.T) {
+	t.Run("styles names bold and types underlined when colorization is enabled", func(t *testing.T) {
 		t.Parallel()
 		var b strings.Builder
-		WriteProperties(&b, "Inputs", []Property{{Name: "name", Type: "string"}}, Inputs)
-		assert.Contains(t, b.String(), Bold("name"))
-		assert.Contains(t, b.String(), Underline("string"))
+		WriteProperties(&b, colors.Always, "Inputs", []Property{{Name: "name", Type: "string"}}, Inputs)
+		assert.Contains(t, b.String(), Bold(colors.Always, "name"))
+		assert.Contains(t, b.String(), Underline(colors.Always, "string"))
 	})
 }


### PR DESCRIPTION
Use the same formatting for inputs/outputs as we do for `pulumi package info`.  It's a little more compact that way, and having the same format for both is probably the right choice.

Note that there's one improvement for `pulumi package info` where we now make use of the `schemainfo.TypeString()` function as well, so for example `[]string` is now `Array<string>`.

There's quite a bit of churn for refactoring included in this PR, but not sure there's a better way to do this.

Before:
<img width="1146" height="463" alt="image" src="https://github.com/user-attachments/assets/8a53cb7d-70b8-4daf-a414-e0ee3071ab80" />

After: 
<img width="1146" height="478" alt="image" src="https://github.com/user-attachments/assets/fe7ec0a3-dc29-454e-b5ec-a5904b3e6ebb" />
