### PR TITLE
add spinner for longer running operations

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -160,6 +160,9 @@ func NewDoCmd(
 		ctx := cmd.Context()
 		tracer := otel.Tracer("pulumi-cli")
 
+		loading := startSpinner(fmt.Sprintf("Loading provider '%s'", pkgargs[0]))
+		defer loading()
+
 		host, err := newHost(ctx, sink, sink)
 		if err != nil {
 			return nil, nil, fmt.Errorf("create plugin host: %w", err)
@@ -216,6 +219,10 @@ func NewDoCmd(
 				Version: resp.Version.String(),
 			}
 		}
+
+		loading()
+		reading := startSpinner(fmt.Sprintf("Reading schema for '%s'", pkgName))
+		defer reading()
 
 		getSchema, err := p.GetSchema(ctx, schemaRequest)
 		if err != nil {
@@ -283,6 +290,7 @@ func NewDoCmd(
 			cleanup()
 			return nil, nil, err
 		}
+		reading()
 		// Replace the short name in Use with the full token so the usage
 		// string shows e.g. "pulumi do aws:s3:Bucket" instead of "pulumi do Bucket".
 		if len(pargs) > 0 {

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -387,6 +387,8 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 				return errors.New("--all and --count are mutually exclusive")
 			}
 			ctx := cmd.Context()
+			listing := startSpinner(fmt.Sprintf("Listing %s resources", res.Token))
+			defer listing()
 			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
@@ -422,6 +424,7 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 					results = append(results, item)
 				}
 				if stream.Computed {
+					listing()
 					output, err := jsonifyProperty(resource.NewProperty("<unknown>"), pc.showSecrets)
 					if err != nil {
 						return err
@@ -442,6 +445,7 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 				}
 			}
 
+			listing()
 			return pc.printListResults(cmd, results)
 		},
 	}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 
 	"github.com/gofrs/uuid"
@@ -54,6 +55,34 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
+
+func startSpinner(prefix string) func() {
+	spinner, ticker := cmdutil.NewSpinnerAndTicker(
+		prefix, nil, cmdutil.GetGlobalColorization(), 8 /*timesPerSecond*/, !cmdutil.Interactive())
+	spinner.Tick()
+	stop := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		for {
+			select {
+			case <-ticker.C:
+				spinner.Tick()
+			case <-stop:
+				spinner.Reset()
+				return
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			ticker.Stop()
+			close(stop)
+			<-stopped
+		})
+	}
+}
 
 type functionEvalContext struct {
 	WorkingDir    string


### PR DESCRIPTION
Loading the provider and/or listing resources can be quite slow
despite some performance improvements we made.  This means `pulumi do`
can look like it's hanging instead of doing something when it starts
up.

Add a spinner explaining that we're loading the provider/listing
resources at startup, so the user knows what's happening, which helps
to at least know what's going on.

Note that this is only added in interactive mode.  In non-interactive
mode we can assume that users are not starting at the output and
waiting in most cases.