### PR TITLE
ci: make the -trimpath cache priming conditional on a cache miss

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -204,21 +204,18 @@ jobs:
             .gocache.tmp
       - name: Prime Go cache
         if: ${{ ! steps.setup-go.outputs.cache-hit }}
-        # Compile every test to ensure we populate a good cache entry.
+        # Compile every test to ensure we populate a good cache entry. The
+        # sdk is also built with -trimpath: the Go language host compiles
+        # test programs with -trimpath (see compileProgram in
+        # sdk/go/pulumi-language-go), and Go's build cache keys entries on
+        # build flags — without these entries the first program build in a
+        # job rebuilds the SDK's whole dependency graph mid-test. Persisted
+        # caches saved before this line existed lack the entries and never
+        # heal on their own; delete them (or otherwise rotate the cache key)
+        # so every matrix cell re-primes.
         run: |
           ( cd sdk && go test -run "_________" ./... )
           ( cd pkg && go test -run "_________" ./... )
-      - name: Prime Go cache for program compilation
-        # The Go language host compiles test programs with -trimpath (see
-        # compileProgram in sdk/go/pulumi-language-go), and Go's build cache
-        # keys entries on build flags. Without matching entries the first
-        # program build in a job rebuilds the SDK's whole dependency graph
-        # mid-test. This step runs unconditionally rather than only on cache
-        # miss: the restored cache may predate -trimpath priming (it is saved
-        # by whichever cache-miss job finishes first, which may never build a
-        # program), and paying the build once up front on an idle runner is
-        # far cheaper than paying it concurrently inside the first tests.
-        run: |
           ( cd sdk && go build -trimpath ./... )
       - name: Install delve
         run: |


### PR DESCRIPTION
<!-- This PR was written by an AI (Claude Code), directed by @iwahbe. -->

## Summary

Stacked on #23845. That PR's priming step runs unconditionally so its own
merge-queue run can demonstrate the effect on the macOS jobs (PR runs
schedule no macOS jobs, and the persisted macOS cache is stale). Once it has,
the unconditional step is redundant work on every job — this PR folds the
`-trimpath` build into the existing cache-miss-gated `Prime Go cache` step.

## Notes for reviewers

A conditional prime only runs on a cache miss, and the persisted caches for
each OS/arch were saved before `-trimpath` priming existed (the ubuntu-x64
cache happens to contain the entries because an integration job once won the
save race; the macos-arm64 cache does not). They never heal on their own —
after this merges, the stale caches need to be deleted (or the key otherwise
rotated) so every matrix cell re-primes once and saves a healed cache.
@iwahbe is doing that deletion manually. From then on, any future cache-miss
job saves a GOCACHE containing the entries, so first-writer-wins no longer
matters.