### PR TITLE
get the right version for looking for the changelog PR

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -98,7 +98,7 @@ jobs:
           BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           set -euo pipefail
-          git fetch --depth=1 origin master
+          git fetch --depth=2 origin master
           git fetch --depth=2 origin "$BASE_SHA"
 
           # No release in progress - nothing to enforce.
@@ -175,9 +175,9 @@ jobs:
             exit 0
           fi
 
-          # Find the open finalizing PR by its predictable title. master's
+          # Find the open finalizing PR by its predictable title. master's parent commits
           # sdk/.version holds the version being released while the marker is set.
-          VERSION=$(git show origin/master:sdk/.version 2>/dev/null | tr -d '[:space:]')
+          VERSION=$(git show origin/master~:sdk/.version 2>/dev/null | tr -d '[:space:]')
           FINALIZE_URL=""
           if [ -n "$VERSION" ]; then
             FINALIZE_URL=$(gh pr list --repo "$REPO" --state open \


### PR DESCRIPTION
When merging the freeze PR and introducing the `.release-pending` file, the version is already the *next* version that's going to be released.  Look at the parent commit instead for finding the right version that is being released, so we can find the right PR.
