### PR TITLE
ci: prime the Go build cache with -trimpath in test jobs

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -208,6 +208,18 @@ jobs:
         run: |
           ( cd sdk && go test -run "_________" ./... )
           ( cd pkg && go test -run "_________" ./... )
+      - name: Prime Go cache for program compilation
+        # The Go language host compiles test programs with -trimpath (see
+        # compileProgram in sdk/go/pulumi-language-go), and Go's build cache
+        # keys entries on build flags. Without matching entries the first
+        # program build in a job rebuilds the SDK's whole dependency graph
+        # mid-test. This step runs unconditionally rather than only on cache
+        # miss: the restored cache may predate -trimpath priming (it is saved
+        # by whichever cache-miss job finishes first, which may never build a
+        # program), and paying the build once up front on an idle runner is
+        # far cheaper than paying it concurrently inside the first tests.
+        run: |
+          ( cd sdk && go build -trimpath ./... )
       - name: Install delve
         run: |
           go install github.com/go-delve/delve/cmd/dlv@latest


### PR DESCRIPTION
<!-- This PR was written by an AI (Claude Code), directed by @iwahbe. -->

## Summary

The Go language host compiles test programs with `-trimpath`
(`compileProgram` in `sdk/go/pulumi-language-go`, added in #23495 to make
temp-dir program builds cacheable), and Go's build cache keys entries on
build flags. CI's "Prime Go cache" step compiles with plain `go test`, so
none of its entries match: the first Go program build in every test job
rebuilds the SDK's entire dependency graph mid-test.

On ubuntu that is roughly a one-minute warm-up tax per job — and the reason
the Performance Gate has failed deterministically on every PR since #23495
(`TestPerfManyComponentUpdate` pays the rebuild inside its measured step,
~45s vs an 18.1s budget; the merge queue masks it via `PULUMI_TEST_RETRIES=2`
with a warm cache on retry). On the 3-core macOS runners the effect is
catastrophic: 8 parallel ProgramTests all rebuild the dependency graph
simultaneously at job start. From merge-queue run 29005477587, the tests
whose programs the engine compiles from source with the Go language host are
5–10x slower on macOS while everything else is ~2x:

| Test | ubuntu | macOS | ratio |
|---|---|---|---|
| `TestEmptyGoRun` | 1.0m | 8.0m | 8.0x |
| `TestConstructGo/testcomponent-go` | 0.8m | 8.1m | 10.5x |
| `TestConstructGo/testcomponent` | 0.8m | 7.7m | 9.1x |
| `TestConstructGo/testcomponent-python` | 0.8m | 7.6m | 9.3x |
| `TestConstructMethodsResourcesPython/testcomponent` | 1.0m | 6.1m | 6.1x |
| `TestConstructResourceOptionsGo` | 0.9m | 4.4m | 4.8x |
| `TestLogDebugGo` | 2.0m | 9.8m | 4.8x |

This PR adds a priming step that runs `go build -trimpath ./...` in `sdk/`
before tests, so program builds hit warm cache entries.

## Notes for reviewers

The step is deliberately **unconditional** (not gated on
`steps.setup-go.outputs.cache-hit`) for two reasons:

1. The persisted cache cannot heal itself under a conditional prime: setup-go
   saves the cache only from cache-miss jobs, and whichever job finishes
   first wins the key — typically a small unit job that never builds a Go
   program, so its GOCACHE never contains `-trimpath` entries.
2. It makes the improvement measurable on this PR's own run instead of only
   after a cache-key rotation.

Cost when the restored cache lacks the entries: the sdk build once, up
front, on an otherwise idle runner — strictly cheaper than paying the same
rebuild concurrently inside the first N tests. Cost when the entries are
present: seconds (warm `go build ./...` is a cache walk; ~7s locally).

`-ldflags "-w -s"` (the other `compileProgram` flag) only affects linking,
which the build cache does not store, so priming does not need it.