### PR TITLE
do: tidy up provider errors

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -140,6 +140,8 @@ func NewDoCmd(
 		sink := diag.DefaultSink(cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{
 			Color: cmdutil.GetGlobalColorization(),
 		})
+		diagFwd := &forwardingSink{base: sink}
+		statusFwd := &forwardingSink{base: sink}
 
 		proj, root, err := ws.ReadProject("")
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
@@ -163,7 +165,7 @@ func NewDoCmd(
 		loading := startSpinner(fmt.Sprintf("Loading provider '%s'", pkgargs[0]))
 		defer loading()
 
-		host, err := newHost(ctx, sink, sink)
+		host, err := newHost(ctx, diagFwd, statusFwd)
 		if err != nil {
 			return nil, nil, fmt.Errorf("create plugin host: %w", err)
 		}
@@ -285,6 +287,8 @@ func NewDoCmd(
 			ws:                ws,
 			lm:                lm,
 			sink:              sink,
+			diagFwd:           diagFwd,
+			statusFwd:         statusFwd,
 		}).newCommand()
 		if err != nil {
 			cleanup()
@@ -519,9 +523,11 @@ type packageCommand struct {
 
 	// ws / lm let configureProvider open the current stack's backend when --provider is set so it
 	// can read the referenced provider resource's Inputs. Plumbed from NewDoCmd.
-	ws   pkgWorkspace.Context
-	lm   cmdBackend.LoginManager
-	sink diag.Sink
+	ws        pkgWorkspace.Context
+	lm        cmdBackend.LoginManager
+	sink      diag.Sink
+	diagFwd   *forwardingSink
+	statusFwd *forwardingSink
 }
 
 // evalContext builds the PCL evaluation context from the workspace state we captured at construction

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -137,11 +137,11 @@ func NewDoCmd(
 		if err != nil {
 			return nil, nil, fmt.Errorf("get working directory: %w", err)
 		}
-		sink := diag.DefaultSink(cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{
+		base := diag.DefaultSink(cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{
 			Color: cmdutil.GetGlobalColorization(),
 		})
-		diagFwd := &forwardingSink{base: sink}
-		statusFwd := &forwardingSink{base: sink}
+		diagFwd := &forwardingSink{base: base}
+		statusFwd := &forwardingSink{base: base}
 
 		proj, root, err := ws.ReadProject("")
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
@@ -171,7 +171,7 @@ func NewDoCmd(
 		}
 
 		pctx, err := plugin.NewContext(
-			ctx, sink, sink, host, nil, wd, nil, false,
+			ctx, diagFwd, statusFwd, host, nil, wd, nil, false,
 			nil)
 		if err != nil {
 			contract.IgnoreClose(host)
@@ -286,7 +286,6 @@ func NewDoCmd(
 			root:              root,
 			ws:                ws,
 			lm:                lm,
-			sink:              sink,
 			diagFwd:           diagFwd,
 			statusFwd:         statusFwd,
 		}).newCommand()
@@ -525,7 +524,6 @@ type packageCommand struct {
 	// can read the referenced provider resource's Inputs. Plumbed from NewDoCmd.
 	ws        pkgWorkspace.Context
 	lm        cmdBackend.LoginManager
-	sink      diag.Sink
 	diagFwd   *forwardingSink
 	statusFwd *forwardingSink
 }

--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -15,6 +15,10 @@
 package do
 
 import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -25,8 +29,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 type displayedStep struct {
@@ -40,12 +47,14 @@ type displayedStep struct {
 func (pc *packageCommand) runDisplayedStep(
 	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
 ) error {
+	urn := step.urn()
+	subject := step.subject()
 	preview := (pc.dryrun || step.Preview) && step.Op != deploy.OpRead
 
 	if pc.jsonOut && !step.Preview {
 		state, err := call()
 		if err != nil || state == nil {
-			return err
+			return tidyProviderError(err, urn, subject)
 		}
 		return pc.printResourceResult(cmd, state)
 	}
@@ -80,8 +89,28 @@ func (pc *packageCommand) runDisplayedStep(
 	start := time.Now()
 	events <- engine.NewEvent(engine.ResourcePreEventPayload{Metadata: metadata, Planning: preview})
 
+	forward := func(ephemeral bool) diagForwarder {
+		return func(sev diag.Severity, d *diag.Diag, args ...any) {
+			prefix, msg := stringifyDiag(sev, d, args...)
+			events <- engine.NewEvent(engine.DiagEventPayload{
+				URN:       urn,
+				Prefix:    logging.FilterString(prefix),
+				Message:   logging.FilterString(tidyProviderMessage(msg, urn, subject)),
+				Color:     colors.Raw,
+				Severity:  sev,
+				StreamID:  d.StreamID,
+				Ephemeral: ephemeral,
+			})
+		}
+	}
+	pc.diagFwd.set(forward(false))
+	pc.statusFwd.set(forward(true))
+
 	result, err := call()
+	pc.diagFwd.clear()
+	pc.statusFwd.clear()
 	if err != nil {
+		err = tidyProviderError(err, urn, subject)
 		events <- engine.NewEvent(engine.ResourceOperationFailedPayload{
 			Metadata: metadata,
 			Status:   resource.StatusOK,
@@ -114,6 +143,38 @@ func (s displayedStep) urn() resource.URN {
 		return s.New.URN
 	}
 	return s.Old.URN
+}
+
+func (s displayedStep) subject() string {
+	id := ""
+	if s.Old != nil && s.Old.ID != "" {
+		id = string(s.Old.ID)
+	}
+	if s.New != nil && s.New.ID != "" {
+		id = string(s.New.ID)
+	}
+	if id == "" {
+		return string(s.urn().Type())
+	}
+	return fmt.Sprintf("%s %q", s.urn().Type(), id)
+}
+
+var singleErrorOccurred = regexp.MustCompile(`(?s)1 error occurred:\s*\n\s*\* (.*?)\s*$`)
+
+func tidyProviderMessage(msg string, urn resource.URN, subject string) string {
+	msg = strings.ReplaceAll(msg, string(urn), subject)
+	return singleErrorOccurred.ReplaceAllString(msg, "$1")
+}
+
+func tidyProviderError(err error, urn resource.URN, subject string) error {
+	if err == nil {
+		return nil
+	}
+	msg := tidyProviderMessage(err.Error(), urn, subject)
+	if msg == err.Error() {
+		return err
+	}
+	return errors.New(msg)
 }
 
 func (s displayedStep) metadata(showSecrets bool) engine.StepEventMetadata {

--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 type displayedStep struct {
@@ -90,8 +91,11 @@ func (pc *packageCommand) runDisplayedStep(
 	events <- engine.NewEvent(engine.ResourcePreEventPayload{Metadata: metadata, Planning: preview})
 
 	forward := func(ephemeral bool) diagForwarder {
-		return func(sev diag.Severity, d *diag.Diag, args ...any) {
-			prefix, msg := stringifyDiag(sev, d, args...)
+		return func(sev diag.Severity, d *diag.Diag, args ...any) bool {
+			if sev == diag.Info {
+				return false
+			}
+			prefix, msg := engine.StringifyDiag(sev, d, args...)
 			events <- engine.NewEvent(engine.DiagEventPayload{
 				URN:       urn,
 				Prefix:    logging.FilterString(prefix),
@@ -101,24 +105,29 @@ func (pc *packageCommand) runDisplayedStep(
 				StreamID:  d.StreamID,
 				Ephemeral: ephemeral,
 			})
+			return true
 		}
 	}
 	pc.diagFwd.set(forward(false))
 	pc.statusFwd.set(forward(true))
 
-	result, err := call()
+	state, err := call()
+	if err != nil {
+		err = tidyProviderError(err, urn, subject)
+		pc.diagFwd.Errorf(diag.RawMessage(urn, err.Error()))
+	}
 	pc.diagFwd.clear()
 	pc.statusFwd.clear()
 	if err != nil {
-		err = tidyProviderError(err, urn, subject)
 		events <- engine.NewEvent(engine.ResourceOperationFailedPayload{
 			Metadata: metadata,
 			Status:   resource.StatusOK,
 			Steps:    1,
 		})
+		err = result.BailError(err)
 	} else {
-		if result != nil {
-			metadata.New = engine.MakeStepEventStateMetadata(result, pc.showSecrets)
+		if state != nil {
+			metadata.New = engine.MakeStepEventStateMetadata(state, pc.showSecrets)
 			metadata.Res = metadata.New
 		}
 		events <- engine.NewEvent(engine.ResourceOutputsEventPayload{Metadata: metadata, Planning: preview})

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -1136,7 +1137,7 @@ func TestDoCmdResourceProviderFlagMergesStackInputs(t *testing.T) {
 func TestDoCmdResourceProviderErrorTidied(t *testing.T) {
 	t.Parallel()
 
-	cmd, _, _ := newDoResourceCommand(t, &testProvider{
+	cmd, _, stderr := newDoResourceCommand(t, &testProvider{
 		spec: doResourceSpec(false),
 		MockProvider: plugin.MockProvider{
 			ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
@@ -1154,5 +1155,7 @@ func TestDoCmdResourceProviderErrorTidied(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
 	err := cmd.Execute()
-	assert.EqualError(t, err, `deleting azure:index:myResource "res-1": cluster busy`)
+	assert.True(t, result.IsBail(err))
+	assert.ErrorContains(t, err, `deleting azure:index:myResource "res-1": cluster busy`)
+	assert.Contains(t, stderr.String(), `deleting azure:index:myResource "res-1": cluster busy`)
 }

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1130,4 +1131,28 @@ func TestDoCmdResourceProviderFlagMergesStackInputs(t *testing.T) {
 	assert.Equal(t, "us-west-2", gotInputs["region"].StringValue(), "overlay should win for explicitly-set keys")
 	assert.Equal(t, "acme", gotInputs["tenant"].StringValue(),
 		"snapshot value should pass through for keys not in overlay")
+}
+
+func TestDoCmdResourceProviderErrorTidied(t *testing.T) {
+	t.Parallel()
+
+	cmd, _, _ := newDoResourceCommand(t, &testProvider{
+		spec: doResourceSpec(false),
+		MockProvider: plugin.MockProvider{
+			ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+				return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+					ID:      req.ID,
+					Inputs:  resource.PropertyMap{},
+					Outputs: resource.PropertyMap{"name": resource.NewProperty("existing")},
+				}}, nil
+			},
+			DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+				return plugin.DeleteResponse{},
+					fmt.Errorf("deleting %s: 1 error occurred:\n\t* cluster busy\n\n", req.URN)
+			},
+		},
+	})
+	cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+	err := cmd.Execute()
+	assert.EqualError(t, err, `deleting azure:index:myResource "res-1": cluster busy`)
 }

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -714,7 +714,7 @@ func (pc *packageCommand) loadProviderInputsFromStack(
 	ctx context.Context, providerURN resource.URN,
 ) (resource.PropertyMap, error) {
 	s, err := cmdStack.RequireStack(
-		ctx, pc.sink, pc.ws, pc.lm,
+		ctx, pc.diagFwd, pc.ws, pc.lm,
 		"", /*stackName — use whatever is currently selected*/
 		cmdStack.LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()},
 		"", /*configFile*/

--- a/pkg/cmd/pulumi/do/do_sink.go
+++ b/pkg/cmd/pulumi/do/do_sink.go
@@ -15,15 +15,12 @@
 package do
 
 import (
-	"bytes"
-	"fmt"
 	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
-type diagForwarder func(sev diag.Severity, d *diag.Diag, args ...any)
+type diagForwarder func(sev diag.Severity, d *diag.Diag, args ...any) bool
 
 type forwardingSink struct {
 	base diag.Sink
@@ -47,8 +44,7 @@ func (s *forwardingSink) clear() {
 func (s *forwardingSink) Logf(sev diag.Severity, d *diag.Diag, args ...any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.forward != nil {
-		s.forward(sev, d, args...)
+	if s.forward != nil && s.forward(sev, d, args...) {
 		return
 	}
 	s.base.Logf(sev, d, args...)
@@ -59,33 +55,3 @@ func (s *forwardingSink) Infof(d *diag.Diag, args ...any)    { s.Logf(diag.Info,
 func (s *forwardingSink) Infoerrf(d *diag.Diag, args ...any) { s.Logf(diag.Infoerr, d, args...) }
 func (s *forwardingSink) Errorf(d *diag.Diag, args ...any)   { s.Logf(diag.Error, d, args...) }
 func (s *forwardingSink) Warningf(d *diag.Diag, args ...any) { s.Logf(diag.Warning, d, args...) }
-
-func stringifyDiag(sev diag.Severity, d *diag.Diag, args ...any) (string, string) {
-	var prefix bytes.Buffer
-	switch sev {
-	case diag.Debug:
-		prefix.WriteString(colors.SpecDebug)
-	case diag.Error:
-		prefix.WriteString(colors.SpecError)
-	case diag.Warning:
-		prefix.WriteString(colors.SpecWarning)
-	case diag.Info, diag.Infoerr:
-	}
-	if prefix.Len() > 0 {
-		prefix.WriteString(string(sev))
-		prefix.WriteString(": ")
-		prefix.WriteString(colors.Reset)
-	}
-
-	var buffer bytes.Buffer
-	buffer.WriteString(colors.SpecNote)
-	if d.Raw {
-		buffer.WriteString(d.Message)
-	} else {
-		fmt.Fprintf(&buffer, d.Message, args...)
-	}
-	buffer.WriteString(colors.Reset)
-	buffer.WriteRune('\n')
-
-	return prefix.String(), buffer.String()
-}

--- a/pkg/cmd/pulumi/do/do_sink.go
+++ b/pkg/cmd/pulumi/do/do_sink.go
@@ -1,0 +1,91 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+type diagForwarder func(sev diag.Severity, d *diag.Diag, args ...any)
+
+type forwardingSink struct {
+	base diag.Sink
+
+	mu      sync.Mutex
+	forward diagForwarder
+}
+
+func (s *forwardingSink) set(forward diagForwarder) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forward = forward
+}
+
+func (s *forwardingSink) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forward = nil
+}
+
+func (s *forwardingSink) Logf(sev diag.Severity, d *diag.Diag, args ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.forward != nil {
+		s.forward(sev, d, args...)
+		return
+	}
+	s.base.Logf(sev, d, args...)
+}
+
+func (s *forwardingSink) Debugf(d *diag.Diag, args ...any)   { s.Logf(diag.Debug, d, args...) }
+func (s *forwardingSink) Infof(d *diag.Diag, args ...any)    { s.Logf(diag.Info, d, args...) }
+func (s *forwardingSink) Infoerrf(d *diag.Diag, args ...any) { s.Logf(diag.Infoerr, d, args...) }
+func (s *forwardingSink) Errorf(d *diag.Diag, args ...any)   { s.Logf(diag.Error, d, args...) }
+func (s *forwardingSink) Warningf(d *diag.Diag, args ...any) { s.Logf(diag.Warning, d, args...) }
+
+func stringifyDiag(sev diag.Severity, d *diag.Diag, args ...any) (string, string) {
+	var prefix bytes.Buffer
+	switch sev {
+	case diag.Debug:
+		prefix.WriteString(colors.SpecDebug)
+	case diag.Error:
+		prefix.WriteString(colors.SpecError)
+	case diag.Warning:
+		prefix.WriteString(colors.SpecWarning)
+	case diag.Info, diag.Infoerr:
+	}
+	if prefix.Len() > 0 {
+		prefix.WriteString(string(sev))
+		prefix.WriteString(": ")
+		prefix.WriteString(colors.Reset)
+	}
+
+	var buffer bytes.Buffer
+	buffer.WriteString(colors.SpecNote)
+	if d.Raw {
+		buffer.WriteString(d.Message)
+	} else {
+		fmt.Fprintf(&buffer, d.Message, args...)
+	}
+	buffer.WriteString(colors.Reset)
+	buffer.WriteRune('\n')
+
+	return prefix.String(), buffer.String()
+}

--- a/pkg/cmd/pulumi/do/do_sink_test.go
+++ b/pkg/cmd/pulumi/do/do_sink_test.go
@@ -33,12 +33,20 @@ func TestForwardingSink(t *testing.T) {
 	s := &forwardingSink{base: base}
 
 	var forwarded []string
-	s.set(func(sev diag.Severity, d *diag.Diag, args ...any) {
+	s.set(func(sev diag.Severity, d *diag.Diag, args ...any) bool {
+		if sev == diag.Info {
+			return false
+		}
 		forwarded = append(forwarded, string(sev)+": "+d.Message)
+		return true
 	})
 	s.Errorf(diag.RawMessage("", "boom"))
 	assert.Empty(t, buf.String())
 	assert.Equal(t, []string{"error: boom"}, forwarded)
+
+	s.Infof(diag.RawMessage("", "hello"))
+	assert.Contains(t, buf.String(), "hello")
+	require.Len(t, forwarded, 1)
 
 	s.clear()
 	s.Warningf(diag.RawMessage("", "careful"))

--- a/pkg/cmd/pulumi/do/do_sink_test.go
+++ b/pkg/cmd/pulumi/do/do_sink_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+func TestForwardingSink(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	base := diag.DefaultSink(&buf, &buf, diag.FormatOptions{Color: colors.Never})
+	s := &forwardingSink{base: base}
+
+	var forwarded []string
+	s.set(func(sev diag.Severity, d *diag.Diag, args ...any) {
+		forwarded = append(forwarded, string(sev)+": "+d.Message)
+	})
+	s.Errorf(diag.RawMessage("", "boom"))
+	assert.Empty(t, buf.String())
+	assert.Equal(t, []string{"error: boom"}, forwarded)
+
+	s.clear()
+	s.Warningf(diag.RawMessage("", "careful"))
+	assert.Contains(t, buf.String(), "careful")
+	require.Len(t, forwarded, 1)
+}

--- a/pkg/engine/eventsink.go
+++ b/pkg/engine/eventsink.go
@@ -57,7 +57,7 @@ func (s *eventSink) Logf(sev diag.Severity, d *diag.Diag, args ...any) {
 func (s *eventSink) Debugf(d *diag.Diag, args ...any) {
 	// For debug messages, write both to the glogger and a stream, if there is one.
 	logging.V(3).Infof(d.Message, args...)
-	prefix, msg := s.Stringify(diag.Debug, d, args...)
+	prefix, msg := StringifyDiag(diag.Debug, d, args...)
 	if logging.V(9).Enabled() {
 		logging.V(9).Infof("eventSink::Debug(%v)", msg[:len(msg)-1])
 	}
@@ -65,7 +65,7 @@ func (s *eventSink) Debugf(d *diag.Diag, args ...any) {
 }
 
 func (s *eventSink) Infof(d *diag.Diag, args ...any) {
-	prefix, msg := s.Stringify(diag.Info, d, args...)
+	prefix, msg := StringifyDiag(diag.Info, d, args...)
 	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Info(%v)", msg[:len(msg)-1])
 	}
@@ -73,7 +73,7 @@ func (s *eventSink) Infof(d *diag.Diag, args ...any) {
 }
 
 func (s *eventSink) Infoerrf(d *diag.Diag, args ...any) {
-	prefix, msg := s.Stringify(diag.Info /* not Infoerr, just "info: "*/, d, args...)
+	prefix, msg := StringifyDiag(diag.Info /* not Infoerr, just "info: "*/, d, args...)
 	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Infoerr(%v)", msg[:len(msg)-1])
 	}
@@ -81,7 +81,7 @@ func (s *eventSink) Infoerrf(d *diag.Diag, args ...any) {
 }
 
 func (s *eventSink) Errorf(d *diag.Diag, args ...any) {
-	prefix, msg := s.Stringify(diag.Error, d, args...)
+	prefix, msg := StringifyDiag(diag.Error, d, args...)
 	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Error(%v)", msg[:len(msg)-1])
 	}
@@ -89,14 +89,14 @@ func (s *eventSink) Errorf(d *diag.Diag, args ...any) {
 }
 
 func (s *eventSink) Warningf(d *diag.Diag, args ...any) {
-	prefix, msg := s.Stringify(diag.Warning, d, args...)
+	prefix, msg := StringifyDiag(diag.Warning, d, args...)
 	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Warning(%v)", msg[:len(msg)-1])
 	}
 	s.events.diagWarningEvent(d, prefix, msg, s.statusSink)
 }
 
-func (s *eventSink) Stringify(sev diag.Severity, d *diag.Diag, args ...any) (string, string) {
+func StringifyDiag(sev diag.Severity, d *diag.Diag, args ...any) (string, string) {
 	var prefix bytes.Buffer
 	if sev != diag.Info && sev != diag.Infoerr {
 		// Unless it's an ordinary stdout message, prepend the message category's prefix (error/warning).

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1341,7 +1341,7 @@ func TestDoCommandLocalCommand(t *testing.T) {
 
 	e.WriteTestFile("inputs.pcl", "create = \"echo hello\"\n")
 
-	stdout, stderr := e.RunCommand(
+	_, stderr := e.RunCommand(
 		"pulumi", "do", "--stateless", "command:local:Command", "create",
 		"--input", "pcl", "--input-file", "inputs.pcl", "--yes")
 
@@ -1350,8 +1350,7 @@ func TestDoCommandLocalCommand(t *testing.T) {
 	// when it happens the test should fail loudly.
 	assert.NotContains(t, stderr, "panic:", "pulumi do should not panic; stderr:\n%s", stderr)
 
-	assert.Truef(t, strings.HasPrefix(stdout, "hello\n"),
-		"stdout did not start with hello\nActual:\n%s", stdout)
+	assert.Contains(t, stderr, "hello")
 }
 
 // Sanity test that we can `pulumi new -y` and then do some basic operations like stack selection and config.

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1341,7 +1341,7 @@ func TestDoCommandLocalCommand(t *testing.T) {
 
 	e.WriteTestFile("inputs.pcl", "create = \"echo hello\"\n")
 
-	_, stderr := e.RunCommand(
+	stdout, stderr := e.RunCommand(
 		"pulumi", "do", "--stateless", "command:local:Command", "create",
 		"--input", "pcl", "--input-file", "inputs.pcl", "--yes")
 
@@ -1350,7 +1350,8 @@ func TestDoCommandLocalCommand(t *testing.T) {
 	// when it happens the test should fail loudly.
 	assert.NotContains(t, stderr, "panic:", "pulumi do should not panic; stderr:\n%s", stderr)
 
-	assert.Contains(t, stderr, "hello")
+	assert.Truef(t, strings.HasPrefix(stdout, "hello\n"),
+		"stdout did not start with hello\nActual:\n%s", stdout)
 }
 
 // Sanity test that we can `pulumi new -y` and then do some basic operations like stack selection and config.


### PR DESCRIPTION
The provider errors as they are right now are a bit ugly.  Notably
they do not show up in diag messages, as they do for `pulumi up` etc.,
and they show the full URN (which we don't really use anywhere in
`pulumi do`, we always only use the ID).

Create diag events for the provider messages, and tidy the message up
a bit, so we don't show the full URN.