### PR TITLE
Unown `/changelog/pending/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @pulumi/platform
+/changelog/pending/ # We don't need a code-owner for changelog changes
 /pkg/cmd/pulumi/neo/ @pulumi/ai
 /pkg/cmd/esc/ @pulumi/iac-cloud
 /sdk/go/common/esc/ @pulumi/iac-cloud


### PR DESCRIPTION
Otherwise `@pulumi/platform` gets pinged on all PRs that add features, even when we don't own any files that motivate the change.