### PR TITLE
do: improve usage section

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -95,9 +95,6 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		Short: shorthelp,
 		Long:  longhelp,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
 	}
 	// Provider configuration applies to all sub-operations, so register here as persistent flags.
 	cmd.PersistentFlags().StringVar(&pc.providerFile, "provider-file", "",

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -122,7 +122,6 @@ List Inputs:
   prefix (string, optional)
 
 Usage:
-  do azure:index:myResource [flags]
   do azure:index:myResource [command]
 
 Available Commands:
@@ -172,7 +171,6 @@ Outputs:
   size (integer)
 
 Usage:
-  do azure:index:myResource [flags]
   do azure:index:myResource [command]
 
 Available Commands:


### PR DESCRIPTION
Currently the usage for `do` is a little confusing, because it
appears that it's possible to do something without specifying a
command, but it isn't really.  This is because we have a `RunE`
function that just prints the help.

This isn't really necessary, as cobra displays the help either way if
no `RunE` function is given, or when `--help` is passed.  So let's
just drop the function, which improves the usage section