### PR TITLE
do: align prompting with up/destroy

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -20,9 +20,9 @@ import (
 	"os"
 
 	survey "github.com/AlecAivazis/survey/v2"
-	surveycore "github.com/AlecAivazis/survey/v2/core"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	sdkDisplay "github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -179,13 +179,6 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 ) (*deploy.Plan, error) {
 	for {
 		opts := op.Opts
-		var response string
-
-		surveycore.DisableColor = true
-		surveyIcons := survey.WithIcons(func(icons *survey.IconSet) {
-			icons.Question = survey.Icon{}
-			icons.SelectFocus = survey.Icon{Text: opts.Display.Color.Colorize(colors.BrightGreen + ">" + colors.Reset)}
-		})
 
 		choices := []string{string(yes), string(no)}
 
@@ -208,23 +201,15 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 		}
 
 		// Create a prompt. If this is a refresh, we'll add some extra text so it's clear we aren't updating resources.
-		prompt := "\b" + opts.Display.Color.Colorize(
-			colors.SpecPrompt+fmt.Sprintf("Do you want to perform this %s%s?",
-				updateTextMap[kind].previewText, previewWarning)+colors.Reset)
+		prompt := fmt.Sprintf("Do you want to perform this %s%s?", updateTextMap[kind].previewText, previewWarning)
 		if kind == apitype.RefreshUpdate {
-			prompt += "\n" +
-				opts.Display.Color.Colorize(colors.SpecImportant+
-					"No resources will be modified as part of this refresh; just your stack's state will be.\n"+
-					colors.Reset)
+			prompt += colors.Reset + "\n" + colors.SpecImportant +
+				"No resources will be modified as part of this refresh; just your stack's state will be.\n"
 		}
 
 		// Now prompt the user for a yes, no, or details, and then proceed accordingly.
-		allAskOpts := append([]survey.AskOpt{surveyIcons}, askOpts...)
-		if err := survey.AskOne(&survey.Select{
-			Message: prompt,
-			Options: choices,
-			Default: string(no),
-		}, &response, allAskOpts...); err != nil {
+		response, err := ui.PromptUserErr(prompt, choices, string(no), opts.Display.Color, askOpts...)
+		if err != nil {
 			return nil, fmt.Errorf("confirmation cancelled, not proceeding with the %s: %w", kind, err)
 		}
 

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -149,8 +149,7 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 			if err != nil {
 				return err
 			}
-			// Create doesn't have an ID yet, so require the user to type "yes" — same pattern as `plugin rm`.
-			if err := pc.confirm(cmd, summary, "yes", yes); err != nil {
+			if err := pc.confirm(cmd, summary, "create", yes); err != nil {
 				return err
 			}
 			response, err := pc.provider.Create(ctx, plugin.CreateRequest{
@@ -279,8 +278,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			}
 			summary := formatPatchSummary(
 				res, id, oldInputs, checked, diff, pc.showSecrets, cmdutil.GetGlobalColorization())
-			// Require the user to type the resource ID — same pattern as `stack rm` requiring the stack name.
-			if err := pc.confirm(cmd, summary, string(id), yes); err != nil {
+			if err := pc.confirm(cmd, summary, "patch", yes); err != nil {
 				return err
 			}
 
@@ -327,8 +325,7 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			}
 			urn := resourceURN(res)
 			id := resource.ID(args[0])
-			// Require the user to type the resource ID — same pattern as `stack rm` requiring the stack name.
-			if err := pc.confirm(cmd, formatDeleteSummary(res, id), string(id), yes); err != nil {
+			if err := pc.confirm(cmd, formatDeleteSummary(res, id), "delete", yes); err != nil {
 				return err
 			}
 			_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -738,7 +738,8 @@ func (pc *packageCommand) requireYesIfNonInteractive(yes bool) error {
 // confirm prints summary and asks the user whether to proceed, using the same yes/no chooser as `pulumi up`
 // and `pulumi destroy`. operation names the operation in the prompt (e.g. "create"). The summary and prompt
 // go to stderr so that stdout stays a clean JSON channel for piping. Returns nil to proceed; a bail error
-// (suppressed by the outer CLI) when the user declines. requireYesIfNonInteractive should have been called
+// (suppressed by the outer CLI) when the user declines; a real error when the prompt is cancelled (e.g.
+// Ctrl-C), matching up/destroy. requireYesIfNonInteractive should have been called
 // earlier; if we somehow reach here non-interactively without --yes we treat it as a decline.
 func (pc *packageCommand) confirm(cmd *cobra.Command, summary, operation string, yes bool) error {
 	stderr := cmd.ErrOrStderr()

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"unicode"
 
+	survey "github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
@@ -733,12 +735,12 @@ func (pc *packageCommand) requireYesIfNonInteractive(yes bool) error {
 	return nil
 }
 
-// confirm prints summary and asks the user to type confirmName to proceed. The summary and prompt go to stderr so
-// that stdout stays a clean JSON channel for piping. Returns nil to proceed; a bail error (suppressed by the
-// outer CLI) when the user declines. requireYesIfNonInteractive should have been called earlier; if we somehow
-// reach here non-interactively without --yes we treat it as a decline. Uses ui.ConfirmPrompt for the prompt
-// itself so the look and feel matches stack rm and friends.
-func (pc *packageCommand) confirm(cmd *cobra.Command, summary, confirmName string, yes bool) error {
+// confirm prints summary and asks the user whether to proceed, using the same yes/no chooser as `pulumi up`
+// and `pulumi destroy`. operation names the operation in the prompt (e.g. "create"). The summary and prompt
+// go to stderr so that stdout stays a clean JSON channel for piping. Returns nil to proceed; a bail error
+// (suppressed by the outer CLI) when the user declines. requireYesIfNonInteractive should have been called
+// earlier; if we somehow reach here non-interactively without --yes we treat it as a decline.
+func (pc *packageCommand) confirm(cmd *cobra.Command, summary, operation string, yes bool) error {
 	stderr := cmd.ErrOrStderr()
 	fmt.Fprint(stderr, summary)
 	if !strings.HasSuffix(summary, "\n") {
@@ -750,12 +752,22 @@ func (pc *packageCommand) confirm(cmd *cobra.Command, summary, confirmName strin
 	if !cmdutil.Interactive() {
 		return backenderr.ErrNonInteractiveRequiresYes
 	}
-	opts := display.Options{
-		Color:  cmdutil.GetGlobalColorization(),
-		Stdin:  cmd.InOrStdin(),
-		Stdout: stderr,
+	// Route the prompt to stderr so stdout stays a clean JSON channel. survey needs file-backed
+	// streams for terminal control, so fall back to its defaults when the command's streams have
+	// been replaced with plain buffers.
+	var askOpts []survey.AskOpt
+	in, inOK := cmd.InOrStdin().(terminal.FileReader)
+	out, outOK := stderr.(terminal.FileWriter)
+	if inOK && outOK {
+		askOpts = append(askOpts, survey.WithStdio(in, out, out))
 	}
-	if !ui.ConfirmPrompt("", confirmName, opts) {
+	response := ui.PromptUser(
+		fmt.Sprintf("Do you want to perform this %s?", operation),
+		[]string{"yes", "no"},
+		"no",
+		cmdutil.GetGlobalColorization(),
+		askOpts...)
+	if response != "yes" {
 		return result.FprintBailf(stderr, "confirmation declined")
 	}
 	return nil

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -183,6 +183,22 @@ func PromptUser(
 	colorization colors.Colorization,
 	surveyAskOpts ...survey.AskOpt,
 ) string {
+	response, err := PromptUserErr(msg, options, defaultOption, colorization, surveyAskOpts...)
+	if err != nil {
+		return ""
+	}
+	return response
+}
+
+// PromptUserErr is like PromptUser but returns the survey error (for example the user pressing
+// Ctrl-C) instead of swallowing it, so callers can distinguish cancellation from a chosen option.
+func PromptUserErr(
+	msg string,
+	options []string,
+	defaultOption string,
+	colorization colors.Colorization,
+	surveyAskOpts ...survey.AskOpt,
+) (string, error) {
 	prompt := "\b" + colorization.Colorize(colors.SpecPrompt+msg+colors.Reset)
 	disableSurveyColorOnce()
 
@@ -200,9 +216,9 @@ func PromptUser(
 		Options: options,
 		Default: defaultOption,
 	}, &response, allSurveyAskOpts...); err != nil {
-		return ""
+		return "", err
 	}
-	return response
+	return response, nil
 }
 
 // PromptUserMultiSkippable wraps over promptUserMulti making it skippable through the "yes" parameter


### PR DESCRIPTION
In `pulumi up` and `pulumi destroy` we just ask a yes or no question,
whether the user wants to do the operation.  `pulumi do` feels like it
should be at a similar level of scrutiny as those, so implement the
same yes/no prompting, instead of making the user type out "yes".