### PR TITLE
Remove the BackendInstance global variable

### DIFF
--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -29,14 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// BackendInstance is used to inject a backend mock from tests.
-var BackendInstance backend.Backend
-
 func IsDIYBackend(ws pkgWorkspace.Context, opts display.Options) (bool, error) {
-	if BackendInstance != nil {
-		return false, nil
-	}
-
 	// Try to read the current project
 	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
@@ -54,10 +47,6 @@ func IsDIYBackend(ws pkgWorkspace.Context, opts display.Options) (bool, error) {
 func NonInteractiveCurrentBackend(
 	ctx context.Context, ws pkgWorkspace.Context, lm LoginManager, project *workspace.Project,
 ) (backend.Backend, error) {
-	if BackendInstance != nil {
-		return BackendInstance, nil
-	}
-
 	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
@@ -72,10 +61,6 @@ func CurrentBackend(
 	ctx context.Context, ws pkgWorkspace.Context, lm LoginManager, project *workspace.Project,
 	opts display.Options,
 ) (backend.Backend, error) {
-	if BackendInstance != nil {
-		return BackendInstance, nil
-	}
-
 	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -875,8 +877,7 @@ func TestDoCmdResourceProviderFlagOutsideStackContext(t *testing.T) {
 // configureProvider's RequireStack → CurrentBackend → CurrentStack chain finds a stack whose
 // snapshot is exactly `snapshot`. Returns the cmd plus output buffers. The fully-qualified stack
 // name avoids tripping getStackNameWithLegacyOrgNameIfNeeded, which would otherwise call into the
-// MockBackend trying to look up a default org. Tests using this helper must not run in parallel
-// because cmdBackend.BackendInstance is process-global.
+// MockBackend trying to look up a default org.
 func providerFlagStackContext(
 	t *testing.T, provider *testProvider, snapshot *deploy.Snapshot,
 ) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
@@ -921,10 +922,20 @@ func providerFlagStackContext(
 			return mockStack, nil
 		},
 	}
-	cmdBackend.BackendInstance = mockBackend
-	t.Cleanup(func() { cmdBackend.BackendInstance = nil })
-
-	mlm := &cmdBackend.MockLoginManager{}
+	mlm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+			bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		return provider, nil

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -35,6 +35,8 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -217,7 +219,7 @@ func (s *neoFakeServer) sawStreamConnect() bool {
 // kept gctx alive, Session.Run blocked on `<-ctx.Done` forever, and g.Wait
 // hung — this test would time out instead of completing.
 //
-//nolint:paralleltest // mutates package globals (BackendInstance, pkgWorkspace.Instance, newTeaProgram, isInteractive)
+//nolint:paralleltest,lll // mutates package globals (DefaultLoginManager, pkgWorkspace.Instance, newTeaProgram, isInteractive)
 func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	isolateWorkspace(t) // PULUMI_STACK="", PULUMI_HOME=t.TempDir()
 
@@ -227,8 +229,7 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	// constructor; it reads no global state and performs no I/O at construction.
 	pc := client.NewClient(srv.server.URL, "", false, nil)
 
-	// Fake backend wired with the real client. CurrentBackend short-circuits
-	// to BackendInstance when set, bypassing all login / cloud-URL resolution.
+	// Fake backend wired with the real client.
 	be := newFakeBackend()
 	be.ClientV = pc
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
@@ -236,9 +237,24 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 		return "test-user", []string{"test-org"}, nil, nil
 	}
 
-	prevBackend := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = be
-	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+			bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	prevLm := cmdBackend.DefaultLoginManager
+	cmdBackend.DefaultLoginManager = lm
+	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prevLm })
 
 	prevWorkspace := pkgWorkspace.Instance
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
@@ -365,9 +381,24 @@ func installNeoTestEnv(t *testing.T, srv *neoFakeServer, interactive bool) {
 	be.ClientV = pc
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
 
-	prevBackend := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = be
-	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+			bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	prevLm := cmdBackend.DefaultLoginManager
+	cmdBackend.DefaultLoginManager = lm
+	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prevLm })
 
 	prevWorkspace := pkgWorkspace.Instance
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
@@ -385,7 +416,7 @@ func installNeoTestEnv(t *testing.T, srv *neoFakeServer, interactive bool) {
 // CreateNeoTask, console URL print, Session construction, session.Run) had no
 // coverage.
 //
-//nolint:paralleltest // mutates package globals (BackendInstance, pkgWorkspace.Instance, isInteractive)
+//nolint:paralleltest // mutates package globals (DefaultLoginManager, pkgWorkspace.Instance, isInteractive)
 func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 	isolateWorkspace(t)
 	srv := newNeoFakeServer(t)
@@ -448,9 +479,26 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	isolateWorkspace(t)
 
 	// A bare MockBackend deliberately doesn't implement httpstate.Backend.
-	prevBackend := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = &backend.MockBackend{}
-	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+	be := &backend.MockBackend{}
+
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string,
+			*workspace.Project, bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+			bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	prevLm := cmdBackend.DefaultLoginManager
+	cmdBackend.DefaultLoginManager = lm
+	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prevLm })
 
 	prevWorkspace := pkgWorkspace.Instance
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
@@ -569,9 +617,24 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	be.ClientV = pc
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
 
-	prevBackend := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = be
-	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+			bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	prevLm := cmdBackend.DefaultLoginManager
+	cmdBackend.DefaultLoginManager = lm
+	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prevLm })
 
 	prevWorkspace := pkgWorkspace.Instance
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
@@ -600,7 +663,7 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 // goroutine, p.Run would block until the test deadline even though createTask
 // had already errored.
 //
-//nolint:paralleltest // mutates package globals (BackendInstance, pkgWorkspace.Instance, newTeaProgram, isInteractive)
+//nolint:paralleltest,lll // mutates package globals (DefaultLoginManager, pkgWorkspace.Instance, newTeaProgram, isInteractive)
 func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 	isolateWorkspace(t)
 
@@ -621,9 +684,24 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 	be.ClientV = pc
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
 
-	prevBackend := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = be
-	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+			bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	prevLm := cmdBackend.DefaultLoginManager
+	cmdBackend.DefaultLoginManager = lm
+	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prevLm })
 
 	prevWorkspace := pkgWorkspace.Instance
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -16,6 +16,7 @@ package tools
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -36,6 +37,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -368,7 +370,7 @@ func newProjectDir(t *testing.T) string {
 // an agent-injected PULUMI_ACCESS_TOKEN is honored rather than a token frozen at neo
 // startup — keeping the tool's identity in lockstep with `pulumi preview`.
 //
-//nolint:paralleltest // mutates the global cmdBackend.BackendInstance and process env
+//nolint:paralleltest // mutates the global cmdBackend.DefaultLoginManager and process env
 func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 	dir := newProjectDir(t)
 
@@ -383,8 +385,7 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 
 	var capturedToken string
 	var resolved bool
-	prev := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = &backend.MockBackend{
+	be := &backend.MockBackend{
 		ParseStackReferenceF: func(string) (backend.StackReference, error) {
 			resolved = true
 			// The agent-injected PULUMI_ACCESS_TOKEN must be visible here, proving the
@@ -393,7 +394,21 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 			return nil, errors.New("stop after resolution")
 		},
 	}
-	t.Cleanup(func() { cmdBackend.BackendInstance = prev })
+	prev := cmdBackend.DefaultLoginManager
+	cmdBackend.DefaultLoginManager = &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+			insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prev })
 
 	ws := &pkgWorkspace.MockContext{
 		ReadProjectF: func() (*workspace.Project, string, error) {
@@ -428,18 +443,33 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 //nolint:paralleltest // mutates the global cmdBackend.BackendInstance
 func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 	for _, method := range []string{"pulumi_preview", "pulumi_up"} {
-		//nolint:paralleltest // mutates the global cmdBackend.BackendInstance
+		//nolint:paralleltest // mutates the global cmdBackend.DefaultLoginManager
 		t.Run(method, func(t *testing.T) {
 			dir := newProjectDir(t)
 
 			var resolved bool
-			cmdBackend.BackendInstance = &backend.MockBackend{
+			be := &backend.MockBackend{
 				ParseStackReferenceF: func(string) (backend.StackReference, error) {
 					resolved = true
 					return nil, errors.New("stop after resolution")
 				},
 			}
-			t.Cleanup(func() { cmdBackend.BackendInstance = nil })
+
+			prev := cmdBackend.DefaultLoginManager
+			cmdBackend.DefaultLoginManager = &cmdBackend.MockLoginManager{
+				CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool,
+				) (backend.Backend, error) {
+					return be, nil
+				},
+				LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool,
+					insecure bool, color colors.Colorization,
+				) (backend.Backend, error) {
+					return be, nil
+				},
+			}
+			t.Cleanup(func() { cmdBackend.DefaultLoginManager = prev })
 
 			ws := &pkgWorkspace.MockContext{
 				ReadProjectF: func() (*workspace.Project, string, error) {

--- a/pkg/cmd/pulumi/packagecmd/package_delete_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_delete_test.go
@@ -21,15 +21,37 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/registry"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:paralleltest // This test uses the global backendInstance variable
+func mockCurrentBackend(t *testing.T, mockBackend backend.Backend) {
+	t.Helper()
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
+}
+
+//nolint:paralleltest // This test uses the global login manager
 func TestPackageDeleteCmd_Run(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -117,7 +139,7 @@ func TestPackageDeleteCmd_Run(t *testing.T) {
 				},
 			}
 
-			testutil.MockBackendInstance(t, &backend.MockBackend{
+			mockCurrentBackend(t, &backend.MockBackend{
 				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 					if tt.registryErr != nil {
 						return nil, tt.registryErr
@@ -145,7 +167,7 @@ func TestPackageDeleteCmd_Run(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // This test uses the global backendInstance variable
+//nolint:paralleltest // This test uses the global login manager
 func TestPackageDeleteCmd_NonInteractiveRequiresYes(t *testing.T) {
 	mockCloudRegistry := &backend.MockCloudRegistry{
 		Mock: registry.Mock{
@@ -168,7 +190,7 @@ func TestPackageDeleteCmd_NonInteractiveRequiresYes(t *testing.T) {
 		},
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 			return mockCloudRegistry, nil
 		},

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/pkg/v3/registry"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
-	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -39,7 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:paralleltest // This test uses the global backendInstance variable
+//nolint:paralleltest // This test uses the global login manager
 func TestPackagePublishCmd_Run(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -361,7 +360,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				},
 			}
 
-			testutil.MockBackendInstance(t, &backend.MockBackend{
+			mockCurrentBackend(t, &backend.MockBackend{
 				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 					return mockCloudRegistry, nil
 				},
@@ -395,9 +394,8 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // This test uses the global backendInstance variable
+//nolint:paralleltest // This test uses the global login manager
 func TestPackagePublishCmd_IOErrors(t *testing.T) {
-	t.Parallel()
 	validSchema := &schema.PackageSpec{
 		Name:      "testpkg",
 		Publisher: "testpublisher",
@@ -455,7 +453,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 			}
 
 			// Mock the backend
-			testutil.MockBackendInstance(t, &backend.MockBackend{
+			mockCurrentBackend(t, &backend.MockBackend{
 				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 					return &backend.MockCloudRegistry{
 						PublishPackageF: func(ctx context.Context, op apitype.PackagePublishOp) error {
@@ -486,7 +484,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // This test uses the global backendInstance variable
+//nolint:paralleltest // This test uses the global login manager
 func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 	validSchema := &schema.PackageSpec{
 		Name:      "testpkg",
@@ -502,7 +500,7 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 		{
 			name: "error getting package registry",
 			setupBackend: func(t *testing.T) {
-				testutil.MockBackendInstance(t, &backend.MockBackend{
+				mockCurrentBackend(t, &backend.MockBackend{
 					GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 						return nil, errors.New("failed to get package registry")
 					},

--- a/pkg/cmd/pulumi/project/newcmd/new_ai_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_ai_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/registry"
-	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +32,7 @@ import (
 func TestErrorsOnNonHTTPBackend(t *testing.T) {
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
@@ -66,7 +65,7 @@ func TestErrorsOnNonHTTPBackend(t *testing.T) {
 		"please log in to Pulumi Cloud to use Pulumi AI")
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestGeneratingProjectWithAIPromptSucceeds(t *testing.T) {
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
@@ -86,7 +85,7 @@ func TestGeneratingProjectWithAIPromptSucceeds(t *testing.T) {
 		}
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -224,14 +224,14 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 	assert.Equal(t, uniqueProjectName, proj.Name.String())
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
@@ -261,7 +261,7 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 	assert.ErrorContains(t, err, "project with this name already exists")
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
@@ -275,7 +275,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 		return func(yield func(apitype.TemplateMetadata, error) bool) {}
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return name == projectName, nil
 		},
@@ -301,14 +301,14 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 	assert.ErrorContains(t, err, "Try again")
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
@@ -346,14 +346,14 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 	assert.Equal(t, projectName, proj.Name.String())
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
@@ -429,14 +429,14 @@ func TestCreatingProjectWithEmptyConfig(t *testing.T) {
 	removeStack(t, tempdir, stackName)
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
@@ -469,14 +469,14 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 	assert.ErrorContains(t, err, "project names may only contain")
 }
 
-//nolint:paralleltest // changes directory for process, mocks backendInstance
+//nolint:paralleltest // changes directory for process, mocks login manager
 func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		DoesProjectExistF: func(ctx context.Context, org string, name string) (bool, error) {
 			return true, nil
 		},
@@ -565,6 +565,23 @@ func tempProjectDir(t *testing.T) string {
 	dir := filepath.Join(t.TempDir(), genUniqueName(t))
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	return dir
+}
+
+func mockCurrentBackend(t *testing.T, mockBackend backend.Backend) {
+	t.Helper()
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 }
 
 func genUniqueName(t *testing.T) string {
@@ -981,7 +998,7 @@ func TestPulumiPromptRuntimeOptions(t *testing.T) {
 	require.Equal(t, "someValue", proj.Runtime.Options()["someOption"])
 }
 
-//nolint:paralleltest // Sets a global mock backend
+//nolint:paralleltest // Sets a mock login manager
 func TestPulumiNewWithOrgTemplates(t *testing.T) {
 	// Set environment variable to disable registry resolution and use org templates
 	t.Setenv("PULUMI_DISABLE_REGISTRY_RESOLVE", "true")
@@ -1036,20 +1053,7 @@ func TestPulumiNewWithOrgTemplates(t *testing.T) {
 			}
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
-		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool,
-			insecure bool, color colors.Colorization,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-	})
+	mockCurrentBackend(t, mockBackend)
 
 	newCmd := NewNewCmd()
 	var stdout, stderr bytes.Buffer
@@ -1086,7 +1090,7 @@ Available Templates:
 
 func ptr[T any](v T) *T { return &v }
 
-//nolint:paralleltest // Sets a global mock backend
+//nolint:paralleltest // Sets a mock login manager
 func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_REGISTRY_RESOLVE", "false")
 	t.Setenv("PULUMI_EXPERIMENTAL", "true")
@@ -1115,19 +1119,7 @@ func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 			return mockRegistry
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
-		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-	})
+	mockCurrentBackend(t, mockBackend)
 
 	newCmd := NewNewCmd()
 	var stdout, stderr bytes.Buffer
@@ -1191,9 +1183,9 @@ Available Templates:
 	assert.Equal(t, "", stderr.String())
 }
 
-//nolint:paralleltest // Sets a global mock backend
+//nolint:paralleltest // Sets a mock login manager
 func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockCurrentBackend(t, &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry {
 			return &backend.MockCloudRegistry{
 				Mock: registry.Mock{
@@ -1225,7 +1217,7 @@ Available Templates:
 	assert.Equal(t, "", stderr.String())
 }
 
-//nolint:paralleltest // Sets a global mock backend, changes the directory
+//nolint:paralleltest // Sets a mock login manager, changes the directory
 func TestPulumiNewOrgTemplate(t *testing.T) {
 	// Set environment variable to disable registry resolution and use org templates
 	t.Setenv("PULUMI_DISABLE_REGISTRY_RESOLVE", "true")
@@ -1293,20 +1285,7 @@ resources:
 			}
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
-		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
-			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
-		) (backend.Backend, error) {
-			return mockBackend, nil
-		},
-	})
+	mockCurrentBackend(t, mockBackend)
 
 	newCmd := NewNewCmd()
 	var stdout, stderr bytes.Buffer

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -22,13 +22,17 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -95,6 +99,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 		},
 	}
 
+	var mockStack *backend.MockStack
 	mockBackend := &backend.MockBackend{
 		ExportDeploymentF: func(ctx context.Context, _ backend.Stack) (*apitype.UntypedDeployment, error) {
 			return stack.SerializeUntypedDeployment(ctx, snapshot, &stack.SerializeOptions{
@@ -109,9 +114,12 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 			snapshot = snap
 			return nil
 		},
+		GetStackF: func(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
+			return mockStack, nil
+		},
 	}
 
-	mockStack := &backend.MockStack{
+	mockStack = &backend.MockStack{
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
@@ -128,9 +136,16 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 		},
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
-		GetStackF: func(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
-			return mockStack, nil
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
 		},
 	})
 
@@ -195,6 +210,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 		},
 	}
 
+	var mockStack *backend.MockStack
 	mockBackend := &backend.MockBackend{
 		ExportDeploymentF: func(ctx context.Context, _ backend.Stack) (*apitype.UntypedDeployment, error) {
 			return stack.SerializeUntypedDeployment(ctx, snapshot, &stack.SerializeOptions{
@@ -209,9 +225,12 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			snapshot = snap
 			return nil
 		},
+		GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+			return mockStack, nil
+		},
 	}
 
-	mockStack := &backend.MockStack{
+	mockStack = &backend.MockStack{
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
@@ -231,9 +250,16 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 		},
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
-		GetStackF: func(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
-			return mockStack, nil
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
 		},
 	})
 

--- a/pkg/cmd/pulumi/stack/stack_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_list_test.go
@@ -25,8 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestParseTagFilter(t *testing.T) {
@@ -142,7 +147,7 @@ func TestListStacksPagination(t *testing.T) {
 		},
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockBackend := &backend.MockBackend{
 		ListStacksF: func(ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
 			[]backend.StackSummary, backend.ContinuationToken, error,
 		) {
@@ -150,6 +155,19 @@ func TestListStacksPagination(t *testing.T) {
 			requestIdx := len(requestsMade) - 1
 			response := cannedResponses[requestIdx]
 			return response.summaries, response.outContToken, nil
+		},
+	}
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
 		},
 	})
 
@@ -196,7 +214,7 @@ func TestListStacksPagination(t *testing.T) {
 func TestListStacksJsonProgress(t *testing.T) {
 	mockTime := time.Unix(1, 0)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockBackend := &backend.MockBackend{
 		ListStacksF: func(ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
 			[]backend.StackSummary, backend.ContinuationToken, error,
 		) {
@@ -225,6 +243,19 @@ func TestListStacksJsonProgress(t *testing.T) {
 		},
 		SupportsProgressF: func() bool {
 			return true
+		},
+	}
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
 		},
 	})
 
@@ -265,7 +296,7 @@ func TestListStacksJsonProgress(t *testing.T) {
 func TestListStacksJsonNoProgress(t *testing.T) {
 	mockTime := time.Unix(1, 0)
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockBackend := &backend.MockBackend{
 		ListStacksF: func(ctx context.Context, filter backend.ListStacksFilter, inContToken backend.ContinuationToken) (
 			[]backend.StackSummary, backend.ContinuationToken, error,
 		) {
@@ -287,6 +318,19 @@ func TestListStacksJsonNoProgress(t *testing.T) {
 		},
 		SupportsProgressF: func() bool {
 			return false
+		},
+	}
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
 		},
 	})
 

--- a/pkg/cmd/pulumi/templatecmd/template_publish_test.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish_test.go
@@ -28,9 +28,12 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/util/testutil"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -249,12 +252,24 @@ runtime: nodejs
 				},
 			}
 
-			testutil.MockBackendInstance(t, &backend.MockBackend{
+			mockBackend := &backend.MockBackend{
 				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 					return mockCloudRegistry, nil
 				},
 				GetDefaultOrgF: func(ctx context.Context) (string, error) {
 					return tt.mockOrg, tt.mockOrgErr
+				},
+			}
+			testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+				CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool,
+				) (backend.Backend, error) {
+					return mockBackend, nil
+				},
+				LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+				) (backend.Backend, error) {
+					return mockBackend, nil
 				},
 			})
 
@@ -282,9 +297,22 @@ func TestTemplatePublishCmd_BackendErrors(t *testing.T) {
 		{
 			name: "error getting cloud registry",
 			setupBackend: func(t *testing.T) {
-				testutil.MockBackendInstance(t, &backend.MockBackend{
+				mockBackend := &backend.MockBackend{
 					GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 						return nil, errors.New("failed to get cloud registry")
+					},
+				}
+
+				testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+					CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+						url string, project *workspace.Project, setCurrent bool,
+					) (backend.Backend, error) {
+						return mockBackend, nil
+					},
+					LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+						url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+					) (backend.Backend, error) {
+						return mockBackend, nil
 					},
 				})
 			},
@@ -389,9 +417,22 @@ func TestTemplatePublishCmd_RelativePathBug(t *testing.T) {
 		},
 	}
 
-	testutil.MockBackendInstance(t, &backend.MockBackend{
+	mockBackend := &backend.MockBackend{
 		GetCloudRegistryF: func() (backend.CloudRegistry, error) { return mockCloudRegistry, nil },
 		GetDefaultOrgF:    func(ctx context.Context) (string, error) { return "org", nil },
+	}
+
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
 	})
 
 	cmd := &templatePublishCmd{}
@@ -514,12 +555,25 @@ dist/
 				},
 			}
 
-			testutil.MockBackendInstance(t, &backend.MockBackend{
+			mockBackend := &backend.MockBackend{
 				GetCloudRegistryF: func() (backend.CloudRegistry, error) {
 					return mockCloudRegistry, nil
 				},
 				GetDefaultOrgF: func(ctx context.Context) (string, error) {
 					return "default-org", nil
+				},
+			}
+
+			testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+				CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool,
+				) (backend.Backend, error) {
+					return mockBackend, nil
+				},
+				LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+				) (backend.Backend, error) {
+					return mockBackend, nil
 				},
 			})
 

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -105,7 +105,6 @@ func TestFilterOnName(t *testing.T) {
 				}, nil
 			},
 		}
-		testutil.MockBackendInstance(t, mockBackend)
 
 		testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 			CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -153,7 +152,6 @@ func TestFilterOnName(t *testing.T) {
 				}
 			},
 		}
-		testutil.MockBackendInstance(t, mockBackend)
 
 		testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 			CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -206,7 +204,6 @@ func TestMultipleTemplateSources_OrgTemplates(t *testing.T) {
 			}, nil
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
 
 	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -250,8 +247,8 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 				ProjectName:        "template3",
 				ProjectDescription: "An ASP.NET application running a simple container in a EKS Cluster",
 			}},
-			orgTemplate{t: template1, org: "org1", source: source, backend: cmdBackend.BackendInstance},
-			orgTemplate{t: template2, org: "org1", source: source, backend: cmdBackend.BackendInstance},
+			orgTemplate{t: template1, org: "org1", source: source, backend: mockBackend},
+			orgTemplate{t: template2, org: "org1", source: source, backend: mockBackend},
 		},
 		template)
 }
@@ -272,7 +269,6 @@ func TestSurfaceListTemplateErrors_OrgTemplates(t *testing.T) {
 			return apitype.ListOrgTemplatesResponse{}, somethingWentWrong
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
 
 	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -318,7 +314,6 @@ func TestSurfaceListTemplateErrors_RegistryTemplates(t *testing.T) {
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
 
 	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -360,7 +355,6 @@ func TestSurfaceOnEmptyError_OrgTemplates(t *testing.T) {
 			return apitype.ListOrgTemplatesResponse{}, nil
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
 
 	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -406,7 +400,6 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 			return mockRegistry
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
 
 	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -477,7 +470,6 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 			}, nil
 		},
 	}
-	testutil.MockBackendInstance(t, mockBackend)
 
 	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
 		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
@@ -503,7 +495,7 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 	template, err := source.Templates()
 	require.NoError(t, err)
 	assert.Equal(t,
-		[]Template{orgTemplate{t: template1, org: "org1", source: source, backend: cmdBackend.BackendInstance}},
+		[]Template{orgTemplate{t: template1, org: "org1", source: source, backend: mockBackend}},
 		template)
 	t.Cleanup(func() {
 		require.NoError(t, source.Close())
@@ -583,8 +575,13 @@ func createMockRegistrySource(
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 
 	return newImpl(ctx, "name1",
 		ScopeAll, workspace.TemplateKindPulumiProject,
@@ -695,8 +692,18 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 
 	source := newImpl(ctx, "", ScopeAll, workspace.TemplateKindPulumiProject,
 		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
@@ -759,8 +766,18 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 
 	source := newImpl(ctx, "target", ScopeAll, workspace.TemplateKindPulumiProject,
 		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
@@ -839,8 +856,18 @@ func TestRegistryTemplateResolution(t *testing.T) {
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 
 	testCases := []struct {
 		name                string
@@ -1035,8 +1062,18 @@ func TestVersionedTemplateResolution(t *testing.T) {
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 
 	testCases := []struct {
 		name                string
@@ -1155,8 +1192,18 @@ func TestVCSBackedTemplateRejectsVersion(t *testing.T) {
 	mockBackend := &backend.MockBackend{
 		GetReadOnlyCloudRegistryF: func() registry.Registry { return mockRegistry },
 	}
-	testutil.MockBackendInstance(t, mockBackend)
-	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{ /* panic on use */ })
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
 
 	source := newImpl(ctx, "github/pulumi/pulumi%2Ftemplates%2Ftypescript@1.0.0",
 		ScopeAll, workspace.TemplateKindPulumiProject,

--- a/pkg/util/testutil/mockbackend.go
+++ b/pkg/util/testutil/mockbackend.go
@@ -17,21 +17,14 @@ package testutil
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 )
 
-// MockBackendInstance sets the backend instance for the test and cleans it up after.
-func MockBackendInstance(t *testing.T, b backend.Backend) {
-	previous := cmdBackend.BackendInstance
-	t.Cleanup(func() {
-		cmdBackend.BackendInstance = previous
-	})
-	cmdBackend.BackendInstance = b
-}
-
 // MockLoginManager sets the login manager for the test and cleans it up after.
 func MockLoginManager(t *testing.T, lm cmdBackend.LoginManager) {
+	// Dummy change dir to trigger testing.T to fail if this test is run in parallel
+	t.Chdir(".")
+
 	previous := cmdBackend.DefaultLoginManager
 	t.Cleanup(func() {
 		cmdBackend.DefaultLoginManager = previous


### PR DESCRIPTION
This can be mocked out via LoginManagers now, so cleanup this old global hook. A lot of command still don't inject login managers, so some tests are just changed from mutating the global BackendInstance to mutating the global DefaultLoginManager.