### PR TITLE
Render strings containing non-UTF8 bytes as b"<base64>" in display output

### DIFF
--- a/changelog/pending/cli-display-improvement-20260710-raw-string-bytes.yaml
+++ b/changelog/pending/cli-display-improvement-20260710-raw-string-bytes.yaml
@@ -3,3 +3,5 @@ kind: improvement
 body: Render strings containing non-UTF8 bytes as b"<base64>" in diffs and JSON
   output
 time: 2026-07-10T09:00:00-07:00
+custom:
+  PR: "23870"

--- a/changelog/pending/cli-display-improvement-20260710-raw-string-bytes.yaml
+++ b/changelog/pending/cli-display-improvement-20260710-raw-string-bytes.yaml
@@ -1,0 +1,5 @@
+component: cli/display
+kind: improvement
+body: Render strings containing non-UTF8 bytes as b"<base64>" in diffs and JSON
+  output
+time: 2026-07-10T09:00:00-07:00

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -16,9 +16,11 @@ package display
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
+	"unicode/utf8"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -32,10 +34,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
+// rawStringBytesDisplay renders a string containing bytes that are not valid UTF-8 as b"<base64>",
+// since such strings cannot be represented in JSON or terminal output directly.
+func rawStringBytesDisplay(s string) string {
+	return `b"` + base64.StdEncoding.EncodeToString([]byte(s)) + `"`
+}
+
 // massagePropertyValue takes a property value and strips out the secrets annotations from it.  If showSecrets is
-// not true any secret values are replaced with "[secret]".
+// not true any secret values are replaced with "[secret]". Strings containing bytes that are not valid UTF-8 are
+// replaced with their b"<base64>" rendering.
 func massagePropertyValue(v resource.PropertyValue, showSecrets bool) resource.PropertyValue {
 	switch {
+	case v.IsString() && !utf8.ValidString(v.StringValue()):
+		return resource.NewProperty(rawStringBytesDisplay(v.StringValue()))
 	case v.IsArray():
 		new := make([]resource.PropertyValue, len(v.ArrayValue()))
 		for i, e := range v.ArrayValue() {

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"gopkg.in/yaml.v3"
@@ -928,7 +929,8 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 			if isPrimitive(diff.Old) && isPrimitive(diff.New) {
 				titleFunc(p)
 
-				if diff.Old.IsString() && diff.New.IsString() {
+				if diff.Old.IsString() && diff.New.IsString() &&
+					utf8.ValidString(diff.Old.StringValue()) && utf8.ValidString(diff.New.StringValue()) {
 					p.printTextDiff(diff.Old.StringValue(), diff.New.StringValue())
 					return
 				}
@@ -977,6 +979,10 @@ func (p *propertyPrinter) printPrimitivePropertyValue(v resource.PropertyValue) 
 			p.writef("%g", number)
 		}
 	} else if v.IsString() {
+		if !utf8.ValidString(v.StringValue()) {
+			p.writeVerbatim(rawStringBytesDisplay(v.StringValue()))
+			return
+		}
 		if vv, kind, ok := p.decodeValue(v.StringValue()); ok {
 			p.writef("(%s) ", kind)
 			p.printPropertyValue(vv)

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -163,6 +163,15 @@ func Test_PrintObject(t *testing.T) {
 <{%reset%}>`,
 			true,
 		},
+		{
+			"raw_string_bytes",
+			resource.NewPropertyMapFromMap(map[string]any{
+				"bytes": resource.NewProperty("\x00hello \x80\xfe\xff world\xf0\x28"),
+			}),
+			`<{%reset%}>bytes: <{%reset%}><{%reset%}>b"AGhlbGxvIID+/yB3b3JsZPAo"<{%reset%}><{%reset%}>
+<{%reset%}>`,
+			false,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Strings holding bytes that are not valid UTF-8 cannot be printed to a
terminal or represented in JSON without corruption. Render them in place
as b"<base64>" in human diff output and in machine-readable JSON
(`pulumi stack output --json`, `pulumi preview --json`), matching the
in-place [secret] convention. String-to-string text diffs fall back to
the old => new form when either side contains such bytes.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
