### PR TITLE
Bind hooks to the onError resource option in PCL

### DIFF
--- a/changelog/pending/pcl-improvement-bind-error-hooks.yaml
+++ b/changelog/pending/pcl-improvement-bind-error-hooks.yaml
@@ -1,0 +1,6 @@
+component: pcl
+kind: improvement
+body: Allow binding hooks to a resource's `onError` option
+time: 2026-07-09T10:00:00.000000+02:00
+custom:
+    PR: "23838"

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -799,14 +799,21 @@ func (b *binder) declareNodes(ctx context.Context, file *syntax.File) (hcl.Diagn
 				diagnostics = append(diagnostics, diags...)
 			case "hook":
 				labels := item.Labels
-				if len(labels) != 1 {
-					diagnostics = append(diagnostics, labelsErrorf(item, "hook blocks must have exactly one label"))
+				if len(labels) != 2 {
+					diagnostics = append(diagnostics, labelsErrorf(item,
+						"hook blocks must have exactly two labels: a kind ('resource' or 'error') and a name"))
 					continue
 				}
-				name := labels[0]
+				kind, name := HookKind(labels[0]), labels[1]
+				if kind != HookKindResource && kind != HookKindError {
+					diagnostics = append(diagnostics, labelsErrorf(item,
+						"invalid hook kind '%s': must be 'resource' or 'error'", labels[0]))
+					continue
+				}
 				v := &Hook{
 					syntax:      item,
 					logicalName: name,
+					Kind:        kind,
 				}
 				diags := b.declareNode(name, v)
 				diagnostics = append(diagnostics, diags...)

--- a/pkg/codegen/pcl/binder_hooks_test.go
+++ b/pkg/codegen/pcl/binder_hooks_test.go
@@ -32,7 +32,7 @@ func TestHookBinding(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = ["test", args.urn, args.id, args.name, args.type, args.newInputs.first,
 		args.oldInputs.second, args.newOutputs.third, args.oldOutputs.forth]
 }
@@ -52,7 +52,7 @@ func TestHookConversionSafe(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = [true, 44]
 }
 `
@@ -71,7 +71,7 @@ func TestHookConversionUnsafe(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = [[], {}]
 }
 `
@@ -89,12 +89,12 @@ hook "foo" {
 			Start: hcl.Pos{
 				Line:   2,
 				Column: 12,
-				Byte:   25,
+				Byte:   34,
 			},
 			End: hcl.Pos{
 				Line:   2,
 				Column: 20,
-				Byte:   33,
+				Byte:   42,
 			},
 		},
 	}, diags[0])
@@ -105,7 +105,7 @@ func TestHookDryRunScope(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = ["test"]
 	onDryRun = args.id == "foo"
 }
@@ -123,12 +123,12 @@ hook "foo" {
 			Start: hcl.Pos{
 				Line:   3,
 				Column: 13,
-				Byte:   46,
+				Byte:   55,
 			},
 			End: hcl.Pos{
 				Line:   3,
 				Column: 17,
-				Byte:   50,
+				Byte:   59,
 			},
 		},
 	}, diags[0])
@@ -139,7 +139,7 @@ func TestHookUnknownAttribute(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = ["test"]
 	what = true
 }
@@ -157,12 +157,12 @@ hook "foo" {
 			Start: hcl.Pos{
 				Line:   3,
 				Column: 2,
-				Byte:   35,
+				Byte:   44,
 			},
 			End: hcl.Pos{
 				Line:   3,
 				Column: 6,
-				Byte:   39,
+				Byte:   48,
 			},
 		},
 	}, diags[0])
@@ -173,7 +173,7 @@ func TestBindingHookOptions(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = ["test"]
 }
 
@@ -215,12 +215,195 @@ resource "example" "infra:index:Vpc" {
 	assert.Equal(t, expected, val)
 }
 
+// Test that options can bind an error hook to a resource and that the hook carries the
+// declared kind.
+func TestBindingOnErrorHookOptions(t *testing.T) {
+	t.Parallel()
+
+	source := `
+hook error "foo" {
+	command = ["test"]
+}
+
+resource "example" "infra:index:Vpc" {
+  options {
+	hooks = {
+		onError = [foo]
+	}
+  }
+}`
+
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+
+	require.NoError(t, err)
+	require.Empty(t, diags)
+
+	hooks := program.Hooks()
+	require.Len(t, hooks, 1)
+	assert.Equal(t, pcl.HookKindError, hooks[0].Kind)
+}
+
+// Test that a hook's declared kind must match the binding it is referenced from.
+func TestBindingHookKindMismatch(t *testing.T) {
+	t.Parallel()
+
+	source := `
+hook resource "foo" {
+	command = ["test"]
+}
+
+resource "example" "infra:index:Vpc" {
+  options {
+	hooks = {
+		onError = [foo]
+	}
+  }
+}`
+
+	_, diags, err := ParseAndBindProgram(t, source, "program.pp")
+
+	require.Error(t, err)
+	require.Len(t, diags, 1)
+	assert.Equal(t, &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "cannot bind resource hook 'foo' to 'onError'",
+		Subject: &hcl.Range{
+			Filename: "program.pp",
+			Start: hcl.Pos{
+				Line:   8,
+				Column: 14,
+				Byte:   121,
+			},
+			End: hcl.Pos{
+				Line:   8,
+				Column: 17,
+				Byte:   124,
+			},
+		},
+	}, diags[0])
+
+	source = `
+hook error "foo" {
+	command = ["test"]
+}
+
+resource "example" "infra:index:Vpc" {
+  options {
+	hooks = {
+		beforeCreate = [foo]
+	}
+  }
+}`
+
+	_, diags, err = ParseAndBindProgram(t, source, "program.pp")
+
+	require.Error(t, err)
+	require.Len(t, diags, 1)
+	assert.Equal(t, &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "cannot bind error hook 'foo' to 'beforeCreate'",
+		Subject: &hcl.Range{
+			Filename: "program.pp",
+			Start: hcl.Pos{
+				Line:   8,
+				Column: 19,
+				Byte:   123,
+			},
+			End: hcl.Pos{
+				Line:   8,
+				Column: 22,
+				Byte:   126,
+			},
+		},
+	}, diags[0])
+}
+
+// Test that hook blocks require a valid kind label and a name label.
+func TestHookLabels(t *testing.T) {
+	t.Parallel()
+
+	source := `
+hook "foo" {
+	command = ["test"]
+}`
+
+	_, diags, err := ParseAndBindProgram(t, source, "program.pp")
+
+	require.Error(t, err)
+	require.Len(t, diags, 1)
+	assert.Equal(t,
+		"hook blocks must have exactly two labels: a kind ('resource' or 'error') and a name",
+		diags[0].Summary)
+
+	source = `
+hook banana "foo" {
+	command = ["test"]
+}`
+
+	_, diags, err = ParseAndBindProgram(t, source, "program.pp")
+
+	require.Error(t, err)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "invalid hook kind 'banana': must be 'resource' or 'error'", diags[0].Summary)
+}
+
+// Test that error hooks reject the onDryRun and ignoreErrors attributes.
+func TestOnErrorHookRejectsLifecycleAttributes(t *testing.T) {
+	t.Parallel()
+
+	source := `
+hook error "foo" {
+	command = ["test"]
+	onDryRun = true
+	ignoreErrors = true
+}`
+
+	_, diags, err := ParseAndBindProgram(t, source, "program.pp")
+
+	require.Error(t, err)
+	require.Len(t, diags, 2)
+	assert.Equal(t, &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "unknown property 'onDryRun' among [command]",
+		Subject: &hcl.Range{
+			Filename: "program.pp",
+			Start: hcl.Pos{
+				Line:   3,
+				Column: 2,
+				Byte:   41,
+			},
+			End: hcl.Pos{
+				Line:   3,
+				Column: 10,
+				Byte:   49,
+			},
+		},
+	}, diags[0])
+	assert.Equal(t, &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "unknown property 'ignoreErrors' among [command]",
+		Subject: &hcl.Range{
+			Filename: "program.pp",
+			Start: hcl.Pos{
+				Line:   4,
+				Column: 2,
+				Byte:   58,
+			},
+			End: hcl.Pos{
+				Line:   4,
+				Column: 14,
+				Byte:   70,
+			},
+		},
+	}, diags[1])
+}
+
 // Test that trying to use a hook name that doesn't exist is a bind error.
 func TestBindingInvalidHookOptions(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = ["test"]
 }
 
@@ -244,12 +427,12 @@ resource "example" "infra:index:Vpc" {
 			Start: hcl.Pos{
 				Line:   8,
 				Column: 3,
-				Byte:   101,
+				Byte:   110,
 			},
 			End: hcl.Pos{
 				Line:   8,
 				Column: 10,
-				Byte:   108,
+				Byte:   117,
 			},
 		},
 	}, diags[0])
@@ -260,7 +443,7 @@ func TestBindingInvalidHookType(t *testing.T) {
 	t.Parallel()
 
 	source := `
-hook "foo" {
+hook resource "foo" {
 	command = ["test"]
 }
 
@@ -282,18 +465,18 @@ resource "example" "infra:index:Vpc" {
 			Start: hcl.Pos{
 				Line:   7,
 				Column: 10,
-				Byte:   97,
+				Byte:   106,
 			},
 			End: hcl.Pos{
 				Line:   7,
 				Column: 15,
-				Byte:   102,
+				Byte:   111,
 			},
 		},
 	}, diags[0])
 
 	source = `
-hook "foo" {
+hook resource "foo" {
 	command = ["test"]
 }
 
@@ -317,12 +500,12 @@ resource "example" "infra:index:Vpc" {
 			Start: hcl.Pos{
 				Line:   8,
 				Column: 18,
-				Byte:   116,
+				Byte:   125,
 			},
 			End: hcl.Pos{
 				Line:   8,
 				Column: 21,
-				Byte:   119,
+				Byte:   128,
 			},
 		},
 	}, diags[0])

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -372,9 +372,13 @@ func (b *binder) bindHook(node *Hook) hcl.Diagnostics {
 		}
 	}
 
-	// Error on any other attribute
+	// Error on any other attribute. Error hooks always run on failures of actual operations,
+	// so onDryRun and ignoreErrors do not apply to them.
+	valid := []string{"onDryRun", "ignoreErrors", "command"}
+	if node.Kind == HookKindError {
+		valid = []string{"command"}
+	}
 	for _, i := range block.Body.Items {
-		valid := []string{"onDryRun", "ignoreErrors", "command"}
 		switch item := i.(type) {
 		case *model.Attribute:
 			if !slices.Contains(valid, item.Name) {

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -817,6 +817,7 @@ func bindResourceOptions(options *model.Block) (*ResourceOptions, hcl.Diagnostic
 					"beforeCreate", "afterCreate",
 					"beforeUpdate", "afterUpdate",
 					"beforeDelete", "afterDelete",
+					"onError",
 				}
 				obj, isObj := item.Value.(*model.ObjectConsExpression)
 				if !isObj {
@@ -840,12 +841,38 @@ func bindResourceOptions(options *model.Block) (*ResourceOptions, hcl.Diagnostic
 							Subject:  kv.Key.SyntaxNode().Range().Ptr(),
 						})
 					}
-					if _, isList := kv.Value.(*model.TupleConsExpression); !isList {
+					list, isList := kv.Value.(*model.TupleConsExpression)
+					if !isList {
 						diagnostics = append(diagnostics, &hcl.Diagnostic{
 							Severity: hcl.DiagError,
 							Summary:  invalidHooksMsg,
 							Subject:  kv.Value.SyntaxNode().Range().Ptr(),
 						})
+						continue
+					}
+					// The kind of each referenced hook must match the binding: `onError` takes
+					// error hooks, the lifecycle bindings take resource hooks.
+					for _, expr := range list.Expressions {
+						trav, isTrav := expr.(*model.ScopeTraversalExpression)
+						if !isTrav || len(trav.Parts) == 0 {
+							continue
+						}
+						hook, isHook := trav.Parts[0].(*Hook)
+						if !isHook {
+							continue
+						}
+						wantKind := HookKindResource
+						if hookType == "onError" {
+							wantKind = HookKindError
+						}
+						if hook.Kind != wantKind {
+							diagnostics = append(diagnostics, &hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary: fmt.Sprintf("cannot bind %s hook '%s' to '%s'",
+									hook.Kind, hook.Name(), hookType),
+								Subject: expr.SyntaxNode().Range().Ptr(),
+							})
+						}
 					}
 				}
 				continue // skip generic type check; structural validation is done above

--- a/pkg/codegen/pcl/hook.go
+++ b/pkg/codegen/pcl/hook.go
@@ -21,14 +21,20 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// Hook represents a named resource lifecycle hook block.
+// Hook represents a named hook block. The first label declares the hook's kind: a
+// `resource` hook runs at resource lifecycle steps, while an `error` hook runs when an
+// operation fails retryably and its command's exit status decides whether to retry.
 //
 // Example PCL:
 //
-//	hook "myHook" {
+//	hook resource "myHook" {
 //	    command      = ["touch", hookTestFile]
 //	    onDryRun     = false
 //	    ignoreErrors = false
+//	}
+//
+//	hook error "myErrorHook" {
+//	    command = ["touch", hookTestFile]
 //	}
 //
 // A hook can then be referenced in a resource's hooks option:
@@ -36,6 +42,7 @@ import (
 //	options {
 //	    hooks = {
 //	        beforeCreate = [myHook]
+//	        onError      = [myErrorHook]
 //	    }
 //	}
 type Hook struct {
@@ -56,7 +63,24 @@ type Hook struct {
 	// IgnoreErrors, when set to true, causes errors from the hook to be logged as warnings
 	// instead of failing the program. Defaults to false.
 	IgnoreErrors model.Expression
+
+	// Kind is the kind of the hook, declared by the block's first label. Resource hooks run
+	// at resource lifecycle steps (`beforeCreate`, `afterDelete`, etc.). Error hooks run when
+	// an operation fails retryably and signal whether it should be retried: the operation is
+	// retried if and only if the hook's command exits successfully.
+	Kind HookKind
 }
+
+// HookKind is the kind of a hook block: resource or error, matching the two hook
+// registration kinds in the language SDKs.
+type HookKind string
+
+const (
+	// HookKindResource is a hook that runs at resource lifecycle steps.
+	HookKindResource HookKind = "resource"
+	// HookKindError is a hook that runs when an operation fails retryably.
+	HookKindError HookKind = "error"
+)
 
 // SyntaxNode returns the syntax node associated with the hook.
 func (h *Hook) SyntaxNode() hclsyntax.Node {

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-hook-after-failure/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-hook-after-failure/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command = ["false"]
 }
 

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-hook-ignore-errors/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-hook-ignore-errors/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command      = ["false"]
     ignoreErrors = true
 }

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-option-hooks/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-option-hooks/main.pp
@@ -1,11 +1,11 @@
 config hookTestFile "string" {}
 config hookPreviewFile "string" {}
 
-hook "createHook" {
+hook resource "createHook" {
     command = ["touch", hookTestFile]
 }
 
-hook "previewHook" {
+hook resource "previewHook" {
     command = ["touch", "${hookPreviewFile}_${args.name}"]
     onDryRun = true
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-hook-after-failure/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-hook-after-failure/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command = ["false"]
 }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-hook-ignore-errors/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-hook-ignore-errors/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command      = ["false"]
     ignoreErrors = true
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-hooks/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-hooks/main.pp
@@ -1,11 +1,11 @@
 config hookTestFile "string" {}
 config hookPreviewFile "string" {}
 
-hook "createHook" {
+hook resource "createHook" {
     command = ["touch", hookTestFile]
 }
 
-hook "previewHook" {
+hook resource "previewHook" {
     command = ["touch", "${hookPreviewFile}_${args.name}"]
     onDryRun = true
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-hook-after-failure/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-hook-after-failure/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command = ["false"]
 }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-hook-ignore-errors/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-hook-ignore-errors/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command      = ["false"]
     ignoreErrors = true
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-option-hooks/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-option-hooks/main.pp
@@ -1,11 +1,11 @@
 config hookTestFile "string" {}
 config hookPreviewFile "string" {}
 
-hook "createHook" {
+hook resource "createHook" {
     command = ["touch", hookTestFile]
 }
 
-hook "previewHook" {
+hook resource "previewHook" {
     command = ["touch", "${hookPreviewFile}_${args.name}"]
     onDryRun = true
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-hook-after-failure/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-hook-after-failure/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command = ["false"]
 }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-hook-ignore-errors/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-hook-ignore-errors/main.pp
@@ -1,4 +1,4 @@
-hook "failingHook" {
+hook resource "failingHook" {
     command      = ["false"]
     ignoreErrors = true
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-hooks/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-hooks/main.pp
@@ -1,11 +1,11 @@
 config hookTestFile "string" {}
 config hookPreviewFile "string" {}
 
-hook "createHook" {
+hook resource "createHook" {
     command = ["touch", hookTestFile]
 }
 
-hook "previewHook" {
+hook resource "previewHook" {
     command = ["touch", "${hookPreviewFile}_${args.name}"]
     onDryRun = true
 }


### PR DESCRIPTION
Accept `onError` in the `hooks` resource option and mark the referenced
hook blocks as error hooks. Error hooks differ from lifecycle hooks in
the language SDKs: they receive the failure reasons and return whether
the failed operation should be retried, so a hook may not be bound as
both a lifecycle hook and an error hook, and error hooks reject the
`onDryRun` and `ignoreErrors` attributes.

Code generation and runtime support for error hooks lands in the
follow-up PR.