### PR TITLE
Don't require the passphrase to read non-secret stack outputs

### DIFF
--- a/changelog/pending/cli-fix-20260707-184545.yaml
+++ b/changelog/pending/cli-fix-20260707-184545.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Make reading non-secret stack outputs and running `pulumi about` no longer require the passphrase for passphrase-encrypted stacks
+time: 2026-07-07T18:45:45-07:00
+custom:
+    PR: "23820"

--- a/pkg/backend/secrets/providers.go
+++ b/pkg/backend/secrets/providers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/service"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 )
 
 // DefaultProvider is the default DefaultProvider to use when deserializing deployments.
@@ -54,6 +55,49 @@ func (secretsProvider) OfType(ctx context.Context, ty string, state json.RawMess
 	}
 
 	return stack.NewBatchingCachingSecretsManager(sm), nil
+}
+
+// BlindingProvider builds secrets managers that redact every secret to config.BlindingCrypter's "[secret]"
+// sentinel instead of decrypting it. It never needs a passphrase or other credentials, so it can be used to
+// deserialize a checkpoint when we only need to read non-secret data (or display secrets masked) — for example
+// reading a non-secret stack output or listing resources in `pulumi about` — without prompting for a passphrase.
+var BlindingProvider secrets.Provider = blindingProvider{}
+
+type blindingProvider struct{}
+
+func (blindingProvider) OfType(_ context.Context, ty string, state json.RawMessage) (secrets.Manager, error) {
+	return blindingManager{ty: ty, state: state}, nil
+}
+
+type blindingManager struct {
+	ty    string
+	state json.RawMessage
+}
+
+func (m blindingManager) Type() string                { return m.ty }
+func (m blindingManager) State() json.RawMessage      { return m.state }
+func (m blindingManager) Encrypter() config.Encrypter { return config.BlindingCrypter }
+func (m blindingManager) Decrypter() config.Decrypter { return redactingDecrypter{} }
+
+type redactingDecrypter struct{}
+
+// DecryptValue returns config.BlindingCrypter's "[secret]" sentinel, JSON-encoded: deployment deserialization
+// unmarshals each decrypted plaintext as a JSON value, so the bare sentinel (not valid JSON) can't be returned
+// directly.
+func (redactingDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
+	redacted, err := config.BlindingCrypter.DecryptValue(ctx, ciphertext)
+	if err != nil {
+		return "", err
+	}
+	plaintext, err := json.Marshal(redacted)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}
+
+func (d redactingDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
+	return config.DefaultBatchDecrypt(ctx, d, ciphertexts)
 }
 
 // NamedStackProvider is the same as the default secrets provider,

--- a/pkg/backend/secrets/providers_test.go
+++ b/pkg/backend/secrets/providers_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The blinding provider must build a secrets manager for any type without needing credentials, so that operations
+// that only round-trip a checkpoint (or display secrets masked) can proceed offline. This is what lets commands
+// like `pulumi stack output` (without --show-secrets) and `pulumi about` run without a passphrase.
+func TestBlindingProviderOfTypeNeverErrors(t *testing.T) {
+	t.Parallel()
+
+	// Even for the passphrase provider (which normally requires PULUMI_CONFIG_PASSPHRASE), OfType succeeds without
+	// any credentials configured.
+	sm, err := BlindingProvider.OfType(t.Context(), "passphrase", json.RawMessage(`{"salt":"v1:xyz"}`))
+	require.NoError(t, err)
+	require.NotNil(t, sm)
+	assert.Equal(t, "passphrase", sm.Type())
+}
+
+// The blinding provider's decrypter must redact every secret to the "[secret]" sentinel rather than decrypting it.
+// The value is JSON-encoded because deployment deserialization unmarshals each decrypted plaintext as a JSON value.
+func TestBlindingProviderRedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	sm, err := BlindingProvider.OfType(t.Context(), "passphrase", nil)
+	require.NoError(t, err)
+
+	plaintext, err := sm.Decrypter().DecryptValue(t.Context(), "any-ciphertext")
+	require.NoError(t, err)
+	assert.JSONEq(t, `"[secret]"`, plaintext)
+}

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -427,7 +427,10 @@ func getCurrentStackAbout(
 
 	name := s.Ref().String()
 	var snapshot *deploy.Snapshot
-	snapshot, err = s.Snapshot(ctx, secrets.DefaultProvider)
+	// `about` only reports resource types and URNs, never secret values, so deserialize with the blinding
+	// provider. This avoids prompting for a passphrase (or other secrets-provider credentials) just to list the
+	// resources in the current stack.
+	snapshot, err = s.Snapshot(ctx, secrets.BlindingProvider)
 	if err != nil {
 		return currentStackAbout{}, err
 	} else if snapshot == nil {

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	backendsecrets "github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -44,7 +45,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -150,7 +150,7 @@ func newPolicyAnalyzeCmd(
 					// redacted so analysis still runs; policies then see "[secret]". A non-secrets
 					// failure recurs identically below, so we surface the original err.
 					var redactErr error
-					snap, redactErr = stack.DeserializeUntypedDeployment(ctx, &deployment, blindingSecretsProvider{})
+					snap, redactErr = stack.DeserializeUntypedDeployment(ctx, &deployment, backendsecrets.BlindingProvider)
 					if redactErr != nil {
 						return fmt.Errorf("deserializing deployment from %s: %w", file, err)
 					}
@@ -284,49 +284,6 @@ func stackReferenceForFile(snap *deploy.Snapshot) backend.StackReference {
 		ref.StringV = "<multiple>"
 	}
 	return ref
-}
-
-// blindingSecretsProvider builds secrets managers that redact every secret to
-// config.BlindingCrypter's "[secret]" sentinel instead of decrypting it. --file mode falls
-// back to it when the real provider can't decrypt a state file offline (e.g. a service-backed
-// export with no local login), so analysis runs instead of failing.
-type blindingSecretsProvider struct{}
-
-func (blindingSecretsProvider) OfType(
-	_ context.Context, ty string, state json.RawMessage,
-) (secrets.Manager, error) {
-	return blindingSecretsManager{ty: ty, state: state}, nil
-}
-
-type blindingSecretsManager struct {
-	ty    string
-	state json.RawMessage
-}
-
-func (m blindingSecretsManager) Type() string                { return m.ty }
-func (m blindingSecretsManager) State() json.RawMessage      { return m.state }
-func (m blindingSecretsManager) Encrypter() config.Encrypter { return config.BlindingCrypter }
-func (m blindingSecretsManager) Decrypter() config.Decrypter { return redactingDecrypter{} }
-
-type redactingDecrypter struct{}
-
-// DecryptValue returns config.BlindingCrypter's "[secret]" sentinel, JSON-encoded:
-// deployment deserialization unmarshals each decrypted plaintext as a JSON value, so the
-// bare sentinel (not valid JSON) can't be returned directly.
-func (redactingDecrypter) DecryptValue(ctx context.Context, ciphertext string) (string, error) {
-	redacted, err := config.BlindingCrypter.DecryptValue(ctx, ciphertext)
-	if err != nil {
-		return "", err
-	}
-	plaintext, err := json.Marshal(redacted)
-	if err != nil {
-		return "", err
-	}
-	return string(plaintext), nil
-}
-
-func (d redactingDecrypter) BatchDecrypt(ctx context.Context, ciphertexts []string) ([]string, error) {
-	return config.DefaultBatchDecrypt(ctx, d, ciphertexts)
 }
 
 // analyzeEvents implements deploy.PolicyEvents and writes human-readable output.

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -144,7 +144,12 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	snapshotStackOutputs, err := s.SnapshotStackOutputs(ctx, secrets.DefaultProvider)
+	// When we're not showing secrets, use a blinding provider to prevent secrets from being disclosed.
+	secretsProvider := secrets.DefaultProvider
+	if !cmd.showSecrets {
+		secretsProvider = secrets.BlindingProvider
+	}
+	snapshotStackOutputs, err := s.SnapshotStackOutputs(ctx, secretsProvider)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Problem

For passphrase-encrypted stacks, `pulumi stack output` (of a non-secret output) and `pulumi about` failed unless `PULUMI_CONFIG_PASSPHRASE` (or `PULUMI_CONFIG_PASSPHRASE_FILE`) was set:

```
$ pulumi stack output aString
error: constructing secrets manager of type "passphrase": ... passphrase must be set with PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE environment variables
```

These commands deserialize the stack's outputs, which eagerly constructs the secrets manager and decrypts **every** secret up front — even ones the command never displays. So reading a plain string output, or listing resources in `pulumi about`, demanded the passphrase unnecessarily.

Fixes #21141

### Fix

Add a shared `BlindingProvider` (in `pkg/backend/secrets`) that redacts every secret to `config.BlindingCrypter`'s `[secret]` sentinel instead of decrypting it, so a checkpoint can be read without any secrets-provider credentials. It's used when:

- **`pulumi stack output`** is run **without** `--show-secrets` — non-secret outputs are shown, secrets are masked as `[secret]`. With `--show-secrets` the real provider is still used and the passphrase is still required.
- **`pulumi about`** reads the snapshot — it only reports resource types and URNs, never secret values.

This consolidates the equivalent blinding provider that already existed locally in `pulumi policy analyze`, which now reuses the shared one.

### Behavior (passphrase unset)

| Command | Before | After |
|---|---|---|
| `stack output aString` | error | `from-qa` |
| `stack output` (all) | error | `aString` shown, `aSecret` → `[secret]` |
| `stack output aSecret` | error | `[secret]` |
| `about` | error | stack info listed |
| `stack output aSecret --show-secrets` | error | error (unchanged — passphrase still required) |
| `stack output aSecret --show-secrets` (passphrase set) | real value | real value (unchanged) |

### Testing

- Unit tests for `BlindingProvider` in `pkg/backend/secrets/providers_test.go`.
- Existing `stack`, `about`, and `policy` package tests pass.
- Manually verified the behavior matrix above against a passphrase-encrypted diy-backend stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)