### PR TITLE
Start build and lint jobs without waiting for the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,41 @@ on:
         description: "GCP service account, required to run tests against GCP"
 
 jobs:
+  # Computes the cheap outputs every other job fans out from. This job must stay fast: the
+  # build and lint jobs wait only on it, not on the matrix job, whose test partitioning
+  # requires compiling the test binaries.
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Compute version set and build targets
+        id: setup
+        run: |
+          VERSION_SET=$(./scripts/get-job-matrix.py \
+            generate-version-set \
+            --version-set current
+          )
+          echo "::group::Version set"
+          echo "$VERSION_SET" | yq -P '.'
+          echo "::endgroup::"
+          printf '%s' "${VERSION_SET}" | ./.github/scripts/set-output version-set
+
+          BUILD_TARGETS='[
+              { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
+              { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
+              { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-latest" },
+              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
+          ]'
+          printf '%s' "${BUILD_TARGETS}" | ./.github/scripts/set-output build-targets
+    outputs:
+      version-set: "${{ fromJson(steps.setup.outputs.version-set) }}"
+      build-targets: "${{ fromJson(steps.setup.outputs.build-targets) }}"
+
   matrix:
     runs-on: ubuntu-latest
     strategy:
@@ -136,14 +171,6 @@ jobs:
           readarray -td' ' VERSION_SETS_TO_TEST < <(echo -n "$TEST_VERSION_SETS"); declare -p VERSION_SETS_TO_TEST;
           readarray -td' ' INTEGRATION_PLATFORMS < <(echo -n "$INPUT_INTEGRATION_TEST_PLATFORMS"); declare -p INTEGRATION_PLATFORMS;
           readarray -td' ' ACCEPTANCE_PLATFORMS < <(echo -n "$INPUT_ACCEPTANCE_TEST_PLATFORMS"); declare -p ACCEPTANCE_PLATFORMS;
-          BUILD_TARGETS='[
-              { "os": "linux",   "arch": "amd64", "build-platform": "ubuntu-latest" },
-              { "os": "linux",   "arch": "arm64", "build-platform": "ubuntu-latest" },
-              { "os": "windows", "arch": "amd64", "build-platform": "ubuntu-latest" },
-              { "os": "windows", "arch": "arm64", "build-platform": "ubuntu-latest" },
-              { "os": "darwin",  "arch": "amd64", "build-platform": "ubuntu-latest" },
-              { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
-          ]'
 
           CODEGEN_TESTS_FLAG=--codegen-tests
           PKG_UNIT_TEST_PARTITIONS=7
@@ -240,13 +267,6 @@ jobs:
           fi
           echo "::endgroup::"
 
-          echo "::group::Version set variable"
-          VERSION_SET=$(./scripts/get-job-matrix.py \
-            generate-version-set \
-            --version-set current
-          )
-          echo "::endgroup::"
-
           echo "::group::Unit test matrix"
           echo "$UNIT_TEST_MATRIX" | yq -P '.'
           echo "::endgroup::"
@@ -259,9 +279,6 @@ jobs:
           echo "::group::acceptance test matrix macos"
           echo "$ACCEPTANCE_TEST_MATRIX_MACOS" | yq -P '.'
           echo "::endgroup::"
-          echo "::group::Version set"
-          echo "$VERSION_SET" | yq -P '.'
-          echo "::endgroup::"
 
           echo "::group::Set outputs"
           # Pipe matrix values via stdin: they can exceed the 128 KiB per-argument limit
@@ -270,35 +287,31 @@ jobs:
           printf '%s' "${INTEGRATION_TEST_MATRIX}" | ./.github/scripts/set-output integration-test-matrix
           printf '%s' "${ACCEPTANCE_TEST_MATRIX_WIN}" | ./.github/scripts/set-output acceptance-test-matrix-win
           printf '%s' "${ACCEPTANCE_TEST_MATRIX_MACOS}" | ./.github/scripts/set-output acceptance-test-matrix-macos
-          printf '%s' "${VERSION_SET}" | ./.github/scripts/set-output version-set
-          printf '%s' "${BUILD_TARGETS}" | ./.github/scripts/set-output build-targets
           echo "::endgroup::"
     outputs:
       unit-test-matrix: "${{ fromJson(steps.matrix.outputs.unit-test-matrix) }}"
       integration-test-matrix: "${{ fromJson(steps.matrix.outputs.integration-test-matrix) }}"
       acceptance-test-matrix-win: "${{ fromJson(steps.matrix.outputs.acceptance-test-matrix-win) }}"
       acceptance-test-matrix-macos: "${{ fromJson(steps.matrix.outputs.acceptance-test-matrix-macos) }}"
-      version-set: "${{ fromJson(steps.matrix.outputs.version-set) }}"
-      build-targets: "${{ fromJson(steps.matrix.outputs.build-targets) }}"
 
   lint:
     name: Lint
-    needs: [matrix]
+    needs: [setup]
     if: ${{ inputs.lint }}
     uses: ./.github/workflows/ci-lint.yml
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
     with:
       ref: ${{ inputs.ref }}
-      version-set: ${{ needs.matrix.outputs.version-set }}
+      version-set: ${{ needs.setup.outputs.version-set }}
 
   build-binaries:
     name: build binaries
-    needs: [matrix]
+    needs: [setup]
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
-        target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
+        target: ${{ fromJson(needs.setup.outputs.build-targets) }}
     uses: ./.github/workflows/ci-build-binaries.yml
     with:
       ref: ${{ inputs.ref }}
@@ -306,7 +319,7 @@ jobs:
       os: ${{ matrix.target.os }}
       arch: ${{ matrix.target.arch }}
       build-platform: ${{ matrix.target.build-platform }}
-      version-set: ${{ needs.matrix.outputs.version-set }}
+      version-set: ${{ needs.setup.outputs.version-set }}
       enable-coverage: ${{ inputs.enable-coverage }}
       # Windows and Linux need CGO and cross compile support to support -race. So for now only enable it for darwin and amd64 linux.
       enable-race-detection: ${{ matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64') }}
@@ -315,7 +328,7 @@ jobs:
 
   build-display-wasm-module:
     name: build display WASM module
-    needs: [matrix]
+    needs: [setup]
     uses: ./.github/workflows/ci-build-binaries.yml
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -325,19 +338,19 @@ jobs:
       os: js
       arch: wasm
       build-platform: "ubuntu-latest"
-      version-set: ${{ needs.matrix.outputs.version-set }}
+      version-set: ${{ needs.setup.outputs.version-set }}
     secrets: inherit
 
   build-sdks:
     name: Build SDKs
-    needs: [matrix]
+    needs: [setup]
     uses: ./.github/workflows/ci-build-sdks.yml
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
-      version-set: ${{ needs.matrix.outputs.version-set }}
+      version-set: ${{ needs.setup.outputs.version-set }}
     secrets: inherit
 
   # Tests that can run concurrently with builds.
@@ -453,7 +466,7 @@ jobs:
   fuzz-test:
     name: Fuzz Test
     uses: ./.github/workflows/ci-run-test.yml
-    needs: [matrix]
+    needs: [setup]
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
@@ -463,7 +476,7 @@ jobs:
       is-integration-test: false
       enable-coverage: false
       test-retries: ${{ inputs.test-retries }}
-      version-set: ${{ needs.matrix.outputs.version-set }}
+      version-set: ${{ needs.setup.outputs.version-set }}
       continue-on-error: ${{ inputs.fuzz-test-optional }}
     secrets: inherit
 
@@ -536,12 +549,12 @@ jobs:
   build-release-binaries:
     # This overwrites the previously built testing binaries with versions without coverage.
     name: Rebuild binaries
-    needs: [matrix]
+    needs: [setup]
     if: ${{ inputs.enable-coverage }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
-        target: ${{ fromJson(needs.matrix.outputs.build-targets) }}
+        target: ${{ fromJson(needs.setup.outputs.build-targets) }}
     uses: ./.github/workflows/ci-build-binaries.yml
     with:
       ref: ${{ inputs.ref }}
@@ -549,6 +562,6 @@ jobs:
       os: ${{ matrix.target.os }}
       arch: ${{ matrix.target.arch }}
       build-platform: ${{ matrix.target.build-platform }}
-      version-set: ${{ needs.matrix.outputs.version-set }}
+      version-set: ${{ needs.setup.outputs.version-set }}
       enable-coverage: false
     secrets: inherit


### PR DESCRIPTION
This PR was authored by an AI agent, directed by @iwahbe.

Stacked on #23857. Every CI run currently spends its first ~11 minutes serially: the matrix job, then the binary/SDK builds, and only then the ~90 test jobs. But the builds never needed the matrix job — only its version set (a sub-second python computation) and a hardcoded list of build targets. Move those into a lightweight `setup` job so builds and lints start seconds into the run, in parallel with the matrix job. **Expected: ~3.5 minutes off the wall time of every PR and merge-queue run**, on top of #23857's ~2.5.

Test jobs still wait on both the matrix and the builds. The only behavioral change: a matrix-job failure no longer prevents build jobs from starting (they're wasted in that case; `ci-ok` still gates the merge).