### PR TITLE
Only check null in HasValue

### DIFF
--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -413,9 +413,6 @@ func NewPropertyValueRepl(v any,
 
 // HasValue returns true if a value is semantically meaningful.
 func (v PropertyValue) HasValue() bool {
-	if v.IsOutput() {
-		return v.OutputValue().Known
-	}
 	return !v.IsNull()
 }
 

--- a/sdk/go/common/resource/properties_test.go
+++ b/sdk/go/common/resource/properties_test.go
@@ -485,7 +485,7 @@ func TestHasValue(t *testing.T) {
 		{
 			name:     "output unknown",
 			prop:     MakeOutput(NewProperty("")),
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "output known",


### PR DESCRIPTION
So that we can get `PropertyValue.Diff` and `property.Value.Diff` to match. Given how we never send Output properties for custom resources, which are the only thing that matter for diffs, I don't think this can actually effect anything.