### PR TITLE
eval: add TraceMode to omit the value Trace on export

### DIFF
--- a/changelog/pending/cli-env-eval-tracemode.yaml
+++ b/changelog/pending/cli-env-eval-tracemode.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Introduce `eval.EvalOptions` and `eval.TraceMode` so callers can export each value without its `Trace.Base` merge-history chain, bounding serialized opened-payload size by its logical content instead of by import-merge depth
 time: 2026-07-06T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23801"

--- a/changelog/pending/cli-env-eval-tracemode.yaml
+++ b/changelog/pending/cli-env-eval-tracemode.yaml
@@ -1,6 +1,0 @@
-component: cli/env
-kind: improvement
-body: Introduce `eval.EvalOptions` and `eval.TraceMode` so callers can export each value without its `Trace.Base` merge-history chain, bounding serialized opened-payload size by its logical content instead of by import-merge depth
-time: 2026-07-06T00:00:00.000000+00:00
-custom:
-    PR: "23801"

--- a/changelog/pending/cli-env-eval-tracemode.yaml
+++ b/changelog/pending/cli-env-eval-tracemode.yaml
@@ -1,0 +1,6 @@
+component: cli/env
+kind: improvement
+body: Introduce `eval.EvalOptions` and `eval.TraceMode` so callers can export each value without its `Trace.Base` merge-history chain, bounding serialized opened-payload size by its logical content instead of by import-merge depth
+time: 2026-07-06T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/pkg/cmd/esc/analysis/describe_test.go
+++ b/pkg/cmd/esc/analysis/describe_test.go
@@ -42,6 +42,7 @@ func TestDescribe(t *testing.T) { //nolint:paralleltest,lll // non-thread-safe s
 		testEnvironments{},
 		execContext,
 		false,
+		eval.EvalOptions{},
 	)
 	require.Empty(t, diags)
 
@@ -128,6 +129,7 @@ func TestDescribeOpen(t *testing.T) { //nolint:paralleltest,lll // non-thread-sa
 		testEnvironments{},
 		execContext,
 		false,
+		eval.EvalOptions{},
 	)
 	require.Empty(t, diags)
 

--- a/pkg/cmd/esc/analysis/traversal_test.go
+++ b/pkg/cmd/esc/analysis/traversal_test.go
@@ -41,6 +41,7 @@ func TestExpressionAt(t *testing.T) { //nolint:paralleltest,lll // non-thread-sa
 		testEnvironments{},
 		execContext,
 		false,
+		eval.EvalOptions{},
 	)
 	require.Empty(t, diags)
 

--- a/pkg/cmd/esc/cli/cli_test.go
+++ b/pkg/cmd/esc/cli/cli_test.go
@@ -430,6 +430,7 @@ func (c *testPulumiClient) checkEnvironment(
 		envLoader,
 		execContext,
 		showSecrets,
+		eval.EvalOptions{TraceMode: eval.TraceModeFull},
 	)
 	diags.Extend(checkDiags...)
 	return checked, mapDiags(diags), nil
@@ -461,7 +462,16 @@ func (c *testPulumiClient) openEnvironment(
 		return "", nil, fmt.Errorf("initializing the ESC exec context: %w", err)
 	}
 
-	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader, execContext)
+	openEnv, evalDiags := eval.EvalEnvironment(
+		ctx,
+		name,
+		decl,
+		rot128{},
+		providers,
+		envLoader,
+		execContext,
+		eval.EvalOptions{TraceMode: eval.TraceModeFull},
+	)
 	diags.Extend(evalDiags...)
 
 	if diags.HasErrors() {

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -229,7 +229,9 @@ func newConfigEnvCmdForInitTest(
 			if err != nil {
 				return nil, err
 			}
-			_, checkDiags := eval.CheckEnvironment(ctx, name, decl, nil, nil, envs, &esc.ExecContext{}, false)
+			_, checkDiags := eval.CheckEnvironment(
+				ctx, name, decl, nil, nil, envs, &esc.ExecContext{}, false, eval.EvalOptions{},
+			)
 			diags.Extend(checkDiags...)
 			if len(diags) != 0 {
 				return mapEvalDiags(diags), nil
@@ -246,7 +248,9 @@ func newConfigEnvCmdForInitTest(
 			if err != nil {
 				return nil, nil, err
 			}
-			env, checkDiags := eval.CheckEnvironment(ctx, "<yaml>", decl, nil, nil, envs, &esc.ExecContext{}, false)
+			env, checkDiags := eval.CheckEnvironment(
+				ctx, "<yaml>", decl, nil, nil, envs, &esc.ExecContext{}, false, eval.EvalOptions{},
+			)
 			diags.Extend(checkDiags...)
 			return env, mapEvalDiags(diags), nil
 		},

--- a/sdk/go/common/esc/eval/eval.go
+++ b/sdk/go/common/esc/eval/eval.go
@@ -85,6 +85,7 @@ func EvalEnvironment(
 	providers ProviderLoader,
 	environments EnvironmentLoader,
 	execContext *esc.ExecContext,
+	opts EvalOptions,
 ) (*esc.Environment, syntax.Diagnostics) {
 	opened, _, diags := evalEnvironment(
 		ctx,
@@ -98,6 +99,7 @@ func EvalEnvironment(
 		execContext,
 		true,
 		nil,
+		opts,
 	)
 	return opened, diags
 }
@@ -113,6 +115,7 @@ func CheckEnvironment(
 	environments EnvironmentLoader,
 	execContext *esc.ExecContext,
 	showSecrets bool,
+	opts EvalOptions,
 ) (*esc.Environment, syntax.Diagnostics) {
 	checked, _, diags := evalEnvironment(
 		ctx,
@@ -126,6 +129,7 @@ func CheckEnvironment(
 		execContext,
 		showSecrets,
 		nil,
+		opts,
 	)
 	return checked, diags
 }
@@ -141,6 +145,7 @@ func RotateEnvironment(
 	environments EnvironmentLoader,
 	execContext *esc.ExecContext,
 	paths []resource.PropertyPath,
+	opts EvalOptions,
 ) (*esc.Environment, RotationResult, syntax.Diagnostics) {
 	rotateDocPaths := make(map[string]bool, len(paths))
 	for _, path := range paths {
@@ -158,6 +163,7 @@ func RotateEnvironment(
 		execContext,
 		true,
 		rotateDocPaths,
+		opts,
 	)
 }
 
@@ -174,6 +180,7 @@ func evalEnvironment(
 	execContext *esc.ExecContext,
 	showSecrets bool,
 	rotatePaths map[string]bool,
+	opts EvalOptions,
 ) (*esc.Environment, RotationResult, syntax.Diagnostics) {
 	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil, nil
@@ -194,6 +201,7 @@ func evalEnvironment(
 		showSecrets,
 		rotatePaths,
 	)
+	ec.traceMode = opts.TraceMode
 	v, diags := ec.evaluate()
 
 	s := schema.Never().Schema()
@@ -205,7 +213,7 @@ func evalEnvironment(
 		}
 	}
 
-	contextProperties, exportDiags := ec.myContext.export(name)
+	contextProperties, exportDiags := ec.myContext.export(name, ec.traceMode)
 	diags.Extend(exportDiags...)
 
 	executionContext := &esc.EvaluatedExecutionContext{
@@ -213,7 +221,7 @@ func evalEnvironment(
 		Schema:     ec.myContext.schema,
 	}
 
-	envProperties, exportDiags := v.export(name)
+	envProperties, exportDiags := v.export(name, ec.traceMode)
 	diags.Extend(exportDiags...)
 
 	return &esc.Environment{
@@ -253,6 +261,8 @@ type evalContext struct {
 	// rotating. if empty, all rotators will be invoked.
 	rotateDocPaths map[string]bool
 	rotationResult RotationResult // result of secret rotations
+
+	traceMode TraceMode // traceMode used during eval and passed to export
 
 	diags syntax.Diagnostics // diagnostics generated during evaluation
 }
@@ -619,6 +629,7 @@ func (e *evalContext) evaluateImport(expr ast.Expr, name string) (*value, bool) 
 
 		// we only want to rotate the root environment, so set rotating flag to false when evaluating imports
 		imp := newEvalContext(e.ctx, e.validating, false, name, env, false, dec, e.providers, e.environments, e.imports, e.execContext, e.showSecrets, nil) //nolint:lll
+		imp.traceMode = e.traceMode
 		v, diags := imp.evaluate()
 		e.diags.Extend(diags...)
 
@@ -1195,7 +1206,7 @@ func (e *evalContext) evaluateBuiltinOpen(x *expr, repr *openExpr) *value {
 		return v
 	}
 
-	inputsV, exportDiags := inputs.export("")
+	inputsV, exportDiags := inputs.export("", e.traceMode)
 	e.diags.Extend(exportDiags...)
 
 	output, err := provider.Open(e.ctx, inputsV.Value.(map[string]esc.Value), e.execContext)
@@ -1263,12 +1274,12 @@ func (e *evalContext) evaluateBuiltinRotate(x *expr, repr *rotateExpr) *value {
 		return v
 	}
 
-	inputsV, exportDiags := inputs.export("")
+	inputsV, exportDiags := inputs.export("", e.traceMode)
 	e.diags.Extend(exportDiags...)
 
 	// if rotating, invoke prior to open
 	if e.shouldRotate(docPath) {
-		stateV, exportDiags := state.export("")
+		stateV, exportDiags := state.export("", e.traceMode)
 		e.diags.Extend(exportDiags...)
 
 		newState, err := rotator.Rotate(
@@ -1309,7 +1320,7 @@ func (e *evalContext) evaluateBuiltinRotate(x *expr, repr *rotateExpr) *value {
 		state = unexport(newState, x)
 	}
 
-	stateV, exportDiags := state.export("")
+	stateV, exportDiags := state.export("", e.traceMode)
 	e.diags.Extend(exportDiags...)
 
 	output, err := rotator.Open(
@@ -1499,7 +1510,7 @@ func (e *evalContext) evaluateBuiltinValidate(x *expr, repr *validateExpr) *valu
 // valueToSchema converts an evaluated value to a *schema.Schema.
 func (e *evalContext) valueToSchema(v *value) (*schema.Schema, error) {
 	// Export the value to esc.Value
-	ev, diags := v.export("")
+	ev, diags := v.export("", e.traceMode)
 	e.diags.Extend(diags...)
 
 	// Convert to JSON representation
@@ -1595,7 +1606,7 @@ func (e *evalContext) evaluateBuiltinToJSON(x *expr, repr *toJSONExpr) *value {
 
 	v.combine(value)
 	if !v.unknown {
-		valueV, exportDiags := value.export("")
+		valueV, exportDiags := value.export("", e.traceMode)
 		e.diags.Extend(exportDiags...)
 
 		b, err := json.Marshal(valueV.ToJSON(false))
@@ -1617,7 +1628,7 @@ func (e *evalContext) evaluateBuiltinToYAML(x *expr, repr *toYAMLExpr) *value {
 
 	v.combine(value)
 	if !v.unknown {
-		valueV, exportDiags := value.export("")
+		valueV, exportDiags := value.export("", e.traceMode)
 		e.diags.Extend(exportDiags...)
 
 		b, err := yaml.Marshal(valueV.ToJSON(false))

--- a/sdk/go/common/esc/eval/eval_options.go
+++ b/sdk/go/common/esc/eval/eval_options.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+// TraceMode controls how much of each value's Trace the eval entry points
+// retain. The Trace is only useful to a consumer that walks the Base
+// merge-history chain end-to-end (e.g. `esc env get`'s provenance view, on the
+// Check path); for callers that never read it, that chain grows the payload
+// with import-merge depth for no benefit.
+type TraceMode int
+
+const (
+	// TraceModeFull builds the entire Trace. The zero value, so EvalOptions{}
+	// preserves historical behavior and no Trace consumer regresses.
+	TraceModeFull TraceMode = iota
+
+	// TraceModeNone omits the Trace entirely (no Def, no Base chain). Safe only
+	// when no consumer reads it.
+	TraceModeNone
+)
+
+// EvalOptions configures an evaluation. Fields must default to historical
+// behavior when zero so EvalOptions{} is a safe default.
+type EvalOptions struct {
+	// TraceMode selects how much of each value's Trace to retain. Applied during
+	// export, so TraceModeNone never allocates the dropped Trace.
+	TraceMode TraceMode
+}

--- a/sdk/go/common/esc/eval/eval_options_test.go
+++ b/sdk/go/common/esc/eval/eval_options_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chainDepth counts a value plus its Trace.Base merge-history chain.
+func chainDepth(v *esc.Value) int {
+	n := 0
+	for cur := v; cur != nil; cur = cur.Trace.Base {
+		n++
+	}
+	return n
+}
+
+// inlineEnvironments is an in-memory EnvironmentLoader so tests can build import
+// topologies without testdata files.
+type inlineEnvironments map[string][]byte
+
+func (e inlineEnvironments) LoadEnvironment(_ context.Context, name string) ([]byte, Decrypter, error) {
+	src, ok := e[name]
+	if !ok {
+		return nil, nil, os.ErrNotExist
+	}
+	return src, rot128{}, nil
+}
+
+// deepImportChain is a 5-environment stack all merging the same key, so the
+// Trace.Base chain is deep enough (>2) for Full and None to diverge observably.
+var deepImportChain = inlineEnvironments{
+	"a":    []byte("values:\n  shared: from-a\n"),
+	"b":    []byte("imports:\n  - a\nvalues:\n  shared: from-b\n"),
+	"c":    []byte("imports:\n  - b\nvalues:\n  shared: from-c\n"),
+	"d":    []byte("imports:\n  - c\nvalues:\n  shared: from-d\n"),
+	"root": []byte("imports:\n  - d\nvalues:\n  shared: from-root\n"),
+}
+
+func evalShared(t *testing.T, envs inlineEnvironments, opts EvalOptions) esc.Value {
+	t.Helper()
+	env, _, err := LoadYAMLBytes("root", envs["root"])
+	require.NoError(t, err)
+	execContext, err := esc.NewExecContext(map[string]esc.Value{})
+	require.NoError(t, err)
+	result, diags := EvalEnvironment(t.Context(), "root", env, rot128{}, testProviders{},
+		envs, execContext, opts)
+	require.False(t, diags.HasErrors(), "%v", diags)
+	require.NotNil(t, result)
+	return result.Properties["shared"]
+}
+
+func TestEvalEnvironment_TraceModeFull(t *testing.T) {
+	t.Parallel()
+	shared := evalShared(t, deepImportChain, EvalOptions{TraceMode: TraceModeFull})
+	assert.Greater(t, chainDepth(&shared), 2,
+		"Full must preserve a chain deeper than 2 for this 5-environment fixture")
+}
+
+// None is the fix for the import-depth payload blowup: the whole Trace is dropped.
+func TestEvalEnvironment_TraceModeNone(t *testing.T) {
+	t.Parallel()
+	shared := evalShared(t, deepImportChain, EvalOptions{TraceMode: TraceModeNone})
+	assert.Equal(t, esc.Trace{}, shared.Trace, "None must omit the entire Trace")
+	assert.Equal(t, 1, chainDepth(&shared), "None must reduce the chain to the value itself")
+}
+
+// Guards the public-API promise: EvalOptions{} stays Full, so no Trace consumer
+// regresses without opting in.
+func TestEvalEnvironment_ZeroOptionsDefaultsToFull(t *testing.T) {
+	t.Parallel()
+	zero := evalShared(t, deepImportChain, EvalOptions{})
+	full := evalShared(t, deepImportChain, EvalOptions{TraceMode: TraceModeFull})
+	assert.Equal(t, chainDepth(&full), chainDepth(&zero),
+		"EvalOptions{} must behave exactly like TraceModeFull")
+	assert.Greater(t, chainDepth(&zero), 2)
+}
+
+// None must apply through nested data, not just the top-level value.
+func TestEvalEnvironment_TraceModeNone_NestedData(t *testing.T) {
+	t.Parallel()
+	envs := inlineEnvironments{
+		"a":    []byte("values:\n  obj:\n    k: from-a\n"),
+		"root": []byte("imports:\n  - a\nvalues:\n  obj:\n    k: from-root\n"),
+	}
+	env, _, err := LoadYAMLBytes("root", envs["root"])
+	require.NoError(t, err)
+	execContext, err := esc.NewExecContext(map[string]esc.Value{})
+	require.NoError(t, err)
+
+	result, diags := EvalEnvironment(t.Context(), "root", env, rot128{}, testProviders{},
+		envs, execContext, EvalOptions{TraceMode: TraceModeNone})
+	require.False(t, diags.HasErrors(), "%v", diags)
+	require.NotNil(t, result)
+
+	obj := result.Properties["obj"]
+	assert.Nil(t, obj.Trace.Base, "None must drop Base on the object")
+	nested := obj.Value.(map[string]esc.Value)["k"]
+	assert.Nil(t, nested.Trace.Base, "None must drop Base on nested data too")
+}

--- a/sdk/go/common/esc/eval/eval_test.go
+++ b/sdk/go/common/esc/eval/eval_test.go
@@ -456,11 +456,11 @@ func TestEval(t *testing.T) {
 				sortEnvironmentDiagnostics(loadDiags)
 
 				check, checkDiags := CheckEnvironment(t.Context(), environmentName, env, rot128{}, testProviders{},
-					&testEnvironments{basePath}, execContext, showSecrets)
+					&testEnvironments{basePath}, execContext, showSecrets, EvalOptions{TraceMode: TraceModeFull})
 				sortEnvironmentDiagnostics(checkDiags)
 
 				actual, evalDiags := EvalEnvironment(t.Context(), environmentName, env, rot128{}, testProviders{},
-					&testEnvironments{basePath}, execContext)
+					&testEnvironments{basePath}, execContext, EvalOptions{TraceMode: TraceModeFull})
 				sortEnvironmentDiagnostics(evalDiags)
 
 				var rotated *esc.Environment
@@ -477,6 +477,7 @@ func TestEval(t *testing.T) {
 						&testEnvironments{basePath},
 						execContext,
 						rotatePaths,
+						EvalOptions{TraceMode: TraceModeFull},
 					)
 					patches = rotationResult.Patches()
 				}
@@ -536,12 +537,12 @@ func TestEval(t *testing.T) {
 			require.Equal(t, expected.LoadDiags, diags)
 
 			check, diags := CheckEnvironment(t.Context(), environmentName, env, rot128{}, testProviders{},
-				&testEnvironments{basePath}, execContext, showSecrets)
+				&testEnvironments{basePath}, execContext, showSecrets, EvalOptions{TraceMode: TraceModeFull})
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.CheckDiags, diags)
 
 			actual, diags := EvalEnvironment(t.Context(), environmentName, env, rot128{}, testProviders{},
-				&testEnvironments{basePath}, execContext)
+				&testEnvironments{basePath}, execContext, EvalOptions{TraceMode: TraceModeFull})
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.EvalDiags, diags)
 
@@ -556,6 +557,7 @@ func TestEval(t *testing.T) {
 					&testEnvironments{basePath},
 					execContext,
 					rotatePaths,
+					EvalOptions{TraceMode: TraceModeFull},
 				)
 				var patches []*Patch
 				if rotationResult != nil {
@@ -649,6 +651,7 @@ func benchmarkEval(b *testing.B, openDelay, loadDelay time.Duration) {
 			testProviders{benchDelay: openDelay},
 			envs,
 			execContext,
+			EvalOptions{},
 		)
 		require.Empty(b, evalDiags)
 	}
@@ -699,7 +702,7 @@ func TestSyntaxErrorCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	check, checkDiags := CheckEnvironment(t.Context(), environmentName, env, rot128{}, testProviders{},
-		&testEnvironments{}, execContext, false)
+		&testEnvironments{}, execContext, false, EvalOptions{})
 
 	assert.True(t, checkDiags.HasErrors())
 	require.NotNil(t, check)

--- a/sdk/go/common/esc/eval/rotate_example_test.go
+++ b/sdk/go/common/esc/eval/rotate_example_test.go
@@ -56,6 +56,7 @@ values:
 		&testEnvironments{},
 		execContext,
 		nil,
+		EvalOptions{},
 	)
 
 	// writeback state patches

--- a/sdk/go/common/esc/eval/value.go
+++ b/sdk/go/common/esc/eval/value.go
@@ -319,8 +319,10 @@ func (v *value) toString() (str string, unknown bool, secret bool) {
 	return s, unknown, secret
 }
 
-// export converts the value into its serializable representation.
-func (v *value) export(environment string) (esc.Value, syntax.Diagnostics) {
+// export converts the value into its serializable representation. traceMode
+// gates how much Trace is built; it is constant for a whole evaluation, so the
+// memoized result below stays consistent across call sites.
+func (v *value) export(environment string, traceMode TraceMode) (esc.Value, syntax.Diagnostics) {
 	if v.exported != nil {
 		return *v.exported, nil
 	}
@@ -341,7 +343,7 @@ func (v *value) export(environment string) (esc.Value, syntax.Diagnostics) {
 		var elemDiags syntax.Diagnostics
 		a := make([]esc.Value, len(repr))
 		for i, v := range repr {
-			a[i], elemDiags = v.export(environment)
+			a[i], elemDiags = v.export(environment, traceMode)
 			diags.Extend(elemDiags...)
 		}
 		pv = a
@@ -351,7 +353,7 @@ func (v *value) export(environment string) (esc.Value, syntax.Diagnostics) {
 		pm := make(map[string]esc.Value, len(keys))
 		for _, k := range keys {
 			pv := v.property(v.def.repr.syntax(), k)
-			pm[k], elemDiags = pv.export(environment)
+			pm[k], elemDiags = pv.export(environment, traceMode)
 			diags.Extend(elemDiags...)
 		}
 		pv = pm
@@ -359,21 +361,26 @@ func (v *value) export(environment string) (esc.Value, syntax.Diagnostics) {
 		pv = repr
 	}
 
-	var base *esc.Value
-	if v.base != nil {
-		b, baseDiags := v.base.export("<import>")
-		diags.Extend(baseDiags...)
-		base = &b
+	// TraceModeNone omits the whole Trace, so the dropped data is never built.
+	var trace esc.Trace
+	if traceMode != TraceModeNone {
+		var base *esc.Value
+		if v.base != nil {
+			b, baseDiags := v.base.export("<import>", traceMode)
+			diags.Extend(baseDiags...)
+			base = &b
+		}
+		trace = esc.Trace{
+			Def:  v.def.defRange(environment),
+			Base: base,
+		}
 	}
 
 	v.exported = &esc.Value{
 		Value:   pv,
 		Secret:  v.secret,
 		Unknown: v.unknown,
-		Trace: esc.Trace{
-			Def:  v.def.defRange(environment),
-			Base: base,
-		},
+		Trace:   trace,
 	}
 	return *v.exported, diags
 }


### PR DESCRIPTION
## Summary

Object merges set `Trace.Base` on every produced value, and serialization recurses through the whole chain. A leaf at the end of a D-deep import-merge chain therefore carried ~D partial copies of its ancestors on the wire, so opened payloads grew super-linearly in import depth for the same logical content. Combined with a `Value.UnmarshalJSON` whose cost was `O(size × depth)`, opened-payload decode came to dominate CPU on import-heavy environments (a large fraction of `esc.(*Value).UnmarshalJSON` on a production profile).

This PR lets callers drop the `Trace` on paths that never read it, so those payloads stay bounded by their logical content.

## What changed

### `eval.TraceMode` + `EvalOptions`

Two modes, with the historical behavior as the default:

- **`TraceModeFull`** — the zero value. Builds the entire `Trace` (`Def` + the full `Base` chain), so `EvalOptions{}` is byte-for-byte the prior behavior and no consumer of `Trace` regresses without opting in.
- **`TraceModeNone`** — exports each value with a **zero `Trace`** (no `Def`, no `Base` chain). Bounds opened-payload size by logical content instead of import-merge depth.

The `Trace` is built **directly during export** — `(*value).export` takes the `TraceMode` (sourced from the `evalContext`, which is set once per evaluation and shared with imports, so export memoization stays consistent). Under `TraceModeNone` the dropped `Trace` is never allocated; there is no build-then-strip post-processing pass.

The three eval entry points (`EvalEnvironment`, `CheckEnvironment`, `RotateEnvironment`) gain a final `EvalOptions` argument.
