### PR TITLE
[esc] Add compositional object:encoding values to env open/get/diff --format

### DIFF
--- a/changelog/pending/cli-env-compositional-open-format.yaml
+++ b/changelog/pending/cli-env-compositional-open-format.yaml
@@ -3,4 +3,4 @@ kind: feat
 body: '`pulumi env open`, `get`, and `diff` accept compositional `<object>:<encoding>` values for `--format`/`--value` (for example `process:json-detailed`), adding a structured JSON/YAML view of the process-environment that carries a per-value secret flag; all existing format values keep working unchanged and `yaml` is now accepted by `get` and `diff`'
 time: 2026-07-07T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23810"

--- a/changelog/pending/cli-env-compositional-open-format.yaml
+++ b/changelog/pending/cli-env-compositional-open-format.yaml
@@ -1,0 +1,6 @@
+component: cli/env
+kind: feat
+body: '`pulumi env open`, `get`, and `diff` accept compositional `<object>:<encoding>` values for `--format`/`--value` (for example `process:json-detailed`), adding a structured JSON/YAML view of the process-environment that carries a per-value secret flag; all existing format values keep working unchanged and `yaml` is now accepted by `get` and `diff`'
+time: 2026-07-07T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/pkg/cmd/esc/cli/env_diff.go
+++ b/pkg/cmd/esc/cli/env_diff.go
@@ -134,7 +134,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 
 	cmd.Flags().StringVarP(
 		&format, "format", "f", "",
-		formatFlagHelp("the output format to use. May be one of "))
+		formatFlagHelp("the output format to use, given as <object>:<encoding>."))
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")

--- a/pkg/cmd/esc/cli/env_diff.go
+++ b/pkg/cmd/esc/cli/env_diff.go
@@ -84,23 +84,11 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 				}
 			}
 
-			switch format {
-			case "":
-				// OK
-			case "detailed", "json", "string":
-				return diff.diffValue(ctx, baseRef, compareRef, path, format, showSecrets)
-			case "dotenv":
-				if len(path) != 0 {
-					return fmt.Errorf("output format '%s' may not be used with a property path", format)
+			if format != "" {
+				if _, err := validateFormat(format, path); err != nil {
+					return err
 				}
 				return diff.diffValue(ctx, baseRef, compareRef, path, format, showSecrets)
-			case "shell":
-				if len(path) != 0 {
-					return fmt.Errorf("output format '%s' may not be used with a property path", format)
-				}
-				return diff.diffValue(ctx, baseRef, compareRef, path, format, showSecrets)
-			default:
-				return fmt.Errorf("unknown output format %q", format)
 			}
 
 			baseData, err := diff.getEnvironment(ctx, baseRef, path, showSecrets)
@@ -146,7 +134,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 
 	cmd.Flags().StringVarP(
 		&format, "format", "f", "",
-		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', or 'shell'")
+		formatFlagHelp("the output format to use. May be one of "))
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")

--- a/pkg/cmd/esc/cli/env_get.go
+++ b/pkg/cmd/esc/cli/env_get.go
@@ -84,23 +84,11 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return errors.New("`--value` and `--definition` flags cannot be used together")
 			}
 
-			switch value {
-			case "":
-				// OK
-			case "detailed", "json", "string":
-				return get.showValue(ctx, ref, path, value, showSecrets)
-			case "dotenv":
-				if len(path) != 0 {
-					return fmt.Errorf("output format '%s' may not be used with a property path", value)
+			if value != "" {
+				if _, err := validateFormat(value, path); err != nil {
+					return err
 				}
 				return get.showValue(ctx, ref, path, value, showSecrets)
-			case "shell":
-				if len(path) != 0 {
-					return fmt.Errorf("output format '%s' may not be used with a property path", value)
-				}
-				return get.showValue(ctx, ref, path, value, showSecrets)
-			default:
-				return fmt.Errorf("unknown output format %q", value)
 			}
 
 			data, err := get.getEnvironment(ctx, ref, path, showSecrets)
@@ -144,7 +132,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 		"Set to print just the definition.")
 	cmd.Flags().StringVar(
 		&value, "value", "",
-		"Set to print just the value in the given format. May be 'dotenv', 'json', 'detailed', 'shell' or 'string'")
+		formatFlagHelp("Set to print just the value in the given format. May be one of "))
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")

--- a/pkg/cmd/esc/cli/env_get.go
+++ b/pkg/cmd/esc/cli/env_get.go
@@ -132,7 +132,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 		"Set to print just the definition.")
 	cmd.Flags().StringVar(
 		&value, "value", "",
-		formatFlagHelp("Set to print just the value in the given format. May be one of "))
+		formatFlagHelp("print just the value in the given format, given as <object>:<encoding>."))
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")

--- a/pkg/cmd/esc/cli/env_open.go
+++ b/pkg/cmd/esc/cli/env_open.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -63,15 +64,8 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				path = p
 			}
 
-			switch format {
-			case "detailed", "json", "yaml", "string":
-				// OK
-			case "dotenv", "shell":
-				if len(path) != 0 {
-					return fmt.Errorf("output format '%s' may not be used with a property path", format)
-				}
-			default:
-				return fmt.Errorf("unknown output format %q", format)
+			if _, err := validateFormat(format, path); err != nil {
+				return err
 			}
 
 			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
@@ -91,7 +85,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 		"the lifetime of the opened environment in the form HhMm (e.g. 2h, 1h30m, 15m)")
 	cmd.Flags().StringVarP(
 		&format, "format", "f", "json",
-		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', 'shell' or 'string'")
+		formatFlagHelp("the output format to use. May be one of "))
 	cmd.Flags().StringVar(
 		&draft, "draft", "",
 		"open an environment draft with --draft=<change-request-id>")
@@ -111,6 +105,15 @@ func (env *envCommand) renderValue(
 		return nil
 	}
 
+	f, err := parseFormat(format)
+	if err != nil {
+		return err
+	}
+
+	if f.isProcess() {
+		return env.renderProcessEnvironment(out, e, f.encoding, pretend, showSecrets)
+	}
+
 	val := esc.NewValue(e.Properties)
 	if len(path) != 0 {
 		if vv, ok := getEnvValue(val, path); ok {
@@ -120,46 +123,22 @@ func (env *envCommand) renderValue(
 		}
 	}
 
-	switch format {
-	case "json":
+	switch f.encoding {
+	case encodingJSON:
 		body := val.ToJSON(!showSecrets)
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(body)
-	case "yaml":
+	case encodingYAML:
 		body := val.ToJSON(!showSecrets)
 		enc := yaml.NewEncoder(out)
 		enc.SetIndent(3)
 		return enc.Encode(body)
-	case "detailed":
+	case encodingJSONDetailed:
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(val)
-	case "dotenv":
-		_, environ, _, err := env.prepareEnvironment(
-			e,
-			PrepareOptions{Pretend: pretend, Quote: true, Redact: !showSecrets},
-		)
-		if err != nil {
-			return err
-		}
-		for _, kvp := range environ {
-			fmt.Fprintln(out, kvp)
-		}
-		return nil
-	case "shell":
-		_, environ, _, err := env.prepareEnvironment(
-			e,
-			PrepareOptions{Pretend: pretend, Quote: true, Redact: !showSecrets},
-		)
-		if err != nil {
-			return err
-		}
-		for _, kvp := range environ {
-			fmt.Fprintf(out, "export %v\n", kvp)
-		}
-		return nil
-	case "string":
+	case encodingString:
 		s := val.ToString(!showSecrets)
 		if strings.HasSuffix(s, "\n") {
 			fmt.Fprintf(out, "%v", s)
@@ -167,10 +146,90 @@ func (env *envCommand) renderValue(
 			fmt.Fprintf(out, "%v\n", s)
 		}
 		return nil
+	case encodingDotenv, encodingShell:
+		return fmt.Errorf("unreachable: value object cannot be encoded as %q", format)
 	default:
-		// NOTE: we shouldn't get here. This was checked at the beginning of the function.
 		return fmt.Errorf("unknown output format %q", format)
 	}
+}
+
+// processEnvironmentEntry is one variable of the structured process-environment (process:json-detailed),
+// pairing the value a process would see with the secret flag the flat dotenv/shell encodings discard.
+type processEnvironmentEntry struct {
+	Value  string `json:"value"`
+	Secret bool   `json:"secret"`
+}
+
+func (env *envCommand) renderProcessEnvironment(
+	out io.Writer,
+	e *esc.Environment,
+	encoding outputEncoding,
+	pretend bool,
+	showSecrets bool,
+) error {
+	switch encoding {
+	case encodingDotenv, encodingShell:
+		_, environ, _, err := env.prepareEnvironment(
+			e,
+			PrepareOptions{Pretend: pretend, Quote: true, Redact: !showSecrets},
+		)
+		if err != nil {
+			return err
+		}
+		prefix := ""
+		if encoding == encodingShell {
+			prefix = "export "
+		}
+		for _, kvp := range environ {
+			fmt.Fprintf(out, "%s%v\n", prefix, kvp)
+		}
+		return nil
+	case encodingJSON, encodingYAML:
+		proj, err := env.projectEnvironment(e, PrepareOptions{Pretend: pretend})
+		if err != nil {
+			return err
+		}
+		body := make(map[string]string, len(proj.Variables)+len(proj.Files))
+		for _, v := range proj.Variables {
+			s := v.Value
+			if v.Secret && !showSecrets {
+				s = "[secret]"
+			}
+			body[v.Name] = s
+		}
+		for _, f := range proj.Files {
+			body[f.Name] = f.Path
+		}
+		return encodeStructured(out, encoding, body)
+	case encodingJSONDetailed:
+		proj, err := env.projectEnvironment(e, PrepareOptions{Pretend: pretend})
+		if err != nil {
+			return err
+		}
+		body := make(map[string]processEnvironmentEntry, len(proj.Variables)+len(proj.Files))
+		for _, v := range proj.Variables {
+			body[v.Name] = processEnvironmentEntry{Value: v.Value, Secret: v.Secret}
+		}
+		for _, f := range proj.Files {
+			body[f.Name] = processEnvironmentEntry{Value: f.Path, Secret: f.Secret}
+		}
+		return encodeStructured(out, encodingJSON, body)
+	case encodingString:
+		return errors.New("unreachable: process object cannot be encoded as a bare string")
+	default:
+		return errors.New("unknown process-environment encoding")
+	}
+}
+
+func encodeStructured(out io.Writer, encoding outputEncoding, body any) error {
+	if encoding == encodingYAML {
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(3)
+		return enc.Encode(body)
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(body)
 }
 
 // prepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
@@ -181,6 +240,15 @@ func (env *envCommand) prepareEnvironment(
 ) (files, environ, secrets []string, err error) {
 	opts.fs = env.esc.fs
 	return PrepareEnvironment(e, &opts)
+}
+
+func (env *envCommand) projectEnvironment(e *esc.Environment, opts PrepareOptions) (*EnvironmentProjection, error) {
+	opts.fs = env.esc.fs
+	proj, err := projectEnvironment(e, &opts)
+	if err != nil {
+		return nil, fmt.Errorf("creating temporary files: %v", err)
+	}
+	return proj, nil
 }
 
 func (env *envCommand) removeTemporaryFiles(paths []string) {

--- a/pkg/cmd/esc/cli/env_open.go
+++ b/pkg/cmd/esc/cli/env_open.go
@@ -82,13 +82,19 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 
 	cmd.Flags().DurationVarP(
 		&duration, "lifetime", "l", 2*time.Hour,
-		"the lifetime of the opened environment in the form HhMm (e.g. 2h, 1h30m, 15m)")
+		"the lifetime of the opened environment in the form HhMm (e.g. 2h, 1h30m, 15m)",
+	)
 	cmd.Flags().StringVarP(
 		&format, "format", "f", "json",
-		formatFlagHelp("the output format to use. May be one of "))
+		formatFlagHelp("the output format to use, given as <object>:<encoding>. Defaults to value:json."),
+	)
+	// The default is stated in the help text above; blank DefValue so cobra does not also append a
+	// "(default ...)" note to the end of the multi-line format list, where it reads as part of the last entry.
+	cmd.Flags().Lookup("format").DefValue = ""
 	cmd.Flags().StringVar(
 		&draft, "draft", "",
-		"open an environment draft with --draft=<change-request-id>")
+		"open an environment draft with --draft=<change-request-id>",
+	)
 
 	return cmd
 }

--- a/pkg/cmd/esc/cli/format.go
+++ b/pkg/cmd/esc/cli/format.go
@@ -1,0 +1,157 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// outputObject is what an `env open`/`get`/`diff` command produces: either the resolved value tree,
+// or the process-environment projection of it (string-valued environment variables plus files
+// materialized to disk and exposed as path variables).
+type outputObject int
+
+const (
+	objectValue outputObject = iota
+	objectProcess
+)
+
+// outputEncoding is how an outputObject is serialized.
+type outputEncoding int
+
+const (
+	encodingString outputEncoding = iota
+	encodingJSON
+	encodingYAML
+	encodingJSONDetailed
+	encodingDotenv
+	encodingShell
+)
+
+// renderFormat is the fully-resolved `<object>:<encoding>` selection behind the `--format`/`--value` flag.
+type renderFormat struct {
+	object   outputObject
+	encoding outputEncoding
+}
+
+// isProcess reports whether the format produces the process-environment projection rather than the value.
+func (f renderFormat) isProcess() bool {
+	return f.object == objectProcess
+}
+
+// formatAliases maps the legacy single-word `--format` values to their compositional equivalents. Every
+// legacy value keeps working and renders identically.
+var formatAliases = map[string]renderFormat{
+	"json":     {objectValue, encodingJSON},
+	"yaml":     {objectValue, encodingYAML},
+	"string":   {objectValue, encodingString},
+	"detailed": {objectValue, encodingJSONDetailed},
+	"dotenv":   {objectProcess, encodingDotenv},
+	"shell":    {objectProcess, encodingShell},
+}
+
+var objectTokens = map[string]outputObject{
+	"value":   objectValue,
+	"process": objectProcess,
+}
+
+var encodingTokens = map[string]outputEncoding{
+	"string":        encodingString,
+	"json":          encodingJSON,
+	"yaml":          encodingYAML,
+	"json-detailed": encodingJSONDetailed,
+	"dotenv":        encodingDotenv,
+	"shell":         encodingShell,
+}
+
+// validEncodings lists the encodings each object may pair with. `value` has no dotenv/shell (those encode
+// only a flat string map), and `process` has no bare string.
+var validEncodings = map[outputObject]map[outputEncoding]bool{
+	objectValue: {
+		encodingString:       true,
+		encodingJSON:         true,
+		encodingYAML:         true,
+		encodingJSONDetailed: true,
+	},
+	objectProcess: {
+		encodingJSON:         true,
+		encodingYAML:         true,
+		encodingJSONDetailed: true,
+		encodingDotenv:       true,
+		encodingShell:        true,
+	},
+}
+
+// parseFormat resolves a `--format`/`--value` string into a renderFormat. It accepts both the legacy
+// single-word aliases and the compositional `<object>:<encoding>` form, and rejects illegal pairs such as
+// `value:dotenv`.
+func parseFormat(s string) (renderFormat, error) {
+	if f, ok := formatAliases[s]; ok {
+		return f, nil
+	}
+
+	objectStr, encodingStr, ok := strings.Cut(s, ":")
+	if !ok {
+		return renderFormat{}, fmt.Errorf("unknown output format %q", s)
+	}
+
+	object, ok := objectTokens[objectStr]
+	if !ok {
+		return renderFormat{}, fmt.Errorf("unknown output object %q in format %q", objectStr, s)
+	}
+	encoding, ok := encodingTokens[encodingStr]
+	if !ok {
+		return renderFormat{}, fmt.Errorf("unknown output encoding %q in format %q", encodingStr, s)
+	}
+	if !validEncodings[object][encoding] {
+		return renderFormat{}, fmt.Errorf("output format %q is not a valid object:encoding pair", s)
+	}
+	return renderFormat{object: object, encoding: encoding}, nil
+}
+
+// validateFormat parses a format and enforces that a property path is only used against the value object;
+// a path navigates the value tree and is meaningless against the process-environment projection.
+func validateFormat(s string, path resource.PropertyPath) (renderFormat, error) {
+	f, err := parseFormat(s)
+	if err != nil {
+		return renderFormat{}, err
+	}
+	if f.isProcess() && len(path) != 0 {
+		return renderFormat{}, fmt.Errorf("output format %q may not be used with a property path", s)
+	}
+	return f, nil
+}
+
+// formatFlagHelp renders the flag help listing every accepted format value: the legacy aliases plus every
+// valid object:encoding pair, sorted.
+func formatFlagHelp(prefix string) string {
+	var values []string
+	for alias := range formatAliases {
+		values = append(values, alias)
+	}
+	for objectStr, object := range objectTokens {
+		for encodingStr, encoding := range encodingTokens {
+			if validEncodings[object][encoding] {
+				values = append(values, objectStr+":"+encodingStr)
+			}
+		}
+	}
+	sort.Strings(values)
+	return prefix + strings.Join(values, ", ")
+}

--- a/pkg/cmd/esc/cli/format.go
+++ b/pkg/cmd/esc/cli/format.go
@@ -55,6 +55,11 @@ func (f renderFormat) isProcess() bool {
 	return f.object == objectProcess
 }
 
+// String renders the format in its canonical `<object>:<encoding>` form.
+func (f renderFormat) String() string {
+	return objectNames[f.object] + ":" + encodingNames[f.encoding]
+}
+
 // formatAliases maps the legacy single-word `--format` values to their compositional equivalents. Every
 // legacy value keeps working and renders identically.
 var formatAliases = map[string]renderFormat{
@@ -80,23 +85,65 @@ var encodingTokens = map[string]outputEncoding{
 	"shell":         encodingShell,
 }
 
-// validEncodings lists the encodings each object may pair with. `value` has no dotenv/shell (those encode
-// only a flat string map), and `process` has no bare string.
-var validEncodings = map[outputObject]map[outputEncoding]bool{
-	objectValue: {
-		encodingString:       true,
-		encodingJSON:         true,
-		encodingYAML:         true,
-		encodingJSONDetailed: true,
-	},
-	objectProcess: {
-		encodingJSON:         true,
-		encodingYAML:         true,
-		encodingJSONDetailed: true,
-		encodingDotenv:       true,
-		encodingShell:        true,
-	},
+var objectNames = map[outputObject]string{
+	objectValue:   "value",
+	objectProcess: "process",
 }
+
+// objectDescriptions explains, for flag help, what each object is and how the two differ.
+var objectDescriptions = map[outputObject]string{
+	objectValue: "the resolved configuration value tree",
+	objectProcess: "the environmentVariables and files reserved keys projected as the string variables a " +
+		"process consumes; files are written to disk and each variable holds the file path",
+}
+
+// objectOrder is the order objects appear in flag help.
+var objectOrder = []outputObject{objectValue, objectProcess}
+
+var encodingNames = map[outputEncoding]string{
+	encodingString:       "string",
+	encodingJSON:         "json",
+	encodingYAML:         "yaml",
+	encodingJSONDetailed: "json-detailed",
+	encodingDotenv:       "dotenv",
+	encodingShell:        "shell",
+}
+
+// formatDescriptor is one valid `<object>:<encoding>` pair together with the one-line description shown in
+// flag help.
+type formatDescriptor struct {
+	renderFormat
+	description string
+}
+
+// formats is the canonical, display-ordered set of valid `<object>:<encoding>` pairs. It is the single source
+// of truth for which pairs are legal (validEncodings is derived from it) and how each is described.
+var formats = []formatDescriptor{
+	{renderFormat{objectValue, encodingString}, "resolved value as a single flattened string"},
+	{renderFormat{objectValue, encodingJSON}, "resolved value tree as JSON"},
+	{renderFormat{objectValue, encodingYAML}, "resolved value tree as YAML"},
+	{
+		renderFormat{objectValue, encodingJSONDetailed},
+		"resolved value tree as JSON, annotated with secret flags and source provenance",
+	},
+	{renderFormat{objectProcess, encodingJSON}, "process environment as a flat JSON object"},
+	{renderFormat{objectProcess, encodingYAML}, "process environment as a flat YAML mapping"},
+	{renderFormat{objectProcess, encodingJSONDetailed}, "process environment as JSON, with a per-variable secret flag"},
+	{renderFormat{objectProcess, encodingDotenv}, "process environment as dotenv assignments"},
+	{renderFormat{objectProcess, encodingShell}, "process environment as shell export statements"},
+}
+
+// validEncodings lists the encodings each object may pair with, derived from formats so the two cannot drift.
+var validEncodings = func() map[outputObject]map[outputEncoding]bool {
+	m := map[outputObject]map[outputEncoding]bool{}
+	for _, f := range formats {
+		if m[f.object] == nil {
+			m[f.object] = map[outputEncoding]bool{}
+		}
+		m[f.object][f.encoding] = true
+	}
+	return m
+}()
 
 // parseFormat resolves a `--format`/`--value` string into a renderFormat. It accepts both the legacy
 // single-word aliases and the compositional `<object>:<encoding>` form, and rejects illegal pairs such as
@@ -138,20 +185,41 @@ func validateFormat(s string, path resource.PropertyPath) (renderFormat, error) 
 	return f, nil
 }
 
-// formatFlagHelp renders the flag help listing every accepted format value: the legacy aliases plus every
-// valid object:encoding pair, sorted.
-func formatFlagHelp(prefix string) string {
-	var values []string
-	for alias := range formatAliases {
-		values = append(values, alias)
+// formatFlagHelp renders the flag help: an intro sentence, then a described list of every canonical
+// `<object>:<encoding>` value, then the legacy single-word aliases that map onto them.
+func formatFlagHelp(intro string) string {
+	width := 0
+	for _, f := range formats {
+		if n := len(f.String()); n > width {
+			width = n
+		}
 	}
-	for objectStr, object := range objectTokens {
-		for encodingStr, encoding := range encodingTokens {
-			if validEncodings[object][encoding] {
-				values = append(values, objectStr+":"+encodingStr)
+
+	var b strings.Builder
+	b.WriteString(intro)
+
+	aliases := make([]string, 0, len(formatAliases))
+	aliasWidth := 0
+	for alias := range formatAliases {
+		aliases = append(aliases, alias)
+		if len(alias) > aliasWidth {
+			aliasWidth = len(alias)
+		}
+	}
+	sort.Strings(aliases)
+	b.WriteString("\n\naliases:")
+	for _, alias := range aliases {
+		fmt.Fprintf(&b, "\n  %-*s  %s", aliasWidth, alias, formatAliases[alias].String())
+	}
+
+	for _, object := range objectOrder {
+		fmt.Fprintf(&b, "\n\n%s: %s", objectNames[object], objectDescriptions[object])
+		for _, f := range formats {
+			if f.object == object {
+				fmt.Fprintf(&b, "\n  %-*s  %s", width, f.String(), f.description)
 			}
 		}
 	}
-	sort.Strings(values)
-	return prefix + strings.Join(values, ", ")
+
+	return b.String()
 }

--- a/pkg/cmd/esc/cli/format_test.go
+++ b/pkg/cmd/esc/cli/format_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFormatAliases(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]renderFormat{
+		"json":     {objectValue, encodingJSON},
+		"yaml":     {objectValue, encodingYAML},
+		"string":   {objectValue, encodingString},
+		"detailed": {objectValue, encodingJSONDetailed},
+		"dotenv":   {objectProcess, encodingDotenv},
+		"shell":    {objectProcess, encodingShell},
+	}
+	for alias, want := range cases {
+		t.Run(alias, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseFormat(alias)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+
+			// The compositional spelling must resolve identically to its alias.
+			spelled := map[string]string{
+				"json": "value:json", "yaml": "value:yaml", "string": "value:string",
+				"detailed": "value:json-detailed", "dotenv": "process:dotenv", "shell": "process:shell",
+			}[alias]
+			gotSpelled, err := parseFormat(spelled)
+			require.NoError(t, err)
+			assert.Equal(t, got, gotSpelled)
+		})
+	}
+}
+
+func TestParseFormatValid(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"value:string", "value:json", "value:yaml", "value:json-detailed",
+		"process:json", "process:yaml", "process:json-detailed", "process:dotenv", "process:shell",
+	}
+	for _, s := range valid {
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseFormat(s)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestParseFormatInvalid(t *testing.T) {
+	t.Parallel()
+
+	invalid := []string{
+		"value:dotenv",   // dotenv encodes only a flat string map
+		"value:shell",    // shell encodes only a flat string map
+		"process:string", // process has no bare string encoding
+		"bogus",
+		"value:bogus",
+		"bogus:json",
+		"value:",
+		":json",
+	}
+	for _, s := range invalid {
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseFormat(s)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestValidateFormatPathGuard(t *testing.T) {
+	t.Parallel()
+
+	path := resource.PropertyPath{"foo"}
+
+	_, err := validateFormat("value:json", path)
+	require.NoError(t, err)
+
+	for _, s := range []string{"process:json", "process:dotenv", "process:json-detailed", "shell"} {
+		_, err := validateFormat(s, path)
+		assert.Error(t, err, s)
+	}
+
+	_, err = validateFormat("process:json", nil)
+	require.NoError(t, err)
+}

--- a/pkg/cmd/esc/cli/prepare.go
+++ b/pkg/cmd/esc/cli/prepare.go
@@ -24,27 +24,35 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func getEnvironmentVariables(env *esc.Environment, quote, redact bool) (environ, secrets []string) {
-	vars := env.GetEnvironmentVariables()
-	keys := maps.Keys(vars)
-	sort.Strings(keys)
+// ProjectedVariable is a projected `environmentVariables` entry: the name of an environment variable and
+// the string value a process would see for it.
+type ProjectedVariable struct {
+	Name   string
+	Value  string
+	Secret bool
+}
 
-	for _, k := range keys {
-		v := vars[k]
-		s := v.Value.(string)
+// ProjectedFile is a projected `files` entry: the name of the environment variable that holds the path to
+// the materialized temporary file. Path is that path, or "[unknown]" when files are not materialized.
+type ProjectedFile struct {
+	Name   string
+	Path   string
+	Secret bool
+}
 
-		if v.Secret {
-			secrets = append(secrets, s)
-			if redact {
-				s = "[secret]"
-			}
-		}
-		if quote {
-			s = strconv.Quote(s)
-		}
-		environ = append(environ, fmt.Sprintf("%v=%v", k, s))
-	}
-	return environ, secrets
+// EnvironmentProjection is the process-environment projection of a resolved environment: the
+// environmentVariables and files reserved properties rendered as the string-valued variables a process
+// consumes. It carries structure (per-variable secret flag, env-var vs file) that the flat dotenv/shell
+// encodings discard.
+type EnvironmentProjection struct {
+	// Variables are the projected environment variables, sorted by name.
+	Variables []ProjectedVariable
+	// Files are the projected files, sorted by name.
+	Files []ProjectedFile
+	// Paths are the temporary files created on disk, for later cleanup.
+	Paths []string
+	// Secrets are the raw secret values (env var values and file contents), for redaction of command output.
+	Secrets []string
 }
 
 func createTemporaryFile(fs escFS, content []byte) (string, error) {
@@ -70,36 +78,6 @@ func removeTemporaryFiles(fs escFS, paths []string) {
 	}
 }
 
-func createTemporaryFiles(e *esc.Environment, opts PrepareOptions) (paths, environ, secrets []string, err error) {
-	files := e.GetTemporaryFiles()
-	keys := maps.Keys(files)
-	sort.Strings(keys)
-
-	for _, k := range keys {
-		v := files[k]
-		s := v.Value.(string)
-
-		if v.Secret {
-			secrets = append(secrets, s)
-		}
-
-		path := "[unknown]"
-		if !opts.Pretend {
-			path, err = createTemporaryFile(opts.fs, []byte(s))
-			if err != nil {
-				removeTemporaryFiles(opts.fs, paths)
-				return nil, nil, nil, err
-			}
-			paths = append(paths, path)
-		}
-		if opts.Quote {
-			path = strconv.Quote(path)
-		}
-		environ = append(environ, fmt.Sprintf("%v=%v", k, path))
-	}
-	return paths, environ, secrets, nil
-}
-
 // PrepareOptions contains options for PrepareEnvironment.
 type PrepareOptions struct {
 	Quote   bool // True to quote environment variable values
@@ -109,9 +87,9 @@ type PrepareOptions struct {
 	fs escFS // The filesystem for temporary files
 }
 
-// PrepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
-// temporary files, environment variable pairs, and secret values.
-func PrepareEnvironment(e *esc.Environment, opts *PrepareOptions) (files, environ, secrets []string, err error) {
+// projectEnvironment computes the process-environment projection of e, materializing temporary files unless
+// opts.Pretend is set. Values are raw: quoting and redaction are presentation concerns applied by callers.
+func projectEnvironment(e *esc.Environment, opts *PrepareOptions) (*EnvironmentProjection, error) {
 	if opts == nil {
 		opts = &PrepareOptions{}
 	}
@@ -119,14 +97,74 @@ func PrepareEnvironment(e *esc.Environment, opts *PrepareOptions) (files, enviro
 		opts.fs = newFS()
 	}
 
-	envVars, envSecrets := getEnvironmentVariables(e, opts.Quote, opts.Redact)
+	proj := &EnvironmentProjection{}
 
-	filePaths, fileVars, fileSecrets, err := createTemporaryFiles(e, *opts)
+	vars := e.GetEnvironmentVariables()
+	varKeys := maps.Keys(vars)
+	sort.Strings(varKeys)
+	for _, k := range varKeys {
+		v := vars[k]
+		s := v.Value.(string)
+		if v.Secret {
+			proj.Secrets = append(proj.Secrets, s)
+		}
+		proj.Variables = append(proj.Variables, ProjectedVariable{Name: k, Value: s, Secret: v.Secret})
+	}
+
+	files := e.GetTemporaryFiles()
+	fileKeys := maps.Keys(files)
+	sort.Strings(fileKeys)
+	for _, k := range fileKeys {
+		v := files[k]
+		s := v.Value.(string)
+		if v.Secret {
+			proj.Secrets = append(proj.Secrets, s)
+		}
+		path := "[unknown]"
+		if !opts.Pretend {
+			p, err := createTemporaryFile(opts.fs, []byte(s))
+			if err != nil {
+				removeTemporaryFiles(opts.fs, proj.Paths)
+				return nil, err
+			}
+			proj.Paths = append(proj.Paths, p)
+			path = p
+		}
+		proj.Files = append(proj.Files, ProjectedFile{Name: k, Path: path, Secret: v.Secret})
+	}
+
+	return proj, nil
+}
+
+// PrepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
+// temporary files, environment variable pairs, and secret values.
+func PrepareEnvironment(e *esc.Environment, opts *PrepareOptions) (files, environ, secrets []string, err error) {
+	if opts == nil {
+		opts = &PrepareOptions{}
+	}
+
+	proj, err := projectEnvironment(e, opts)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("creating temporary files: %v", err)
 	}
 
-	environ = append(envVars, fileVars...)
-	secrets = append(envSecrets, fileSecrets...)
-	return filePaths, environ, secrets, nil
+	for _, v := range proj.Variables {
+		s := v.Value
+		if v.Secret && opts.Redact {
+			s = "[secret]"
+		}
+		if opts.Quote {
+			s = strconv.Quote(s)
+		}
+		environ = append(environ, fmt.Sprintf("%v=%v", v.Name, s))
+	}
+	for _, f := range proj.Files {
+		s := f.Path
+		if opts.Quote {
+			s = strconv.Quote(s)
+		}
+		environ = append(environ, fmt.Sprintf("%v=%v", f.Name, s))
+	}
+
+	return proj.Paths, environ, proj.Secrets, nil
 }

--- a/pkg/cmd/esc/cli/prepare_test.go
+++ b/pkg/cmd/esc/cli/prepare_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func projectionTestEnvironment() *esc.Environment {
+	return &esc.Environment{
+		Properties: map[string]esc.Value{
+			"environmentVariables": esc.NewValue(map[string]esc.Value{
+				"FOO":    esc.NewValue("bar"),
+				"SECRET": esc.NewSecret("shh"),
+			}),
+			"files": esc.NewValue(map[string]esc.Value{
+				"FILE":        esc.NewValue("contents"),
+				"SECRET_FILE": esc.NewSecret("secret contents"),
+			}),
+		},
+	}
+}
+
+func TestProjectEnvironmentStructure(t *testing.T) {
+	t.Parallel()
+
+	fs := testFS{MapFS: fstest.MapFS{}}
+	proj, err := projectEnvironment(projectionTestEnvironment(), &PrepareOptions{fs: fs})
+	require.NoError(t, err)
+
+	// Environment variables come first, sorted by name; then files, sorted by name.
+	assert.Equal(t, []ProjectedVariable{
+		{Name: "FOO", Value: "bar", Secret: false},
+		{Name: "SECRET", Value: "shh", Secret: true},
+	}, proj.Variables)
+	assert.Equal(t, []ProjectedFile{
+		{Name: "FILE", Path: "temp/esc-temp-0", Secret: false},
+		{Name: "SECRET_FILE", Path: "temp/esc-temp-1", Secret: true},
+	}, proj.Files)
+
+	// env run's redactor depends on this order: secret env-var values, then secret file contents.
+	assert.Equal(t, []string{"shh", "secret contents"}, proj.Secrets)
+	assert.Equal(t, []string{"temp/esc-temp-0", "temp/esc-temp-1"}, proj.Paths)
+}
+
+func TestProjectEnvironmentPretendSkipsMaterialization(t *testing.T) {
+	t.Parallel()
+
+	fs := testFS{MapFS: fstest.MapFS{}}
+	proj, err := projectEnvironment(projectionTestEnvironment(), &PrepareOptions{Pretend: true, fs: fs})
+	require.NoError(t, err)
+
+	assert.Equal(t, []ProjectedFile{
+		{Name: "FILE", Path: "[unknown]", Secret: false},
+		{Name: "SECRET_FILE", Path: "[unknown]", Secret: true},
+	}, proj.Files)
+	assert.Empty(t, proj.Paths)
+	assert.Empty(t, fs.MapFS)
+}
+
+func TestPrepareEnvironmentQuoteRedact(t *testing.T) {
+	t.Parallel()
+
+	fs := testFS{MapFS: fstest.MapFS{}}
+	files, environ, secrets, err := PrepareEnvironment(
+		projectionTestEnvironment(),
+		&PrepareOptions{Quote: true, Redact: true, fs: fs},
+	)
+	require.NoError(t, err)
+
+	// Secret env-var values redact to [secret]; file paths are never redacted; everything is quoted.
+	assert.Equal(t, []string{
+		`FOO="bar"`,
+		`SECRET="[secret]"`,
+		`FILE="temp/esc-temp-0"`,
+		`SECRET_FILE="temp/esc-temp-1"`,
+	}, environ)
+	assert.Equal(t, []string{"shh", "secret contents"}, secrets)
+	assert.Equal(t, []string{"temp/esc-temp-0", "temp/esc-temp-1"}, files)
+}
+
+func TestPrepareEnvironmentUnquotedUnredacted(t *testing.T) {
+	t.Parallel()
+
+	fs := testFS{MapFS: fstest.MapFS{}}
+	_, environ, _, err := PrepareEnvironment(projectionTestEnvironment(), &PrepareOptions{fs: fs})
+	require.NoError(t, err)
+
+	// This is the shape env run feeds to the child process: raw, unquoted, unredacted.
+	assert.Equal(t, []string{
+		"FOO=bar",
+		"SECRET=shh",
+		"FILE=temp/esc-temp-0",
+		"SECRET_FILE=temp/esc-temp-1",
+	}, environ)
+}

--- a/pkg/cmd/esc/cli/testdata/env-diff-formats.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-diff-formats.yaml
@@ -1,0 +1,52 @@
+run: |
+  esc env diff default/test@stable --format yaml
+  esc env diff default/test@stable --format process:json
+environments:
+  test-user/default/test:
+    revisions:
+      - yaml:
+          values:
+            pi: 3.14
+            environmentVariables:
+              FOO: bar
+        tags:
+          - stable
+      - yaml:
+          values:
+            pi: 3.14
+            secret:
+              fn::secret:
+                ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+            environmentVariables:
+              FOO: baz
+              SECRET: ${secret}
+            files:
+              NUM_FILE: ${pi}
+
+---
+> esc env diff default/test@stable --format yaml
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1,3 +1,7 @@
+ environmentVariables:
+-   FOO: bar
++   FOO: baz
++   SECRET: '[secret]'
++files:
++   NUM_FILE: "3.14"
+ pi: "3.14"
++secret: '[secret]'
+> esc env diff default/test@stable --format process:json
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1,3 +1,5 @@
+ {
+-  "FOO": "bar"
++  "FOO": "baz",
++  "NUM_FILE": "[unknown]",
++  "SECRET": "[secret]"
+ }
+
+---
+> esc env diff default/test@stable --format yaml
+> esc env diff default/test@stable --format process:json

--- a/pkg/cmd/esc/cli/testdata/env-get-value-yaml.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-get-value-yaml.yaml
@@ -1,0 +1,66 @@
+run: |
+  esc env get default/test --value value:yaml
+  esc env get default/test --value process:json-detailed
+  esc env get default/test --value process:json
+  esc env get default/test --value process:yaml
+  esc env get default/test --value process:json --show-secrets
+environments:
+  test-user/default/test:
+    values:
+      pi: 3.14
+      secret:
+        fn::secret:
+          ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+      environmentVariables:
+        FOO: bar
+        SECRET: ${secret}
+      files:
+        FILE: ${pi}
+
+---
+> esc env get default/test --value value:yaml
+environmentVariables:
+   FOO: bar
+   SECRET: '[secret]'
+files:
+   FILE: "3.14"
+pi: "3.14"
+secret: '[secret]'
+> esc env get default/test --value process:json-detailed
+{
+  "FILE": {
+    "value": "[unknown]",
+    "secret": false
+  },
+  "FOO": {
+    "value": "bar",
+    "secret": false
+  },
+  "SECRET": {
+    "value": "[unknown]",
+    "secret": true
+  }
+}
+> esc env get default/test --value process:json
+{
+  "FILE": "[unknown]",
+  "FOO": "bar",
+  "SECRET": "[secret]"
+}
+> esc env get default/test --value process:yaml
+FILE: '[unknown]'
+FOO: bar
+SECRET: '[secret]'
+> esc env get default/test --value process:json --show-secrets
+{
+  "FILE": "[unknown]",
+  "FOO": "bar",
+  "SECRET": "secretAccessKey"
+}
+
+---
+> esc env get default/test --value value:yaml
+> esc env get default/test --value process:json-detailed
+> esc env get default/test --value process:json
+> esc env get default/test --value process:yaml
+> esc env get default/test --value process:json --show-secrets

--- a/pkg/cmd/esc/cli/testdata/open-format-invalid-pair.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-format-invalid-pair.yaml
@@ -1,0 +1,14 @@
+run: esc open default/test --format value:dotenv
+error: exit status 1
+environments:
+  test-user/default/test:
+    values:
+      environmentVariables:
+        FOO: bar
+
+---
+> esc open default/test --format value:dotenv
+
+---
+> esc open default/test --format value:dotenv
+Error: output format "value:dotenv" is not a valid object:encoding pair

--- a/pkg/cmd/esc/cli/testdata/open-format-process-path.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-format-process-path.yaml
@@ -1,0 +1,15 @@
+run: esc open default/test foo --format process:json
+error: exit status 1
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      environmentVariables:
+        FOO: ${foo}
+
+---
+> esc open default/test foo --format process:json
+
+---
+> esc open default/test foo --format process:json
+Error: output format "process:json" may not be used with a property path

--- a/pkg/cmd/esc/cli/testdata/open-process.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-process.yaml
@@ -1,0 +1,70 @@
+run: |
+  esc open default/test --format process:json-detailed
+  esc open default/test --format process:json
+  esc open default/test --format process:yaml
+  esc open default/test --format dotenv
+environments:
+  test-user/default/test:
+    values:
+      pi: 3.14
+      secret:
+        fn::secret:
+          ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+      environmentVariables:
+        FOO: bar
+        NUM: ${pi}
+        SECRET: ${secret}
+      files:
+        NUM_FILE: ${pi}
+        SECRET_FILE: ${secret}
+
+---
+> esc open default/test --format process:json-detailed
+{
+  "FOO": {
+    "value": "bar",
+    "secret": false
+  },
+  "NUM": {
+    "value": "3.14",
+    "secret": false
+  },
+  "NUM_FILE": {
+    "value": "temp/esc-temp-0",
+    "secret": false
+  },
+  "SECRET": {
+    "value": "secretAccessKey",
+    "secret": true
+  },
+  "SECRET_FILE": {
+    "value": "temp/esc-temp-1",
+    "secret": true
+  }
+}
+> esc open default/test --format process:json
+{
+  "FOO": "bar",
+  "NUM": "3.14",
+  "NUM_FILE": "temp/esc-temp-2",
+  "SECRET": "secretAccessKey",
+  "SECRET_FILE": "temp/esc-temp-3"
+}
+> esc open default/test --format process:yaml
+FOO: bar
+NUM: "3.14"
+NUM_FILE: temp/esc-temp-4
+SECRET: secretAccessKey
+SECRET_FILE: temp/esc-temp-5
+> esc open default/test --format dotenv
+FOO="bar"
+NUM="3.14"
+SECRET="secretAccessKey"
+NUM_FILE="temp/esc-temp-6"
+SECRET_FILE="temp/esc-temp-7"
+
+---
+> esc open default/test --format process:json-detailed
+> esc open default/test --format process:json
+> esc open default/test --format process:yaml
+> esc open default/test --format dotenv


### PR DESCRIPTION
Design: https://app.notion.com/p/Separate-what-pulumi-env-open-produces-from-how-it-encodes-it-396fdbdf1cce80c5b1bae7d1cedcecc5

Motivated by the esc-action masking work (pulumi/esc-action#44, fixing pulumi/esc-action#24): to mask only real secrets the action needs the process-environment plus a per-value secret flag, which today means two opens (`dotenv` for values, `detailed` for flags) and a hand-rolled dotenv parser. `process:json-detailed` gives it both in one open.

`--format`/`--value` values become `<object>:<encoding>` pairs:

- objects `value`, `process`; encodings `string`, `json`, `yaml`, `json-detailed`, `dotenv`, `shell`
- illegal pairs (`value:dotenv`, `process:string`) are unrepresentable
- legacy values are aliases, rendering byte-identically (`json` = `value:json`, `detailed` = `value:json-detailed`, `dotenv` = `process:dotenv`, ...)
- new `process:json`/`process:yaml`/`process:json-detailed` encode the process-environment as a structured document; `process:json-detailed` carries the per-value secret flag that dotenv/shell discard

Consolidates the three drifted format validators (open/get/diff) into one `parseFormat` table; `yaml` now works on `get` and `diff`. The process-environment projection moves to a structured `EnvironmentProjection` beneath the unchanged `PrepareEnvironment` signature, leaving `env run` and config/policypack consumers untouched.

## Help text

```
Usage:
  open [<org-name>/][<project-name>/]<environment-name>[@<version>] [flags]

Flags:
  -f, --format string   the output format to use, given as <object>:<encoding>. Defaults to value:json.

                        aliases:
                          detailed  value:json-detailed
                          dotenv    process:dotenv
                          json      value:json
                          shell     process:shell
                          string    value:string
                          yaml      value:yaml

                        value: the resolved configuration value tree
                          value:string           resolved value as a single flattened string
                          value:json             resolved value tree as JSON
                          value:yaml             resolved value tree as YAML
                          value:json-detailed    resolved value tree as JSON, annotated with secret flags and source provenance

                        process: the environmentVariables and files reserved keys projected as the string variables a process consumes; files are written to disk and each variable holds the file path
                          process:json           process environment as a flat JSON object
                          process:yaml           process environment as a flat YAML mapping
                          process:json-detailed  process environment as JSON, with a per-variable secret flag
                          process:dotenv         process environment as dotenv assignments
                          process:shell          process environment as shell export statements

runtime default var value = "json"
```

## Test plan

- Automated
  - `format_test.go`, `prepare_test.go`: format parsing/validation and projection contract
  - `testdata/` goldens: `open-process`, `env-get-value-yaml`, `env-diff-formats`, `open-format-invalid-pair`, `open-format-process-path`; existing 101 goldens confirm legacy output is byte-identical
- Manual, run against review stack https://app-fnune-review.review-stacks.pulumi-dev.io/pulumi_local/ on an env with vars, files, and a secret
  - `open --format process:json-detailed`: per-value secret flags correct (`SECRET`/`SECRET_FILE` -> `secret: true`); files materialized to real paths with correct content (`NUM_FILE` -> `3.14`, `SECRET_FILE` -> `secretAccessKey`)
  - `open --format detailed` vs `--format value:json-detailed`: byte-identical (alias equivalence); `dotenv` output unchanged
  - `get --value process:json`: `SECRET` -> `[secret]` without `--show-secrets`, plaintext with `--show-secrets`
  - `diff --format yaml` and `--format process:json` across versions: `FOO` change shown, secrets redacted to `[secret]`, files `[unknown]`
  - error cases: `value:dotenv` (invalid pair), `process:json` with a property path (guard), `bogus:json` (unknown object)