### PR TITLE
Fail outputs on failed creates

### DIFF
--- a/changelog/pending/sdk-fix-20260709-191943.yaml
+++ b/changelog/pending/sdk-fix-20260709-191943.yaml
@@ -1,0 +1,4 @@
+component: sdk
+kind: fix
+body: Failed resource registrations will return faulted outputs, not unknown outputs
+time: 2026-07-09T19:19:43.24112+01:00

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1911,6 +1911,12 @@ func (ctx *Context) registerResource(
 				}
 				deps[key] = resources
 			}
+			// If the engine reported that the resource failed or was skipped, synthesize an
+			// error so downstream outputs fault. This allows Output.Recover to intercept the
+			// failure.
+			if err == nil && resp.Result != pulumirpc.Result_SUCCESS {
+				err = fmt.Errorf("resource %s [%s] failed to register", name, t)
+			}
 		}
 	}()
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -777,13 +777,22 @@ export function registerResource(
                         };
                     }
 
-                    resop.resolveURN(resp.getUrn(), err);
+                    // If the engine reported that the resource failed or was skipped, synthesize
+                    // an error so downstream outputs reject. This allows `pulumi.recover` to
+                    // intercept the failure.
+                    const resultFailed = resp.getResult() !== resproto.Result.SUCCESS;
+                    let effectiveErr = err;
+                    if (!effectiveErr && resultFailed) {
+                        effectiveErr = new Error(`resource ${name} [${t}] failed to register`);
+                    }
+
+                    resop.resolveURN(resp.getUrn(), effectiveErr);
 
                     // Note: 'id || undefined' is intentional.  We intentionally collapse falsy values to
                     // undefined so that later parts of our system don't have to deal with values like 'null'.
                     if (resop.resolveID) {
                         const id = resp.getId() || undefined;
-                        resop.resolveID(id, id !== undefined, err);
+                        resop.resolveID(id, id !== undefined, effectiveErr);
                     }
 
                     const deps: Record<string, Resource[]> = {};
@@ -796,7 +805,6 @@ export function registerResource(
                     }
 
                     // Now resolve the output properties.
-                    const keepUnknowns = resp.getResult() !== resproto.Result.SUCCESS;
                     await resolveOutputs(
                         res,
                         t,
@@ -805,8 +813,8 @@ export function registerResource(
                         resp.getObject(),
                         deps,
                         resop.resolvers,
-                        err,
-                        keepUnknowns,
+                        effectiveErr,
+                        resultFailed,
                     );
                     done();
                 });

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -1205,7 +1205,15 @@ def register_resource(
         try:
             log.debug(f"resource registration successful: ty={ty}, urn={resp.urn}")
 
-            resolve_urn(resp.urn, True, False, None)
+            # If the engine reported that the resource failed or was skipped, synthesize an
+            # exception so downstream outputs fault. This allows `Output.recover` to intercept
+            # the failure.
+            result_failed = resp.result != resource_pb2.Result.SUCCESS
+            register_exn: Optional[Exception] = None
+            if result_failed:
+                register_exn = Exception(f"resource {name} [{ty}] failed to register")
+
+            resolve_urn(resp.urn, True, False, register_exn)
             resolve_urn_called = True
 
             if resolve_id is not None:
@@ -1213,7 +1221,7 @@ def register_resource(
                 # empty string, we should treat it as unknown. TFBridge in particular is known to send
                 # the empty string as an ID when doing a preview.
                 is_known = bool(resp.id)
-                resolve_id(resp.id, is_known, False, None)
+                resolve_id(resp.id, is_known, False, register_exn)
                 resolve_id_called = True
 
             property_deps = {}
@@ -1223,17 +1231,20 @@ def register_resource(
                     urns = list(v.urns)
                     property_deps[k] = set(map(new_dependency, urns))
 
-            keep_unknowns = resp.result == resource_pb2.Result.SUCCESS
-            rpc.resolve_outputs(
-                res,
-                resolver.serialized_props,
-                resp.object,
-                property_deps,
-                resolvers,
-                custom,
-                transform_using_type_metadata,
-                keep_unknowns,
-            )
+            if register_exn is not None:
+                rpc.resolve_outputs_due_to_exception(resolvers, register_exn)
+            else:
+                keep_unknowns = resp.result == resource_pb2.Result.SUCCESS
+                rpc.resolve_outputs(
+                    res,
+                    resolver.serialized_props,
+                    resp.object,
+                    property_deps,
+                    resolvers,
+                    custom,
+                    transform_using_type_metadata,
+                    keep_unknowns,
+                )
             resolve_outputs_called = True
 
         except Exception as exn:


### PR DESCRIPTION
This is so we can use `recover` to recover from failed resource operations. These used to be resolved as 'unknown' which also blocked using them in other resources at update time, and ignored for `apply` calls. The error state is basically the same, except `recover` can be used to see it error'd and return back to a normal value.