### PR TITLE
Support import pending creates parameter

### DIFF
--- a/changelog/pending/20260708--auto-go--support-import-pending-creates-for-refresh.yaml
+++ b/changelog/pending/20260708--auto-go--support-import-pending-creates-for-refresh.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go
+  description: Support --import-pending-creates for refresh command in Go Automation API for preview refresh and refresh operations

--- a/changelog/pending/20260708--auto-go--support-import-pending-creates-for-refresh.yaml
+++ b/changelog/pending/20260708--auto-go--support-import-pending-creates-for-refresh.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: auto/go
-  description: Support --import-pending-creates for refresh command in Go Automation API for preview refresh and refresh operations

--- a/changelog/pending/auto-go-feat-20260709-091520.yaml
+++ b/changelog/pending/auto-go-feat-20260709-091520.yaml
@@ -1,0 +1,4 @@
+component: auto/go
+kind: feat
+body: Support --import-pending-creates for refresh command in Go Automation API for preview refresh and refresh operations
+time: 2026-07-09T09:15:20.993508-04:00

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -45,6 +45,23 @@ func ClearPendingCreates() Option {
 	})
 }
 
+// PendingCreate describes a pending create operation to import into the state, mapping the
+// resource's URN to the physical ID it was assigned by the provider.
+type PendingCreate struct {
+	// URN is the Pulumi resource URN of the pending create.
+	URN string
+	// ID is the provider-assigned physical ID of the created resource.
+	ID string
+}
+
+// ImportPendingCreates will cause the refresh to import the given pending creates into the
+// state, mapping each resource URN to the physical ID it was assigned by the provider.
+func ImportPendingCreates(creates []PendingCreate) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ImportPendingCreates = creates
+	})
+}
+
 // Message (optional) to associate with the refresh operation
 func Message(message string) Option {
 	return optionFunc(func(opts *Options) {
@@ -182,6 +199,8 @@ type Options struct {
 	ExpectNoChanges bool
 	// Clear all pending creates, dropping them from the state
 	ClearPendingCreates bool
+	// Import the given pending creates into the state, mapping each resource URN to its provider ID
+	ImportPendingCreates []PendingCreate
 	// Specify an exclusive of resource URNs to refresh
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -795,6 +795,11 @@ func refreshOptsToCmd(o *optrefresh.Options, s *Stack, isPreview bool) ([]string
 	if o.ClearPendingCreates {
 		args = append(args, "--clear-pending-creates")
 	}
+	// Each --import-pending-creates invocation accepts exactly one value, and the URN must be
+	// immediately followed by its provider ID, so we emit two flags per pending create.
+	for _, pc := range o.ImportPendingCreates {
+		args = append(args, "--import-pending-creates="+pc.URN, "--import-pending-creates="+pc.ID)
+	}
 	for _, tURN := range o.Target {
 		args = append(args, "--target="+tURN)
 	}

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 	"time"
 
@@ -373,6 +374,54 @@ func TestRefreshOptsClearPendingCreates(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, args, "--clear-pending-creates")
+}
+
+func TestRefreshOptsImportPendingCreates(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+	// Copy the test project to a temp directory.
+	pDir := t.TempDir()
+	err := fsutil.CopyFile(pDir, filepath.Join(".", "test", "testproj"), nil)
+	require.NoError(t, err)
+
+	stack, err := NewStackLocalSource(ctx, stackName, pDir)
+	require.NoError(t, err)
+
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
+
+	args, _, err := refreshOptsToCmd(
+		&optrefresh.Options{
+			ImportPendingCreates: []optrefresh.PendingCreate{
+				{URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket1", ID: "bucket1-id"},
+				{URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket2", ID: "bucket2-id"},
+			},
+		},
+		&stack,
+		true,
+	)
+	require.NoError(t, err)
+
+	// The URN must be immediately followed by its ID, so assert the exact contiguous sequence.
+	want := []string{
+		"--import-pending-creates=urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket1",
+		"--import-pending-creates=bucket1-id",
+		"--import-pending-creates=urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket2",
+		"--import-pending-creates=bucket2-id",
+	}
+	found := false
+	for i := 0; i+len(want) <= len(args); i++ {
+		if slices.Equal(args[i:i+len(want)], want) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected contiguous import-pending-creates args, got %v", args)
 }
 
 func TestRename(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
