### PR TITLE
Upgrade Node.js SDK OpenTelemetry deps to 2.x (CVE-2026-54285)

### DIFF
--- a/changelog/pending/sdk-nodejs-upgrade-otel-2x.yaml
+++ b/changelog/pending/sdk-nodejs-upgrade-otel-2x.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: fix
+body: Upgrade OpenTelemetry dependencies to 2.x to address CVE-2026-54285
+time: 2026-07-07T00:00:00.000000+00:00
+custom:
+    PR: "23806"

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -322,7 +322,7 @@ export class LocalWorkspace implements Workspace {
                     loadProjectSettings(wsOpts.workDir);
                 } catch (e) {
                     // If it failed to find the project settings file, set a default project.
-                    if (e.toString().includes("failed to find project settings")) {
+                    if ((e as Error).toString().includes("failed to find project settings")) {
                         wsOpts.projectSettings = defaultProject(args.projectName);
                     } else {
                         throw e;

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -99,7 +99,7 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
                     process.off("uncaughtException", uncaughtHandler);
                     process.off("unhandledRejection", uncaughtHandler);
 
-                    if (!isGrpcError(e)) {
+                    if (!isGrpcError(e as Error)) {
                         throw e;
                     }
                 }

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -177,7 +177,7 @@ export class Stack {
                 log.warn(`Failed to parse engine event
 If you're seeing this warning, please comment on https://github.com/pulumi/pulumi/issues/6768 with the event and any
 details about your environment.
-Event: ${line}\n${e.toString()}`);
+Event: ${line}\n${(e as Error).toString()}`);
             }
         });
 
@@ -2370,7 +2370,7 @@ class EventsServer implements eventsrpc.IEventsServer {
                 const event: EngineEvent = JSON.parse(eventStr);
                 this.onEvent(event);
             } catch (e) {
-                log.warn(`Failed to parse engine event: ${e.toString()}`);
+                log.warn(`Failed to parse engine event: ${(e as Error).toString()}`);
             }
         });
 

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -177,7 +177,7 @@ class ResourceProviderService implements provrpc.IResourceProviderServer {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -229,7 +229,7 @@ class ResourceProviderService implements provrpc.IResourceProviderServer {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -258,7 +258,7 @@ class ResourceProviderService implements provrpc.IResourceProviderServer {
 
             callback(undefined, resp);
         } catch (e) {
-            const response = grpcResponseFromError(e);
+            const response = grpcResponseFromError(e as { id: string; properties: any; message: string; reasons?: string[] });
             return callback(/*err:*/ response, /*value:*/ null, /*metadata:*/ response.metadata);
         }
     }
@@ -293,7 +293,7 @@ class ResourceProviderService implements provrpc.IResourceProviderServer {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -324,7 +324,7 @@ class ResourceProviderService implements provrpc.IResourceProviderServer {
 
             callback(undefined, resp);
         } catch (e) {
-            const response = grpcResponseFromError(e);
+            const response = grpcResponseFromError(e as { id: string; properties: any; message: string; reasons?: string[] });
             return callback(/*err:*/ response, /*value:*/ null, /*metadata:*/ response.metadata);
         }
     }
@@ -339,7 +339,7 @@ class ResourceProviderService implements provrpc.IResourceProviderServer {
             }
             callback(undefined, new emptyproto.Empty());
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }

--- a/sdk/nodejs/cmd/run/error.ts
+++ b/sdk/nodejs/cmd/run/error.ts
@@ -53,7 +53,7 @@ export function defaultErrorMessage(err: any): string {
         try {
             return util.inspect(err);
         } catch (error) {
-            return `an error occurred while inspecting an error: ${error.message}`;
+            return `an error occurred while inspecting an error: ${(error as Error).message}`;
         }
     }
 }

--- a/sdk/nodejs/cmd/run/instrumentation.ts
+++ b/sdk/nodejs/cmd/run/instrumentation.ts
@@ -29,12 +29,12 @@ if (process.env.TRACEPARENT) {
     const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
     const { W3CTraceContextPropagator } = require("@opentelemetry/core");
     const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
-    const { Resource } = require("@opentelemetry/resources");
+    const { defaultResource, resourceFromAttributes } = require("@opentelemetry/resources");
     const { ATTR_SERVICE_NAME } = require("@opentelemetry/semantic-conventions");
 
     const provider = new NodeTracerProvider({
-        resource: Resource.default().merge(
-            new Resource({
+        resource: defaultResource().merge(
+            resourceFromAttributes({
                 [ATTR_SERVICE_NAME]: "pulumi-sdk-nodejs",
             }),
         ),

--- a/sdk/nodejs/cmd/run/tracing.ts
+++ b/sdk/nodejs/cmd/run/tracing.ts
@@ -15,7 +15,7 @@
 
 import * as packageJson from "../../package.json";
 import * as opentelemetry from "@opentelemetry/api";
-import { Resource } from "@opentelemetry/resources";
+import { defaultResource, resourceFromAttributes } from "@opentelemetry/resources";
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { ZipkinExporter } from "@opentelemetry/exporter-zipkin";
 import { GrpcInstrumentation } from "@opentelemetry/instrumentation-grpc";
@@ -65,8 +65,8 @@ export function start(destinationUrl: string) {
     });
 
     // Tag traces from this program with metadata about their source.
-    const resource = Resource.default().merge(
-        new Resource({
+    const resource = defaultResource().merge(
+        resourceFromAttributes({
             [ATTR_SERVICE_NAME]: serviceName,
             [ATTR_SERVICE_VERSION]: packageJson.version,
         }),
@@ -84,15 +84,15 @@ export function start(destinationUrl: string) {
      * registered here.
      */
 
-    // Create a new tracer provider, acting as a factory for tracers.
-    const provider = new NodeTracerProvider({
-        resource: resource,
-    });
-
     // Configure span processor to send spans to the exporter
     log.debug(`Registering tracing url: ${destinationUrl}`);
     exporter = new ZipkinExporter({ url: destinationUrl, serviceName });
-    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+
+    // Create a new tracer provider, acting as a factory for tracers.
+    const provider = new NodeTracerProvider({
+        resource: resource,
+        spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
 
     provider.register();
     const tracer = opentelemetry.trace.getTracer("nodejs-runtime");

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -288,7 +288,7 @@ See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.`;
         };
 
         return new Proxy(this, {
-            get: (obj, prop: keyof T) => {
+            get: (obj, prop: string | symbol) => {
                 // Recreate the prototype walk to ensure we find any actual members defined directly
                 // on `Output<T>`.
                 for (let o = obj; o; o = Object.getPrototypeOf(o)) {

--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -1,25 +1,25 @@
 {
     "name": "@pulumi/pulumi",
-    "version": "3.249.0",
+    "version": "3.251.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pulumi/pulumi",
-            "version": "3.249.0",
+            "version": "3.251.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
                 "@logdna/tail-file": "^2.0.6",
                 "@npmcli/arborist": "^9.0.0",
                 "@opentelemetry/api": "^1.9",
-                "@opentelemetry/exporter-trace-otlp-grpc": "^0.57",
-                "@opentelemetry/exporter-zipkin": "^1.30",
-                "@opentelemetry/instrumentation": "^0.57",
-                "@opentelemetry/instrumentation-grpc": "^0.57",
-                "@opentelemetry/resources": "^1.30",
-                "@opentelemetry/sdk-trace-base": "^1.30",
-                "@opentelemetry/sdk-trace-node": "^1.30",
+                "@opentelemetry/exporter-trace-otlp-grpc": "^0.220",
+                "@opentelemetry/exporter-zipkin": "^2.9",
+                "@opentelemetry/instrumentation": "^0.220",
+                "@opentelemetry/instrumentation-grpc": "^0.220",
+                "@opentelemetry/resources": "^2.9",
+                "@opentelemetry/sdk-trace-base": "^2.9",
+                "@opentelemetry/sdk-trace-node": "^2.9",
                 "@types/google-protobuf": "^3.15.5",
                 "@types/semver": "^7.5.6",
                 "execa": "^5.1.0",
@@ -51,7 +51,7 @@
                 "nyc": "15.1.0",
                 "ts-node": "7.0.1",
                 "tsx": "4.19.3",
-                "typescript": "3.8.3"
+                "typescript": "^5.9.3"
             },
             "engines": {
                 "node": ">=22"
@@ -1865,294 +1865,274 @@
             }
         },
         "node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+            "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=8.0.0"
             }
         },
         "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-            "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
+            "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/core": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-            "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+            "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
-            "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.220.0.tgz",
+            "integrity": "sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1"
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/sdk-trace": "2.9.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-zipkin": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.30.1.tgz",
-            "integrity": "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.9.0.tgz",
+            "integrity": "sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.0.0"
             }
         },
         "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+            "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
+                "@opentelemetry/api-logs": "0.220.0",
+                "import-in-the-middle": "^3.0.0",
+                "require-in-the-middle": "^8.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/instrumentation-grpc": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.2.tgz",
-            "integrity": "sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.220.0.tgz",
+            "integrity": "sha512-U1EF8KKu52XwH2ybUkjVDmaVQZGf3mXirRSw1KJQrOV5aymgJgkPJV7+kRPqawZe0rpVc/BK+pPSyMWuQoyJJQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "0.57.2",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/instrumentation": "0.220.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/otlp-exporter-base": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
-            "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+            "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-transformer": "0.57.2"
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-transformer": "0.220.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
-            "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.220.0.tgz",
+            "integrity": "sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2"
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/otlp-transformer": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
-            "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+            "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-logs": "0.57.2",
-                "@opentelemetry/sdk-metrics": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
-                "protobufjs": "^7.3.0"
+                "@opentelemetry/api-logs": "0.220.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-logs": "0.220.0",
+                "@opentelemetry/sdk-metrics": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/propagator-b3": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
-            "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/propagator-jaeger": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
-            "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/resources": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+            "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
-            "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+            "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1"
+                "@opentelemetry/api-logs": "0.220.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.4.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-metrics": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-            "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+            "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1"
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+            "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+            "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-trace-node": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
-            "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
+            "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/context-async-hooks": "1.30.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/propagator-b3": "1.30.1",
-                "@opentelemetry/propagator-jaeger": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
-                "semver": "^7.5.2"
+                "@opentelemetry/context-async-hooks": "2.9.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/sdk-trace-base": "2.9.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.42.0.tgz",
+            "integrity": "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -2394,12 +2374,6 @@
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-            "license": "MIT"
-        },
-        "node_modules/@types/shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3170,9 +3144,9 @@
             }
         },
         "node_modules/cjs-module-lexer": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+            "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
             "license": "MIT"
         },
         "node_modules/clean-stack": {
@@ -3656,10 +3630,17 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
@@ -4542,6 +4523,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4930,6 +4912,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -5065,36 +5048,17 @@
             }
         },
         "node_modules/import-in-the-middle": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.0.tgz",
+            "integrity": "sha512-v4+k+PLt4z6g2ydEcXhfinTJxfgKJDWOW0v0GZNA5n2qToHFObpH4nGLhJdwnXnX4T14oREx/M62dS9GkpmSbQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "acorn": "^8.14.0",
-                "acorn-import-attributes": "^1.9.5",
-                "cjs-module-lexer": "^1.2.2",
-                "module-details-from-path": "^1.0.3"
-            }
-        },
-        "node_modules/import-in-the-middle/node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
+                "cjs-module-lexer": "^2.2.0",
+                "es-module-lexer": "^2.2.0",
+                "module-details-from-path": "^1.0.4"
             },
             "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/import-in-the-middle/node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": "^8"
+                "node": ">=18"
             }
         },
         "node_modules/imurmurhash": {
@@ -5257,6 +5221,7 @@
             "version": "2.16.2",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
             "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.3"
@@ -7317,6 +7282,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-scurry": {
@@ -7701,38 +7667,16 @@
             }
         },
         "node_modules/require-in-the-middle": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+            "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.5",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.22.8"
+                "module-details-from-path": "^1.0.3"
             },
             "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/require-in-the-middle/node_modules/resolve": {
-            "version": "1.22.12",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=9.3.0 || >=8.10.0 <9.0.0"
             }
         },
         "node_modules/require-main-filename": {
@@ -8072,12 +8016,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-            "license": "BSD-2-Clause"
         },
         "node_modules/side-channel": {
             "version": "1.1.1",
@@ -8544,6 +8482,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -8963,9 +8902,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8973,7 +8912,7 @@
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,13 +13,13 @@
         "@logdna/tail-file": "^2.0.6",
         "@npmcli/arborist": "^9.0.0",
         "@opentelemetry/api": "^1.9",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.57",
-        "@opentelemetry/exporter-zipkin": "^1.30",
-        "@opentelemetry/instrumentation": "^0.57",
-        "@opentelemetry/instrumentation-grpc": "^0.57",
-        "@opentelemetry/resources": "^1.30",
-        "@opentelemetry/sdk-trace-base": "^1.30",
-        "@opentelemetry/sdk-trace-node": "^1.30",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.220",
+        "@opentelemetry/exporter-zipkin": "^2.9",
+        "@opentelemetry/instrumentation": "^0.220",
+        "@opentelemetry/instrumentation-grpc": "^0.220",
+        "@opentelemetry/resources": "^2.9",
+        "@opentelemetry/sdk-trace-base": "^2.9",
+        "@opentelemetry/sdk-trace-node": "^2.9",
         "@types/google-protobuf": "^3.15.5",
         "@types/semver": "^7.5.6",
         "execa": "^5.1.0",
@@ -51,11 +51,11 @@
         "nyc": "15.1.0",
         "ts-node": "7.0.1",
         "tsx": "4.19.3",
-        "typescript": "3.8.3"
+        "typescript": "^5.9.3"
     },
     "peerDependencies": {
         "ts-node": ">= 7.0.1 < 12",
-        "typescript": ">= 3.8.3 < 7"
+        "typescript": ">= 5.0.4 < 7"
     },
     "peerDependenciesMeta": {
         "typescript": {
@@ -72,8 +72,14 @@
         "node": ">=22"
     },
     "mocha": {
-        "require": ["source-map-support/register"],
-        "node-option": ["import=tsx"]
+        "require": [
+            "source-map-support/register"
+        ],
+        "node-option": [
+            "import=tsx"
+        ]
     },
-    "//": ["NOTE: @types/node is pinned due to grpc/grpc-node#2002"]
+    "//": [
+        "NOTE: @types/node is pinned due to grpc/grpc-node#2002"
+    ]
 }

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -403,14 +403,14 @@ Please ensure these components are properly imported to your package's entry poi
     ): PropertyDefinition {
         // Check if the property is optional, e.g.: myProp?: string; This is
         // defined on the symbol, not the type.
-        const propType = this.checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration);
+        const propType = this.checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration!);
         const optional = isOptional(symbol);
         const dNode = symbol.valueDeclaration as docNode;
         let docString: string | undefined = undefined;
         if (dNode?.jsDoc && dNode.jsDoc.length > 0) {
             docString = dNode.jsDoc.map((doc: typescript.JSDoc) => doc.comment).join("\n");
         }
-        return this.analyzeType({ ...context }, propType, symbol.valueDeclaration, optional, docString);
+        return this.analyzeType({ ...context }, propType, symbol.valueDeclaration!, optional, docString);
     }
 
     private analyzeType(

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -217,7 +217,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -250,7 +250,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -271,7 +271,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
             callback(undefined, resp);
         } catch (e) {
-            const response = grpcResponseFromError(e);
+            const response = grpcResponseFromError(e as { id: string; properties: any; message: string; reasons?: string[] });
             return callback(/*err:*/ response, /*value:*/ null, /*metadata:*/ response.metadata);
         }
     }
@@ -298,7 +298,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -327,7 +327,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
             callback(undefined, resp);
         } catch (e) {
-            const response = grpcResponseFromError(e);
+            const response = grpcResponseFromError(e as { id: string; properties: any; message: string; reasons?: string[] });
             return callback(/*err:*/ response, /*value:*/ null, /*metadata:*/ response.metadata);
         }
     }
@@ -341,7 +341,7 @@ class Server implements grpc.UntypedServiceImplementation {
             }
             callback(undefined, new emptyproto.Empty());
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }
@@ -595,7 +595,7 @@ class Server implements grpc.UntypedServiceImplementation {
 
             callback(undefined, resp);
         } catch (e) {
-            console.error(`${e}: ${e.stack}`);
+            console.error(`${e}: ${(e as Error).stack}`);
             callback(e, undefined);
         }
     }

--- a/sdk/nodejs/runtime/asyncIterableUtil.ts
+++ b/sdk/nodejs/runtime/asyncIterableUtil.ts
@@ -71,7 +71,7 @@ export class PushableAsyncIterable<T> implements AsyncIterable<T | undefined> {
                 }
                 this.nextQueue.push(resolve);
             } else {
-                resolve(this.bufferedData.shift());
+                resolve(this.bufferedData.shift()!);
             }
         });
     }

--- a/sdk/nodejs/runtime/callbacks.ts
+++ b/sdk/nodejs/runtime/callbacks.ts
@@ -454,7 +454,7 @@ export class CallbackServer implements ICallbackServer {
         this.registerTransform(transform)
             .then(
                 (req) => {
-                    return new Promise((resolve, reject) => {
+                    return new Promise<void>((resolve, reject) => {
                         this._monitor.registerStackTransform(req, (err, _) => {
                             if (err !== null) {
                                 // Remove this from the list of callbacks given we didn't manage to actually register it.
@@ -551,7 +551,7 @@ export class CallbackServer implements ICallbackServer {
         this.registerStackInvokeTransformAsync(transform)
             .then(
                 (req) => {
-                    return new Promise((resolve, reject) => {
+                    return new Promise<void>((resolve, reject) => {
                         this._monitor.registerStackInvokeTransform(req, (err, _) => {
                             if (err !== null) {
                                 // Remove this from the list of callbacks given we didn't manage to actually register it.
@@ -605,7 +605,7 @@ export class CallbackServer implements ICallbackServer {
                 });
             } catch (error) {
                 const response = new resproto.ResourceHookResponse();
-                response.setError(error.message);
+                response.setError((error as Error).message);
                 return response;
             }
             return new resproto.ResourceHookResponse();
@@ -670,7 +670,7 @@ export class CallbackServer implements ICallbackServer {
                 return response;
             } catch (error) {
                 const response = new resproto.ErrorHookResponse();
-                response.setError(error.message);
+                response.setError((error as Error).message);
                 return response;
             }
         };

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -584,7 +584,7 @@ async function analyzeFunctionInfoAsync(
                     capturedValues.set(name, { entry: value });
                 }
             } catch (err) {
-                throwSerializationError(func, context, err.message);
+                throwSerializationError(func, context, (err as Error).message);
             }
         }
 
@@ -727,7 +727,7 @@ async function analyzeFunctionInfoAsync(
                 try {
                     value = await v8.lookupCapturedVariableValueAsync(func, name, throwOnFailure);
                 } catch (err) {
-                    throwSerializationError(func, context, err.message);
+                    throwSerializationError(func, context, (err as Error).message);
                 }
 
                 const moduleName = await findNormalizedModuleNameAsync(value);

--- a/sdk/nodejs/runtime/closure/rewriteSuper.ts
+++ b/sdk/nodejs/runtime/closure/rewriteSuper.ts
@@ -18,13 +18,23 @@ import * as semver from "semver";
 import * as utils from "./utils";
 
 type Factory = {
-    createIdentifier: typeof typescript.createIdentifier;
-    createThis: typeof typescript.createThis;
-    createPropertyAccessExpression: typeof typescript.createPropertyAccess;
-    updatePropertyAccessExpression: typeof typescript.updatePropertyAccess;
-    updateFunctionDeclaration: typeof typescript.updateFunctionDeclaration;
-    updateElementAccessExpression: typeof typescript.updateElementAccess;
-    updateCallExpression: typeof typescript.updateCall;
+    createIdentifier: (text: string) => typescript.Identifier;
+    createThis: () => typescript.ThisExpression;
+    createPropertyAccessExpression: (expression: typescript.Expression, name: string | typescript.MemberName) => typescript.PropertyAccessExpression;
+    updatePropertyAccessExpression: (node: typescript.PropertyAccessExpression, expression: typescript.Expression, name: typescript.MemberName) => typescript.PropertyAccessExpression;
+    updateFunctionDeclaration: (
+        node: typescript.FunctionDeclaration,
+        decorators: readonly typescript.Decorator[] | undefined,
+        modifiers: readonly typescript.Modifier[] | undefined,
+        asteriskToken: typescript.AsteriskToken | undefined,
+        name: typescript.Identifier | undefined,
+        typeParameters: readonly typescript.TypeParameterDeclaration[] | undefined,
+        parameters: readonly typescript.ParameterDeclaration[],
+        type: typescript.TypeNode | undefined,
+        body: typescript.Block | undefined,
+    ) => typescript.FunctionDeclaration;
+    updateElementAccessExpression: (node: typescript.ElementAccessExpression, expression: typescript.Expression, argumentExpression: typescript.Expression) => typescript.ElementAccessExpression;
+    updateCallExpression: (node: typescript.CallExpression, expression: typescript.Expression, typeArguments: readonly typescript.TypeNode[] | undefined, argumentsArray: readonly typescript.Expression[]) => typescript.CallExpression;
 };
 
 // TypeScript 4.0 moved the factory functions to the transformationContext
@@ -51,7 +61,7 @@ function getFactory(transformationContext: typescript.TransformationContext): Fa
         body: typescript.Block | undefined,
     ): typescript.FunctionDeclaration {
         if (tsLessThan4) {
-            return ts.updateFunctionDeclaration(
+            return (ts as any).updateFunctionDeclaration(
                 node,
                 decorators,
                 modifiers,
@@ -89,19 +99,19 @@ function getFactory(transformationContext: typescript.TransformationContext): Fa
     }
 
     return {
-        createIdentifier: tsLessThan4 ? ts.createIdentifier : transformationContextFactory.createIdentifier,
-        createThis: tsLessThan4 ? ts.createThis : transformationContextFactory.createThis,
+        createIdentifier: tsLessThan4 ? (ts as any).createIdentifier : transformationContextFactory.createIdentifier,
+        createThis: tsLessThan4 ? (ts as any).createThis : transformationContextFactory.createThis,
         createPropertyAccessExpression: tsLessThan4
-            ? ts.createPropertyAccess
+            ? (ts as any).createPropertyAccess
             : transformationContextFactory.createPropertyAccessExpression,
         updatePropertyAccessExpression: tsLessThan4
-            ? ts.updatePropertyAccess
+            ? (ts as any).updatePropertyAccess
             : transformationContextFactory.updatePropertyAccessExpression,
         updateFunctionDeclaration,
         updateElementAccessExpression: tsLessThan4
-            ? ts.updateElementAccess
+            ? (ts as any).updateElementAccess
             : transformationContextFactory.updateElementAccessExpression,
-        updateCallExpression: tsLessThan4 ? ts.updateCall : transformationContextFactory.updateCallExpression,
+        updateCallExpression: tsLessThan4 ? (ts as any).updateCall : transformationContextFactory.updateCallExpression,
     };
 }
 
@@ -143,8 +153,8 @@ export function rewriteSuperReferences(code: string, isStatic: boolean): string 
                 const text = utils.isLegalMemberName(funcDecl.name!.text) ? "/*" + funcDecl.name!.text + "*/" : "";
                 return factory.updateFunctionDeclaration(
                     funcDecl,
-                    funcDecl.decorators,
-                    funcDecl.modifiers,
+                    (funcDecl as any).decorators,
+                    funcDecl.modifiers as readonly typescript.Modifier[] | undefined,
                     funcDecl.asteriskToken,
                     factory.createIdentifier(text),
                     funcDecl.typeParameters,

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -291,7 +291,7 @@ export function getResource(
                             };
                         }
                     } catch (e) {
-                        err = e;
+                        err = e as Error;
                         resp = {
                             urn: "",
                             id: undefined,
@@ -435,7 +435,7 @@ export function readResource(
                             };
                         }
                     } catch (e) {
-                        err = e;
+                        err = e as Error;
                         resp = {
                             getUrn: () => "",
                             getProperties: () => undefined,
@@ -767,7 +767,7 @@ export function registerResource(
                             };
                         }
                     } catch (e) {
-                        err = e;
+                        err = e as Error;
                         resp = {
                             getUrn: () => "",
                             getId: () => undefined,

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -307,7 +307,7 @@ export function resolveProperties(
             resolve(value, /*isKnown*/ true, isSecret, deps[k]);
         } catch (resolveError) {
             throw new Error(
-                `Unable to set property '${k}' on resource '${name}' [${t}]; error: ${errorString(resolveError)}`,
+                `Unable to set property '${k}' on resource '${name}' [${t}]; error: ${errorString(resolveError as Error)}`,
             );
         }
     }

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -74,7 +74,7 @@ describe("LocalWorkspace", () => {
             assert.fail("expected create with invalid workDir to throw");
         } catch (err) {
             assert.strictEqual(
-                err.toString(),
+                (err as Error).toString(),
                 "Error: Invalid workDir passed to local workspace: 'invalid-missing-workdir' does not exist",
             );
         }
@@ -1073,8 +1073,8 @@ describe("LocalWorkspace", () => {
                     });
                     assert.fail("expected canceled preview to throw");
                 } catch (err) {
-                    assert.match(err.toString(), /stderr: Command was killed with SIGINT|error: preview canceled/);
-                    assert.match(err.toString(), /CommandError: code: -2/);
+                    assert.match((err as Error).toString(), /stderr: Command was killed with SIGINT|error: preview canceled/);
+                    assert.match((err as Error).toString(), /CommandError: code: -2/);
                 }
                 clearTimeout(timeout);
             },

--- a/sdk/nodejs/tests/unwrap.spec.ts
+++ b/sdk/nodejs/tests/unwrap.spec.ts
@@ -160,13 +160,13 @@ describe("unwrap", () => {
     function createOutput<T>(cv: T, ...resources: TestResource[]): Output<T> {
         return Output.isInstance<T>(cv)
             ? cv
-            : new Output(
+            : (new Output(
                   <any>new Set(resources),
                   Promise.resolve(cv),
                   Promise.resolve(true),
                   Promise.resolve(false),
                   Promise.resolve(<any>new Set(resources)),
-              );
+              ) as unknown as Output<T>);
     }
 
     describe("preserves resources", () => {

--- a/sdk/nodejs/tests/util.ts
+++ b/sdk/nodejs/tests/util.ts
@@ -32,7 +32,7 @@ export function asyncTest(test: () => Promise<void>): (func: MochaFunc) => void 
             try {
                 await test();
             } catch (err) {
-                caught = err;
+                caught = err as Error;
             } finally {
                 done(caught);
             }
@@ -50,7 +50,7 @@ export async function assertAsyncThrows(test: () => Promise<void>): Promise<stri
     try {
         await test();
     } catch (err) {
-        return err.message;
+        return (err as Error).message;
     }
 
     assert(false, "Function was expected to throw, but didn't");


### PR DESCRIPTION
Upgrades `@opentelemetry/{resources,sdk-trace-base,sdk-trace-node,exporter-zipkin}` from `^1.30` to `^2.9` and `{instrumentation,instrumentation-grpc,exporter-trace-otlp-grpc}` to `^0.220`, fixing CVE-2026-54285 (unbounded memory in W3C Baggage propagation).

**Breaking change:** bumps TypeScript peer dependency minimum from `>=3.8.3` to `>=5.0.4`. otel 2.x `.d.ts` files use labeled tuple syntax and `import { type }` which require TS 5.0.4+. The devDependency is updated to `^5.9.3`.

**API changes in `tracing.ts` and `instrumentation.ts`:** `Resource.default()` / `new Resource()` removed in otel 2.x; replaced with `defaultResource()` / `resourceFromAttributes()`. `NodeTracerProvider.addSpanProcessor()` replaced with `spanProcessors` constructor option.

**TS 5.x strict-mode fixes:** catch blocks (`unknown` type), Proxy handler signatures, removed TS 3.x APIs in `rewriteSuper.ts` (`ts.updatePropertyAccess`, `ts.updateCall`, etc.).

Test output: 629 passing, 1 pre-existing failure in `analyzer.spec.ts` (unrelated to this change — error message string mismatch for enum union types).

Closes #23806