### PR TITLE
Add an ecosystem to converter mapping requests

### DIFF
--- a/changelog/pending/cli-convert-improvement-20260707-102124.yaml
+++ b/changelog/pending/cli-convert-improvement-20260707-102124.yaml
@@ -1,0 +1,4 @@
+component: cli/convert
+kind: improvement
+body: Add an `ecosystem` field to converter mapping requests so a converter can request mappings for the ecosystem it consumes rather than its own name
+time: 2026-07-07T10:21:24.766053+02:00

--- a/changelog/pending/cli-convert-improvement-20260707-102124.yaml
+++ b/changelog/pending/cli-convert-improvement-20260707-102124.yaml
@@ -2,3 +2,5 @@ component: cli/convert
 kind: improvement
 body: Add an `ecosystem` field to converter mapping requests so a converter can request mappings for the ecosystem it consumes rather than its own name
 time: 2026-07-07T10:21:24.766053+02:00
+custom:
+    PR: "23804"

--- a/pkg/codegen/convert/base_plugin_mapper.go
+++ b/pkg/codegen/convert/base_plugin_mapper.go
@@ -201,7 +201,15 @@ func (m *basePluginMapper) GetMapping(
 	ctx context.Context,
 	provider string,
 	hint *MapperPackageHint,
+	ecosystem string,
 ) ([]byte, error) {
+	// The ecosystem passed on the request identifies the mappings the caller consumes and takes precedence over
+	// the conversion key this mapper was configured with. When empty, fall back to the configured key.
+	key := m.conversionKey
+	if ecosystem != "" {
+		key = ecosystem
+	}
+
 	// See https://github.com/pulumi/pulumi/issues/14718 for why we need this lock. It may be possible to be
 	// smarter about this and only lock when mutating, or at least splitting to a read/write lock, but this is
 	// a quick fix to unblock providers. If you do attempt this then write tests to ensure this doesn't
@@ -270,12 +278,12 @@ func (m *basePluginMapper) GetMapping(
 		defer contract.IgnoreClose(providerPlugin)
 
 		mappings, err := providerPlugin.GetMappings(ctx, plugin.GetMappingsRequest{
-			Key: m.conversionKey,
+			Key: key,
 		})
 		if err != nil {
 			return nil, fmt.Errorf(
 				"could not get %s mappings for package %s: %w",
-				m.conversionKey, descriptor.PackageName(), err,
+				key, descriptor.PackageName(), err,
 			)
 		}
 
@@ -285,17 +293,17 @@ func (m *basePluginMapper) GetMapping(
 			}
 
 			mapping, err := providerPlugin.GetMapping(ctx, plugin.GetMappingRequest{
-				Key:      m.conversionKey,
+				Key:      key,
 				Provider: provider,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("could not get advertized %s mapping for provider %s: %w", m.conversionKey, provider, err)
+				return nil, fmt.Errorf("could not get advertized %s mapping for provider %s: %w", key, provider, err)
 			}
 
 			if mapping.Provider != provider {
 				return nil, fmt.Errorf(
 					"unexpected provider in %s mapping response for provider %s: %s",
-					m.conversionKey, provider, mapping.Provider,
+					key, provider, mapping.Provider,
 				)
 			}
 
@@ -306,11 +314,11 @@ func (m *basePluginMapper) GetMapping(
 		// none of them matched. We'll try a blind GetMapping call with an empty provider name to see if the plugin has
 		// a mapping that matches that way.
 		mapping, err := providerPlugin.GetMapping(ctx, plugin.GetMappingRequest{
-			Key:      m.conversionKey,
+			Key:      key,
 			Provider: "",
 		})
 		if err != nil {
-			return nil, fmt.Errorf("could not get %s mapping for provider %s: %w", m.conversionKey, provider, err)
+			return nil, fmt.Errorf("could not get %s mapping for provider %s: %w", key, provider, err)
 		}
 
 		if mapping.Provider == provider {

--- a/pkg/codegen/convert/base_plugin_mapper_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_test.go
@@ -63,7 +63,7 @@ func TestBasePluginMapper_UsesEntries(t *testing.T) {
 	require.NotNil(t, mapper)
 
 	// Act.
-	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -116,7 +116,58 @@ func TestBasePluginMapper_InstalledPluginMatches(t *testing.T) {
 	require.NotNil(t, mapper)
 
 	// Act.
-	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+}
+
+// Tests that an ecosystem supplied on the request overrides the mapper's configured conversion key.
+func TestBasePluginMapper_EcosystemOverridesConversionKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange.
+	ws := &testWorkspace{
+		infos: []workspace.PluginInfo{
+			{
+				Name:    "provider",
+				Kind:    apitype.ResourcePlugin,
+				Version: semverMustParse("1.0.0"),
+			},
+		},
+	}
+
+	testProvider := &testProvider{
+		pkg: "provider",
+		GetMappingF: func(key, provider string) ([]byte, string, error) {
+			// The request ecosystem ("terraform") takes precedence over the configured key ("key").
+			assert.Equal(t, "terraform", key)
+			return []byte("data"), "provider", nil
+		},
+	}
+
+	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		return testProvider, nil
+	}
+
+	installPlugin := func(pluginName string) *semver.Version {
+		t.Fatal("should not be called")
+		return nil
+	}
+
+	mapper, err := NewBasePluginMapper(
+		ws,
+		"key", /*conversionKey*/
+		providerFactory,
+		installPlugin,
+		nil, /*mappings*/
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mapper)
+
+	// Act.
+	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/, "terraform" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -177,7 +228,7 @@ func TestBasePluginMapper_MappedNameDiffersFromPulumiName(t *testing.T) {
 	require.NotNil(t, mapper)
 
 	// Act.
-	data, err := mapper.GetMapping(t.Context(), "otherProvider", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "otherProvider", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	assert.True(t, installCalled, "installPlugin should have been called")
@@ -238,7 +289,7 @@ func TestBasePluginMapper_NoPluginMatches_ButCanBeInstalled(t *testing.T) {
 	require.NotNil(t, mapper)
 
 	// Act.
-	data, err := mapper.GetMapping(t.Context(), "yetAnotherProvider", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "yetAnotherProvider", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	assert.True(t, installCalled, "installPlugin should have been called")
@@ -298,7 +349,7 @@ func TestBasePluginMapper_UseMatchingNameFirst(t *testing.T) {
 	require.NotNil(t, mapper)
 
 	// Act.
-	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -384,7 +435,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiName(t *testing.T) {
 	require.NotNil(t, mapper)
 
 	// Act.
-	data, err := mapper.GetMapping(t.Context(), "gcp", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "gcp", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	assert.Equal(t, 1, installCalls, "installPlugin should have been called once")
@@ -392,7 +443,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiName(t *testing.T) {
 	assert.Equal(t, []byte("datagcp"), data)
 
 	// Act.
-	data, err = mapper.GetMapping(t.Context(), "aws", nil /*hint*/)
+	data, err = mapper.GetMapping(t.Context(), "aws", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	assert.Equal(t, 2, installCalls, "installPlugin should have been called twice")
@@ -454,7 +505,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithHint(t *testing.T) 
 	// Act.
 	data, err := mapper.GetMapping(t.Context(), "gcp", &MapperPackageHint{
 		PluginName: "pulumiProviderGcp",
-	})
+	}, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -527,7 +578,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithParameterizedHint(t
 			Version: semver.MustParse("2.0.0"),
 			Value:   []byte("value"),
 		},
-	})
+	}, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -591,7 +642,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithUnusableParameteriz
 			Version: semver.MustParse("2.0.0"),
 			Value:   []byte("value"),
 		},
-	})
+	}, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -653,7 +704,7 @@ func TestBasePluginMapper_InfiniteLoopRegression(t *testing.T) {
 	// Act.
 
 	// Attempt to get the mapping for the GCP provider, which we don't have a plugin for.
-	data, err := mapper.GetMapping(t.Context(), "gcp", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "gcp", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)

--- a/pkg/codegen/convert/caching_mapper.go
+++ b/pkg/codegen/convert/caching_mapper.go
@@ -19,13 +19,20 @@ import (
 	"sync"
 )
 
-// cachingMapper wraps another Mapper, caching the results of GetMapping calls by source provider name.
+// cacheKey identifies a cached mapping by the ecosystem it was requested for and the source provider name.
+// Both matter: the same provider name can resolve to different mappings under different ecosystems.
+type cacheKey struct {
+	ecosystem string
+	provider  string
+}
+
+// cachingMapper wraps another Mapper, caching the results of GetMapping calls by (ecosystem, source provider).
 type cachingMapper struct {
 	// The underlying Mapper to which calls will be delegated when there is no cache hit.
 	mapper Mapper
 
-	// A cache of provider mappings, keyed by source provider name.
-	entries map[string][]byte
+	// A cache of provider mappings, keyed by (ecosystem, source provider name).
+	entries map[cacheKey][]byte
 
 	// Mutex to protect concurrent access to the entries map
 	mu sync.RWMutex
@@ -35,31 +42,34 @@ type cachingMapper struct {
 func NewCachingMapper(mapper Mapper) Mapper {
 	return &cachingMapper{
 		mapper:  mapper,
-		entries: map[string][]byte{},
+		entries: map[cacheKey][]byte{},
 	}
 }
 
-// Implements Mapper.GetMapping. Returned results are cached by source provider key.
+// Implements Mapper.GetMapping. Returned results are cached by (ecosystem, source provider) key.
 func (m *cachingMapper) GetMapping(
 	ctx context.Context,
 	provider string,
 	hint *MapperPackageHint,
+	ecosystem string,
 ) ([]byte, error) {
+	entryKey := cacheKey{ecosystem: ecosystem, provider: provider}
+
 	m.mu.RLock()
-	mapping, ok := m.entries[provider]
+	mapping, ok := m.entries[entryKey]
 	m.mu.RUnlock()
 
 	if ok {
 		return mapping, nil
 	}
 
-	mapping, err := m.mapper.GetMapping(ctx, provider, hint)
+	mapping, err := m.mapper.GetMapping(ctx, provider, hint, ecosystem)
 	if err != nil {
 		return nil, err
 	}
 
 	m.mu.Lock()
-	m.entries[provider] = mapping
+	m.entries[entryKey] = mapping
 	m.mu.Unlock()
 
 	return mapping, nil

--- a/pkg/codegen/convert/caching_mapper_test.go
+++ b/pkg/codegen/convert/caching_mapper_test.go
@@ -61,7 +61,7 @@ func TestCachingPluginMapper_OnlyInstallsOnce(t *testing.T) {
 	// Act.
 	//
 	// After the first time, we should have attempted an installation.
-	data, err := mapper.GetMapping(t.Context(), "gcp", nil /*hint*/)
+	data, err := mapper.GetMapping(t.Context(), "gcp", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestCachingPluginMapper_OnlyInstallsOnce(t *testing.T) {
 	// Act.
 	//
 	// After the second time, we should still have only attempted an installation once.
-	data, err = mapper.GetMapping(t.Context(), "gcp", nil /*hint*/)
+	data, err = mapper.GetMapping(t.Context(), "gcp", nil /*hint*/, "" /*ecosystem*/)
 
 	// Assert.
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestCachingPluginMapper_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 
 			// Get the mapping - this will cause concurrent map writes without proper locking
-			_, err := mapper.GetMapping(t.Context(), p, nil /*hint*/)
+			_, err := mapper.GetMapping(t.Context(), p, nil /*hint*/, "" /*ecosystem*/)
 			require.NoError(t, err)
 		}(provider)
 	}

--- a/pkg/codegen/convert/mapper.go
+++ b/pkg/codegen/convert/mapper.go
@@ -31,7 +31,9 @@ type Mapper interface {
 	// package that is expected to provide the mapping and satisfy the request, which implementations may use to optimise
 	// their efforts to return the best possible mapping. The ecosystem parameter identifies the source ecosystem whose
 	// mappings are being requested (e.g. "terraform"); when empty, implementations fall back to the conversion key they
-	// were configured with. If no matching mapping exists, implementations should return an empty byte array result.
+	// were configured with (most instances default to "terraform"; `pulumi convert` and `pulumi import` default it to
+	// the source converter's plugin name). If no matching mapping exists, implementations should return an empty byte
+	// array result.
 	GetMapping(ctx context.Context, provider string, hint *MapperPackageHint, ecosystem string) ([]byte, error)
 }
 

--- a/pkg/codegen/convert/mapper.go
+++ b/pkg/codegen/convert/mapper.go
@@ -29,9 +29,10 @@ type Mapper interface {
 	// GetMapping returns any available mapping data for the given source provider name (so again, this is e.g. the name
 	// of a Terraform provider if converting from Terraform). Callers may pass a "hint" parameter that describes a Pulumi
 	// package that is expected to provide the mapping and satisfy the request, which implementations may use to optimise
-	// their efforts to return the best possible mapping. If no matching mapping exists, implementations should return an
-	// empty byte array result.
-	GetMapping(ctx context.Context, provider string, hint *MapperPackageHint) ([]byte, error)
+	// their efforts to return the best possible mapping. The ecosystem parameter identifies the source ecosystem whose
+	// mappings are being requested (e.g. "terraform"); when empty, implementations fall back to the conversion key they
+	// were configured with. If no matching mapping exists, implementations should return an empty byte array result.
+	GetMapping(ctx context.Context, provider string, hint *MapperPackageHint, ecosystem string) ([]byte, error)
 }
 
 // MapperPackageHint is the type of hints that may be passed to GetMapping to help guide implementations to picking

--- a/pkg/codegen/convert/mapper_client.go
+++ b/pkg/codegen/convert/mapper_client.go
@@ -68,9 +68,10 @@ func (m *mapperClient) GetMapping(
 	ctx context.Context,
 	provider string,
 	hint *MapperPackageHint,
+	ecosystem string,
 ) ([]byte, error) {
 	label := "GetMapping"
-	logging.V(7).Infof("%s executing: provider=%s, hint=%v", label, provider, hint)
+	logging.V(7).Infof("%s executing: provider=%s, hint=%v, ecosystem=%s", label, provider, hint, ecosystem)
 
 	pluginName := ""
 	var parameterizationHint *codegenrpc.MapperParameterizationHint
@@ -89,6 +90,7 @@ func (m *mapperClient) GetMapping(
 		Provider:             provider,
 		PulumiProvider:       pluginName,
 		ParameterizationHint: parameterizationHint,
+		Ecosystem:            ecosystem,
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)

--- a/pkg/codegen/convert/mapper_server.go
+++ b/pkg/codegen/convert/mapper_server.go
@@ -44,7 +44,9 @@ type contextMapper struct {
 	err    error
 }
 
-func (m *contextMapper) GetMapping(ctx context.Context, provider string, hint *MapperPackageHint) ([]byte, error) {
+func (m *contextMapper) GetMapping(
+	ctx context.Context, provider string, hint *MapperPackageHint, ecosystem string,
+) ([]byte, error) {
 	m.once.Do(func() {
 		base, err := NewBasePluginMapper(
 			pluginstorage.Instance,
@@ -62,7 +64,7 @@ func (m *contextMapper) GetMapping(ctx context.Context, provider string, hint *M
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.mapper.GetMapping(ctx, provider, hint)
+	return m.mapper.GetMapping(ctx, provider, hint, ecosystem)
 }
 
 type mapperServer struct {
@@ -79,7 +81,8 @@ func (m *mapperServer) GetMapping(ctx context.Context,
 	req *codegenrpc.GetMappingRequest,
 ) (*codegenrpc.GetMappingResponse, error) {
 	label := "GetMapping"
-	logging.V(7).Infof("%s executing: provider=%s, pulumi=%s", label, req.Provider, req.PulumiProvider)
+	logging.V(7).Infof("%s executing: provider=%s, pulumi=%s, ecosystem=%s",
+		label, req.Provider, req.PulumiProvider, req.Ecosystem)
 
 	var hint *MapperPackageHint
 	if len(req.PulumiProvider) > 0 {
@@ -99,7 +102,7 @@ func (m *mapperServer) GetMapping(ctx context.Context,
 		}
 	}
 
-	data, err := m.mapper.GetMapping(ctx, req.Provider, hint)
+	data, err := m.mapper.GetMapping(ctx, req.Provider, hint, req.Ecosystem)
 	if err != nil {
 		logging.V(7).Infof("%s failed: %v", label, err)
 		return nil, err

--- a/proto/pulumi/codegen/mapper.proto
+++ b/proto/pulumi/codegen/mapper.proto
@@ -48,6 +48,12 @@ message GetMappingRequest {
 
     // An optional parameterization that should be used on the named plugin before asking it for mappings.
     MapperParameterizationHint parameterization_hint = 3;
+
+    // The ecosystem whose mappings are being requested (e.g. "terraform"). This identifies the source ecosystem
+    // the caller consumes, which is not necessarily the caller's own name -- the hcl converter, for instance,
+    // executes Terraform programs and so requests "terraform" mappings. If left empty, the mapper falls back to
+    // the conversion key it was configured with.
+    string ecosystem = 4;
 }
 
 // `MapperPackageParameterizationHint` is the type of hints that may be passed to [](codegen.Mapper.GetMapping) when it

--- a/proto/pulumi/codegen/mapper.proto
+++ b/proto/pulumi/codegen/mapper.proto
@@ -52,7 +52,11 @@ message GetMappingRequest {
     // The ecosystem whose mappings are being requested (e.g. "terraform"). This identifies the source ecosystem
     // the caller consumes, which is not necessarily the caller's own name -- the hcl converter, for instance,
     // executes Terraform programs and so requests "terraform" mappings. If left empty, the mapper falls back to
-    // the conversion key it was configured with.
+    // the conversion key it was configured with: most mapper instances (those served to `plugin run` and to
+    // providers and language runtimes) default to "terraform", while `pulumi convert` and `pulumi import` default
+    // it to the source converter's plugin name. Setting this field lets a caller request a specific ecosystem
+    // regardless of that configured default, which is particularly useful for `plugin run` and providers
+    // accessing the mapper.
     string ecosystem = 4;
 }
 

--- a/sdk/nodejs/proto/codegen/mapper_pb.d.ts
+++ b/sdk/nodejs/proto/codegen/mapper_pb.d.ts
@@ -16,6 +16,8 @@ export class GetMappingRequest extends jspb.Message {
     clearParameterizationHint(): void;
     getParameterizationHint(): MapperParameterizationHint | undefined;
     setParameterizationHint(value?: MapperParameterizationHint): GetMappingRequest;
+    getEcosystem(): string;
+    setEcosystem(value: string): GetMappingRequest;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): GetMappingRequest.AsObject;
@@ -32,6 +34,7 @@ export namespace GetMappingRequest {
         provider: string,
         pulumiProvider: string,
         parameterizationHint?: MapperParameterizationHint.AsObject,
+        ecosystem: string,
     }
 }
 

--- a/sdk/nodejs/proto/codegen/mapper_pb.js
+++ b/sdk/nodejs/proto/codegen/mapper_pb.js
@@ -115,7 +115,8 @@ proto.codegen.GetMappingRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
 provider: jspb.Message.getFieldWithDefault(msg, 1, ""),
 pulumiProvider: jspb.Message.getFieldWithDefault(msg, 2, ""),
-parameterizationHint: (f = msg.getParameterizationHint()) && proto.codegen.MapperParameterizationHint.toObject(includeInstance, f)
+parameterizationHint: (f = msg.getParameterizationHint()) && proto.codegen.MapperParameterizationHint.toObject(includeInstance, f),
+ecosystem: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -164,6 +165,10 @@ proto.codegen.GetMappingRequest.deserializeBinaryFromReader = function(msg, read
       var value = new proto.codegen.MapperParameterizationHint;
       reader.readMessage(value,proto.codegen.MapperParameterizationHint.deserializeBinaryFromReader);
       msg.setParameterizationHint(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setEcosystem(value);
       break;
     default:
       reader.skipField();
@@ -214,6 +219,13 @@ proto.codegen.GetMappingRequest.serializeBinaryToWriter = function(message, writ
       3,
       f,
       proto.codegen.MapperParameterizationHint.serializeBinaryToWriter
+    );
+  }
+  f = message.getEcosystem();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
     );
   }
 };
@@ -289,6 +301,24 @@ proto.codegen.GetMappingRequest.prototype.clearParameterizationHint = function()
  */
 proto.codegen.GetMappingRequest.prototype.hasParameterizationHint = function() {
   return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional string ecosystem = 4;
+ * @return {string}
+ */
+proto.codegen.GetMappingRequest.prototype.getEcosystem = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.codegen.GetMappingRequest} returns this
+ */
+proto.codegen.GetMappingRequest.prototype.setEcosystem = function(value) {
+  return jspb.Message.setProto3StringField(this, 4, value);
 };
 
 

--- a/sdk/proto/go/codegen/mapper.pb.go
+++ b/sdk/proto/go/codegen/mapper.pb.go
@@ -49,7 +49,11 @@ type GetMappingRequest struct {
 	// The ecosystem whose mappings are being requested (e.g. "terraform"). This identifies the source ecosystem
 	// the caller consumes, which is not necessarily the caller's own name -- the hcl converter, for instance,
 	// executes Terraform programs and so requests "terraform" mappings. If left empty, the mapper falls back to
-	// the conversion key it was configured with.
+	// the conversion key it was configured with: most mapper instances (those served to `plugin run` and to
+	// providers and language runtimes) default to "terraform", while `pulumi convert` and `pulumi import` default
+	// it to the source converter's plugin name. Setting this field lets a caller request a specific ecosystem
+	// regardless of that configured default, which is particularly useful for `plugin run` and providers
+	// accessing the mapper.
 	Ecosystem     string `protobuf:"bytes,4,opt,name=ecosystem,proto3" json:"ecosystem,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/sdk/proto/go/codegen/mapper.pb.go
+++ b/sdk/proto/go/codegen/mapper.pb.go
@@ -46,8 +46,13 @@ type GetMappingRequest struct {
 	PulumiProvider string `protobuf:"bytes,2,opt,name=pulumi_provider,json=pulumiProvider,proto3" json:"pulumi_provider,omitempty"`
 	// An optional parameterization that should be used on the named plugin before asking it for mappings.
 	ParameterizationHint *MapperParameterizationHint `protobuf:"bytes,3,opt,name=parameterization_hint,json=parameterizationHint,proto3" json:"parameterization_hint,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// The ecosystem whose mappings are being requested (e.g. "terraform"). This identifies the source ecosystem
+	// the caller consumes, which is not necessarily the caller's own name -- the hcl converter, for instance,
+	// executes Terraform programs and so requests "terraform" mappings. If left empty, the mapper falls back to
+	// the conversion key it was configured with.
+	Ecosystem     string `protobuf:"bytes,4,opt,name=ecosystem,proto3" json:"ecosystem,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetMappingRequest) Reset() {
@@ -99,6 +104,13 @@ func (x *GetMappingRequest) GetParameterizationHint() *MapperParameterizationHin
 		return x.ParameterizationHint
 	}
 	return nil
+}
+
+func (x *GetMappingRequest) GetEcosystem() string {
+	if x != nil {
+		return x.Ecosystem
+	}
+	return ""
 }
 
 // `MapperPackageParameterizationHint` is the type of hints that may be passed to [](codegen.Mapper.GetMapping) when it
@@ -220,11 +232,12 @@ var File_pulumi_codegen_mapper_proto protoreflect.FileDescriptor
 
 const file_pulumi_codegen_mapper_proto_rawDesc = "" +
 	"\n" +
-	"\x1bpulumi/codegen/mapper.proto\x12\acodegen\"\xb2\x01\n" +
+	"\x1bpulumi/codegen/mapper.proto\x12\acodegen\"\xd0\x01\n" +
 	"\x11GetMappingRequest\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12'\n" +
 	"\x0fpulumi_provider\x18\x02 \x01(\tR\x0epulumiProvider\x12X\n" +
-	"\x15parameterization_hint\x18\x03 \x01(\v2#.codegen.MapperParameterizationHintR\x14parameterizationHint\"`\n" +
+	"\x15parameterization_hint\x18\x03 \x01(\v2#.codegen.MapperParameterizationHintR\x14parameterizationHint\x12\x1c\n" +
+	"\tecosystem\x18\x04 \x01(\tR\tecosystem\"`\n" +
 	"\x1aMapperParameterizationHint\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x14\n" +

--- a/sdk/python/lib/pulumi/runtime/proto/codegen/mapper_pb2.py
+++ b/sdk/python/lib/pulumi/runtime/proto/codegen/mapper_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1bpulumi/codegen/mapper.proto\x12\x07\x63odegen\"\x82\x01\n\x11GetMappingRequest\x12\x10\n\x08provider\x18\x01 \x01(\t\x12\x17\n\x0fpulumi_provider\x18\x02 \x01(\t\x12\x42\n\x15parameterization_hint\x18\x03 \x01(\x0b\x32#.codegen.MapperParameterizationHint\"J\n\x1aMapperParameterizationHint\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"\"\n\x12GetMappingResponse\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x32Q\n\x06Mapper\x12G\n\nGetMapping\x12\x1a.codegen.GetMappingRequest\x1a\x1b.codegen.GetMappingResponse\"\x00\x42\x32Z0github.com/pulumi/pulumi/sdk/v3/proto/go/codegenb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1bpulumi/codegen/mapper.proto\x12\x07\x63odegen\"\x95\x01\n\x11GetMappingRequest\x12\x10\n\x08provider\x18\x01 \x01(\t\x12\x17\n\x0fpulumi_provider\x18\x02 \x01(\t\x12\x42\n\x15parameterization_hint\x18\x03 \x01(\x0b\x32#.codegen.MapperParameterizationHint\x12\x11\n\tecosystem\x18\x04 \x01(\t\"J\n\x1aMapperParameterizationHint\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"\"\n\x12GetMappingResponse\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x32Q\n\x06Mapper\x12G\n\nGetMapping\x12\x1a.codegen.GetMappingRequest\x1a\x1b.codegen.GetMappingResponse\"\x00\x42\x32Z0github.com/pulumi/pulumi/sdk/v3/proto/go/codegenb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -22,11 +22,11 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'Z0github.com/pulumi/pulumi/sdk/v3/proto/go/codegen'
   _globals['_GETMAPPINGREQUEST']._serialized_start=41
-  _globals['_GETMAPPINGREQUEST']._serialized_end=171
-  _globals['_MAPPERPARAMETERIZATIONHINT']._serialized_start=173
-  _globals['_MAPPERPARAMETERIZATIONHINT']._serialized_end=247
-  _globals['_GETMAPPINGRESPONSE']._serialized_start=249
-  _globals['_GETMAPPINGRESPONSE']._serialized_end=283
-  _globals['_MAPPER']._serialized_start=285
-  _globals['_MAPPER']._serialized_end=366
+  _globals['_GETMAPPINGREQUEST']._serialized_end=190
+  _globals['_MAPPERPARAMETERIZATIONHINT']._serialized_start=192
+  _globals['_MAPPERPARAMETERIZATIONHINT']._serialized_end=266
+  _globals['_GETMAPPINGRESPONSE']._serialized_start=268
+  _globals['_GETMAPPINGRESPONSE']._serialized_end=302
+  _globals['_MAPPER']._serialized_start=304
+  _globals['_MAPPER']._serialized_end=385
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/lib/pulumi/runtime/proto/codegen/mapper_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/codegen/mapper_pb2.pyi
@@ -32,6 +32,7 @@ class GetMappingRequest(google.protobuf.message.Message):
     PROVIDER_FIELD_NUMBER: builtins.int
     PULUMI_PROVIDER_FIELD_NUMBER: builtins.int
     PARAMETERIZATION_HINT_FIELD_NUMBER: builtins.int
+    ECOSYSTEM_FIELD_NUMBER: builtins.int
     provider: builtins.str
     """The name of the source provider (e.g. the Terraform provider name if a Terraform program is being converted) for
     which a mapping into Pulumi should be returned.
@@ -39,6 +40,12 @@ class GetMappingRequest(google.protobuf.message.Message):
     pulumi_provider: builtins.str
     """The name of the Pulumi plugin that is expected to provide the mapping. If left empty, will be defaulted to the
     source provider name.
+    """
+    ecosystem: builtins.str
+    """The ecosystem whose mappings are being requested (e.g. "terraform"). This identifies the source ecosystem
+    the caller consumes, which is not necessarily the caller's own name -- the hcl converter, for instance,
+    executes Terraform programs and so requests "terraform" mappings. If left empty, the mapper falls back to
+    the conversion key it was configured with.
     """
     @property
     def parameterization_hint(self) -> global___MapperParameterizationHint:
@@ -50,9 +57,10 @@ class GetMappingRequest(google.protobuf.message.Message):
         provider: builtins.str = ...,
         pulumi_provider: builtins.str = ...,
         parameterization_hint: global___MapperParameterizationHint | None = ...,
+        ecosystem: builtins.str = ...,
     ) -> None: ...
     def HasField(self, field_name: typing.Literal["parameterization_hint", b"parameterization_hint"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing.Literal["parameterization_hint", b"parameterization_hint", "provider", b"provider", "pulumi_provider", b"pulumi_provider"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["ecosystem", b"ecosystem", "parameterization_hint", b"parameterization_hint", "provider", b"provider", "pulumi_provider", b"pulumi_provider"]) -> None: ...
 
 global___GetMappingRequest = GetMappingRequest
 

--- a/sdk/python/lib/pulumi/runtime/proto/codegen/mapper_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/codegen/mapper_pb2.pyi
@@ -45,7 +45,11 @@ class GetMappingRequest(google.protobuf.message.Message):
     """The ecosystem whose mappings are being requested (e.g. "terraform"). This identifies the source ecosystem
     the caller consumes, which is not necessarily the caller's own name -- the hcl converter, for instance,
     executes Terraform programs and so requests "terraform" mappings. If left empty, the mapper falls back to
-    the conversion key it was configured with.
+    the conversion key it was configured with: most mapper instances (those served to `plugin run` and to
+    providers and language runtimes) default to "terraform", while `pulumi convert` and `pulumi import` default
+    it to the source converter's plugin name. Setting this field lets a caller request a specific ecosystem
+    regardless of that configured default, which is particularly useful for `plugin run` and providers
+    accessing the mapper.
     """
     @property
     def parameterization_hint(self) -> global___MapperParameterizationHint:


### PR DESCRIPTION
We want `import --from hcl` to do state import without favouring static bridging. #23803 was the first attempt, but @Frassle suggested this: we allow providers to specify the ecosystem they care about. This means that `hcl` can say it cares about `terraform`, rather than us assuming it cares about `hcl` and finding no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)