### PR TITLE
Skip TestMain setup when the test binary is only listing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,6 @@ jobs:
           path: test-results
           key: read-gotestsum-timing-${{ github.run_number }}
           restore-keys: gotestsum-timing-
-      - uses: ./.github/actions/retry
-        with:
-          action: jdx/mise-action@v2
-          with: |
-            experimental: true
       - name: build matrix
         id: matrix
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,6 @@ jobs:
           action: jdx/mise-action@v2
           with: |
             experimental: true
-      - name: Install CLI
-        run: SDKS='' make install
       - name: build matrix
         id: matrix
         env:

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -16,6 +16,7 @@ package testutil
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,11 +29,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// listOnly reports whether the test binary was invoked with -test.list, in which case it
+// prints matching test names without running any tests. CI computes test partitions by
+// running `go test --list .`, which executes TestMain; setup helpers must not require the
+// pulumi binary (or perform any other setup work) just to enumerate test names.
+func listOnly() bool {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	f := flag.Lookup("test.list")
+	return f != nil && f.Value.String() != ""
+}
+
 // If the PULUMI_INTEGRATION_REBUILD_BINARIES environment variable is set to "true", this function will rebuild the
 // Pulumi CLI and the language runtime plugins into the `bin` directory of the repository root. It will then set up the
 // $PATH environment variable to include this directory, so that when the tests run we will use the newly built binaries
 // without polluting the global $PATH, where the integration tests usually expect to find the binaries.
 func SetupPulumiBinary() {
+	if listOnly() {
+		return
+	}
 	// Find the root of the repository
 	repoRoot, err := ptesting.RepoRoot()
 	if err != nil {
@@ -67,6 +83,9 @@ func SetupPulumiBinary() {
 
 // This runs pulumi install on the python provider so it's venv is setup for running.
 func InstallPythonProvider() {
+	if listOnly() {
+		return
+	}
 	// Find the root of the repository
 	repoRoot, err := ptesting.RepoRoot()
 	if err != nil {


### PR DESCRIPTION
This PR was authored by an AI agent, directed by @iwahbe.

The `CI / matrix` job is a serial prefix for every job in a CI run — builds, lints, and ~90 test jobs all wait on its outputs. This PR takes it from **~6.5 minutes to ~4** by no longer building the pulumi CLI, and the venv for `testprovider-py`, just to list test names.

Two commits:

1. Test partitioning runs `go test --list .`, which executes `TestMain`. The `TestMain`s in `tests/integration` and `tests/smoke` unconditionally run `pulumi install`, forcing the matrix job to build the whole CLI first (~140s). Guard the `testutil` setup helpers to no-op under `-test.list`, and drop the `Install CLI` step.
2. With the CLI build gone, the job no longer needs the mise toolchain (~115s) — everything left (Go via `setup-go`, python3, yq) is already on the runner.

Measured on this PR's own runs: `CI / matrix` **234s** vs 393s / 405s / 309s on recent successful PR runs (402s in the merge queue).