### PR TITLE
Fix recursive property log marshaling

### DIFF
--- a/changelog/pending/fix-recursive-property-log-marshaling.yaml
+++ b/changelog/pending/fix-recursive-property-log-marshaling.yaml
@@ -1,0 +1,4 @@
+component: cli/engine
+kind: fix
+body: Fix recursive property log marshaling
+time: 2026-07-01T18:59:38+02:00

--- a/pkg/logging/property_recursion_test.go
+++ b/pkg/logging/property_recursion_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// countingHandler is an slog.Handler that is enabled at every level and counts how many records it receives.
+type countingHandler struct{ count *atomic.Int64 }
+
+func (h countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h countingHandler) Handle(context.Context, slog.Record) error {
+	h.count.Add(1)
+	return nil
+}
+
+func (h countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h countingHandler) WithGroup(string) slog.Handler      { return h }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/23772
+//
+//nolint:paralleltest // sets global logging sink
+func TestPropertySinkHandlerNoRecursion(t *testing.T) {
+	var count atomic.Int64
+	logging.SetSinkHandler(NewPropertySinkHandler(countingHandler{count: &count}))
+	t.Cleanup(func() { logging.SetSinkHandler(nil) })
+
+	m := resource.PropertyMap{
+		"scalar": resource.NewProperty("s"),
+		"nested": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty(42.0),
+			"deep": resource.NewProperty(resource.PropertyMap{
+				"b": resource.NewProperty(true),
+			}),
+		}),
+	}
+
+	_, err := plugin.MarshalProperties(m, plugin.MarshalOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, int64(5), count.Load(), "sink handler should log exactly one record per property")
+}

--- a/pkg/resource/plugin/property_handler.go
+++ b/pkg/resource/plugin/property_handler.go
@@ -28,6 +28,9 @@ var propertyLogMarshalOpts = MarshalOptions{
 	KeepSecrets:      true,
 	KeepUnknowns:     true,
 	KeepOutputValues: true,
+	// Suppress verbose marshal logging: this marshal runs *inside* the logging path (to build a log
+	// attribute), and logging here would re-enter and recurse.
+	skipLogging: true,
 }
 
 // PropertyExportHandler wraps the OTLP export handler, converting

--- a/pkg/resource/plugin/rpc.go
+++ b/pkg/resource/plugin/rpc.go
@@ -47,6 +47,11 @@ type MarshalOptions struct {
 
 	// true if a nil input should result in a nil output, false if it should result in an empty struct/map.
 	PropagateNil bool
+
+	// skipLogging suppresses the verbose per-property marshal logging. It is set when marshaling a
+	// property in order to build a log attribute, so that the marshal does not re-enter the logging
+	// path and recurse.
+	skipLogging bool
 }
 
 const (
@@ -82,11 +87,17 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 	fields := make(map[string]*structpb.Value)
 	for _, key := range props.StableKeys() {
 		v := props[key]
-		logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
+		if !opts.skipLogging {
+			logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
+		}
 		if opts.SkipNulls && v.IsNull() {
-			logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)
+			if !opts.skipLogging {
+				logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)
+			}
 		} else if opts.SkipInternalKeys && resource.IsInternalPropertyKey(key) {
-			logging.V(9).Infof("Skipping internal property for RPC[%s]: %s (as requested)", opts.Label, key)
+			if !opts.skipLogging {
+				logging.V(9).Infof("Skipping internal property for RPC[%s]: %s (as requested)", opts.Label, key)
+			}
 		} else {
 			// Only skip top level internal keys
 			copts := opts
@@ -201,7 +212,9 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 		return MarshalPropertyValue(key, output, opts)
 	} else if v.IsSecret() {
 		if !opts.KeepSecrets {
-			logging.V(5).Infof("marshalling secret value as raw value as opts.KeepSecrets is false")
+			if !opts.skipLogging {
+				logging.V(5).Infof("marshalling secret value as raw value as opts.KeepSecrets is false")
+			}
 			return MarshalPropertyValue(key, v.SecretValue().Element, opts)
 		}
 		if opts.KeepOutputValues && opts.UpgradeToOutputValues {
@@ -224,7 +237,9 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			if !ref.ID.IsNull() {
 				return MarshalPropertyValue(key, ref.ID, opts)
 			}
-			logging.V(5).Infof("marshalling resource value as raw URN or ID as opts.KeepResources is false")
+			if !opts.skipLogging {
+				logging.V(5).Infof("marshalling resource value as raw URN or ID as opts.KeepResources is false")
+			}
 			return MarshalString(val, opts), nil
 		}
 		m := resource.PropertyMap{

--- a/sdk/go/common/resource/plugin/property_handler.go
+++ b/sdk/go/common/resource/plugin/property_handler.go
@@ -28,6 +28,9 @@ var propertyLogMarshalOpts = MarshalOptions{
 	KeepSecrets:      true,
 	KeepUnknowns:     true,
 	KeepOutputValues: true,
+	// Suppress verbose marshal logging: this marshal runs *inside* the logging path (to build a log
+	// attribute), and logging here would re-enter and recurse.
+	skipLogging: true,
 }
 
 // PropertyExportHandler wraps the OTLP export handler, converting

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -47,6 +47,11 @@ type MarshalOptions struct {
 
 	// true if a nil input should result in a nil output, false if it should result in an empty struct/map.
 	PropagateNil bool
+
+	// skipLogging suppresses the verbose per-property marshal logging. It is set when marshaling a
+	// property in order to build a log attribute, so that the marshal does not re-enter the logging
+	// path and recurse.
+	skipLogging bool
 }
 
 const (
@@ -82,11 +87,17 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 	fields := make(map[string]*structpb.Value)
 	for _, key := range props.StableKeys() {
 		v := props[key]
-		logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
+		if !opts.skipLogging {
+			logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
+		}
 		if opts.SkipNulls && v.IsNull() {
-			logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)
+			if !opts.skipLogging {
+				logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)
+			}
 		} else if opts.SkipInternalKeys && resource.IsInternalPropertyKey(key) {
-			logging.V(9).Infof("Skipping internal property for RPC[%s]: %s (as requested)", opts.Label, key)
+			if !opts.skipLogging {
+				logging.V(9).Infof("Skipping internal property for RPC[%s]: %s (as requested)", opts.Label, key)
+			}
 		} else {
 			// Only skip top level internal keys
 			copts := opts
@@ -201,7 +212,9 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 		return MarshalPropertyValue(key, output, opts)
 	} else if v.IsSecret() {
 		if !opts.KeepSecrets {
-			logging.V(5).Infof("marshalling secret value as raw value as opts.KeepSecrets is false")
+			if !opts.skipLogging {
+				logging.V(5).Infof("marshalling secret value as raw value as opts.KeepSecrets is false")
+			}
 			return MarshalPropertyValue(key, v.SecretValue().Element, opts)
 		}
 		if opts.KeepOutputValues && opts.UpgradeToOutputValues {
@@ -224,7 +237,9 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			if !ref.ID.IsNull() {
 				return MarshalPropertyValue(key, ref.ID, opts)
 			}
-			logging.V(5).Infof("marshalling resource value as raw URN or ID as opts.KeepResources is false")
+			if !opts.skipLogging {
+				logging.V(5).Infof("marshalling resource value as raw URN or ID as opts.KeepResources is false")
+			}
 			return MarshalString(val, opts), nil
 		}
 		m := resource.PropertyMap{


### PR DESCRIPTION
`MarshalProperties` is called within our logging handler, so we need to ensure it's not    logging when called on that path, or we end up with exponential logs.

Fixes https://github.com/pulumi/pulumi/issues/23772