### PR TITLE
Split the ubuntu tests-module partitions finer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,8 @@ jobs:
                 sdk/nodejs/cmd/pulumi-language-nodejs 3 \
             --partition-package github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3 \
                 sdk/python/cmd/pulumi-language-python 4 \
-            --partition-module tests 2 \
+            --partition-module tests 4 \
+            --partition-package github.com/pulumi/pulumi/tests/stack tests/stack 2 \
             --partition-package github.com/pulumi/pulumi/tests/smoke tests/smoke 4 \
             --partition-package github.com/pulumi/pulumi/tests/integration tests/integration 8
           )


### PR DESCRIPTION
This PR was authored by an AI agent, directed by @iwahbe.

Stacked on #23863. The two `Integration Test / tests N/2` jobs are the longest steady jobs in a merge-queue run at ~24 minutes — and only ~2.5 minutes of that is setup, so finer partitioning pays almost 1:1. Split the `tests` module 2 → 4 partitions and partition the ~11-minute `tests/stack` package by test name (the mechanism `tests/integration`/`tests/smoke` already use). **Expected: the wall-setting test jobs drop from ~24 to ~9 minutes.**