### PR TITLE
do: use display code for output

### DIFF
--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -61,6 +61,8 @@ type Options struct {
 	ShowURNs                 bool                // true to display full URNs instead of short resource names.
 	SuppressDiagEventsInDiff bool                // true to suppress displaying diagnostic events in the diff display
 
+	SuppressStackRow bool // true to hide the synthetic stack row when no stack is involved.
+
 	// Neo options
 	ShowLinkToNeo       bool // true to display a 'explainFailure' link to Neo.
 	ShowNeoFeatures     bool // true to display Neo features like summaries and explanations.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -634,8 +634,14 @@ func (display *ProgressDisplay) filterOutUnnecessaryNodesAndSetDisplayTimes(node
 	for _, node := range nodes {
 		node.childNodes = display.filterOutUnnecessaryNodesAndSetDisplayTimes(node.childNodes)
 
-		if node.row.HideRowIfUnnecessary() && len(node.childNodes) == 0 {
-			continue
+		if node.row.HideRowIfUnnecessary() {
+			if len(node.childNodes) == 0 {
+				continue
+			}
+			if rr, ok := node.row.(*resourceRowData); ok && rr.syntheticStackRow {
+				result = append(result, node.childNodes...)
+				continue
+			}
 		}
 
 		display.displayOrderCounter++
@@ -1025,15 +1031,13 @@ func (display *ProgressDisplay) printOutputs() {
 	if display.opts.SuppressOutputs {
 		return
 	}
-	// Cannot display outputs for the stack if we don't know its URN.
-	if display.stackUrn == "" {
+	step, ok := display.outputsStep()
+	if !ok {
 		return
 	}
 
-	stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
-
 	props := getResourceOutputsPropertiesString(
-		stackStep,
+		step,
 		1, /* indent */
 		display.isPreview,
 		display.opts.Debug,
@@ -1045,6 +1049,29 @@ func (display *ProgressDisplay) printOutputs() {
 		display.println(colors.SpecHeadline + "Outputs:" + colors.Reset)
 		display.println(props)
 	}
+}
+
+// outputsStep picks the step whose outputs the Outputs section prints: normally the root stack's;
+// with SuppressStackRow (no stack participates), the single operated resource's.
+func (display *ProgressDisplay) outputsStep() (engine.StepEventMetadata, bool) {
+	if display.stackUrn != "" {
+		return display.eventUrnToResourceRow[display.stackUrn].Step(), true
+	}
+	if !display.opts.SuppressStackRow {
+		return engine.StepEventMetadata{}, false
+	}
+	var step engine.StepEventMetadata
+	found := false
+	for urn, row := range display.eventUrnToResourceRow {
+		if urn == "" {
+			continue
+		}
+		if found {
+			return engine.StepEventMetadata{}, false
+		}
+		step, found = row.Step(), true
+	}
+	return step, found
 }
 
 // printSummary prints the Stack's SummaryEvent in a new section if applicable.
@@ -1444,7 +1471,8 @@ func (display *ProgressDisplay) ensureHeaderAndStackRows() {
 		tick:                 display.currentTick,
 		diagInfo:             &DiagInfo{},
 		step:                 engine.StepEventMetadata{Op: deploy.OpSame},
-		hideRowIfUnnecessary: false,
+		hideRowIfUnnecessary: display.opts.SuppressStackRow,
+		syntheticStackRow:    true,
 	}
 
 	display.eventUrnToResourceRow[display.stackUrn] = stackRow

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -435,6 +435,62 @@ func TestProgressPolicyPacks(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Loading policy packs...")
 }
 
+func TestSuppressStackRow(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("stack", "project", "", "pkgA:index:typA", "resA")
+	metadata := engine.StepEventMetadata{
+		Op:   deploy.OpCreate,
+		URN:  urn,
+		Type: urn.Type(),
+	}
+
+	run := func(t *testing.T, interactive, suppress bool) string {
+		eventChannel, doneChannel := make(chan engine.Event), make(chan bool)
+
+		var stdout, stderr bytes.Buffer
+		opts := Options{
+			IsInteractive:       interactive,
+			Color:               colors.Never,
+			Stdout:              &stdout,
+			Stderr:              &stderr,
+			SuppressStackRow:    suppress,
+			DeterministicOutput: true,
+		}
+		if interactive {
+			opts.term = terminal.NewMockTerminal(&stdout, 80, 24, true)
+		}
+
+		go ShowProgressEvents(
+			"test", "update", tokens.MustParseStackName("stack"), "project", "", eventChannel, doneChannel,
+			opts, false)
+
+		eventChannel <- engine.NewEvent(engine.ResourcePreEventPayload{Metadata: metadata})
+		eventChannel <- engine.NewEvent(engine.ResourceOutputsEventPayload{Metadata: metadata})
+		close(eventChannel)
+		<-doneChannel
+
+		return stdout.String()
+	}
+
+	for _, interactive := range []bool{true, false} {
+		name := "non-interactive"
+		if interactive {
+			name = "interactive"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			suppressed := run(t, interactive, true)
+			assert.Contains(t, suppressed, "pkgA:index:typA")
+			assert.NotContains(t, suppressed, "pulumi:pulumi:Stack")
+
+			visible := run(t, interactive, false)
+			assert.Contains(t, visible, "pulumi:pulumi:Stack")
+		})
+	}
+}
+
 func testSimpleRenderer(
 	t testing.TB,
 	path string,

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -139,6 +139,10 @@ type resourceRowData struct {
 	// If this row should be hidden by default.  We will hide unless we have any child nodes
 	// we need to show.
 	hideRowIfUnnecessary bool
+
+	// True for the placeholder stack row synthesized by ensureHeaderAndStackRows before any
+	// stack event arrives.
+	syntheticStackRow bool
 }
 
 func (data *resourceRowData) DisplayOrderIndex() int {

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -92,6 +92,7 @@ func NewDoCmd(
 	var dryrun bool
 	var showSecrets bool
 	var stateless bool
+	var output string
 
 	// buildSubcommand returns the dynamically constructed subcommand along with a cleanup function that must be
 	// deferred by the caller. The cleanup tears down the provider gRPC channel — running it as a defer inside
@@ -107,6 +108,10 @@ func NewDoCmd(
 		contract.Assertf(!errors.Is(err, pflag.ErrHelp), "unexpected --help flag")
 		if err != nil {
 			return nil, nil, fmt.Errorf("parse arguments: %w", err)
+		}
+
+		if output != "" && output != "default" && output != "json" {
+			return nil, nil, fmt.Errorf("unsupported output format %q (supported: default, json)", output)
 		}
 
 		pargs := flags.Args()
@@ -266,6 +271,7 @@ func NewDoCmd(
 			dryrun:            dryrun,
 			showSecrets:       showSecrets,
 			stateless:         stateless,
+			jsonOut:           output == "json",
 			wd:                wd,
 			proj:              proj,
 			root:              root,
@@ -434,6 +440,8 @@ to use another format.`,
 
 	cmd.PersistentFlags().BoolVar(&dryrun, "dry-run", false, "Run the operation in preview mode")
 	cmd.PersistentFlags().BoolVar(&showSecrets, "show-secrets", false, "Show secret values in output")
+	cmd.PersistentFlags().StringVar(&output, "output", "",
+		"Output format for resource operation results (supported: default, json)")
 	cmd.PersistentFlags().BoolVar(&stateless, "stateless", false,
 		"Run create/patch/delete directly against the provider without persisting state. "+
 			"Required for now: the stateful (engine-driven) implementation is still in development, "+
@@ -491,6 +499,7 @@ type packageCommand struct {
 	dryrun            bool
 	showSecrets       bool
 	stateless         bool
+	jsonOut           bool
 
 	// wd / proj / root capture the working-directory and project-loading state from buildSubcommand
 	// — kept here rather than baked into a snapshot of functionEvalContext so the evalContext()

--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -1,0 +1,146 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	backenddisplay "github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+type displayedStep struct {
+	Op           display.StepOp
+	Old, New     *resource.State
+	Diffs        []resource.PropertyKey
+	DetailedDiff map[string]plugin.PropertyDiff
+}
+
+func (pc *packageCommand) runDisplayedStep(
+	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
+) error {
+	preview := pc.dryrun && step.Op != deploy.OpRead
+
+	if pc.jsonOut {
+		state, err := call()
+		if err != nil || state == nil {
+			return err
+		}
+		return pc.printResourceResult(cmd, state)
+	}
+
+	stderr := cmd.ErrOrStderr()
+	opts := backenddisplay.Options{
+		Color:               cmdutil.GetGlobalColorization(),
+		IsInteractive:       cmdutil.Interactive(),
+		Type:                backenddisplay.DisplayProgress,
+		Stdin:               cmd.InOrStdin(),
+		Stdout:              stderr,
+		Stderr:              stderr,
+		ShowSecrets:         pc.showSecrets,
+		ShowReads:           true,
+		ShowResourceChanges: len(step.Diffs) > 0 || len(step.DetailedDiff) > 0,
+		SuppressProgress:    true,
+		SuppressStackRow:    true,
+	}
+
+	kind := apitype.UpdateUpdate
+	if step.Op == deploy.OpDelete {
+		kind = apitype.DestroyUpdate
+	}
+
+	events := make(chan engine.Event)
+	done := make(chan bool)
+	go backenddisplay.ShowEvents(
+		string(step.Op), kind, doDisplayStack, doDisplayProject,
+		"" /*permalink*/, events, done, opts, preview)
+
+	metadata := step.metadata(pc.showSecrets)
+	start := time.Now()
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{Metadata: metadata, Planning: preview})
+
+	result, err := call()
+	if err != nil {
+		events <- engine.NewEvent(engine.ResourceOperationFailedPayload{
+			Metadata: metadata,
+			Status:   resource.StatusOK,
+			Steps:    1,
+		})
+	} else {
+		if result != nil {
+			metadata.New = engine.MakeStepEventStateMetadata(result, pc.showSecrets)
+			metadata.Res = metadata.New
+		}
+		events <- engine.NewEvent(engine.ResourceOutputsEventPayload{Metadata: metadata, Planning: preview})
+		if step.Op != deploy.OpRead {
+			events <- engine.NewEvent(engine.SummaryEventPayload{
+				IsPreview:       preview,
+				Duration:        time.Since(start),
+				ResourceChanges: display.ResourceChanges{step.Op: 1},
+			})
+		}
+	}
+
+	events <- engine.NewCancelEvent()
+	<-done
+	close(events)
+
+	return err
+}
+
+func (s displayedStep) urn() resource.URN {
+	if s.New != nil {
+		return s.New.URN
+	}
+	return s.Old.URN
+}
+
+func (s displayedStep) metadata(showSecrets bool) engine.StepEventMetadata {
+	oldMeta := engine.MakeStepEventStateMetadata(s.Old, showSecrets)
+	newMeta := engine.MakeStepEventStateMetadata(s.New, showSecrets)
+	resMeta := newMeta
+	if resMeta == nil {
+		resMeta = oldMeta
+	}
+	return engine.StepEventMetadata{
+		Op:           s.Op,
+		URN:          s.urn(),
+		Type:         s.urn().Type(),
+		Old:          oldMeta,
+		New:          newMeta,
+		Res:          resMeta,
+		Diffs:        s.Diffs,
+		DetailedDiff: s.DetailedDiff,
+	}
+}
+
+func operationState(urn resource.URN, id resource.ID, inputs, outputs resource.PropertyMap) *resource.State {
+	return &resource.State{
+		Type:    urn.Type(),
+		URN:     urn,
+		Custom:  true,
+		ID:      id,
+		Inputs:  inputs,
+		Outputs: outputs,
+	}
+}

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -133,6 +133,7 @@ Flags:
   -h, --help                   help for do
       --input string           Format of the configuration files (default "yaml")
       --input-file string      Path to a file containing function inputs
+      --output string          Output format for resource operation results (supported: default, json)
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
       --param1 string          To set param1 things (alias for --input:param1)
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -29,6 +29,7 @@ import (
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -152,20 +153,26 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 			if err := pc.confirm(cmd, summary, "create", yes); err != nil {
 				return err
 			}
-			response, err := pc.provider.Create(ctx, plugin.CreateRequest{
-				URN:        urn,
-				Name:       urn.Name(),
-				Type:       urn.Type(),
-				Properties: checked,
-				Preview:    pc.dryrun,
+			return pc.runDisplayedStep(cmd, displayedStep{
+				Op:  deploy.OpCreate,
+				New: operationState(urn, "", nil, nil),
+			}, func() (*resource.State, error) {
+				response, err := pc.provider.Create(ctx, plugin.CreateRequest{
+					URN:        urn,
+					Name:       urn.Name(),
+					Type:       urn.Type(),
+					Properties: checked,
+					Preview:    pc.dryrun,
+				})
+				if err != nil {
+					return nil, err
+				}
+				id := response.ID
+				if id == "" {
+					id = resource.ID("[unknown]")
+				}
+				return resultState(urn, id, nil, response.Properties, res), nil
 			})
-			if err != nil {
-				return err
-			}
-			if response.ID == "" {
-				response.ID = resource.ID("[unknown]")
-			}
-			return pc.printResourceResult(cmd, response.ID, response.Properties, res)
 		},
 	}
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
@@ -186,25 +193,30 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 				return err
 			}
 			urn := resourceURN(res)
-			response, err := pc.provider.Read(ctx, plugin.ReadRequest{
-				URN:    urn,
-				Name:   urn.Name(),
-				Type:   urn.Type(),
-				ID:     resource.ID(args[0]),
-				Inputs: resource.PropertyMap{},
-				State:  resource.PropertyMap{},
+			id := resource.ID(args[0])
+			return pc.runDisplayedStep(cmd, displayedStep{
+				Op:  deploy.OpRead,
+				New: operationState(urn, id, nil, nil),
+			}, func() (*resource.State, error) {
+				response, err := pc.provider.Read(ctx, plugin.ReadRequest{
+					URN:    urn,
+					Name:   urn.Name(),
+					Type:   urn.Type(),
+					ID:     id,
+					Inputs: resource.PropertyMap{},
+					State:  resource.PropertyMap{},
+				})
+				if err != nil {
+					return nil, err
+				}
+				if response.Outputs == nil {
+					return nil, fmt.Errorf("resource %q was not found", args[0])
+				}
+				if response.ID != "" {
+					id = response.ID
+				}
+				return resultState(urn, id, nil, response.Outputs, res), nil
 			})
-			if err != nil {
-				return err
-			}
-			if response.Outputs == nil {
-				return fmt.Errorf("resource %q was not found", args[0])
-			}
-			id := response.ID
-			if id == "" {
-				id = resource.ID(args[0])
-			}
-			return pc.printResourceResult(cmd, id, response.Outputs, res)
 		},
 	}
 }
@@ -282,20 +294,28 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 				return err
 			}
 
-			response, err := pc.provider.Update(ctx, plugin.UpdateRequest{
-				URN:        urn,
-				Name:       urn.Name(),
-				Type:       urn.Type(),
-				ID:         id,
-				OldInputs:  oldInputs,
-				OldOutputs: read.Outputs,
-				NewInputs:  checked,
-				Preview:    pc.dryrun,
+			return pc.runDisplayedStep(cmd, displayedStep{
+				Op:           deploy.OpUpdate,
+				Old:          operationState(urn, id, oldInputs, read.Outputs),
+				New:          operationState(urn, id, checked, nil),
+				Diffs:        diff.ChangedKeys,
+				DetailedDiff: diff.DetailedDiff,
+			}, func() (*resource.State, error) {
+				response, err := pc.provider.Update(ctx, plugin.UpdateRequest{
+					URN:        urn,
+					Name:       urn.Name(),
+					Type:       urn.Type(),
+					ID:         id,
+					OldInputs:  oldInputs,
+					OldOutputs: read.Outputs,
+					NewInputs:  checked,
+					Preview:    pc.dryrun,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return resultState(urn, id, checked, response.Properties, res), nil
 			})
-			if err != nil {
-				return err
-			}
-			return pc.printResourceResult(cmd, id, response.Properties, res)
 		},
 	}
 	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Format of the configuration files")
@@ -332,15 +352,20 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			if pc.dryrun {
 				return nil
 			}
-			_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{
-				URN:     urn,
-				Name:    urn.Name(),
-				Type:    urn.Type(),
-				ID:      id,
-				Inputs:  resource.PropertyMap{},
-				Outputs: resource.PropertyMap{},
+			return pc.runDisplayedStep(cmd, displayedStep{
+				Op:  deploy.OpDelete,
+				Old: operationState(urn, id, nil, nil),
+			}, func() (*resource.State, error) {
+				_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{
+					URN:     urn,
+					Name:    urn.Name(),
+					Type:    urn.Type(),
+					ID:      id,
+					Inputs:  resource.PropertyMap{},
+					Outputs: resource.PropertyMap{},
+				})
+				return nil, err
 			})
-			return err
 		},
 	}
 	cmd.Flags().BoolVar(&yes, "yes", false,
@@ -469,16 +494,25 @@ func (pc *packageCommand) checkResourceInputs(
 	return checked.Properties, nil
 }
 
-func (pc *packageCommand) printResourceResult(
-	cmd *cobra.Command, id resource.ID, outputs resource.PropertyMap, res *schema.Resource,
-) error {
+func resultOutputs(id resource.ID, outputs resource.PropertyMap, res *schema.Resource) resource.PropertyMap {
 	contract.Requiref(id != "", "id", "id should not be blank")
-
 	if res.Properties != nil {
 		outputs = filterOutputs(outputs, res.Properties)
+	} else {
+		outputs = outputs.Copy()
 	}
 	outputs["id"] = resource.NewProperty(string(id))
-	output, err := jsonifyProperty(resource.NewProperty(outputs), pc.showSecrets)
+	return outputs
+}
+
+func resultState(
+	urn resource.URN, id resource.ID, inputs, outputs resource.PropertyMap, res *schema.Resource,
+) *resource.State {
+	return operationState(urn, id, inputs, resultOutputs(id, outputs, res))
+}
+
+func (pc *packageCommand) printResourceResult(cmd *cobra.Command, state *resource.State) error {
+	output, err := jsonifyProperty(resource.NewProperty(state.Outputs), pc.showSecrets)
 	if err != nil {
 		return fmt.Errorf("failed to convert outputs to JSON: %w", err)
 	}

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -17,6 +17,8 @@ package do
 import (
 	"bytes"
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -135,6 +137,7 @@ Flags:
       --dry-run                Run the operation in preview mode
   -h, --help                   help for do
       --input string           Format of the provider configuration file (default "yaml")
+      --output string          Output format for resource operation results (supported: default, json)
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
@@ -183,6 +186,7 @@ Flags:
       --dry-run                Run the operation in preview mode
   -h, --help                   help for do
       --input string           Format of the provider configuration file (default "yaml")
+      --output string          Output format for resource operation results (supported: default, json)
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
@@ -198,7 +202,7 @@ func TestDoCmdResourceCreate(t *testing.T) {
 	t.Parallel()
 
 	var calls []string
-	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+	cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
 		spec: doResourceSpec(false),
 		MockProvider: plugin.MockProvider{
 			CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
@@ -229,7 +233,7 @@ size = 2
 `)
 	cmd.SetArgs([]string{
 		"--stateless", "azure:index:myResource", "create", "--yes",
-		"--input", "pcl", "--input-file", inputFile,
+		"--input", "pcl", "--input-file", inputFile, "--output", "json",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -241,6 +245,9 @@ size = 2
   "size": 2,
   "extra": "hidden"
 }`, stdout.String())
+	assert.NotContains(t, stderr.String(), "creating")
+	assert.NotContains(t, stderr.String(), "Outputs:")
+	assert.NotContains(t, stderr.String(), "Resources:")
 }
 
 func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
@@ -293,6 +300,7 @@ func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
 		"--stateless",
 		"azure:index:myResource", "create",
 		"--yes",
+		"--output", "json",
 		"--input", "pcl",
 		"--input-file", inputFile,
 		"--int-value", "42",
@@ -333,7 +341,7 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 				},
 			},
 		})
-		cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1"})
+		cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1", "--output", "json"})
 		err := cmd.Execute()
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"id":"res-1","name":"read","size":3}`, stdout.String())
@@ -422,7 +430,7 @@ enabled = true
 `)
 		cmd.SetArgs([]string{
 			"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
-			"--input", "pcl", "--input-file", inputFile,
+			"--input", "pcl", "--input-file", inputFile, "--output", "json",
 		})
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -474,7 +482,7 @@ enabled = true
 		inputFile := writeHCLFile(t, "patch.pcl", `enabled = true`)
 		cmd.SetArgs([]string{
 			"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
-			"--input", "pcl", "--input-file", inputFile,
+			"--input", "pcl", "--input-file", inputFile, "--output", "json",
 		})
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -648,7 +656,7 @@ func TestDoCmdResourceDryRunIgnoredForReadOnlyOps(t *testing.T) {
 				},
 			},
 		})
-		cmd.SetArgs([]string{"--dry-run", "azure:index:myResource", "read", "res-1"})
+		cmd.SetArgs([]string{"--dry-run", "azure:index:myResource", "read", "res-1", "--output=json"})
 		require.NoError(t, cmd.Execute())
 		assert.JSONEq(t, `{"id":"res-1","name":"read"}`, stdout.String())
 	})
@@ -694,7 +702,85 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 		})
 		require.NoError(t, cmd.Execute())
 		assert.Contains(t, stderr.String(), "This will create azure:index:myResource")
-		assert.NotContains(t, stdout.String(), "This will create")
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource creating")
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource created")
+		assert.Contains(t, stderr.String(), "+ 1 created")
+		assert.NotContains(t, stderr.String(), "pulumi:pulumi:Stack")
+		assert.Contains(t, stderr.String(), "Outputs:")
+		assert.Contains(t, stderr.String(), `"example"`)
+		assert.Contains(t, stderr.String(), `"res-1"`)
+		assert.Empty(t, stdout.String())
+	})
+
+	t.Run("create failure", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					return plugin.CreateResponse{}, errors.New("quota exceeded")
+				},
+			},
+		})
+		inputFile := writeHCLFile(t, "inputs.pcl", `name = "example"`)
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "create", "--yes",
+			"--input", "pcl", "--input-file", inputFile,
+		})
+		err := cmd.Execute()
+		assert.ErrorContains(t, err, "quota exceeded")
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource creating")
+		assert.Contains(t, stderr.String(), "failed")
+		assert.NotContains(t, stdout.String(), "creating")
+		assert.NotContains(t, stdout.String(), "failed")
+	})
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      "res-1",
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("read")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("read")},
+					}}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1"})
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource read")
+		assert.Contains(t, stderr.String(), "Outputs:")
+		assert.Contains(t, stderr.String(), `"read"`)
+		assert.Contains(t, stderr.String(), `"res-1"`)
+		assert.NotContains(t, stderr.String(), "pulumi:pulumi:Stack")
+		assert.NotContains(t, stderr.String(), "Resources:")
+		assert.Empty(t, stdout.String())
+	})
+
+	t.Run("read masks secrets", func(t *testing.T) {
+		t.Parallel()
+		cmd, _, stderr := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      "res-1",
+						Inputs:  resource.PropertyMap{},
+						Outputs: resource.PropertyMap{"name": resource.MakeSecret(resource.NewProperty("hunter2"))},
+					}}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1"})
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, stderr.String(), "[secret]")
+		assert.NotContains(t, stderr.String(), "hunter2")
 	})
 
 	t.Run("patch surfaces diff", func(t *testing.T) {
@@ -733,6 +819,17 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 		assert.Contains(t, stderr.String(), "This will update azure:index:myResource")
 		assert.Contains(t, stderr.String(), "~ name")
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource updating")
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource updated")
+		assert.Contains(t, stderr.String(), "[diff: ~name]")
+		assert.Contains(t, stderr.String(), "~ 1 updated")
+		changesIdx := strings.Index(stderr.String(), "Changes:")
+		outputsIdx := strings.Index(stderr.String(), "Outputs:")
+		require.GreaterOrEqual(t, changesIdx, 0)
+		require.Greater(t, outputsIdx, changesIdx)
+		changes := stderr.String()[changesIdx:outputsIdx]
+		assert.Contains(t, changes, `~ name: "old" => "new"`)
+		assert.Contains(t, stderr.String()[outputsIdx:], `"res-1"`)
 		assert.NotContains(t, stdout.String(), "This will update")
 	})
 
@@ -749,6 +846,9 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
 		require.NoError(t, cmd.Execute())
 		assert.Contains(t, stderr.String(), `This will delete azure:index:myResource "res-1"`)
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource deleting")
+		assert.Contains(t, stderr.String(), "azure:index:myResource myResource deleted")
+		assert.Contains(t, stderr.String(), "- 1 deleted")
 		assert.Empty(t, stdout.String())
 	})
 }

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -28,8 +28,6 @@ import (
 	"strings"
 	"unicode"
 
-	survey "github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
@@ -606,10 +604,14 @@ func unwrapType(typ schema.Type) schema.Type {
 	return typ
 }
 
+var doDisplayStack = tokens.MustParseStackName("dev")
+
+const doDisplayProject tokens.PackageName = "default"
+
 func resourceURN(res *schema.Resource) resource.URN {
 	_, _, name, diags := pcl.DecomposeToken(res.Token, hcl.Range{})
 	contract.Assertf(!diags.HasErrors(), "token should decompose")
-	return resource.NewURN("dev", "default", "", tokens.Type(res.Token), name)
+	return resource.NewURN(doDisplayStack.Q(), doDisplayProject, "", tokens.Type(res.Token), name)
 }
 
 func (pc *packageCommand) configureProvider(cmd *cobra.Command, ctx context.Context) error {
@@ -753,21 +755,15 @@ func (pc *packageCommand) confirm(cmd *cobra.Command, summary, operation string,
 	if !cmdutil.Interactive() {
 		return backenderr.ErrNonInteractiveRequiresYes
 	}
-	// Route the prompt to stderr so stdout stays a clean JSON channel. survey needs file-backed
-	// streams for terminal control, so fall back to its defaults when the command's streams have
-	// been replaced with plain buffers.
-	var askOpts []survey.AskOpt
-	in, inOK := cmd.InOrStdin().(terminal.FileReader)
-	out, outOK := stderr.(terminal.FileWriter)
-	if inOK && outOK {
-		askOpts = append(askOpts, survey.WithStdio(in, out, out))
-	}
-	response := ui.PromptUser(
+	response, err := ui.PromptUserErr(
 		fmt.Sprintf("Do you want to perform this %s?", operation),
 		[]string{"yes", "no"},
 		"no",
 		cmdutil.GetGlobalColorization(),
-		askOpts...)
+		ui.SurveyStdio(cmd.InOrStdin(), stderr)...)
+	if err != nil {
+		return fmt.Errorf("confirmation cancelled, not proceeding with the %s: %w", operation, err)
+	}
 	if response != "yes" {
 		return result.FprintBailf(stderr, "confirmation declined")
 	}

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -183,11 +183,20 @@ func PromptUser(
 	colorization colors.Colorization,
 	surveyAskOpts ...survey.AskOpt,
 ) string {
-	response, err := PromptUserErr(msg, options, defaultOption, colorization, surveyAskOpts...)
-	if err != nil {
-		return ""
-	}
+	response, _ := PromptUserErr(msg, options, defaultOption, colorization, surveyAskOpts...)
 	return response
+}
+
+// SurveyStdio routes survey prompts through the given streams when they are file-backed (survey
+// needs real file handles for terminal control), and returns nothing otherwise so survey falls
+// back to its defaults.
+func SurveyStdio(in io.Reader, out io.Writer) []survey.AskOpt {
+	fin, inOK := in.(terminal.FileReader)
+	fout, outOK := out.(terminal.FileWriter)
+	if !inOK || !outOK {
+		return nil
+	}
+	return []survey.AskOpt{survey.WithStdio(fin, fout, fout)}
 }
 
 // PromptUserErr is like PromptUser but returns the survey error (for example the user pressing

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -500,6 +500,12 @@ func queueEvents(events chan<- Event, buffer chan Event, done chan bool) {
 	}
 }
 
+// MakeStepEventStateMetadata converts a resource state into the event metadata engine events
+// carry, redacting property values the same way real engine events do.
+func MakeStepEventStateMetadata(state *resource.State, showSecrets bool) *StepEventStateMetadata {
+	return makeStepEventStateMetadata(state, false /*debug*/, showSecrets)
+}
+
 func makeStepEventMetadata(op display.StepOp, step deploy.Step, debug bool, showSecrets bool) StepEventMetadata {
 	contract.Assertf(op == step.Op() || step.Op() == deploy.OpRefresh,
 		"step must be %v or %v, got %v", op, deploy.OpRefresh, step.Op())


### PR DESCRIPTION
Currently `pulumi do` invents its own output format. However we
already have a whole display layer implemented for pulumi, that we can
re-use here.  This way we will show "progress" as the resource is
created.

The outputs will be shown as outputs in the display layer, and we'll
also get the diff display "for free" this way.  We do this by just
sending engine events. The root stack resource is suppressed, because
we don't really have a stack for this at least in stateless mode.

<img width="1728" height="1736" alt="image" src="https://github.com/user-attachments/assets/9bb09257-58dc-4583-b853-3653a3523431" />

<img width="1728" height="1314" alt="image" src="https://github.com/user-attachments/assets/8f5b3f52-2bd3-48df-b6ce-9bf96b9f561e" />

We might want to do a similar thing for the "preview" part, before the confirmation, but for now only the actual creation part is implemented.

(Not sure if this integrates well with stateful do, cc @Frassle)