### PR TITLE
Configure dependency cooldowns for npm, pnpm, uv, pip, poetry and bun

### DIFF
--- a/.github/actions/dependency-cooldown/action.yml
+++ b/.github/actions/dependency-cooldown/action.yml
@@ -1,0 +1,39 @@
+name: Dependency cooldown
+description: >-
+  Supply-chain hardening: restrict npm, pnpm, uv, pip, poetry and bun to package versions
+  older than a cooldown window (https://cooldowns.dev). Yarn classic is not covered.
+inputs:
+  days:
+    description: Cooldown window in days. Versions published more recently than this are excluded.
+    default: "3"
+runs:
+  using: composite
+  steps:
+    - name: Configure dependency cooldown (${{ inputs.days }} days)
+      shell: bash
+      env:
+        COOLDOWN_DAYS: ${{ inputs.days }}
+      run: |
+        set -euo pipefail
+
+        # uv wants an absolute cutoff instant; everything else takes a relative age.
+        cutoff="$(python3 -c "import datetime, os; d = int(os.environ['COOLDOWN_DAYS']); print((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=d)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+
+        pnpm_minutes=$(( COOLDOWN_DAYS * 1440 ))
+        bun_seconds=$(( COOLDOWN_DAYS * 86400 ))
+
+        echo "Dependency cooldown: excluding package versions published after ${cutoff} (${COOLDOWN_DAYS} days)"
+
+        {
+          echo "UV_EXCLUDE_NEWER=${cutoff}"                     # uv (Python)
+          echo "npm_config_min_release_age=${COOLDOWN_DAYS}"    # npm (days)
+          echo "npm_config_minimum_release_age=${pnpm_minutes}" # pnpm (minutes)
+          echo "POETRY_SOLVER_MIN_RELEASE_AGE=${COOLDOWN_DAYS}" # poetry (days)
+          echo "PIP_UPLOADED_PRIOR_TO=P${COOLDOWN_DAYS}D"       # pip >= 26.1 (ISO-8601 duration; older pip ignores it)
+        } >> "$GITHUB_ENV"
+
+        # bun has no environment variable form, but reads a global config from $HOME.
+        cat > "${HOME}/.bunfig.toml" <<EOF
+        [install]
+        minimumReleaseAge = ${bun_seconds}
+        EOF

--- a/.github/actions/dependency-cooldown/action.yml
+++ b/.github/actions/dependency-cooldown/action.yml
@@ -16,16 +16,14 @@ runs:
       run: |
         set -euo pipefail
 
-        # uv wants an absolute cutoff instant; everything else takes a relative age.
-        cutoff="$(python3 -c "import datetime, os; d = int(os.environ['COOLDOWN_DAYS']); print((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=d)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
-
+        # Each manager takes the window in its own unit; all are relative to "now".
         pnpm_minutes=$(( COOLDOWN_DAYS * 1440 ))
         bun_seconds=$(( COOLDOWN_DAYS * 86400 ))
 
-        echo "Dependency cooldown: excluding package versions published after ${cutoff} (${COOLDOWN_DAYS} days)"
+        echo "Dependency cooldown: excluding package versions published in the last ${COOLDOWN_DAYS} days"
 
         {
-          echo "UV_EXCLUDE_NEWER=${cutoff}"                     # uv (Python)
+          echo "UV_EXCLUDE_NEWER=P${COOLDOWN_DAYS}D"            # uv (ISO-8601 duration)
           echo "npm_config_min_release_age=${COOLDOWN_DAYS}"    # npm (days)
           echo "npm_config_minimum_release_age=${pnpm_minutes}" # pnpm (minutes)
           echo "POETRY_SOLVER_MIN_RELEASE_AGE=${COOLDOWN_DAYS}" # poetry (days)

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -110,6 +110,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.ref }}
+      - name: Configure dependency cooldown
+        uses: ./.github/actions/dependency-cooldown
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -158,6 +158,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.ref }}
+      - name: Configure dependency cooldown
+        uses: ./.github/actions/dependency-cooldown
       # Frees ~24GiB; test jobs run out of disk otherwise (#17470). The bulk of
       # the cleanup runs in the background, overlapping the setup steps below.
       # The "Wait for disk cleanup" step joins it before tests run.

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -505,6 +505,9 @@ func fakeNPMRegistry(t testing.TB) string {
 			fmt.Fprintf(w, `{
 				"name": "@pulumi/pulumi",
 				"dist-tags": {"latest": "3.0.0"},
+				"time": {
+					"3.0.0": "2020-01-01T00:00:00.000Z"
+				},
 				"versions": {
 					"3.0.0": {
 						"name": "@pulumi/pulumi",


### PR DESCRIPTION
Set a cooldown of 3 days for dependencies installed via npm, pnpm, uv, pip and poetry. Note that yarn 1 does not support any setting for this. With these settings, package managers will not install packages that have been released in the past 3 days.

Tests that require the latest core SDK already manually install the local build of the SDK, so are unaffected by this.

Configuration for various package managers can be found at https://cooldowns.dev