### PR TITLE
do: fix `--dry-run` for delete

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -181,9 +181,6 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 		Short: "Read a resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if pc.dryrun {
-				return errDryRunNotSupported("read")
-			}
 			ctx := cmd.Context()
 			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
@@ -316,9 +313,6 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 		Short: "Delete a resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if pc.dryrun {
-				return errDryRunNotSupported("delete")
-			}
 			if !pc.stateless {
 				return errStatefulNotImplemented("delete")
 			}
@@ -331,8 +325,12 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			}
 			urn := resourceURN(res)
 			id := resource.ID(args[0])
-			if err := pc.confirm(cmd, formatDeleteSummary(res, id), "delete", yes); err != nil {
+			if err := pc.confirm(cmd, formatDeleteSummary(res, id, pc.dryrun), string(id), yes); err != nil {
 				return err
+			}
+			// The provider protocol has no preview mode for Delete, so the summary above is the whole dry run.
+			if pc.dryrun {
+				return nil
 			}
 			_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{
 				URN:     urn,
@@ -360,9 +358,6 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 		Short: "List resources",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if pc.dryrun {
-				return errDryRunNotSupported("list")
-			}
 			if all && count > 0 {
 				return errors.New("--all and --count are mutually exclusive")
 			}
@@ -507,10 +502,6 @@ func (pc *packageCommand) printListResults(cmd *cobra.Command, results []plugin.
 	return nil
 }
 
-func errDryRunNotSupported(op string) error {
-	return fmt.Errorf("--dry-run is not supported for `%s`", op)
-}
-
 // errStatefulNotImplemented is returned from create/patch/delete when the user did not pass
 // --stateless. The stateful (engine-driven) implementation of these operations is the planned
 // default but isn't built yet, so for now the only working path is opting in to the stateless one.
@@ -527,7 +518,10 @@ func formatCreateSummary(res *schema.Resource, inputs resource.PropertyMap, show
 	return fmt.Sprintf("This will create %s with the following inputs:\n%s", res.Token, body), nil
 }
 
-func formatDeleteSummary(res *schema.Resource, id resource.ID) string {
+func formatDeleteSummary(res *schema.Resource, id resource.ID, dryrun bool) string {
+	if dryrun {
+		return fmt.Sprintf("This would delete %s %q.", res.Token, id)
+	}
 	return fmt.Sprintf("This will delete %s %q.", res.Token, id)
 }
 

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -181,6 +181,9 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 		Short: "Read a resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if pc.dryrun {
+				return errDryRunNotSupported("read")
+			}
 			ctx := cmd.Context()
 			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
@@ -313,6 +316,9 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 		Short: "Delete a resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if pc.dryrun {
+				return errDryRunNotSupported("delete")
+			}
 			if !pc.stateless {
 				return errStatefulNotImplemented("delete")
 			}
@@ -354,6 +360,9 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 		Short: "List resources",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if pc.dryrun {
+				return errDryRunNotSupported("list")
+			}
 			if all && count > 0 {
 				return errors.New("--all and --count are mutually exclusive")
 			}
@@ -496,6 +505,10 @@ func (pc *packageCommand) printListResults(cmd *cobra.Command, results []plugin.
 	}
 	fmt.Fprint(cmd.OutOrStdout(), output)
 	return nil
+}
+
+func errDryRunNotSupported(op string) error {
+	return fmt.Errorf("--dry-run is not supported for `%s`", op)
 }
 
 // errStatefulNotImplemented is returned from create/patch/delete when the user did not pass

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -607,6 +607,48 @@ func TestDoCmdResourceNonInteractiveRequiresYes(t *testing.T) {
 	}
 }
 
+// TestDoCmdResourceDryRunNotSupported asserts that operations without a preview mode reject --dry-run instead
+// of ignoring it. For delete this is load-bearing: --dry-run skips the confirmation prompt, so accepting it
+// would delete the resource without asking.
+func TestDoCmdResourceDryRunNotSupported(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"delete", []string{"--dry-run", "--stateless", "azure:index:myResource", "delete", "res-1", "--yes"}},
+		{"read", []string{"--dry-run", "azure:index:myResource", "read", "res-1"}},
+		{"list", []string{"--dry-run", "azure:index:myResource", "list"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &testProvider{
+				spec: doResourceSpec(true),
+				MockProvider: plugin.MockProvider{
+					DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+						require.Fail(t, "Delete should not be called with --dry-run")
+						return plugin.DeleteResponse{}, nil
+					},
+					ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						require.Fail(t, "Read should not be called with --dry-run")
+						return plugin.ReadResponse{}, nil
+					},
+					ListF: func(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
+						require.Fail(t, "List should not be called with --dry-run")
+						return nil, nil
+					},
+				},
+			}
+			cmd, _, _ := newDoResourceCommand(t, provider)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			require.ErrorContains(t, err, "--dry-run is not supported for `"+tc.name+"`")
+		})
+	}
+}
+
 // TestDoCmdResourceConfirmationSummary asserts the operation summary lands on stderr (so stdout stays a clean
 // JSON channel for piping) and that the patch summary surfaces the Diff response.
 func TestDoCmdResourceConfirmationSummary(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -607,46 +607,66 @@ func TestDoCmdResourceNonInteractiveRequiresYes(t *testing.T) {
 	}
 }
 
-// TestDoCmdResourceDryRunNotSupported asserts that operations without a preview mode reject --dry-run instead
-// of ignoring it. For delete this is load-bearing: --dry-run skips the confirmation prompt, so accepting it
-// would delete the resource without asking.
-func TestDoCmdResourceDryRunNotSupported(t *testing.T) {
+// TestDoCmdResourceDeleteDryRun asserts that delete --dry-run prints what would be deleted and never
+// calls the provider. Delete has no provider-side preview mode, so the summary is the whole dry run;
+// crucially --dry-run must not act like --yes (the confirmation prompt is skipped on dry runs).
+func TestDoCmdResourceDeleteDryRun(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		args []string
-	}{
-		{"delete", []string{"--dry-run", "--stateless", "azure:index:myResource", "delete", "res-1", "--yes"}},
-		{"read", []string{"--dry-run", "azure:index:myResource", "read", "res-1"}},
-		{"list", []string{"--dry-run", "azure:index:myResource", "list"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			provider := &testProvider{
-				spec: doResourceSpec(true),
-				MockProvider: plugin.MockProvider{
-					DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
-						require.Fail(t, "Delete should not be called with --dry-run")
-						return plugin.DeleteResponse{}, nil
-					},
-					ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
-						require.Fail(t, "Read should not be called with --dry-run")
-						return plugin.ReadResponse{}, nil
-					},
-					ListF: func(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
-						require.Fail(t, "List should not be called with --dry-run")
-						return nil, nil
-					},
+	cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
+		spec: doResourceSpec(false),
+		MockProvider: plugin.MockProvider{
+			DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+				require.Fail(t, "Delete should not be called with --dry-run")
+				return plugin.DeleteResponse{}, nil
+			},
+		},
+	})
+	cmd.SetArgs([]string{"--dry-run", "--stateless", "azure:index:myResource", "delete", "res-1"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stderr.String(), `This would delete azure:index:myResource "res-1"`)
+	assert.Empty(t, stdout.String())
+}
+
+// TestDoCmdResourceDryRunIgnoredForReadOnlyOps asserts that read and list ignore --dry-run: they never
+// mutate anything, so there is nothing to preview and they behave as if the flag wasn't passed.
+func TestDoCmdResourceDryRunIgnoredForReadOnlyOps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Outputs: resource.PropertyMap{"name": resource.NewProperty("read")},
+						},
+					}, nil
 				},
-			}
-			cmd, _, _ := newDoResourceCommand(t, provider)
-			cmd.SetArgs(tc.args)
-			err := cmd.Execute()
-			require.ErrorContains(t, err, "--dry-run is not supported for `"+tc.name+"`")
+			},
 		})
-	}
+		cmd.SetArgs([]string{"--dry-run", "azure:index:myResource", "read", "res-1"})
+		require.NoError(t, cmd.Execute())
+		assert.JSONEq(t, `{"id":"res-1","name":"read"}`, stdout.String())
+	})
+
+	t.Run("list", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(true),
+			MockProvider: plugin.MockProvider{
+				ListF: func(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
+					return plugin.NewListStream([]plugin.ListResult{{ID: "1", Name: "one"}}, ""), nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--dry-run", "azure:index:myResource", "list"})
+		require.NoError(t, cmd.Execute())
+		assert.JSONEq(t, `[{"id":"1","name":"one"}]`, stdout.String())
+	})
 }
 
 // TestDoCmdResourceConfirmationSummary asserts the operation summary lands on stderr (so stdout stays a clean


### PR DESCRIPTION
`--dry-run` is a global flag for `pulumi do`.  However there's no
provider support for this in `read`, `list` and most importantly for
`delete`.  In the case of `delete`, the user can currently pass a
`--dry-run` flag, which then rather than `--dry-run` is effectively
interpreted as `--yes`, deleting the resource directly.

Just reject the flag when it is passed to one of those three commands.