### PR TITLE
Add a production runtime option for Node.js projects

### DIFF
--- a/changelog/pending/sdk-nodejs-production-install-option.yaml
+++ b/changelog/pending/sdk-nodejs-production-install-option.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: feat
+body: Add a `production` runtime option for Node.js projects. When set to `true` in
+  `Pulumi.yaml`, `pulumi install` skips `devDependencies` (npm `--production`, pnpm
+  `--production`, yarn `--production`).
+time: 2026-07-09T17:30:00.000000+02:00

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/installcache.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/installcache.go
@@ -77,15 +77,17 @@ func installCacheKey(projectDir string) string {
 // node_modules tree with other projects that have an identical dependency
 // manifest when the host's install cache is enabled.
 func (host *nodeLanguageHost) installShared(
-	ctx context.Context, packagemanager npm.PackageManagerType, workspaceRoot string, isPlugin bool,
+	ctx context.Context, packagemanager npm.PackageManagerType, workspaceRoot string, isPlugin bool, production bool,
 	stdout, stderr io.Writer,
 ) error {
 	cacheKey := ""
-	if host.installCacheDir != "" && !isPlugin {
+	// Production installs don't participate in the cache: a production
+	// node_modules tree differs from a full one for the same manifest.
+	if host.installCacheDir != "" && !isPlugin && !production {
 		cacheKey = installCacheKey(workspaceRoot)
 	}
 	if cacheKey == "" {
-		_, err := npm.Install(ctx, packagemanager, workspaceRoot, false /*production*/, stdout, stderr)
+		_, err := npm.Install(ctx, packagemanager, workspaceRoot, production, stdout, stderr)
 		return err
 	}
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -284,6 +284,8 @@ type nodeOptions struct {
 	// The packagemanger to use to install dependencies.
 	// One of auto, npm, yarn, pnpm or bun, defaults to auto.
 	packagemanager npm.PackageManagerType
+	// Skip devDependencies when installing dependencies.
+	production bool
 }
 
 func parseOptions(options map[string]any, runtime string) (nodeOptions, error) {
@@ -313,6 +315,14 @@ func parseOptions(options map[string]any, runtime string) (nodeOptions, error) {
 			nodeOptions.nodeargs = args
 		} else {
 			return nodeOptions, errors.New("nodeargs option must be a string")
+		}
+	}
+
+	if production, ok := options["production"]; ok {
+		if prod, ok := production.(bool); ok {
+			nodeOptions.production = prod
+		} else {
+			return nodeOptions, errors.New("production option must be a boolean")
 		}
 	}
 
@@ -1210,7 +1220,7 @@ func (host *nodeLanguageHost) InstallDependencies(
 	}
 	otelSpan.SetAttributes(append(setOptionsAttributes(opts), attribute.String("workspaceRoot", workspaceRoot))...)
 
-	if err := host.installShared(ctx, opts.packagemanager, workspaceRoot, req.IsPlugin, stdout, stderr); err != nil {
+	if err := host.installShared(ctx, opts.packagemanager, workspaceRoot, req.IsPlugin, opts.production, stdout, stderr); err != nil {
 		return err
 	}
 
@@ -2298,5 +2308,6 @@ func setOptionsAttributes(opts nodeOptions) []attribute.KeyValue {
 		attribute.String("nodeOptions.packageManager", string(opts.packagemanager)),
 		attribute.String("nodeOptions.tsConfigPath", opts.tsconfigpath),
 		attribute.String("nodeOptions.nodeArgs", opts.nodeargs),
+		attribute.Bool("nodeOptions.production", opts.production),
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1220,7 +1220,8 @@ func (host *nodeLanguageHost) InstallDependencies(
 	}
 	otelSpan.SetAttributes(append(setOptionsAttributes(opts), attribute.String("workspaceRoot", workspaceRoot))...)
 
-	if err := host.installShared(ctx, opts.packagemanager, workspaceRoot, req.IsPlugin, opts.production, stdout, stderr); err != nil {
+	err = host.installShared(ctx, opts.packagemanager, workspaceRoot, req.IsPlugin, opts.production, stdout, stderr)
+	if err != nil {
 		return err
 	}
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -713,6 +713,21 @@ func TestParseOptions(t *testing.T) {
 	}, "nodejs")
 	require.ErrorContains(t, err, "packagemanager option must be one of")
 
+	opts, err = parseOptions(nil, "nodejs")
+	require.NoError(t, err)
+	require.False(t, opts.production)
+
+	opts, err = parseOptions(map[string]any{
+		"production": true,
+	}, "nodejs")
+	require.NoError(t, err)
+	require.True(t, opts.production)
+
+	_, err = parseOptions(map[string]any{
+		"production": "yes",
+	}, "nodejs")
+	require.ErrorContains(t, err, "production option must be a boolean")
+
 	for _, tt := range []struct {
 		input    string
 		expected npm.PackageManagerType


### PR DESCRIPTION
## Summary

Adds a `production` option to the Node.js runtime options in `Pulumi.yaml`:

```yaml
runtime:
  name: nodejs
  options:
    packagemanager: pnpm
    production: true
```

When set, `pulumi install` (and the automation API's `Workspace.Install`) skips `devDependencies`: the language host passes `production=true` to the package manager layer, which already supports it (`npm install --production`, `pnpm install --production`, yarn classic `--production`; bun currently ignores the flag due to a known bun bug, as already noted in `bun.go`).

## Motivation

In CI, installing devDependencies for a Pulumi program is often pure overhead: with Node's native TypeScript type stripping (or precompiled programs), nothing from `devDependencies` is needed at `pulumi preview/up` time — test frameworks, linters and type-checkers only matter in separate CI jobs.

The `production` boolean was already plumbed through `npm.Install` for all package managers, but nothing exposed it for programs. pnpm ≥ 10 deliberately ignores `NODE_ENV=production` and all env/config equivalents (pnpm/pnpm#8839), so a CLI-level flag injected by Pulumi is the only clean way to get production installs there — hence a project-level runtime option.

## Changes

- `parseOptions`: accept `production` (boolean) for the nodejs runtime
- `InstallDependencies`: thread `opts.production` into `installShared` → `npm.Install`
- Production installs skip the shared install cache (a production `node_modules` tree differs from a full one for the same manifest)
- Unit tests for option parsing; changelog entry

Happy to follow up with a pulumi/docs PR for the project-file reference if this lands.

## Checklist

- [x] I have run `make changelog` and committed the `changelog/pending/<file>.yaml` documenting my change
- [x] I have run `make lint` locally (gofmt clean; parseOptions tests pass)
- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Automation and Language SDKs (nodejs language host option)