### PR TITLE
docs: update repository links to reference main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ aws.cloudwatch.onSchedule("daily-yc-snapshot", "cron(30 8 * * ? *)", async () =>
 Many examples are available spanning containers, serverless, and infrastructure in
 [pulumi/examples](https://github.com/pulumi/examples).
 
-Pulumi is open source under the [Apache 2.0 license](https://github.com/pulumi/pulumi/blob/master/LICENSE), supports many languages and clouds, and is easy to extend.  This
+Pulumi is open source under the [Apache 2.0 license](https://github.com/pulumi/pulumi/blob/main/LICENSE), supports many languages and clouds, and is easy to extend.  This
 repo contains the `pulumi` CLI, language SDKs, and core Pulumi engine, and individual libraries are in their own repos.
 
 ## Welcome
@@ -201,4 +201,4 @@ Visit the [Registry](https://www.pulumi.com/registry/) for the full list of supp
 
 ## Contributing
 
-Visit [CONTRIBUTING.md](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) for information on building Pulumi from source or contributing improvements.
+Visit [CONTRIBUTING.md](https://github.com/pulumi/pulumi/blob/main/CONTRIBUTING.md) for information on building Pulumi from source or contributing improvements.


### PR DESCRIPTION
## Summary
This PR updates outdated hardcoded references targeting the old `master` branch name to the current `main` branch configuration in the root README file.

## Test plan
- [x] Verified markdown files look correct and links are properly structured.

## Validation
- [x] `make lint` — clean

## Changelog
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply the `impact/no-changelog-required` label.

## Risk
None. Pure documentation update.
-->
