### PR TITLE
Fix the initial prompt printing above the neo welcome banner

### DIFF
--- a/changelog/pending/cli-neo-fix-welcome-banner-order.yaml
+++ b/changelog/pending/cli-neo-fix-welcome-banner-order.yaml
@@ -1,0 +1,4 @@
+component: cli/neo
+kind: fix
+body: Fix the initial prompt sometimes rendering above the welcome banner in `pulumi neo`
+time: 2026-07-08T00:00:00.000000+00:00

--- a/changelog/pending/cli-neo-fix-welcome-banner-order.yaml
+++ b/changelog/pending/cli-neo-fix-welcome-banner-order.yaml
@@ -2,3 +2,5 @@ component: cli/neo
 kind: fix
 body: Fix the initial prompt sometimes rendering above the welcome banner in `pulumi neo`
 time: 2026-07-08T00:00:00.000000+00:00
+custom:
+    PR: "23831"

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -69,9 +69,13 @@ type permissionDebounceTickMsg struct {
 // tea.Println until after bubbletea v2's first renderer flush. Calling
 // Println inside the WindowSizeMsg handler runs while cellbuf is still
 // sized to the terminal, so insertAbove would scroll a screenful of blank
-// lines above the prompt.
+// lines above the prompt. rendered is the whole flush pre-joined into one
+// string so it can be emitted as a single, atomic Println — Update returns
+// its cmds via tea.Batch, which runs them concurrently, so per-block
+// Printlns would race each other (and any event-driven print) for
+// scrollback order.
 type firstFlushReadyMsg struct {
-	rendered []string
+	rendered string
 }
 
 // blockKind identifies the type of rendered block in the output log.
@@ -592,31 +596,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case firstFlushReadyMsg:
-		// Sequence, not Batch: Update returns cmds via tea.Batch, which runs
-		// them concurrently with no ordering guarantee — the banner and a
-		// pre-seeded initial-prompt block would race for scrollback order.
-		seq := make([]tea.Cmd, 0, len(msg.rendered))
-		for _, r := range msg.rendered {
-			seq = append(seq, m.printlnBlock(r))
-		}
-		cmds = append(cmds, tea.Sequence(seq...))
+		cmds = append(cmds, m.printlnBlock(msg.rendered))
 
 	case tea.ResumeMsg:
 		// Resuming from a Ctrl+Z suspend (via `fg`): bubbletea repaints only the
 		// live frame, but the committed transcript was emitted to scrollback via
 		// tea.Println and isn't redrawn. Clear the viewport and re-emit the
-		// committed blocks so the session reads continuously after `fg`. Reset
-		// hasEmittedScrollback so the first re-emitted block skips its leading
-		// blank line, matching the initial flush. Sequence keeps the clear ahead
-		// of the prints and the prints in transcript order.
+		// committed transcript so the session reads continuously after `fg`.
+		// Reset hasEmittedScrollback so the re-emit skips its leading blank
+		// line, matching the initial flush. Sequence keeps the clear ahead of
+		// the print.
 		m.hasEmittedScrollback = false
-		scrollback := m.committedScrollback()
-		seq := make([]tea.Cmd, 0, 1+len(scrollback))
-		seq = append(seq, tea.ClearScreen)
-		for _, r := range scrollback {
-			seq = append(seq, m.printlnBlock(r))
-		}
-		return m, tea.Sequence(seq...)
+		return m, tea.Sequence(tea.ClearScreen, m.printlnBlock(m.committedScrollback()))
 
 	case ctrlCDisarmMsg:
 		// Stale tick: the user already pressed another key (gen still
@@ -1335,17 +1326,19 @@ func (m *Model) commitBlock(b block) tea.Cmd {
 }
 
 // committedScrollback returns the welcome banner followed by every committed
-// block's rendered text, in transcript order — i.e. everything that belongs in
-// terminal scrollback. Used for the initial flush and to re-emit the transcript
-// after a suspend/resume.
-func (m Model) committedScrollback() []string {
+// block's rendered text, in transcript order, joined with the same blank-line
+// separator printlnBlock puts between incremental prints — i.e. everything
+// that belongs in terminal scrollback, as one string ready for a single
+// atomic tea.Println. Used for the initial flush and to re-emit the
+// transcript after a suspend/resume.
+func (m Model) committedScrollback() string {
 	out := []string{m.welcome.View()}
 	for _, b := range m.blocks {
 		if isCommittedKind(b) && b.rendered != "" {
 			out = append(out, b.rendered)
 		}
 	}
-	return out
+	return strings.Join(out, "\n\n")
 }
 
 // printlnBlock emits rendered to scrollback, prepending a blank line so each

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -527,8 +527,13 @@ func NewModel(cfg ModelConfig) Model {
 	if cfg.InitialPrompt != "" {
 		// Render the initial-prompt block now so tests can find it via
 		// findBlockKind. The actual scrollback emission happens on the first
-		// WindowSizeMsg, when we have the real terminal width.
-		m.appendUserMessageBlock(cfg.InitialPrompt)
+		// WindowSizeMsg, when we have the real terminal width. Seed the block
+		// directly rather than via commitBlock: its printlnBlock side effect
+		// would flip hasEmittedScrollback before anything is actually printed,
+		// giving the welcome banner a stray leading blank line.
+		b := block{kind: blockUserMessage, raw: cfg.InitialPrompt}
+		m.renderBlock(&b)
+		m.appendBlock(b)
 		m.pendingUserEchoes = append(m.pendingUserEchoes, cfg.InitialPrompt)
 	}
 	if cfg.Busy {
@@ -587,9 +592,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case firstFlushReadyMsg:
+		// Sequence, not Batch: Update returns cmds via tea.Batch, which runs
+		// them concurrently with no ordering guarantee — the banner and a
+		// pre-seeded initial-prompt block would race for scrollback order.
+		seq := make([]tea.Cmd, 0, len(msg.rendered))
 		for _, r := range msg.rendered {
-			cmds = append(cmds, m.printlnBlock(r))
+			seq = append(seq, m.printlnBlock(r))
 		}
+		cmds = append(cmds, tea.Sequence(seq...))
 
 	case tea.ResumeMsg:
 		// Resuming from a Ctrl+Z suspend (via `fg`): bubbletea repaints only the

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -556,7 +556,7 @@ func TestModel_CommittedScrollback(t *testing.T) {
 	}
 
 	got := m.committedScrollback()
-	want := []string{m.welcome.View(), "user one", "assistant one"}
+	want := m.welcome.View() + "\n\nuser one\n\nassistant one"
 	assert.Equal(t, want, got,
 		"welcome leads, committed blocks follow in order, live and empty blocks dropped")
 }
@@ -579,9 +579,9 @@ func TestModel_Update_Resume_ReprintsTranscript(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	printed := collectPrintln(cmd)
-	want := []string{m.welcome.View(), "\nuser one", "\nassistant one"}
+	want := []string{m.welcome.View() + "\n\nuser one\n\nassistant one"}
 	assert.Equal(t, want, printed,
-		"resume must reprint welcome + committed blocks, first without a leading blank")
+		"resume must reprint welcome + committed blocks as one atomic print, without a leading blank")
 }
 
 func TestModel_Update_KeyCtrlD_BehavesLikeCtrlC(t *testing.T) {
@@ -2363,12 +2363,11 @@ func TestModel_Update_FirstWindowSize_EmitsWelcomeAndInitialPromptToScrollback(t
 func TestModel_Update_FirstFlush_EmitsWelcomeBeforeInitialPrompt(t *testing.T) {
 	t.Parallel()
 
-	// The first flush prints the welcome banner and the pre-seeded
-	// initial-prompt block as separate tea.Println cmds. Update returns its
-	// cmds via tea.Batch, which runs them concurrently with no ordering
-	// guarantee — left as sibling batch entries, the prompt block races the
-	// banner and can land above it in scrollback. The flush must therefore be
-	// a single tea.Sequence, which is what pins the transcript order.
+	// Update returns its cmds via tea.Batch, which runs them concurrently
+	// with no ordering guarantee — emitted as separate tea.Println cmds, the
+	// pre-seeded initial-prompt block would race the welcome banner and could
+	// land above it in scrollback. The flush must therefore be a single
+	// atomic Println with the banner ahead of the prompt inside it.
 	m := NewModel(ModelConfig{InitialPrompt: "deploy prod"})
 	updated, sizeCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 	um := updated.(Model)
@@ -2376,17 +2375,15 @@ func TestModel_Update_FirstFlush_EmitsWelcomeBeforeInitialPrompt(t *testing.T) {
 	_, cmd := um.Update(runFirstFlushTick(t, sizeCmd))
 	require.NotNil(t, cmd)
 
-	msg, ok := runCmd(cmd)
-	require.True(t, ok, "flush cmd must produce a message")
-	require.Equal(t, "sequenceMsg", reflect.TypeOf(msg).Name(),
-		"first flush must emit its prints as a tea.Sequence, not unordered batch siblings")
-
 	printed := collectPrintln(cmd)
-	require.Len(t, printed, 2, "flush must print exactly the banner and the prompt block; got: %v", printed)
-	assert.Contains(t, printed[0], "Pulumi Neo", "welcome banner must print first")
-	assert.Contains(t, printed[1], "deploy prod", "initial-prompt block must print after the banner")
+	require.Len(t, printed, 1, "flush must be a single atomic print; got: %v", printed)
+	banner := strings.Index(printed[0], "Pulumi Neo")
+	prompt := strings.Index(printed[0], "deploy prod")
+	require.NotEqual(t, -1, banner, "flush must contain the welcome banner")
+	require.NotEqual(t, -1, prompt, "flush must contain the initial-prompt block")
+	assert.Less(t, banner, prompt, "welcome banner must precede the initial-prompt block")
 	assert.False(t, strings.HasPrefix(printed[0], "\n"),
-		"the banner is the first thing printed and must not open with a blank line")
+		"the flush is the first thing printed and must not open with a blank line")
 }
 
 func TestModel_Update_UIPulumiEnd_CommitsRenderedToScrollback(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1387,6 +1387,12 @@ func TestNewModel_InitialPromptRendersUserBlock(t *testing.T) {
 	// The busy block still sits at the bottom so the spinner is visible
 	// while the agent starts its first turn.
 	assert.Equal(t, blockBusy, m.blocks[len(m.blocks)-1].kind)
+
+	// Nothing has actually been printed yet, so the latch that adds a leading
+	// blank line before each subsequent print must still be unset — otherwise
+	// the welcome banner opens with a stray empty line.
+	assert.False(t, m.hasEmittedScrollback,
+		"seeding the initial prompt must not flip hasEmittedScrollback before anything is printed")
 }
 
 func TestModel_View_ShowsHintBasedOnBusy(t *testing.T) {
@@ -2352,6 +2358,35 @@ func TestModel_Update_FirstWindowSize_EmitsWelcomeAndInitialPromptToScrollback(t
 		assert.NotContains(t, line, "Pulumi Neo", "second resize must not re-emit the welcome banner")
 		assert.NotContains(t, line, "deploy prod", "second resize must not re-emit the initial-prompt block")
 	}
+}
+
+func TestModel_Update_FirstFlush_EmitsWelcomeBeforeInitialPrompt(t *testing.T) {
+	t.Parallel()
+
+	// The first flush prints the welcome banner and the pre-seeded
+	// initial-prompt block as separate tea.Println cmds. Update returns its
+	// cmds via tea.Batch, which runs them concurrently with no ordering
+	// guarantee — left as sibling batch entries, the prompt block races the
+	// banner and can land above it in scrollback. The flush must therefore be
+	// a single tea.Sequence, which is what pins the transcript order.
+	m := NewModel(ModelConfig{InitialPrompt: "deploy prod"})
+	updated, sizeCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	um := updated.(Model)
+
+	_, cmd := um.Update(runFirstFlushTick(t, sizeCmd))
+	require.NotNil(t, cmd)
+
+	msg, ok := runCmd(cmd)
+	require.True(t, ok, "flush cmd must produce a message")
+	require.Equal(t, "sequenceMsg", reflect.TypeOf(msg).Name(),
+		"first flush must emit its prints as a tea.Sequence, not unordered batch siblings")
+
+	printed := collectPrintln(cmd)
+	require.Len(t, printed, 2, "flush must print exactly the banner and the prompt block; got: %v", printed)
+	assert.Contains(t, printed[0], "Pulumi Neo", "welcome banner must print first")
+	assert.Contains(t, printed[1], "deploy prod", "initial-prompt block must print after the banner")
+	assert.False(t, strings.HasPrefix(printed[0], "\n"),
+		"the banner is the first thing printed and must not open with a blank line")
 }
 
 func TestModel_Update_UIPulumiEnd_CommitsRenderedToScrollback(t *testing.T) {


### PR DESCRIPTION
## Summary

When `pulumi neo "<prompt>"` is run with an initial prompt, the `❯ <prompt>` user-message block sometimes prints **above** the welcome banner:

```
 Debug the failed Pulumi preview … of this stack and fix it directly …

╭─
│ Pulumi Neo
│ …
╰─
```

### Root cause

The TUI defers its initial scrollback flush (welcome banner + pre-seeded initial-prompt block) behind a `firstFlushReadyMsg` tick, then emits each string as a separate `tea.Println` cmd. `Update` returns its cmds via `tea.Batch`, which per bubbletea's docs "performs a bunch of commands concurrently with **no ordering guarantees** about the results" — so the prompt block's print races the banner's and can reach the renderer first. With no initial prompt the flush contains a single string, which is why the bug only shows when a prompt is passed on the command line.

### Fix

- `committedScrollback` now returns the transcript pre-joined into one string (using the same blank-line separator `printlnBlock` puts between incremental prints — byte-identical output), and both flush paths (first flush and the Ctrl+Z resume re-emit) emit it as a **single atomic `tea.Println`**. Nothing to reorder, and no window for an event-driven print to interleave mid-transcript.
- Stop seeding the initial-prompt block through `commitBlock` in `NewModel`: its discarded `printlnBlock` cmd flipped `hasEmittedScrollback` as a side effect, giving the banner a stray leading blank line.

### Testing

- New `TestModel_Update_FirstFlush_EmitsWelcomeBeforeInitialPrompt` asserts the flush is a single print with the banner ahead of the prompt block and no leading blank line.
- Extended `TestNewModel_InitialPromptRendersUserBlock` to guard the `hasEmittedScrollback` side effect; updated the scrollback/resume tests for the joined-transcript shape.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change

🤖 Generated with [Claude Code](https://claude.com/claude-code)