### PR TITLE
Add test coverage for esc ast, client, and env set

### DIFF
--- a/pkg/cmd/esc/cli/client/client_coverage_test.go
+++ b/pkg/cmd/esc/cli/client/client_coverage_test.go
@@ -1,0 +1,616 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRevisionNumber(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("empty version defaults to latest tag lookup", func(t *testing.T) {
+		t.Parallel()
+
+		expected := EnvironmentRevisionTag{Name: "latest", Revision: 42}
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags/latest",
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewEncoder(w).Encode(expected)
+				require.NoError(t, err)
+			})
+		rev, err := client.GetRevisionNumber(ctx, "org", "proj", "env", "")
+		require.NoError(t, err)
+		assert.Equal(t, 42, rev)
+	})
+
+	t.Run("numeric version parsed directly", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/unused",
+			func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("should not make API call for numeric version")
+			})
+		rev, err := client.GetRevisionNumber(ctx, "org", "proj", "env", "7")
+		require.NoError(t, err)
+		assert.Equal(t, 7, rev)
+	})
+
+	t.Run("invalid numeric version", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/unused",
+			func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("should not make API call")
+			})
+		_, err := client.GetRevisionNumber(ctx, "org", "proj", "env", "99999999999999999999")
+		assert.ErrorContains(t, err, "invalid revision number")
+	})
+
+	t.Run("tag version lookup", func(t *testing.T) {
+		t.Parallel()
+
+		expected := EnvironmentRevisionTag{Name: "stable", Revision: 10}
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags/stable",
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewEncoder(w).Encode(expected)
+				require.NoError(t, err)
+			})
+		rev, err := client.GetRevisionNumber(ctx, "org", "proj", "env", "stable")
+		require.NoError(t, err)
+		assert.Equal(t, 10, rev)
+	})
+
+	t.Run("tag not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags/missing",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "not found"})
+				require.NoError(t, err)
+			})
+		_, err := client.GetRevisionNumber(ctx, "org", "proj", "env", "missing")
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestCloneEnvironment(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		destEnv := CloneEnvironmentRequest{
+			Project:         "dest-proj",
+			Name:            "dest-env",
+			PreserveHistory: true,
+		}
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/org/proj/env/clone",
+			func(w http.ResponseWriter, r *http.Request) {
+				var req CloneEnvironmentRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				require.NoError(t, err)
+				assert.Equal(t, destEnv, req)
+				w.WriteHeader(http.StatusOK)
+			})
+		err := client.CloneEnvironment(ctx, "org", "proj", "env", destEnv)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/org/proj/env/clone",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "not found"})
+				require.NoError(t, err)
+			})
+		err := client.CloneEnvironment(ctx, "org", "proj", "env", CloneEnvironmentRequest{Name: "x"})
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestGetEnvironmentDraft(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		yamlContent := []byte("values:\n  key: val\n")
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/drafts/cr-123",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("ETag", "etag-abc")
+				_, err := w.Write(yamlContent)
+				require.NoError(t, err)
+			})
+		yaml, etag, err := client.GetEnvironmentDraft(ctx, "org", "proj", "env", "cr-123")
+		require.NoError(t, err)
+		assert.Equal(t, yamlContent, yaml)
+		assert.Equal(t, "etag-abc", etag)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/drafts/cr-bad",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "draft not found"})
+				require.NoError(t, err)
+			})
+		_, _, err := client.GetEnvironmentDraft(ctx, "org", "proj", "env", "cr-bad")
+		assert.ErrorContains(t, err, "draft not found")
+	})
+}
+
+func TestUpdateEnvironmentDraft(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/org/proj/env/drafts/cr-123",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "etag-1", r.Header.Get("If-Match"))
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				assert.Equal(t, `"values:\n  key: val\n"`, string(body))
+				err = json.NewEncoder(w).Encode(UpdateEnvironmentDraftResponse{ChangeRequestID: "cr-123"})
+				require.NoError(t, err)
+			})
+		diags, err := client.UpdateEnvironmentDraft(
+			ctx, "org", "proj", "env", "cr-123", []byte(`"values:\n  key: val\n"`), "etag-1")
+		require.NoError(t, err)
+		assert.Nil(t, diags)
+	})
+
+	t.Run("diagnostics error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/org/proj/env/drafts/cr-123",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
+					Code:    400,
+					Message: "bad",
+					Diagnostics: []EnvironmentDiagnostic{
+						{Summary: "invalid yaml"},
+					},
+				})
+				require.NoError(t, err)
+			})
+		diags, err := client.UpdateEnvironmentDraft(ctx, "org", "proj", "env", "cr-123", []byte(`bad`), "etag-1")
+		require.NoError(t, err)
+		require.Len(t, diags, 1)
+		assert.Equal(t, "invalid yaml", diags[0].Summary)
+	})
+}
+
+func TestGetEnvironmentRevision(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		expected := EnvironmentRevision{Number: 5, CreatorLogin: "user"}
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "6", r.URL.Query().Get("before"))
+				assert.Equal(t, "1", r.URL.Query().Get("count"))
+				err := json.NewEncoder(w).Encode([]EnvironmentRevision{expected})
+				require.NoError(t, err)
+			})
+		rev, err := client.GetEnvironmentRevision(ctx, "org", "proj", "env", 5)
+		require.NoError(t, err)
+		require.NotNil(t, rev)
+		assert.Equal(t, 5, rev.Number)
+	})
+
+	t.Run("not found returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions",
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewEncoder(w).Encode([]EnvironmentRevision{})
+				require.NoError(t, err)
+			})
+		rev, err := client.GetEnvironmentRevision(ctx, "org", "proj", "env", 999)
+		require.NoError(t, err)
+		assert.Nil(t, rev)
+	})
+}
+
+func TestListEnvironmentRevisions(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Now().Truncate(time.Second)
+		expected := []EnvironmentRevision{
+			{Number: 3, Created: now, CreatorLogin: "alice"},
+			{Number: 2, Created: now, CreatorLogin: "bob"},
+		}
+		before := 4
+		count := 2
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "4", r.URL.Query().Get("before"))
+				assert.Equal(t, "2", r.URL.Query().Get("count"))
+				err := json.NewEncoder(w).Encode(expected)
+				require.NoError(t, err)
+			})
+		revs, err := client.ListEnvironmentRevisions(ctx, "org", "proj", "env", ListEnvironmentRevisionsOptions{
+			Before: &before,
+			Count:  &count,
+		})
+		require.NoError(t, err)
+		require.Len(t, revs, 2)
+		assert.Equal(t, 3, revs[0].Number)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 500, Message: "server error"})
+				require.NoError(t, err)
+			})
+		_, err := client.ListEnvironmentRevisions(ctx, "org", "proj", "env", ListEnvironmentRevisionsOptions{})
+		assert.ErrorContains(t, err, "server error")
+	})
+}
+
+func TestRetractEnvironmentRevision(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		replacement := 4
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/org/proj/env/versions/5/retract",
+			func(w http.ResponseWriter, r *http.Request) {
+				var req RetractEnvironmentRevisionRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				require.NoError(t, err)
+				assert.Equal(t, &replacement, req.Replacement)
+				assert.Equal(t, "bad revision", req.Reason)
+				w.WriteHeader(http.StatusOK)
+			})
+		err := client.RetractEnvironmentRevision(ctx, "org", "proj", "env", "5", &replacement, "bad revision")
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/org/proj/env/versions/5/retract",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "revision not found"})
+				require.NoError(t, err)
+			})
+		err := client.RetractEnvironmentRevision(ctx, "org", "proj", "env", "5", nil, "")
+		assert.ErrorContains(t, err, "revision not found")
+	})
+}
+
+func TestCreateEnvironmentRevisionTag(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		revision := 3
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/org/proj/env/versions/tags",
+			func(w http.ResponseWriter, r *http.Request) {
+				var req CreateEnvironmentRevisionTagRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				require.NoError(t, err)
+				assert.Equal(t, "stable", req.Name)
+				assert.Equal(t, &revision, req.Revision)
+				w.WriteHeader(http.StatusOK)
+			})
+		err := client.CreateEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable", &revision)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/org/proj/env/versions/tags",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 409, Message: "tag already exists"})
+				require.NoError(t, err)
+			})
+		err := client.CreateEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable", nil)
+		assert.ErrorContains(t, err, "tag already exists")
+	})
+}
+
+func TestGetEnvironmentRevisionTag(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		expected := EnvironmentRevisionTag{Name: "stable", Revision: 5}
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags/stable",
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewEncoder(w).Encode(expected)
+				require.NoError(t, err)
+			})
+		tag, err := client.GetEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable")
+		require.NoError(t, err)
+		assert.Equal(t, "stable", tag.Name)
+		assert.Equal(t, 5, tag.Revision)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags/missing",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "tag not found"})
+				require.NoError(t, err)
+			})
+		_, err := client.GetEnvironmentRevisionTag(ctx, "org", "proj", "env", "missing")
+		assert.ErrorContains(t, err, "tag not found")
+	})
+}
+
+func TestUpdateEnvironmentRevisionTag(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		revision := 7
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/org/proj/env/versions/tags/stable",
+			func(w http.ResponseWriter, r *http.Request) {
+				var req UpdateEnvironmentRevisionTagRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				require.NoError(t, err)
+				assert.Equal(t, &revision, req.Revision)
+				w.WriteHeader(http.StatusOK)
+			})
+		err := client.UpdateEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable", &revision)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/org/proj/env/versions/tags/stable",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "not found"})
+				require.NoError(t, err)
+			})
+		err := client.UpdateEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable", nil)
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestDeleteEnvironmentRevisionTag(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/org/proj/env/versions/tags/stable",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+		err := client.DeleteEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable")
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/org/proj/env/versions/tags/stable",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "not found"})
+				require.NoError(t, err)
+			})
+		err := client.DeleteEnvironmentRevisionTag(ctx, "org", "proj", "env", "stable")
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestListEnvironmentRevisionTags(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		expected := ListEnvironmentRevisionTagsResponse{
+			Tags: []EnvironmentRevisionTag{
+				{Name: "latest", Revision: 10},
+				{Name: "stable", Revision: 8},
+			},
+			NextToken: "next",
+		}
+		count := 10
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "prev", r.URL.Query().Get("after"))
+				assert.Equal(t, "10", r.URL.Query().Get("count"))
+				err := json.NewEncoder(w).Encode(expected)
+				require.NoError(t, err)
+			})
+		tags, err := client.ListEnvironmentRevisionTags(ctx, "org", "proj", "env", ListEnvironmentRevisionTagsOptions{
+			After: "prev",
+			Count: &count,
+		})
+		require.NoError(t, err)
+		require.Len(t, tags, 2)
+		assert.Equal(t, "latest", tags[0].Name)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/versions/tags",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 500, Message: "server error"})
+				require.NoError(t, err)
+			})
+		_, err := client.ListEnvironmentRevisionTags(ctx, "org", "proj", "env", ListEnvironmentRevisionTagsOptions{})
+		assert.ErrorContains(t, err, "server error")
+	})
+}
+
+func TestEnvironmentExists(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("exists", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+		exists, err := client.EnvironmentExists(ctx, "org", "proj", "env")
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "not found"})
+				require.NoError(t, err)
+			})
+		exists, err := client.EnvironmentExists(ctx, "org", "proj", "env")
+		assert.Error(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestGetEnvironmentSettings(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		expected := EnvironmentSettings{DeletionProtected: true}
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/settings",
+			func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewEncoder(w).Encode(expected)
+				require.NoError(t, err)
+			})
+		settings, err := client.GetEnvironmentSettings(ctx, "org", "proj", "env")
+		require.NoError(t, err)
+		assert.True(t, settings.DeletionProtected)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org/proj/env/settings",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 404, Message: "not found"})
+				require.NoError(t, err)
+			})
+		_, err := client.GetEnvironmentSettings(ctx, "org", "proj", "env")
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestPatchEnvironmentSettings(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		prot := true
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/org/proj/env/settings",
+			func(w http.ResponseWriter, r *http.Request) {
+				var req PatchEnvironmentSettingsRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				require.NoError(t, err)
+				assert.Equal(t, &prot, req.DeletionProtected)
+				w.WriteHeader(http.StatusOK)
+			})
+		err := client.PatchEnvironmentSettings(ctx, "org", "proj", "env", PatchEnvironmentSettingsRequest{
+			DeletionProtected: &prot,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/org/proj/env/settings",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				err := json.NewEncoder(w).Encode(apitype.ErrorResponse{Code: 403, Message: "forbidden"})
+				require.NoError(t, err)
+			})
+		err := client.PatchEnvironmentSettings(ctx, "org", "proj", "env", PatchEnvironmentSettingsRequest{})
+		assert.ErrorContains(t, err, "forbidden")
+	})
+}

--- a/pkg/cmd/esc/cli/env_set_test.go
+++ b/pkg/cmd/esc/cli/env_set_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLooksLikeSecret(t *testing.T) {
+	t.Parallel()
+
+	highEntropyValue := "aB3$xZ9!mK7@qW2"
+
+	tests := []struct {
+		name     string
+		path     resource.PropertyPath
+		node     yaml.Node
+		expected bool
+	}{
+		{
+			name: "non-scalar node returns false",
+			path: resource.PropertyPath{"password"},
+			node: yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"},
+		},
+		{
+			name: "non-string tag returns false",
+			path: resource.PropertyPath{"password"},
+			node: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "12345"},
+		},
+		{
+			name: "key does not match pattern",
+			path: resource.PropertyPath{"username"},
+			node: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+		},
+		{
+			name: "key matches pattern but low entropy value",
+			path: resource.PropertyPath{"password"},
+			node: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "hello"},
+		},
+		{
+			name:     "key matches password with high entropy value",
+			path:     resource.PropertyPath{"password"},
+			node:     yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+			expected: true,
+		},
+		{
+			name:     "key matches token with high entropy value",
+			path:     resource.PropertyPath{"token"},
+			node:     yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+			expected: true,
+		},
+		{
+			name:     "key matches secret with high entropy value",
+			path:     resource.PropertyPath{"secret"},
+			node:     yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+			expected: true,
+		},
+		{
+			name:     "case insensitive key match",
+			path:     resource.PropertyPath{"Password"},
+			node:     yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+			expected: true,
+		},
+		{
+			name: "integer path element returns false",
+			path: resource.PropertyPath{0},
+			node: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+		},
+		{
+			name:     "nested path uses last element",
+			path:     resource.PropertyPath{"config", "dbPassword"},
+			node:     yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: highEntropyValue},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := looksLikeSecret(tt.path, tt.node)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/sdk/go/common/esc/ast/builders_test.go
+++ b/sdk/go/common/esc/ast/builders_test.go
@@ -1,0 +1,456 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/syntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringBuilder(t *testing.T) {
+	t.Parallel()
+
+	s := String("hello")
+	assert.Equal(t, "hello", s.Value)
+	require.NotNil(t, s.Syntax())
+}
+
+func TestStringSyntaxValue(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.String("raw-syntax-value")
+	s := StringSyntaxValue(node, "overridden-value")
+	assert.Equal(t, "overridden-value", s.Value)
+	assert.Equal(t, "raw-syntax-value", node.Value())
+}
+
+func TestStringGetValue(t *testing.T) {
+	t.Parallel()
+
+	s := String("hello")
+	assert.Equal(t, "hello", s.GetValue())
+
+	var nilStr *StringExpr
+	assert.Equal(t, "", nilStr.GetValue())
+}
+
+func TestInterpolate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantParts int
+		wantErr   bool
+	}{
+		{"plain string", "hello world", 1, false},
+		{"single interpolation", "${foo.bar}", 1, false},
+		{"mixed text and interpolation", "prefix-${foo.bar}-suffix", 2, false},
+		{"multiple interpolations", "${a.b} and ${c.d}", 2, false},
+		{"escaped dollar", "$${not-interpolated}", 1, false},
+		{"unclosed interpolation", "${foo", 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, diags := Interpolate(tt.input)
+			if tt.wantErr {
+				assert.True(t, diags.HasErrors())
+			} else {
+				assert.False(t, diags.HasErrors())
+			}
+			require.Len(t, expr.Parts, tt.wantParts)
+		})
+	}
+}
+
+func TestMustInterpolateValid(t *testing.T) {
+	t.Parallel()
+
+	expr := MustInterpolate("hello ${foo.bar}")
+	require.NotNil(t, expr)
+	require.Len(t, expr.Parts, 1)
+	assert.Equal(t, "hello ", expr.Parts[0].Text)
+	require.NotNil(t, expr.Parts[0].Value)
+}
+
+func TestMustInterpolatePanics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		MustInterpolate("${foo")
+	})
+}
+
+func TestInterpolateExprString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text", "hello", "hello"},
+		{"single access", "${foo.bar}", "${foo.bar}"},
+		{"mixed", "prefix-${foo.bar}-suffix", "prefix-${foo.bar}-suffix"},
+		{"escaped dollar in text", "$${literal}", "$${literal}"},
+		{"multiple accesses", "${a.b} and ${c.d}", "${a.b} and ${c.d}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expr, diags := Interpolate(tt.input)
+			assert.False(t, diags.HasErrors())
+			assert.Equal(t, tt.want, expr.String())
+		})
+	}
+}
+
+func TestSymbolExprString(t *testing.T) {
+	t.Parallel()
+
+	sym := Symbol(&PropertyName{Name: "foo"}, &PropertyName{Name: "bar"})
+	assert.Equal(t, "${foo.bar}", sym.String())
+
+	sym2 := Symbol(&PropertyName{Name: "root"}, &PropertySubscript{Index: 0}, &PropertyName{Name: "nested"})
+	assert.Equal(t, "${root[0].nested}", sym2.String())
+
+	sym3 := Symbol(&PropertyName{Name: "root"}, &PropertySubscript{Index: "key with dots"})
+	assert.Equal(t, `${root["key with dots"]}`, sym3.String())
+}
+
+func TestParseExprNull(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Null()
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	_, ok := expr.(*NullExpr)
+	assert.True(t, ok)
+}
+
+func TestParseExprBoolean(t *testing.T) {
+	t.Parallel()
+
+	for _, val := range []bool{true, false} {
+		node := syntax.Boolean(val)
+		expr, diags := ParseExpr(node)
+		assert.False(t, diags.HasErrors())
+		b, ok := expr.(*BooleanExpr)
+		require.True(t, ok)
+		assert.Equal(t, val, b.Value)
+	}
+}
+
+func TestParseExprNumber(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Number(42)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	n, ok := expr.(*NumberExpr)
+	require.True(t, ok)
+	assert.Equal(t, "42", n.Value.String())
+}
+
+func TestParseExprPlainString(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.String("hello world")
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	s, ok := expr.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, "hello world", s.Value)
+}
+
+func TestParseExprSymbol(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.String("${foo.bar}")
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	sym, ok := expr.(*SymbolExpr)
+	require.True(t, ok)
+	require.Len(t, sym.Property.Accessors, 2)
+	assert.Equal(t, "foo", sym.Property.Accessors[0].(*PropertyName).Name)
+	assert.Equal(t, "bar", sym.Property.Accessors[1].(*PropertyName).Name)
+}
+
+func TestParseExprInterpolation(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.String("prefix-${foo.bar}-suffix")
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	interp, ok := expr.(*InterpolateExpr)
+	require.True(t, ok)
+	assert.Equal(t, "prefix-", interp.Parts[0].Text)
+	require.NotNil(t, interp.Parts[0].Value)
+	assert.Equal(t, "-suffix", interp.Parts[1].Text)
+}
+
+func TestParseExprArray(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Array(syntax.String("a"), syntax.Number(1), syntax.Boolean(true))
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	arr, ok := expr.(*ArrayExpr)
+	require.True(t, ok)
+	require.Len(t, arr.Elements, 3)
+	_, ok = arr.Elements[0].(*StringExpr)
+	assert.True(t, ok)
+	_, ok = arr.Elements[1].(*NumberExpr)
+	assert.True(t, ok)
+	_, ok = arr.Elements[2].(*BooleanExpr)
+	assert.True(t, ok)
+}
+
+func TestParseExprObject(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("key1"), syntax.String("val1")),
+		syntax.ObjectProperty(syntax.String("key2"), syntax.Number(2)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	obj, ok := expr.(*ObjectExpr)
+	require.True(t, ok)
+	require.Len(t, obj.Entries, 2)
+	assert.Equal(t, "key1", obj.Entries[0].Key.Value)
+	s, ok := obj.Entries[0].Value.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, "val1", s.Value)
+}
+
+func TestParseExprBuiltinFnOpen(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::open"), syntax.Object(
+			syntax.ObjectProperty(syntax.String("provider"), syntax.String("test-provider")),
+			syntax.ObjectProperty(syntax.String("inputs"), syntax.Object(
+				syntax.ObjectProperty(syntax.String("key"), syntax.String("value")),
+			)),
+		)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	open, ok := expr.(*OpenExpr)
+	require.True(t, ok)
+	assert.Equal(t, "test-provider", open.Provider.Value)
+	require.NotNil(t, open.Inputs)
+}
+
+func TestParseExprBuiltinFnSecret(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::secret"), syntax.String("my-secret")),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	secret, ok := expr.(*SecretExpr)
+	require.True(t, ok)
+	assert.Equal(t, "my-secret", secret.Plaintext.Value)
+}
+
+func TestParseExprBuiltinFnJoin(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::join"), syntax.Array(
+			syntax.String(","),
+			syntax.Array(syntax.String("a"), syntax.String("b")),
+		)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	join, ok := expr.(*JoinExpr)
+	require.True(t, ok)
+	delim, ok := join.Delimiter.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, ",", delim.Value)
+}
+
+func TestParseExprBuiltinFnToJSON(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::toJSON"), syntax.String("value")),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	_, ok := expr.(*ToJSONExpr)
+	assert.True(t, ok)
+}
+
+func TestParseExprBuiltinFnFinal(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::final"), syntax.String("immutable")),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	final, ok := expr.(*FinalExpr)
+	require.True(t, ok)
+	v, ok := final.Value.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, "immutable", v.Value)
+}
+
+func TestParseExprBuiltinReservedPrefix(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::unknown"), syntax.String("value")),
+	)
+	_, diags := ParseExpr(node)
+	assert.True(t, diags.HasErrors())
+}
+
+func TestParseExprBuiltinMultipleKeysWithFn(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::open"), syntax.String("value")),
+		syntax.ObjectProperty(syntax.String("extra"), syntax.String("value")),
+	)
+	_, diags := ParseExpr(node)
+	assert.True(t, diags.HasErrors())
+}
+
+func TestParseExprShortOpen(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::open::my-provider"), syntax.Object(
+			syntax.ObjectProperty(syntax.String("key"), syntax.String("value")),
+		)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	open, ok := expr.(*OpenExpr)
+	require.True(t, ok)
+	assert.Equal(t, "my-provider", open.Provider.Value)
+}
+
+func TestExprErrorWithVariousTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		expr Expr
+	}{
+		{"nil StringExpr", (*StringExpr)(nil)},
+		{"nil NullExpr", (*NullExpr)(nil)},
+		{"nil BooleanExpr", (*BooleanExpr)(nil)},
+		{"non-nil StringExpr", String("test")},
+		{"non-nil NullExpr", Null()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ExprError(tt.expr, "test error")
+			assert.Equal(t, "test error", err.Summary)
+		})
+	}
+}
+
+func TestParseExprEscapedDollar(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.String("$${not-interp}")
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	s, ok := expr.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, "${not-interp}", s.Value)
+}
+
+func TestParseExprEmptyString(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.String("")
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	s, ok := expr.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, "", s.Value)
+}
+
+func TestParseExprBuiltinFnConcat(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::concat"), syntax.Array(
+			syntax.Array(syntax.String("a")),
+			syntax.Array(syntax.String("b")),
+		)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	_, ok := expr.(*ConcatExpr)
+	assert.True(t, ok)
+}
+
+func TestParseExprBuiltinFnSplit(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::split"), syntax.Array(
+			syntax.String(","),
+			syntax.String("a,b,c"),
+		)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	split, ok := expr.(*SplitExpr)
+	require.True(t, ok)
+	delim, ok := split.Delimiter.(*StringExpr)
+	require.True(t, ok)
+	assert.Equal(t, ",", delim.Value)
+}
+
+func TestParseExprBuiltinFnValidate(t *testing.T) {
+	t.Parallel()
+
+	node := syntax.Object(
+		syntax.ObjectProperty(syntax.String("fn::validate"), syntax.Object(
+			syntax.ObjectProperty(syntax.String("schema"), syntax.Object(
+				syntax.ObjectProperty(syntax.String("type"), syntax.String("string")),
+			)),
+			syntax.ObjectProperty(syntax.String("value"), syntax.String("test")),
+		)),
+	)
+	expr, diags := ParseExpr(node)
+	assert.False(t, diags.HasErrors())
+	v, ok := expr.(*ValidateExpr)
+	require.True(t, ok)
+	require.NotNil(t, v.Schema)
+	require.NotNil(t, v.Value)
+}


### PR DESCRIPTION
Migrated from https://github.com/pulumi/esc/pull/629.

## Summary

Add test coverage for packages identified in the code coverage epic (pulumi/esc#129).

Closes pulumi/esc#130
Closes pulumi/esc#133
Closes pulumi/esc#134
Closes pulumi/esc#135
