### PR TITLE
Fix TestRunningViaCLIWrapper

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1672,10 +1672,8 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	e.RunCommand("pulumi", "stack", "init", "dev")
 	e.RunCommand("pulumi", "stack", "select", "-s", "dev")
-	// `pulumi package add` rewrites package.json, so install the local SDK *after* it: InstallDependencies
-	// pins @pulumi/pulumi to the local build with a matching npm override.
-	e.RunCommand("pulumi", "package", "add", providerPath)
 	e.InstallDependencies()
+	e.RunCommand("pulumi", "package", "add", providerPath)
 	e.CWD = e.RootPath
 
 	// Run pulumi via a wrapper that does not start Pulumi in its own process group.

--- a/tests/integration/interrupt/program/package.json
+++ b/tests/integration/interrupt/program/package.json
@@ -3,7 +3,7 @@
     "license": "Apache-2.0",
     "type": "module",
     "version": "0.0.1",
-    "peerDependencies": {
+    "dependencies": {
         "@pulumi/pulumi": "*"
     }
 }


### PR DESCRIPTION
Run `InstallDependencies` first to lock in the local version of `@pulumi/pulumi` then `package add` the local provider sdk.