### PR TITLE
Report the TypeScript version in `pulumi about`

### DIFF
--- a/changelog/pending/sdk-nodejs-chore-20260709-184303.yaml
+++ b/changelog/pending/sdk-nodejs-chore-20260709-184303.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: chore
+body: Report the TypeScript version in `pulumi about`
+time: 2026-07-09T18:43:03.136109+02:00

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1393,7 +1393,7 @@ func (host *nodeLanguageHost) About(ctx context.Context,
 		return nil, fmt.Errorf("could not find executable %q: %w", runtimeExec, err)
 	}
 
-	var runtimeVersion, pmVersion string
+	var runtimeVersion, pmVersion, tsVersion string
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -1416,6 +1416,22 @@ func (host *nodeLanguageHost) About(ctx context.Context,
 		pmVersion = version.String()
 		return nil
 	})
+	g.Go(func() error {
+		// Report the TypeScript version the program would load. We resolve it via the runtime's
+		// module resolution from the program directory, since that is how it is loaded at run
+		// time; a `tsc` on PATH may be a different installation. Reading package.json avoids
+		// loading the whole compiler.
+		cmd := exec.CommandContext(ctx, runtimeExec, "-e",
+			"console.log(require('typescript/package.json').version)")
+		cmd.Dir = req.Info.ProgramDirectory
+		out, err := cmd.Output()
+		if err != nil {
+			// Don't fail if we could not determine the typescript version
+			return nil
+		}
+		tsVersion = strings.TrimSpace(string(out))
+		return nil
+	})
 
 	if err := g.Wait(); err != nil {
 		return &pulumirpc.AboutResponse{
@@ -1426,13 +1442,18 @@ func (host *nodeLanguageHost) About(ctx context.Context,
 		}, nil
 	}
 
+	metadata := map[string]string{
+		"packagemanager":        pm.Name(),
+		"packagemanagerVersion": pmVersion,
+	}
+	if tsVersion != "" {
+		metadata["typescriptVersion"] = tsVersion
+	}
+
 	return &pulumirpc.AboutResponse{
 		Executable: runtimeExecutable,
 		Version:    runtimeVersion,
-		Metadata: map[string]string{
-			"packagemanager":        pm.Name(),
-			"packagemanagerVersion": pmVersion,
-		},
+		Metadata:   metadata,
 	}, nil
 }
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -416,6 +416,56 @@ func setupFiles(t *testing.T, files []filePathAndContents) string {
 	return dir
 }
 
+func TestAbout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("With typescript installed", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := setupFiles(t, []filePathAndContents{
+			{
+				path:    "package.json",
+				content: `{ "name": "test", "dependencies": { "typescript": "^5.4.5" } }`,
+			},
+			{
+				path:    filepath.Join("node_modules", "typescript", "package.json"),
+				content: `{ "name": "typescript", "version": "5.4.5", "main": "./lib/typescript.js" }`,
+			},
+		})
+		host := &nodeLanguageHost{runtime: "nodejs"}
+		resp, err := host.About(t.Context(), &pulumirpc.AboutRequest{
+			Info: &pulumirpc.ProgramInfo{
+				RootDirectory:    testDir,
+				ProgramDirectory: testDir,
+				EntryPoint:       ".",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "5.4.5", resp.Metadata["typescriptVersion"])
+	})
+
+	t.Run("Without typescript installed", func(t *testing.T) {
+		t.Parallel()
+
+		testDir := setupFiles(t, []filePathAndContents{
+			{
+				path:    "package.json",
+				content: `{ "name": "test" }`,
+			},
+		})
+		host := &nodeLanguageHost{runtime: "nodejs"}
+		resp, err := host.About(t.Context(), &pulumirpc.AboutRequest{
+			Info: &pulumirpc.ProgramInfo{
+				RootDirectory:    testDir,
+				ProgramDirectory: testDir,
+				EntryPoint:       ".",
+			},
+		})
+		require.NoError(t, err)
+		require.NotContains(t, resp.Metadata, "typescriptVersion")
+	})
+}
+
 func TestGetProgramDependencies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Grab the TypeScript version and add it to `About`, which will also include it in `UpdateMetadata`.
