### PR TITLE
do: make default input YAML

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -388,12 +388,11 @@ installed locally.
 
 Provider configuration can be supplied via:
   - the provider's standard environment variables (e.g. AWS_REGION)
-  - an input file passed with --provider-file (PCL by default;
-    set --input to convert from another format)
+  - an input file passed with --provider-file (YAML by default;
+    set --input to use another format)
 
-Function inputs come from --input-file. PCL is the default; pass --input
-to convert from another format such as YAML. Non-PCL formats require a
-converter plugin for that format to be installed.`,
+Function inputs come from --input-file. YAML is the default; pass --input
+to use another format.`,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			subcmd, cleanup, err := buildSubcommand(cmd, args)

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -150,7 +150,7 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing function inputs")
 	cmd.Flags().StringVar(&pc.providerFile, "provider-file", "",
 		"Path to a file containing provider configuration")
-	cmd.Flags().StringVar(&pc.format, "input", "pcl",
+	cmd.Flags().StringVar(&pc.format, "input", "yaml",
 		"Format of the configuration files")
 	cmd.Flags().StringVar(&pc.providerURN, "provider", "",
 		"The URN of a provider resource in the current stack whose inputs to use as the "+

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -131,7 +131,7 @@ Usage:
 Flags:
       --dry-run                Run the operation in preview mode
   -h, --help                   help for do
-      --input string           Format of the configuration files (default "pcl")
+      --input string           Format of the configuration files (default "yaml")
       --input-file string      Path to a file containing function inputs
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
       --param1 string          To set param1 things (alias for --input:param1)
@@ -215,7 +215,7 @@ param2 = 42
 param3 = true
 `)
 
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
 
@@ -660,7 +660,7 @@ param = "hello"
 `)
 
 	stdout.Reset()
-	cmd.SetArgs([]string{"pkg:mod1/mod2:fun", "--input-file", inputFile})
+	cmd.SetArgs([]string{"pkg:mod1/mod2:fun", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
 
@@ -725,7 +725,7 @@ param2 = 42
 param3 = true
 `)
 
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.ErrorContains(t, err, `Missing required input "param1"`)
 }
@@ -900,7 +900,7 @@ param3 = {
 			cmd.SetErr(&stdout)
 
 			inputFile := writeHCLFile(t, "inputs.pcl", tt.input)
-			cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+			cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 			err := cmd.Execute()
 			require.Error(t, err)
 			for _, want := range tt.wantErrs {
@@ -949,7 +949,7 @@ func TestDoCmdFunctionInvokeInputFileForInputlessFunction(t *testing.T) {
 	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "unsupported attribute 'bogus'")
@@ -1005,7 +1005,7 @@ stuff {
 	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, `unexpected block "stuff"`)
@@ -1065,7 +1065,7 @@ param2 = "true"
 param3 = "45"
 `)
 
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
 
@@ -1148,7 +1148,7 @@ param2 = 42
 param3 = true
 `)
 
-	cmd.SetArgs([]string{"--dry-run", "azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"--dry-run", "azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
 
@@ -1221,7 +1221,7 @@ param2 = max(1, length(split(":", "a:b:c")), 6)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
 
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
 }
@@ -1286,7 +1286,7 @@ func TestDoCmdFunctionInvokeWithUnsupportedBuiltinFunction(t *testing.T) {
 
 			inputFile := writeHCLFile(t, "inputs.pcl", tt.input)
 
-			cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+			cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 			err := cmd.Execute()
 			require.ErrorContains(t, err, tt.expected)
 		})
@@ -1365,7 +1365,7 @@ project = project()
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
 
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
 }
@@ -1462,6 +1462,7 @@ param3 = true
 
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
+		"--input", "pcl",
 		"--provider-file", providerFile,
 		"--input-file", inputFile,
 	})
@@ -1796,7 +1797,7 @@ func TestDoCmdFunctionInvokeWithParameterizedPackage(t *testing.T) {
 	// First positional is the package spec: base provider name plus any Parameterize args, shlex-quoted.
 	cmd.SetArgs([]string{
 		"--package", "terraform-provider foo/bar 1.2.3",
-		"myparam:index:myFunction", "--input-file", inputFile,
+		"myparam:index:myFunction", "--input", "pcl", "--input-file", inputFile,
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -1933,6 +1934,88 @@ param3: true
   "output1": "world",
   "output2": 43,
   "output3": false
+}
+`
+	assert.Equal(t, expected, stdout.String())
+}
+
+// TestDoCmdFunctionInvokeYAMLInputByDefault verifies that YAML is the default input format: an input file
+// passed without --input is routed through the yaml converter.
+func TestDoCmdFunctionInvokeYAMLInputByDefault(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
+		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
+		// `do` forwards to the converter as its TargetLoader.
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
+	}
+	loadConverter := func(
+		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
+	) (plugin.Converter, error) {
+		assert.Equal(t, "yaml", name)
+		return &plugin.MockConverter{
+			ConvertSnippetF: func(ctx context.Context, req *plugin.ConvertSnippetRequest) (
+				*plugin.ConvertSnippetResponse, error,
+			) {
+				assert.Equal(t, "inputs.yaml", filepath.Base(req.Filename))
+				assert.Equal(t, "x: hello\n", string(req.Source))
+				return &plugin.ConvertSnippetResponse{
+					Filename: "inputs.pp",
+					Source:   []byte(`x = "hello"` + "\n"),
+				}, nil
+			},
+		}, nil
+	}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"x": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"y": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					assert.Equal(t, "hello", req.Args["x"].StringValue())
+					return plugin.InvokeResponse{
+						Properties: resource.PropertyMap{"y": resource.NewProperty("world")},
+					}, nil
+				},
+			},
+		}, nil
+	}
+
+	inputFile := writeHCLFile(t, "inputs.yaml", "x: hello\n")
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, yamlHost, loadConverter)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	expected := `{
+  "y": "world"
 }
 `
 	assert.Equal(t, expected, stdout.String())
@@ -2488,6 +2571,7 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
+		"--input", "pcl",
 		"--provider-file", providerFile,
 		"--azure:opt-two", "val2",
 		"--in1", "p1",

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -99,7 +99,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 	// Provider configuration applies to all sub-operations, so register here as persistent flags.
 	cmd.PersistentFlags().StringVar(&pc.providerFile, "provider-file", "",
 		"Path to a file containing provider configuration")
-	cmd.PersistentFlags().StringVar(&pc.format, "input", "pcl",
+	cmd.PersistentFlags().StringVar(&pc.format, "input", "yaml",
 		"Format of the provider configuration file")
 	cmd.PersistentFlags().StringVar(&pc.providerURN, "provider", "",
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
@@ -300,7 +300,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			return pc.printResourceResult(cmd, id, response.Properties, res)
 		},
 	}
-	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Format of the configuration files")
+	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Format of the configuration files")
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
@@ -419,7 +419,7 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 			return pc.printListResults(cmd, results)
 		},
 	}
-	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
+	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Input file format")
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource list inputs")
 	cmd.Flags().BoolVar(&all, "all", false, "Enumerate all matching resources")
 	cmd.Flags().Int64Var(&count, "count", 0, "Enumerate up to count matching resources")

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -134,7 +134,7 @@ Available Commands:
 Flags:
       --dry-run                Run the operation in preview mode
   -h, --help                   help for do
-      --input string           Format of the provider configuration file (default "pcl")
+      --input string           Format of the provider configuration file (default "yaml")
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
@@ -182,7 +182,7 @@ Available Commands:
 Flags:
       --dry-run                Run the operation in preview mode
   -h, --help                   help for do
-      --input string           Format of the provider configuration file (default "pcl")
+      --input string           Format of the provider configuration file (default "yaml")
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
@@ -227,7 +227,10 @@ func TestDoCmdResourceCreate(t *testing.T) {
 name = "example"
 size = 2
 `)
-	cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "create", "--yes", "--input-file", inputFile})
+	cmd.SetArgs([]string{
+		"--stateless", "azure:index:myResource", "create", "--yes",
+		"--input", "pcl", "--input-file", inputFile,
+	})
 	err := cmd.Execute()
 	require.NoError(t, err)
 
@@ -290,6 +293,7 @@ func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
 		"--stateless",
 		"azure:index:myResource", "create",
 		"--yes",
+		"--input", "pcl",
 		"--input-file", inputFile,
 		"--int-value", "42",
 		"--already-kebab-case", "kebab",
@@ -416,7 +420,10 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 name = "new"
 enabled = true
 `)
-		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "patch", "res-1", "--yes", "--input-file", inputFile})
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile,
+		})
 		err := cmd.Execute()
 		require.NoError(t, err)
 		assert.Equal(t, []string{"read", "check", "diff", "update"}, calls)
@@ -465,7 +472,10 @@ enabled = true
 		})
 
 		inputFile := writeHCLFile(t, "patch.pcl", `enabled = true`)
-		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "patch", "res-1", "--yes", "--input-file", inputFile})
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile,
+		})
 		err := cmd.Execute()
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"id":"res-1","name":"existing","enabled":true}`, stdout.String())
@@ -489,7 +499,7 @@ func TestDoCmdResourceList(t *testing.T) {
 			},
 		})
 		inputFile := writeHCLFile(t, "list.pcl", `prefix = "prod"`)
-		cmd.SetArgs([]string{"azure:index:myResource", "list", "--input-file", inputFile})
+		cmd.SetArgs([]string{"azure:index:myResource", "list", "--input", "pcl", "--input-file", inputFile})
 		err := cmd.Execute()
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
@@ -616,7 +626,10 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 			},
 		})
 		inputFile := writeHCLFile(t, "inputs.pcl", `name = "example"`)
-		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "create", "--yes", "--input-file", inputFile})
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "create", "--yes",
+			"--input", "pcl", "--input-file", inputFile,
+		})
 		require.NoError(t, cmd.Execute())
 		assert.Contains(t, stderr.String(), "This will create azure:index:myResource")
 		assert.NotContains(t, stdout.String(), "This will create")
@@ -651,7 +664,10 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 			},
 		})
 		inputFile := writeHCLFile(t, "patch.pcl", `name = "new"`)
-		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "patch", "res-1", "--yes", "--input-file", inputFile})
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile,
+		})
 		require.NoError(t, cmd.Execute())
 		assert.Contains(t, stderr.String(), "This will update azure:index:myResource")
 		assert.Contains(t, stderr.String(), "~ name")

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -987,7 +987,7 @@ stack = stack()
 	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
-	cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	require.NoError(t, cmd.Execute())
 }
 
@@ -1057,7 +1057,7 @@ func TestDoCmdFunctionInvokeWithoutStackContext(t *testing.T) {
 		cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
 		cmd.SetOut(&stdout)
 		cmd.SetErr(&stdout)
-		cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+		cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 		require.NoError(t, cmd.Execute())
 	})
 
@@ -1075,7 +1075,7 @@ func TestDoCmdFunctionInvokeWithoutStackContext(t *testing.T) {
 		cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
 		cmd.SetOut(&stdout)
 		cmd.SetErr(&stdout)
-		cmd.SetArgs([]string{"azure:index:myFunction", "--input-file", inputFile})
+		cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 		err := cmd.Execute()
 		require.ErrorContains(t, err, "organization is not supported")
 	})

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1288,7 +1288,7 @@ func TestDoCommandLocalRun(t *testing.T) {
 	// is the JSON result. The provider still captures stdout/stderr as outputs.
 	e.WriteTestFile("inputs.pcl", `command = "echo hello"`+"\n"+`logging = "none"`+"\n")
 
-	stdout, stderr := e.RunCommand("pulumi", "do", "command:local:run", "--input-file", "inputs.pcl")
+	stdout, stderr := e.RunCommand("pulumi", "do", "command:local:run", "--input", "pcl", "--input-file", "inputs.pcl")
 
 	// Guard against the dynamic-subcommand re-execute racing with the root command's update-check goroutine and
 	// producing a "send on closed channel" panic. The panic is intermittent so it doesn't always reproduce, but
@@ -1343,7 +1343,7 @@ func TestDoCommandLocalCommand(t *testing.T) {
 
 	stdout, stderr := e.RunCommand(
 		"pulumi", "do", "--stateless", "command:local:Command", "create",
-		"--input-file", "inputs.pcl", "--yes")
+		"--input", "pcl", "--input-file", "inputs.pcl", "--yes")
 
 	// Guard against the dynamic-subcommand re-execute racing with the root command's update-check goroutine and
 	// producing a "send on closed channel" panic. The panic is intermittent so it doesn't always reproduce, but


### PR DESCRIPTION
PCL is not documented, and the PCL runtime has not been released
publicly yet.  It's better to have a documented format for
`--input-file` and `--provider-file` inputs instead.  Choose yaml as
default, as it's the closest to a config language.

PCL can still be used using `--input pcl` if the user wishes to do so.