### PR TITLE
Drop mise from the CI matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,6 @@ jobs:
           path: test-results
           key: read-gotestsum-timing-${{ github.run_number }}
           restore-keys: gotestsum-timing-
-      - uses: ./.github/actions/retry
-        with:
-          action: jdx/mise-action@v2
-          with: |
-            experimental: true
       - name: build matrix
         id: matrix
         env:


### PR DESCRIPTION
This PR was authored by an AI agent, directed by @iwahbe.

Stacked on #23857. With the CLI build gone from the `CI / matrix` job, the mise toolchain install (~115s, retry-wrapped `jdx/mise-action`) is no longer needed there either. The job's remaining dependencies are already present without it:

- **Go** — installed by the job's own `setup-go` step (already used to build gotestsum, and version-decoupled from the version sets); modules with newer `go` directives are handled by `GOTOOLCHAIN=auto`.
- **python3** for `scripts/get-job-matrix.py` — the script is stdlib-only, and python3 is preinstalled on ubuntu runners.
- **yq** — preinstalled on ubuntu runners.

Combined with #23857 this should take `CI / matrix` from ~6.7m to ~2.5m, off the head of the critical path of every CI run.