### PR TITLE
do: use display code for preview as well

### DIFF
--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -34,12 +34,22 @@ type displayedStep struct {
 	Old, New     *resource.State
 	Diffs        []resource.PropertyKey
 	DetailedDiff map[string]plugin.PropertyDiff
+	Preview      bool
+	ShowChanges  bool
+}
+
+func (pc *packageCommand) previewDisplayedStep(
+	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
+) error {
+	step.Preview = true
+	step.ShowChanges = true
+	return pc.runDisplayedStep(cmd, step, call)
 }
 
 func (pc *packageCommand) runDisplayedStep(
 	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
 ) error {
-	preview := pc.dryrun && step.Op != deploy.OpRead
+	preview := (pc.dryrun || step.Preview) && step.Op != deploy.OpRead
 
 	if pc.jsonOut {
 		state, err := call()
@@ -59,7 +69,7 @@ func (pc *packageCommand) runDisplayedStep(
 		Stderr:              stderr,
 		ShowSecrets:         pc.showSecrets,
 		ShowReads:           true,
-		ShowResourceChanges: len(step.Diffs) > 0 || len(step.DetailedDiff) > 0,
+		ShowResourceChanges: step.ShowChanges || len(step.Diffs) > 0 || len(step.DetailedDiff) > 0,
 		SuppressProgress:    true,
 		SuppressStackRow:    true,
 	}

--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -35,14 +35,12 @@ type displayedStep struct {
 	Diffs        []resource.PropertyKey
 	DetailedDiff map[string]plugin.PropertyDiff
 	Preview      bool
-	ShowChanges  bool
 }
 
 func (pc *packageCommand) previewDisplayedStep(
 	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
 ) error {
 	step.Preview = true
-	step.ShowChanges = true
 	return pc.runDisplayedStep(cmd, step, call)
 }
 
@@ -69,7 +67,7 @@ func (pc *packageCommand) runDisplayedStep(
 		Stderr:              stderr,
 		ShowSecrets:         pc.showSecrets,
 		ShowReads:           true,
-		ShowResourceChanges: step.ShowChanges || len(step.Diffs) > 0 || len(step.DetailedDiff) > 0,
+		ShowResourceChanges: preview || len(step.Diffs) > 0 || len(step.DetailedDiff) > 0,
 		SuppressProgress:    true,
 		SuppressStackRow:    true,
 	}

--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -37,19 +37,12 @@ type displayedStep struct {
 	Preview      bool
 }
 
-func (pc *packageCommand) previewDisplayedStep(
-	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
-) error {
-	step.Preview = true
-	return pc.runDisplayedStep(cmd, step, call)
-}
-
 func (pc *packageCommand) runDisplayedStep(
 	cmd *cobra.Command, step displayedStep, call func() (*resource.State, error),
 ) error {
 	preview := (pc.dryrun || step.Preview) && step.Op != deploy.OpRead
 
-	if pc.jsonOut {
+	if pc.jsonOut && !step.Preview {
 		state, err := call()
 		if err != nil || state == nil {
 			return err

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -131,32 +131,26 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 				return err
 			}
 			ctx := cmd.Context()
-			if err := pc.configureProvider(cmd, ctx); err != nil {
-				return err
-			}
 			urn := resourceURN(res)
-			inputs, err := evaluateResourceFile(
-				ctx, inputFile, "input", pc.format, res, pc.evalContext(),
-				pc.converter, pc.loaderTarget, pc.packageDescriptor,
-				collectInputFlags(cmd, "input", res.InputProperties))
-			if err != nil {
-				return fmt.Errorf("parse input file: %w", err)
+			var checked resource.PropertyMap
+			prepare := func() (*resource.State, error) {
+				if err := pc.configureProvider(cmd, ctx); err != nil {
+					return nil, err
+				}
+				inputs, err := evaluateResourceFile(
+					ctx, inputFile, "input", pc.format, res, pc.evalContext(),
+					pc.converter, pc.loaderTarget, pc.packageDescriptor,
+					collectInputFlags(cmd, "input", res.InputProperties))
+				if err != nil {
+					return nil, fmt.Errorf("parse input file: %w", err)
+				}
+				checked, err = pc.checkResourceInputs(ctx, urn, res, nil, inputs)
+				if err != nil {
+					return nil, err
+				}
+				return operationState(urn, "", checked, nil), nil
 			}
-			checked, err := pc.checkResourceInputs(ctx, urn, res, nil, inputs)
-			if err != nil {
-				return err
-			}
-			summary, err := formatCreateSummary(res, checked, pc.showSecrets)
-			if err != nil {
-				return err
-			}
-			if err := pc.confirm(cmd, summary, "create", yes); err != nil {
-				return err
-			}
-			return pc.runDisplayedStep(cmd, displayedStep{
-				Op:  deploy.OpCreate,
-				New: operationState(urn, "", nil, nil),
-			}, func() (*resource.State, error) {
+			create := func() (*resource.State, error) {
 				response, err := pc.provider.Create(ctx, plugin.CreateRequest{
 					URN:        urn,
 					Name:       urn.Name(),
@@ -172,7 +166,48 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 					id = resource.ID("[unknown]")
 				}
 				return resultState(urn, id, nil, response.Properties, res), nil
-			})
+			}
+			if pc.jsonOut {
+				if _, err := prepare(); err != nil {
+					return err
+				}
+				summary, err := formatCreateSummary(res, checked, pc.showSecrets)
+				if err != nil {
+					return err
+				}
+				if err := pc.confirm(cmd, summary, "create", yes); err != nil {
+					return err
+				}
+				return pc.runDisplayedStep(cmd, displayedStep{
+					Op:  deploy.OpCreate,
+					New: operationState(urn, "", nil, nil),
+				}, create)
+			}
+			if pc.dryrun {
+				return pc.runDisplayedStep(cmd, displayedStep{
+					Op:          deploy.OpCreate,
+					New:         operationState(urn, "", nil, nil),
+					ShowChanges: true,
+				}, func() (*resource.State, error) {
+					if _, err := prepare(); err != nil {
+						return nil, err
+					}
+					return create()
+				})
+			}
+			if err := pc.previewDisplayedStep(cmd, displayedStep{
+				Op:  deploy.OpCreate,
+				New: operationState(urn, "", nil, nil),
+			}, prepare); err != nil {
+				return err
+			}
+			if err := pc.confirm(cmd, "", "create", yes); err != nil {
+				return err
+			}
+			return pc.runDisplayedStep(cmd, displayedStep{
+				Op:  deploy.OpCreate,
+				New: operationState(urn, "", checked, nil),
+			}, create)
 		},
 	}
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -167,22 +167,6 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 				}
 				return resultState(urn, id, nil, response.Properties, res), nil
 			}
-			if pc.jsonOut {
-				if _, err := prepare(); err != nil {
-					return err
-				}
-				summary, err := formatCreateSummary(res, checked, pc.showSecrets)
-				if err != nil {
-					return err
-				}
-				if err := pc.confirm(cmd, summary, "create", yes); err != nil {
-					return err
-				}
-				return pc.runDisplayedStep(cmd, displayedStep{
-					Op:  deploy.OpCreate,
-					New: operationState(urn, "", nil, nil),
-				}, create)
-			}
 			if pc.dryrun {
 				return pc.runDisplayedStep(cmd, displayedStep{
 					Op:  deploy.OpCreate,
@@ -194,9 +178,10 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 					return create()
 				})
 			}
-			if err := pc.previewDisplayedStep(cmd, displayedStep{
-				Op:  deploy.OpCreate,
-				New: operationState(urn, "", nil, nil),
+			if err := pc.runDisplayedStep(cmd, displayedStep{
+				Op:      deploy.OpCreate,
+				New:     operationState(urn, "", nil, nil),
+				Preview: true,
 			}, prepare); err != nil {
 				return err
 			}
@@ -576,14 +561,6 @@ func (pc *packageCommand) printListResults(cmd *cobra.Command, results []plugin.
 func errStatefulNotImplemented(op string) error {
 	return fmt.Errorf("`%s` is not yet implemented in stateful mode; pass --stateless to use the "+
 		"direct-provider implementation", op)
-}
-
-func formatCreateSummary(res *schema.Resource, inputs resource.PropertyMap, showSecrets bool) (string, error) {
-	body, err := jsonifyProperty(resource.NewProperty(inputs), showSecrets)
-	if err != nil {
-		return "", fmt.Errorf("format inputs: %w", err)
-	}
-	return fmt.Sprintf("This will create %s with the following inputs:\n%s", res.Token, body), nil
 }
 
 func formatDeleteSummary(res *schema.Resource, id resource.ID, dryrun bool) string {

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -185,9 +185,8 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 			}
 			if pc.dryrun {
 				return pc.runDisplayedStep(cmd, displayedStep{
-					Op:          deploy.OpCreate,
-					New:         operationState(urn, "", nil, nil),
-					ShowChanges: true,
+					Op:  deploy.OpCreate,
+					New: operationState(urn, "", nil, nil),
 				}, func() (*resource.State, error) {
 					if _, err := prepare(); err != nil {
 						return nil, err

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -245,9 +245,11 @@ size = 2
   "size": 2,
   "extra": "hidden"
 }`, stdout.String())
+	assert.Contains(t, stderr.String(), "+ 1 to create")
+	assert.Contains(t, stderr.String(), `name: "example"`)
 	assert.NotContains(t, stderr.String(), "creating")
 	assert.NotContains(t, stderr.String(), "Outputs:")
-	assert.NotContains(t, stderr.String(), "Resources:")
+	assert.NotContains(t, stderr.String(), "+ 1 created")
 }
 
 func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -701,7 +701,9 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 			"--input", "pcl", "--input-file", inputFile,
 		})
 		require.NoError(t, cmd.Execute())
-		assert.Contains(t, stderr.String(), "This will create azure:index:myResource")
+		assert.Contains(t, stderr.String(), "+ azure:index:myResource: (create)")
+		assert.Contains(t, stderr.String(), `name: "example"`)
+		assert.Contains(t, stderr.String(), "+ 1 to create")
 		assert.Contains(t, stderr.String(), "azure:index:myResource myResource creating")
 		assert.Contains(t, stderr.String(), "azure:index:myResource myResource created")
 		assert.Contains(t, stderr.String(), "+ 1 created")

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -745,9 +745,11 @@ func (pc *packageCommand) requireYesIfNonInteractive(yes bool) error {
 // earlier; if we somehow reach here non-interactively without --yes we treat it as a decline.
 func (pc *packageCommand) confirm(cmd *cobra.Command, summary, operation string, yes bool) error {
 	stderr := cmd.ErrOrStderr()
-	fmt.Fprint(stderr, summary)
-	if !strings.HasSuffix(summary, "\n") {
-		fmt.Fprintln(stderr)
+	if summary != "" {
+		fmt.Fprint(stderr, summary)
+		if !strings.HasSuffix(summary, "\n") {
+			fmt.Fprintln(stderr)
+		}
 	}
 	if yes || pc.dryrun {
 		return nil


### PR DESCRIPTION
We've started using the display code for the actual create in a
previous PR.  Align the preview for stateless do with regular pulumi
up previews and use the display code for it as well.

Example output:

<img width="1732" height="946" alt="image" src="https://github.com/user-attachments/assets/c22f9ac2-208f-482e-9a57-7b272a8ad34f" />
