### PR TITLE
Call Read before Delete in do

### DIFF
--- a/changelog/pending/cli-do-fix-20260709-102541.yaml
+++ b/changelog/pending/cli-do-fix-20260709-102541.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: fix
+body: Fix calling delete on PF resources that need read called first
+time: 2026-07-09T10:25:41.25996+01:00

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -324,7 +324,29 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 				return err
 			}
 			urn := resourceURN(res)
-			id := resource.ID(args[0])
+
+			// First we need to read the resource. The ID given here is an "import id", while the actual
+			// Delete call needs the real ID + any inputs/outputs. terraform-pf bridge for example will fail to
+			// delete if just passed the ID and no state.
+			response, err := pc.provider.Read(ctx, plugin.ReadRequest{
+				URN:    urn,
+				Name:   urn.Name(),
+				Type:   urn.Type(),
+				ID:     resource.ID(args[0]),
+				Inputs: resource.PropertyMap{},
+				State:  resource.PropertyMap{},
+			})
+			if err != nil {
+				return err
+			}
+			if response.Outputs == nil {
+				return fmt.Errorf("resource %q was not found", args[0])
+			}
+			id := response.ID
+			if id == "" {
+				id = resource.ID(args[0])
+			}
+
 			if err := pc.confirm(cmd, formatDeleteSummary(res, id, pc.dryrun), string(id), yes); err != nil {
 				return err
 			}
@@ -332,13 +354,13 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			if pc.dryrun {
 				return nil
 			}
-			_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{
+			_, err = pc.provider.Delete(ctx, plugin.DeleteRequest{
 				URN:     urn,
 				Name:    urn.Name(),
 				Type:    urn.Type(),
 				ID:      id,
-				Inputs:  resource.PropertyMap{},
-				Outputs: resource.PropertyMap{},
+				Inputs:  response.Inputs,
+				Outputs: response.Outputs,
 			})
 			return err
 		},

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -345,11 +345,20 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
 			spec: doResourceSpec(false),
 			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+							Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+						},
+					}, nil
+				},
 				DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
-					deleted = true
 					assert.Equal(t, resource.ID("res-1"), req.ID)
-					assert.Empty(t, req.Inputs)
-					assert.Empty(t, req.Outputs)
+					assert.Equal(t, resource.PropertyMap{"name": resource.NewProperty("in")}, req.Inputs)
+					assert.Equal(t, resource.PropertyMap{"name": resource.NewProperty("out")}, req.Outputs)
+					deleted = true
 					return plugin.DeleteResponse{}, nil
 				},
 			},
@@ -616,6 +625,15 @@ func TestDoCmdResourceDeleteDryRun(t *testing.T) {
 	cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
 		spec: doResourceSpec(false),
 		MockProvider: plugin.MockProvider{
+			ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+				return plugin.ReadResponse{
+					ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("read")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("read")},
+					},
+				}, nil
+			},
 			DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
 				require.Fail(t, "Delete should not be called with --dry-run")
 				return plugin.DeleteResponse{}, nil
@@ -741,7 +759,18 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 		cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
 			spec: doResourceSpec(false),
 			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+							Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+						},
+					}, nil
+				},
 				DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					assert.Equal(t, resource.PropertyMap{"name": resource.NewProperty("in")}, req.Inputs)
+					assert.Equal(t, resource.PropertyMap{"name": resource.NewProperty("out")}, req.Outputs)
 					return plugin.DeleteResponse{}, nil
 				},
 			},


### PR DESCRIPTION
The terraform pf bridge needs `Read` to be called before `Delete` because it pulls the id to delete out of `outputs` not from the `id` passed in. Other providers might also need the state of the resource before properly deleting it.