### PR TITLE
Construct rapid property value generators in linear time

### DIFF
--- a/sdk/go/common/resource/property_compatibility_test.go
+++ b/sdk/go/common/resource/property_compatibility_test.go
@@ -38,8 +38,9 @@ import (
 func TestRoundTripConvert(t *testing.T) {
 	t.Parallel()
 
+	value := pTest.Value(10)
 	rapid.Check(t, func(t *rapid.T) {
-		source := pTest.Value(10).Draw(t, "round-trip value")
+		source := value.Draw(t, "round-trip value")
 		propertyValue := resource.ToResourcePropertyValue(source)
 		roundTripped := resource.FromResourcePropertyValue(propertyValue)
 
@@ -81,8 +82,9 @@ func testRoundTripThroughGRPC(t require.TestingT, v property.Value) {
 func TestConversionThroughGRPCRapid(t *testing.T) {
 	t.Parallel()
 
+	value := pTest.Value(10)
 	rapid.Check(t, func(t *rapid.T) {
-		source := pTest.Value(10).Draw(t, "round-trip value")
+		source := value.Draw(t, "round-trip value")
 		testRoundTripThroughGRPC(t, source)
 	})
 }

--- a/sdk/go/property/testing/equal_test.go
+++ b/sdk/go/property/testing/equal_test.go
@@ -29,16 +29,18 @@ import (
 
 func TestSameIsEqual(t *testing.T) {
 	t.Parallel()
+	value := Value(10)
 	rapid.Check(t, func(t *rapid.T) {
-		same := Value(10).Draw(t, "value")
+		same := value.Draw(t, "value")
 		assert.True(t, same.Equals(same))
 	})
 }
 
 func TestDifferentIsNotEqual(t *testing.T) {
 	t.Parallel()
+	distinctPair := rapid.SliceOfNDistinct(Value(10), 2, 2, valueKey)
 	rapid.Check(t, func(t *rapid.T) {
-		arr := rapid.SliceOfNDistinct(Value(10), 2, 2, valueKey).Draw(t, "values")
+		arr := distinctPair.Draw(t, "values")
 		v1, v2 := arr[0], arr[1]
 		assert.False(t, v1.Equals(v2))
 	})

--- a/sdk/go/property/testing/rapid.go
+++ b/sdk/go/property/testing/rapid.go
@@ -30,16 +30,20 @@ import (
 )
 
 func Value(maxDepth int) *rapid.Generator[property.Value] {
-	if maxDepth <= 1 {
-		return Primitive()
+	// Build one generator per depth level, sharing the shallower generator
+	// between the composite branches. Constructing a fresh sub-generator per
+	// branch instead would make construction time exponential in maxDepth.
+	value := Primitive()
+	for i := 1; i < maxDepth; i++ {
+		value = rapid.OneOf(
+			Primitive(),
+			ArrayOf(value),
+			MapOf(value),
+			SecretOf(value),
+			DependenciesOf(value),
+		)
 	}
-	return rapid.OneOf(
-		Primitive(),
-		Array(maxDepth),
-		Map(maxDepth),
-		Secret(maxDepth),
-		Dependencies(maxDepth),
-	)
+	return value
 }
 
 func Primitive() *rapid.Generator[property.Value] {


### PR DESCRIPTION
<!-- This PR was written by an AI (Claude Code), directed by @iwahbe. -->

## Summary

`testing.Value(maxDepth)` in `sdk/go/property/testing` constructed its
generator tree eagerly and recursively: `Value(n)` built four composite
branches, each of which constructed a fresh `Value(n-1)`, making construction
O(4^maxDepth) — hundreds of thousands of generator allocations for the
`Value(10)` our property tests use. The four tests drawing from it also
called `Value(10)` *inside* their `rapid.Check` callbacks, so the exponential
construction re-ran on every one of the 100 check iterations. A CPU profile
shows the construction functions dominating application time, with ~60% of
total samples in GC digesting the resulting garbage.

Those four tests are the long pole of the `Unit Test / sdk` CI job on every
platform. From merge-queue run 29005477587 (2026-07-09):

| Test | ubuntu | macOS |
|---|---|---|
| `TestDifferentIsNotEqual` | 13m54s | 30m32s |
| `TestSameIsEqual` | 13m19s | 30m00s |
| `TestConversionThroughGRPCRapid` | 13m08s | 28m23s |
| `TestRoundTripConvert` | 12m56s | 28m01s |

They put `go/property/testing` at 30m34s and `go/common/resource` at 28m25s
package time, making the macOS job 41.6m and the ubuntu job ~24m while every
other package in the module finishes in seconds.

This PR makes `Value` construct one generator per depth level, sharing the
shallower generator across the four composite branches — construction is now
linear in `maxDepth` — and hoists generator construction out of the four
check loops. Locally with `-race -cover` at the default 100 checks, the tests
now run in 13.5s / 24.4s / 14.8s / 23.8s (~10x faster per check; the before
per-check cost was ~1.4s). The remaining cost is genuinely drawing and
comparing depth-10 values.

## Notes for reviewers

The generated value distribution is unchanged: the `OneOf` branch structure
is identical at every depth, the branches just share one sub-generator
instead of each rebuilding it. rapid generators are immutable descriptors, so
sharing is safe. No public signatures change, and `Array`/`Map`/`Secret`/
`Dependencies` become linear too since they delegate to `Value`.