### PR TITLE
Key `import --from` mapping lookups by consumed ecosystem

### DIFF
--- a/changelog/pending/cli-import-fix-20260706-152445.yaml
+++ b/changelog/pending/cli-import-fix-20260706-152445.yaml
@@ -1,0 +1,4 @@
+component: cli/import
+kind: fix
+body: Key converter mapping lookups for `import --from <converter>` by the ecosystem the converter consumes, so `import --from hcl` resolves terraform mappings
+time: 2026-07-06T15:24:45.220354+02:00

--- a/changelog/pending/cli-import-fix-20260706-152445.yaml
+++ b/changelog/pending/cli-import-fix-20260706-152445.yaml
@@ -2,3 +2,5 @@ component: cli/import
 kind: fix
 body: Key converter mapping lookups for `import --from <converter>` by the ecosystem the converter consumes, so `import --from hcl` resolves terraform mappings
 time: 2026-07-06T15:24:45.220354+02:00
+custom:
+    PR: "23803"

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -91,6 +91,20 @@ func parseResourceSpec(spec string) (string, resource.URN, error) {
 	return name, urn, nil
 }
 
+// converterMappingKey returns the conversion key to use for mapping lookups on
+// behalf of the given converter. The key identifies the ecosystem whose
+// mappings the converter consumes, which is not necessarily the converter's own
+// name: the hcl converter executes Terraform programs, so its provider
+// mappings are "terraform" mappings — the same key the engine uses when
+// serving mappings to the hcl language runtime (see deploy.program_source and
+// deploy.source_eval).
+func converterMappingKey(from string) string {
+	if from == "hcl" {
+		return "terraform"
+	}
+	return from
+}
+
 func makeImportFileFromResourceList(resources []plugin.ResourceImport) (importFile, error) {
 	nameTable := map[string]resource.URN{}
 	specs := make([]importSpec, len(resources))
@@ -863,7 +877,7 @@ func NewImportCmd() *cobra.Command {
 
 				baseMapper, err := convert.NewBasePluginMapper(
 					pluginstorage.Instance,
-					from, /*conversionKey*/
+					converterMappingKey(from),
 					convert.ProviderFactoryFromHost(ctx, pCtx),
 					installPlugin,
 					nil, /*mappings*/

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -748,3 +748,14 @@ func TestImportCmd_OutputAndJSONMutuallyExclusive(t *testing.T) {
 	assert.Contains(t, err.Error(), "none of the others can be",
 		"expected cobra's mutually-exclusive error, got: %v", err)
 }
+
+// TestConverterMappingKey verifies that mapping lookups for `import --from X`
+// are keyed by the ecosystem the converter consumes rather than the converter
+// name: the hcl converter consumes terraform mappings, matching the key the
+// engine uses when serving mappings to the hcl language runtime.
+func TestConverterMappingKey(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "terraform", converterMappingKey("hcl"))
+	assert.Equal(t, "terraform", converterMappingKey("terraform"))
+	assert.Equal(t, "yaml", converterMappingKey("yaml"))
+}


### PR DESCRIPTION
`pulumi import --from <converter>` reused the converter's **name** as the mapper's conversion key. That key identifies the *ecosystem whose mappings the converter consumes*, which is not necessarily the converter's own name — and every mapper the engine builds for runtime use hardcodes `"terraform"` (`deploy.program_source`, `deploy.source_eval`, `codegen/convert.mapper_server`). `hcl` is the first converter whose name differs from its mapping key.

With the key `"hcl"`, the parameterized `terraform-provider` hint advertises no mappings, so `basePluginMapper.GetMapping` fell through to enumerating every installed plugin (and hard-errors if any unrelated installed plugin is broken). Net effect: `import --from hcl` emitted warnings and imported **zero** resources. Translating the key to `"terraform"` resolves the hinted plugin immediately — the same key the engine already uses when serving mappings to the hcl language runtime.

Deliberately minimal: a `converterMappingKey` helper (`hcl` → `terraform`, everything else unchanged) at the `NewBasePluginMapper` call site, plus a table test.

Follow-up to #23763; found during the first live end-to-end run of `pulumi import --from hcl` ([pulumi-labs/pulumi-hcl#167](https://github.com/pulumi-labs/pulumi-hcl/issues/167)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)