### PR TITLE
fix flaky TestGeneratePackage{One,Two} tests

### DIFF
--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -92,6 +92,7 @@ func testGeneratedPackage(t *testing.T, pwd string) {
 		// If mocha is a dev dependency but no test files exist, this will fail.
 		test.RunCommand(t, "mocha", pwd,
 			filepath.Join(pwd, "node_modules", ".bin", "mocha"),
+			"--timeout", "120000",
 			"--require", "ts-node/register",
 			"tests/**/*.spec.ts")
 	} else {

--- a/pkg/codegen/testing/test/nodejs.go
+++ b/pkg/codegen/testing/test/nodejs.go
@@ -108,6 +108,16 @@ func typeCheckNodeJS(t *testing.T, path string, _ codegen.StringSet, linkLocal b
 
 func TypeCheckNodeJSPackage(t *testing.T, pwd string, linkLocal bool) {
 	if linkLocal {
+		pkgPath := filepath.Join(pwd, "package.json")
+		original, err := os.ReadFile(pkgPath)
+		existed := err == nil
+		t.Cleanup(func() {
+			if existed {
+				require.NoError(t, os.WriteFile(pkgPath, original, 0o600))
+			} else {
+				require.NoError(t, os.RemoveAll(pkgPath))
+			}
+		})
 		ptesting.ConfigureNodejsCoreSDK(t, pwd)
 	}
 	RunCommandWithRetries(t, "npm_install", pwd, 3, "npm", "install")


### PR DESCRIPTION
These tests occasionally time out in CI while running.  This is
because of varying load in CI, so let's just increase the timeout
here.

While there also make sure to restore the original `package.json`
when configuring the nodejs core SDK.  Not doing so leads to potential
retries failing because we might have changed the package.json in the
repo.  See
https://github.com/pulumi/pulumi/actions/runs/28844837062/job/85546991728
for example.