### PR TITLE
Show revision number when an environment definition is updated

### DIFF
--- a/changelog/pending/cli-env-show-revision-on-update.yaml
+++ b/changelog/pending/cli-env-show-revision-on-update.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Report the new revision number when an environment definition is updated (e.g. `pulumi env edit`, `pulumi env provider`, `pulumi env version rollback`)
 time: 2026-07-06T12:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23799"

--- a/changelog/pending/cli-env-show-revision-on-update.yaml
+++ b/changelog/pending/cli-env-show-revision-on-update.yaml
@@ -1,0 +1,6 @@
+component: cli/env
+kind: improvement
+body: Report the new revision number when an environment definition is updated (e.g. `pulumi env edit`, `pulumi env provider`, `pulumi env version rollback`)
+time: 2026-07-06T12:00:00.000000+00:00
+custom:
+    PR: ""

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -495,12 +495,12 @@ func (esc *escCommand) updateEnvironment(
 		}
 		return diags, nil
 	} else {
-		diags, _, err := esc.client.UpdateEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
+		diags, revision, err := esc.client.UpdateEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
 		if err != nil {
 			return nil, fmt.Errorf("updating environment definition: %w", err)
 		}
 		if !client.DiagnosticsHaveErrors(diags) && envUpdateSuccessMessage != "" {
-			fmt.Fprintln(esc.stdout, envUpdateSuccessMessage)
+			fmt.Fprintf(esc.stdout, "%s (revision %d)\n", envUpdateSuccessMessage, revision)
 		}
 		return diags, nil
 	}

--- a/pkg/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
@@ -16,7 +16,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-file-warnings.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-file-warnings.yaml
@@ -8,7 +8,7 @@ environments:
 
 ---
 > esc env edit default/test -f=-
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-file.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-file.yaml
@@ -11,7 +11,7 @@ environments:
 
 ---
 > esc env edit default/test -f=-
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json
@@ -26,7 +26,7 @@ Environment updated.
 ```
 
 > esc env edit default/test -f=def.yaml
-Environment updated.
+Environment updated. (revision 4)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -13,7 +13,7 @@ environments:
 
 ---
 > esc env edit default/test --editor code
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -12,7 +12,7 @@ environments:
 
 ---
 > esc env edit default/test --editor my-editor
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -12,7 +12,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/pkg/cmd/esc/cli/testdata/env-provider-aws-login-oidc.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-aws-login-oidc.yaml
@@ -8,7 +8,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider aws-login oidc default/test arn:aws:iam::123456789012:role/role-name sess
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   aws:
@@ -18,7 +18,7 @@ values:
           roleArn: arn:aws:iam::123456789012:role/role-name
           sessionName: sess
 > esc env provider aws-login oidc default/test arn:aws:iam::123456789012:role/role-name sess --duration 1h
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   aws:
@@ -29,7 +29,7 @@ values:
           sessionName: sess
           duration: 1h
 > esc env provider aws-login oidc default/test arn:aws:iam::123456789012:role/role-name sess --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess --policy-arn arn:aws:iam::aws:policy/Other --subject-attribute env --subject-attribute team
-Provider updated.
+Provider updated. (revision 4)
 > esc env get default/test --definition
 values:
   aws:

--- a/pkg/cmd/esc/cli/testdata/env-provider-aws-login-static.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-aws-login-static.yaml
@@ -8,7 +8,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider aws-login static default/test AKIAEXAMPLE shhhhhh
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   aws:
@@ -20,7 +20,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAHz6Ojo6OjoVtjhwQ==
 > esc env provider aws-login static default/test AKIAEXAMPLE shhhhhh --session-token toktok
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   aws:
@@ -35,7 +35,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAH07+v07+saq0zU
 > esc env provider aws-login static default/test AKIANEW newshhh --path other.creds
-Provider updated.
+Provider updated. (revision 4)
 > esc env get default/test --definition
 values:
   aws:

--- a/pkg/cmd/esc/cli/testdata/env-provider-azure-login-oidc.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-azure-login-oidc.yaml
@@ -7,7 +7,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider azure-login oidc default/test tid /subscriptions/sub cid
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   azure:
@@ -18,7 +18,7 @@ values:
         subscriptionId: /subscriptions/sub
         oidc: true
 > esc env provider azure-login oidc default/test tid /subscriptions/sub cid --subject-attribute env --subject-attribute team
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   azure:

--- a/pkg/cmd/esc/cli/testdata/env-provider-azure-login-static.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-azure-login-static.yaml
@@ -6,7 +6,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider azure-login static default/test tid /subscriptions/sub cid shhhhhh
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   azure:

--- a/pkg/cmd/esc/cli/testdata/env-provider-gcp-login-oidc.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-gcp-login-oidc.yaml
@@ -7,7 +7,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider gcp-login oidc default/test 123456789 --workload-pool-id pool --provider-id provider --service-account sa@proj.iam.gserviceaccount.com
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   gcp:
@@ -19,7 +19,7 @@ values:
           providerId: provider
           serviceAccount: sa@proj.iam.gserviceaccount.com
 > esc env provider gcp-login oidc default/test 123456789 --workload-pool-id pool --provider-id provider --service-account sa@proj.iam.gserviceaccount.com --region us-central1 --token-lifetime 1h --subject-attribute env
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   gcp:

--- a/pkg/cmd/esc/cli/testdata/env-provider-gcp-login-static.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-gcp-login-static.yaml
@@ -7,7 +7,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider gcp-login static default/test 123456789 ya29.token
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   gcp:
@@ -19,7 +19,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAH54bK5rvTv6+Xuek7KOw==
 > esc env provider gcp-login static default/test 123456789 ya29.token --service-account sa@proj.iam.gserviceaccount.com --token-lifetime 1h
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   gcp:

--- a/pkg/cmd/esc/cli/testdata/env-provider-missing-env.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-provider-missing-env.yaml
@@ -6,7 +6,7 @@ run: |
 ---
 > esc env provider aws-login static default/created AKIAEXAMPLE shhhhhh --create
 Environment created: test-user/default/created
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/created --definition
 values:
   aws:
@@ -18,7 +18,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAHz6Ojo6OjoVtjhwQ==
 > esc env provider aws-login static default/created AKIANEW newshhh
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/created --definition
 values:
   aws:

--- a/pkg/cmd/esc/cli/testdata/env-version-rollback.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-version-rollback.yaml
@@ -37,7 +37,7 @@ environments:
 
 ---
 > esc env version rollback default/test@stable
-Environment updated.
+Environment updated. (revision 5)
 > esc env get default/test
 # Value
 ```json


### PR DESCRIPTION
## Summary

Port of [pulumi/esc#666](https://github.com/pulumi/esc/pull/666) — the final ESC PR that landed after the ESC merge into the monorepo (#23746) and was therefore missed.

The `pulumi env` update commands now report the new revision number in their success message:

```
❯ pulumi env edit syeh/aaa/yo
Environment updated. (revision 19)
```

This applies to `pulumi env edit`, `pulumi env provider ...`, and `pulumi env version rollback`.

resolves https://github.com/pulumi/esc/issues/509

## Risk

Low. Output-only change to a CLI success message; no behavior change to the update itself. Golden tests updated and passing.

## Rollback

Revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)