### PR TITLE
Fix empty node_modules folders in serialized function archives when using pnpm or symlinked workspace packages

### DIFF
--- a/changelog/pending/sdk-nodejs-fix-20260708-pnpm-codepaths.yaml
+++ b/changelog/pending/sdk-nodejs-fix-20260708-pnpm-codepaths.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: fix
+body: Fix empty node_modules folders in serialized function archives when using pnpm or symlinked workspace packages
+time: 2026-07-10T09:16:29.636375+02:00

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -116,8 +116,10 @@ async function computeCodePathsWorker(options: CodePathOptions): Promise<Map<str
     // Construct the set of paths to include in the archive for upload.
 
     // Find folders for all packages requested by the user.  Note: all paths in this should
-    // be normalized.
-    const normalizedPathSet = await allFoldersForPackages(
+    // be normalized. Keys are the paths at which the packages are included in the archive,
+    // values are the on-disk paths the contents are read from. The two differ when a package
+    // is symlinked, e.g. with pnpm's virtual store or workspace packages.
+    const packagePaths = await allFoldersForPackages(
         new Set<string>(options.extraIncludePackages || []),
         new Set<string>(options.extraExcludePackages || []),
         options.logResource,
@@ -126,27 +128,29 @@ async function computeCodePathsWorker(options: CodePathOptions): Promise<Map<str
     // Add all paths explicitly requested by the user
     const extraIncludePaths = options.extraIncludePaths || [];
     for (const path of extraIncludePaths) {
-        normalizedPathSet.add(upath.normalize(path));
+        const normalizedPath = upath.normalize(path);
+        packagePaths.set(normalizedPath, normalizedPath);
     }
 
     const codePaths: Map<string, asset.Asset | asset.Archive> = new Map();
 
     // For each of the required paths, add the corresponding FileArchive or FileAsset to the
     // AssetMap.
-    for (const normalizedPath of normalizedPathSet) {
+    const sourcePaths = new Set<string>(packagePaths.values());
+    for (const [archivePath, sourcePath] of packagePaths) {
         // Don't include a path if there is another path higher up that will include this one.
-        if (isSubsumedByHigherPath(normalizedPath, normalizedPathSet)) {
+        if (isSubsumedByHigherPath(sourcePath, sourcePaths)) {
             continue;
         }
 
         // The Asset model does not support a consistent way to embed a file-or-directory into an
         // `AssetArchive`, so we stat the path to figure out which it is and use the appropriate
         // Asset constructor.
-        const stats = fs.statSync(normalizedPath);
+        const stats = fs.statSync(sourcePath);
         if (stats.isDirectory()) {
-            codePaths.set(normalizedPath, new asset.FileArchive(normalizedPath));
+            codePaths.set(archivePath, new asset.FileArchive(sourcePath));
         } else {
-            codePaths.set(normalizedPath, new asset.FileAsset(normalizedPath));
+            codePaths.set(archivePath, new asset.FileAsset(sourcePath));
         }
     }
 
@@ -236,14 +240,30 @@ function parseWorkspaces(packageJsonPath: string): string[] {
 }
 
 /**
- * Computes the set of package folders that are transitively required by the root
- * `dependencies` node in the client's `package.json` file.
+ * Computes the package folders that are transitively required by the root
+ * `dependencies` node in the client's `package.json` file. Returns a map from
+ * the path at which the package is included in the archive to the on-disk path
+ * of the package's contents.
+ *
+ * The two paths differ when packages are symlinked, most notably by pnpm,
+ * which lays out node_modules as symlinks into a versioned virtual store:
+ *
+ *     node_modules/foo -> node_modules/.pnpm/foo@1.0.0/node_modules/foo
+ *     node_modules/.pnpm/foo@1.0.0/node_modules/bar -> node_modules/.pnpm/bar@2.0.0/node_modules/bar
+ *
+ * The archive instead recreates the physical layout npm would produce:
+ * symlinks cannot be represented in the archive, store paths embed version
+ * numbers and would change on every upgrade, and the serialized code
+ * `require`s packages by name, which Node resolves from
+ * `node_modules/<name>`. Virtual store paths are therefore flattened to
+ * `node_modules/<name>`, and contents are read from the package's real
+ * directory. This also covers symlinked workspace packages.
  */
 async function allFoldersForPackages(
     includedPackages: Set<string>,
     excludedPackages: Set<string>,
     logResource: Resource | undefined,
-): Promise<Set<string>> {
+): Promise<Map<string, string>> {
     // the working directory is the directory containing the package.json file
     let workingDir = searchUp(".", "package.json");
     if (workingDir === null) {
@@ -288,12 +308,37 @@ async function allFoldersForPackages(
     // So keep track of the paths we've looked and don't recurse if we hit something again.
     const seenPaths = new Set<string>();
 
-    const normalizedPackagePaths = new Set<string>();
+    const packagePaths = new Map<string, string>();
+
+    // Pre-claim the archive paths for the root's direct dependencies so that a transitive
+    // dependency processed earlier in the loop below can never claim `node_modules/<name>`
+    // with a different version of a package that is also a direct dependency.
     for (const pkg of referencedPackages) {
-        addPackageAndDependenciesToSet(root, pkg, seenPaths, normalizedPackagePaths, excludedPackages);
+        if (excludedPackages.has(pkg) || pkg.startsWith("@pulumi")) {
+            continue;
+        }
+        const child = findDependency(root, pkg);
+        if (!child || child.package.pulumi) {
+            continue;
+        }
+        const { archivePath, sourcePath } = packageArchiveEntry(child);
+        if (!packagePaths.has(archivePath)) {
+            packagePaths.set(archivePath, sourcePath);
+        }
     }
 
-    return normalizedPackagePaths;
+    for (const pkg of referencedPackages) {
+        addPackageAndDependenciesToMap(
+            root,
+            pkg,
+            seenPaths,
+            packagePaths,
+            excludedPackages,
+            /*dependentPath*/ undefined,
+        );
+    }
+
+    return packagePaths;
 }
 
 function computeDependenciesDirectlyFromPackageFile(path: string, logResource: Resource | undefined): any {
@@ -340,16 +385,40 @@ function computeDependenciesDirectlyFromPackageFile(path: string, logResource: R
 }
 
 /**
+ * Computes the path at which a package is included in the archive, and the
+ * on-disk path its contents are read from.
+ */
+function packageArchiveEntry(child: arborist.Node | arborist.Link): { archivePath: string; sourcePath: string } {
+    const nominalPath = upath.relative(upath.resolve("."), upath.resolve(child.path));
+    const sourcePath = upath.relative(upath.resolve("."), upath.resolve(child.realpath));
+    return { archivePath: packageArchivePath(nominalPath, child.name), sourcePath };
+}
+
+/**
+ * Returns the path at which a package with the given nominal node_modules
+ * location should be included in the archive.
+ *
+ * @internal exported for testing.
+ */
+export function packageArchivePath(nominalPath: string, packageName: string): string {
+    if (nominalPath.split("/").includes(".pnpm")) {
+        return `node_modules/${packageName}`;
+    }
+    return nominalPath;
+}
+
+/**
  * Adds all required dependencies for the requested package name from the given
- * root package into the set. It will recurse into all dependencies of the
+ * root package into the map. It will recurse into all dependencies of the
  * package.
  */
-function addPackageAndDependenciesToSet(
+function addPackageAndDependenciesToMap(
     root: arborist.Node,
     pkg: string,
     seenPaths: Set<string>,
-    normalizedPackagePaths: Set<string>,
+    packagePaths: Map<string, string>,
     excludedPackages: Set<string>,
+    dependentPath: string | undefined,
 ) {
     // Don't process this packages if it was in the set the user wants to exclude.
     if (excludedPackages.has(pkg)) {
@@ -362,12 +431,7 @@ function addPackageAndDependenciesToSet(
         return;
     }
 
-    // Don't process a child path if we've already encountered it.
-    const normalizedPath = upath.relative(upath.resolve("."), upath.resolve(child.path));
-    if (seenPaths.has(normalizedPath)) {
-        return;
-    }
-    seenPaths.add(normalizedPath);
+    const { archivePath, sourcePath } = packageArchiveEntry(child);
 
     if (child.package.pulumi) {
         // This was a pulumi deployment-time package.  Check if it had a:
@@ -376,22 +440,50 @@ function addPackageAndDependenciesToSet(
         //
         // section.  In this case, we don't want to add this specific package, but we do want to
         // include all the runtime dependencies it says are necessary.
-        recurse(child.package.pulumi.runtimeDependencies);
+        if (seenPaths.has(sourcePath)) {
+            return;
+        }
+        seenPaths.add(sourcePath);
+        recurse(child.package.pulumi.runtimeDependencies, dependentPath);
+        return;
     } else if (pkg.startsWith("@pulumi")) {
         // exclude it if it's an @pulumi package.  These packages are intended for deployment
         // time only and will only bloat up the serialized lambda package.  Note: this code can
         // be removed once all pulumi packages add a "pulumi" section to their package.json.
         return;
-    } else {
-        // Normal package.  Add the normalized path to it, and all transitively add all of its
-        // dependencies.
-        normalizedPackagePaths.add(normalizedPath);
-        recurse(child.package.dependencies);
     }
+
+    // Normal package. Determine where to place it in the archive, then transitively add all
+    // of its dependencies.
+    let childArchivePath = archivePath;
+    const existing = packagePaths.get(childArchivePath);
+    if (existing !== undefined && existing !== sourcePath && dependentPath !== undefined) {
+        // Another version of this package already occupies this location in the archive.
+        // Mirror npm's layout by nesting this copy under its dependent, so that Node's module
+        // resolution picks the right version at runtime.
+        childArchivePath = `${dependentPath}/node_modules/${child.name}`;
+    }
+    const nested = packagePaths.get(childArchivePath);
+    if (nested === undefined) {
+        packagePaths.set(childArchivePath, sourcePath);
+    } else if (nested !== sourcePath) {
+        log.warn(
+            `Cannot include multiple versions of package '${child.name}' at '${childArchivePath}': ` +
+                `keeping '${nested}', ignoring '${sourcePath}'.`,
+        );
+        return;
+    }
+
+    // Don't recurse into a package's dependencies if we've already done so.
+    if (seenPaths.has(sourcePath)) {
+        return;
+    }
+    seenPaths.add(sourcePath);
+    recurse(child.package.dependencies, childArchivePath);
 
     return;
 
-    function recurse(dependencies: any) {
+    function recurse(dependencies: any, parentArchivePath: string | undefined) {
         if (dependencies) {
             for (const dep of Object.keys(dependencies)) {
                 let next: arborist.Node;
@@ -400,7 +492,14 @@ function addPackageAndDependenciesToSet(
                 } else {
                     next = child!;
                 }
-                addPackageAndDependenciesToSet(next!, dep, seenPaths, normalizedPackagePaths, excludedPackages);
+                addPackageAndDependenciesToMap(
+                    next!,
+                    dep,
+                    seenPaths,
+                    packagePaths,
+                    excludedPackages,
+                    parentArchivePath,
+                );
             }
         }
     }

--- a/sdk/nodejs/tests/runtime/closure-integration-tests.ts
+++ b/sdk/nodejs/tests/runtime/closure-integration-tests.ts
@@ -118,6 +118,8 @@ async function run(
     await copyDir(path.join(sdkRoot, "tests", "runtime", "testdata", "closure-tests"), tmpDir);
 
     await install(packageManager, tmpDir, pnpmVersion);
+    // Install the codepaths-app fixture used by the computeCodePaths test.
+    await install(packageManager, path.join(tmpDir, "codepaths-app"), pnpmVersion);
 
     await execa("npx", ["--no-install", "tsc"], { cwd: tmpDir });
 

--- a/sdk/nodejs/tests/runtime/codePaths.spec.ts
+++ b/sdk/nodejs/tests/runtime/codePaths.spec.ts
@@ -1,0 +1,62 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import { packageArchivePath } from "../../runtime/closure/codePaths";
+
+describe("packageArchivePath", () => {
+    it("keeps plain node_modules paths as-is", () => {
+        assert.strictEqual(packageArchivePath("node_modules/semver", "semver"), "node_modules/semver");
+    });
+
+    it("keeps nested node_modules paths as-is", () => {
+        assert.strictEqual(
+            packageArchivePath("node_modules/execa/node_modules/semver", "semver"),
+            "node_modules/execa/node_modules/semver",
+        );
+    });
+
+    it("keeps scoped package paths as-is", () => {
+        assert.strictEqual(packageArchivePath("node_modules/@scope/name", "@scope/name"), "node_modules/@scope/name");
+    });
+
+    it("keeps workspace paths as-is", () => {
+        assert.strictEqual(packageArchivePath("../node_modules/semver", "semver"), "../node_modules/semver");
+    });
+
+    it("flattens pnpm store paths", () => {
+        assert.strictEqual(
+            packageArchivePath("node_modules/.pnpm/semver@7.5.4/node_modules/semver", "semver"),
+            "node_modules/semver",
+        );
+    });
+
+    it("flattens scoped pnpm store paths", () => {
+        assert.strictEqual(
+            packageArchivePath("node_modules/.pnpm/@scope+name@1.0.0/node_modules/@scope/name", "@scope/name"),
+            "node_modules/@scope/name",
+        );
+    });
+
+    it("flattens peer-suffixed pnpm store paths", () => {
+        assert.strictEqual(
+            packageArchivePath("node_modules/.pnpm/foo@1.0.0_react@18.2.0/node_modules/foo", "foo"),
+            "node_modules/foo",
+        );
+    });
+
+    it("only matches .pnpm as a full path segment", () => {
+        assert.strictEqual(packageArchivePath("node_modules/.pnpm-utils", ".pnpm-utils"), "node_modules/.pnpm-utils");
+    });
+});

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/codepaths-app/package.json
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/codepaths-app/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "codepaths-app",
+    "version": "1.0.0",
+    "private": true,
+    "license": "Apache-2.0",
+    "dependencies": {
+        "execa": "5.1.1",
+        "mockpackage": "file:../mockpackage-src",
+        "semver": "7.5.4",
+        "which": "1.3.1"
+    }
+}

--- a/sdk/nodejs/tests/runtime/testdata/closure-tests/test.ts
+++ b/sdk/nodejs/tests/runtime/testdata/closure-tests/test.ts
@@ -15,7 +15,7 @@
 import * as assert from "assert";
 import execa from "execa";
 import * as fs from "fs/promises";
-import { readdirSync } from "fs";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "fs";
 import * as path from "path";
 import * as semver from "semver";
 import * as typescript from "typescript";
@@ -118,6 +118,77 @@ describe(`closure tests (TypeScript ${typescript.version})`, function () {
 function anonymizeFunctionNames(text: string): string {
     return text.replace(/function '.+'/g, "function '<anonymous>'");
 }
+
+describe("computeCodePaths", () => {
+    it("computes the expected archive layout", async () => {
+        const packageManager = process.env.CLOSURE_TEST_PACKAGE_MANAGER ?? "npm";
+        const cwd = process.cwd();
+        process.chdir(path.join(__dirname, "codepaths-app"));
+        try {
+            const codePaths: Map<string, any> = await runtime.computeCodePaths();
+
+            const expected = [
+                "node_modules/cross-spawn",
+                "node_modules/execa",
+                "node_modules/get-stream",
+                "node_modules/human-signals",
+                "node_modules/is-stream",
+                "node_modules/isexe",
+                "node_modules/lru-cache",
+                "node_modules/merge-stream",
+                "node_modules/mimic-fn",
+                "node_modules/mockpackage",
+                "node_modules/npm-run-path",
+                "node_modules/onetime",
+                "node_modules/path-key",
+                "node_modules/semver",
+                "node_modules/shebang-command",
+                "node_modules/shebang-regex",
+                "node_modules/signal-exit",
+                "node_modules/strip-final-newline",
+                "node_modules/which",
+                "node_modules/yallist",
+            ];
+            if (packageManager === "pnpm") {
+                // In the zip, which@2 sits at node_modules/cross-spawn/node_modules/which under
+                // both package managers, but only pnpm needs an archive entry to put it there:
+                // its store keeps cross-spawn and which@2 in disjoint directories. npm physically
+                // nests which@2 inside cross-spawn's directory on disk, so it is carried along by
+                // the node_modules/cross-spawn entry and a separate entry would duplicate it.
+                expected.push("node_modules/cross-spawn/node_modules/which");
+            }
+            assert.deepStrictEqual([...codePaths.keys()].sort(), expected.sort());
+
+            const sources = new Map<string, string>();
+            for (const [key, archive] of codePaths) {
+                const sourcePath = await archive.path;
+                // The engine's archiver does not follow directory symlinks, so each entry must
+                // be backed by a real directory.
+                assert.ok(
+                    lstatSync(sourcePath).isDirectory(),
+                    `'${key}' source '${sourcePath}' is not a real directory`,
+                );
+                assert.ok(
+                    existsSync(path.join(sourcePath, "package.json")),
+                    `'${key}' source '${sourcePath}' has no package.json`,
+                );
+                sources.set(key, sourcePath);
+            }
+
+            // Both `which` versions must end up at the node_modules location Node resolves
+            // them from at runtime.
+            const versionOf = (dir: string) =>
+                JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8")).version;
+            assert.strictEqual(versionOf(sources.get("node_modules/which")!), "1.3.1");
+            const nestedWhich =
+                sources.get("node_modules/cross-spawn/node_modules/which") ??
+                path.join(sources.get("node_modules/cross-spawn")!, "node_modules", "which");
+            assert.ok(semver.satisfies(versionOf(nestedWhich), "2.x"));
+        } finally {
+            process.chdir(cwd);
+        }
+    });
+});
 
 describe("mock package", () => {
     describe("module", () => {

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -102,6 +102,7 @@
         "tests/unwrap.spec.ts",
         "tests/util.ts",
         "tests/runtime/asyncIterableUtil.spec.ts",
+        "tests/runtime/codePaths.spec.ts",
         "tests/runtime/dependsOn.spec.ts",
         "tests/runtime/findWorkspaceRoot.spec.ts",
         "tests/runtime/manifest.spec.ts",


### PR DESCRIPTION
Follow up to #23767 which fixed how we serialized `require(...)` expressions for pnpm. This PR fixes how we build code archives for serialized functions.

 pnpm lays out `node_modules` as symlinks into a versioned virtual store:

    node_modules/foo -> node_modules/.pnpm/foo@1.0.0/node_modules/foo
    node_modules/.pnpm/foo@1.0.0/node_modules/bar -> node_modules/.pnpm/bar@2.0.0/node_modules/bar

That layout can't go into the archive because the engine's archiver skips symlinks. Even if we do fix that, store paths embed version numbers and would change on every upgrade, and the serialized code `require`s packages by name, which Node resolves from `node_modules/<name>`, so we would have to archive the symlink and the target.

To work around this, `computeCodePaths` now tracks each package as archive path -> on-disk source path, recreating the physical layout npm would produce: virtual store paths are flattened to `node_modules/<name>`, contents are read from the package's real directory, and when two versions of a package collide on the same name the transitive copy is nested under its dependent, as npm would, so Node resolves the correct version at runtime.

Symlinked workspace or `file:` dependencies, which previously also produced empty folders, are fixed as well by this.

