### PR TITLE
Add a byte string encoding for non-UTF8 strings to property marshaling

### DIFF
--- a/pkg/resource/plugin/rpc.go
+++ b/pkg/resource/plugin/rpc.go
@@ -15,10 +15,12 @@
 package plugin
 
 import (
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"reflect"
 	"slices"
+	"unicode/utf8"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -44,6 +46,11 @@ type MarshalOptions struct {
 	KeepOutputValues      bool   // true if we are keeping output values.
 	UpgradeToOutputValues bool   // true if secrets and unknowns should be upgraded to output values.
 	WorkingDirectory      string // the optional working directory to use when serializing assets & archives.
+
+	// true if the receiver understands strings containing bytes that are not valid UTF-8, which are marshaled with
+	// the byte string signature. Otherwise marshaling such a string returns an error, since it cannot be
+	// transported as a protobuf string field without corruption.
+	KeepByteString bool
 
 	// true if a nil input should result in a nil output, false if it should result in an empty struct/map.
 	PropagateNil bool
@@ -134,7 +141,20 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			},
 		}, nil
 	} else if v.IsString() {
-		return MarshalString(v.StringValue(), opts), nil
+		s := v.StringValue()
+		if !utf8.ValidString(s) {
+			if !opts.KeepByteString {
+				return nil, fmt.Errorf(
+					"the value of property %q is a string that contains non-UTF8 bytes, which the receiver does not support",
+					key)
+			}
+			raw := resource.NewProperty(resource.PropertyMap{
+				resource.SigKey: resource.NewProperty(resource.ByteStringSig),
+				"value":         resource.NewProperty(base64.StdEncoding.EncodeToString([]byte(s))),
+			})
+			return MarshalPropertyValue(key, raw, opts)
+		}
+		return MarshalString(s, opts), nil
 	} else if v.IsArray() {
 		var elems []*structpb.Value
 		for _, elem := range v.ArrayValue() {
@@ -456,6 +476,20 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				return nil, fmt.Errorf("malformed RPC secret: missing value for %q", key)
 			}
 			return unmarshalSecretPropertyValue(value, opts), nil
+		case resource.ByteStringSig:
+			value, ok := obj["value"]
+			if !ok {
+				return nil, fmt.Errorf("malformed byte string for %q: missing value", key)
+			}
+			if !value.IsString() {
+				return nil, fmt.Errorf("malformed byte string for %q: value is not a string", key)
+			}
+			decoded, err := base64.StdEncoding.DecodeString(value.StringValue())
+			if err != nil {
+				return nil, fmt.Errorf("malformed byte string for %q: value is not valid base64: %w", key, err)
+			}
+			m := resource.NewProperty(string(decoded))
+			return &m, nil
 		case resource.ResourceReferenceSig:
 			urn, ok := obj["urn"]
 			if !ok {

--- a/pkg/resource/plugin/rpc_test.go
+++ b/pkg/resource/plugin/rpc_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -1943,5 +1944,110 @@ func TestUpgradeToOutputValues(t *testing.T) {
 		assert.Equal(t, resource.URN(urn), propU.ResourceReferenceValue().URN)
 		id := propU.ResourceReferenceValue().ID
 		assert.True(t, id.IsComputed())
+	}
+}
+
+func TestByteStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = "\x00hello \x80\xfe\xff world\xf0\x28"
+	pk := resource.PropertyKey("pk")
+	opts := MarshalOptions{KeepByteString: true}
+
+	prop, err := MarshalPropertyValue(pk, resource.NewProperty(raw), opts)
+	require.NoError(t, err)
+	assert.Equal(t, &structpb.Value{
+		Kind: &structpb.Value_StructValue{
+			StructValue: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					resource.SigKey: structpb.NewStringValue(resource.ByteStringSig),
+					"value":         structpb.NewStringValue("AGhlbGxvIID+/yB3b3JsZPAo"),
+				},
+			},
+		},
+	}, prop)
+
+	// The whole point of the encoding is that the resulting protobuf value is valid on the wire.
+	_, err = proto.Marshal(prop)
+	require.NoError(t, err)
+
+	val, err := UnmarshalPropertyValue(pk, prop, opts)
+	require.NoError(t, err)
+	assert.Equal(t, resource.NewProperty(raw), *val)
+}
+
+func TestByteStringValidUTF8Unchanged(t *testing.T) {
+	t.Parallel()
+
+	pk := resource.PropertyKey("pk")
+	opts := MarshalOptions{KeepByteString: true}
+
+	prop, err := MarshalPropertyValue(pk, resource.NewProperty("héllo wörld"), opts)
+	require.NoError(t, err)
+	assert.Equal(t, structpb.NewStringValue("héllo wörld"), prop)
+}
+
+func TestByteStringUnsupported(t *testing.T) {
+	t.Parallel()
+
+	pk := resource.PropertyKey("pk")
+	_, err := MarshalPropertyValue(pk, resource.NewProperty("\x80"), MarshalOptions{})
+	assert.EqualError(t, err,
+		"the value of property \"pk\" is a string that contains non-UTF8 bytes, which the receiver does not support")
+}
+
+func TestByteStringInSecretRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = "\x80\xfe\xff"
+	pk := resource.PropertyKey("pk")
+	opts := MarshalOptions{KeepSecrets: true, KeepByteString: true}
+
+	prop, err := MarshalPropertyValue(pk, resource.MakeSecret(resource.NewProperty(raw)), opts)
+	require.NoError(t, err)
+	_, err = proto.Marshal(prop)
+	require.NoError(t, err)
+
+	val, err := UnmarshalPropertyValue(pk, prop, opts)
+	require.NoError(t, err)
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty(raw)), *val)
+}
+
+func TestByteStringMalformed(t *testing.T) {
+	t.Parallel()
+
+	pk := resource.PropertyKey("pk")
+
+	cases := []struct {
+		name string
+		obj  map[string]any
+		want string
+	}{
+		{
+			name: "missing value",
+			obj:  map[string]any{resource.SigKey: resource.ByteStringSig},
+			want: "malformed byte string for \"pk\": missing value",
+		},
+		{
+			name: "value not a string",
+			obj:  map[string]any{resource.SigKey: resource.ByteStringSig, "value": true},
+			want: "malformed byte string for \"pk\": value is not a string",
+		},
+		{
+			name: "value not base64",
+			obj:  map[string]any{resource.SigKey: resource.ByteStringSig, "value": "!!!"},
+			want: "malformed byte string for \"pk\": value is not valid base64: illegal base64 data at input byte 0",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			prop, err := MarshalPropertyValue(pk,
+				resource.NewProperty(resource.NewPropertyMapFromMap(c.obj)), MarshalOptions{})
+			require.NoError(t, err)
+			_, err = UnmarshalPropertyValue(pk, prop, MarshalOptions{})
+			assert.EqualError(t, err, c.want)
+		})
 	}
 }

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -15,10 +15,12 @@
 package plugin
 
 import (
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"reflect"
 	"slices"
+	"unicode/utf8"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -44,6 +46,11 @@ type MarshalOptions struct {
 	KeepOutputValues      bool   // true if we are keeping output values.
 	UpgradeToOutputValues bool   // true if secrets and unknowns should be upgraded to output values.
 	WorkingDirectory      string // the optional working directory to use when serializing assets & archives.
+
+	// true if the receiver understands strings containing bytes that are not valid UTF-8, which are marshaled with
+	// the byte string signature. Otherwise marshaling such a string returns an error, since it cannot be
+	// transported as a protobuf string field without corruption.
+	KeepByteString bool
 
 	// true if a nil input should result in a nil output, false if it should result in an empty struct/map.
 	PropagateNil bool
@@ -134,7 +141,20 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			},
 		}, nil
 	} else if v.IsString() {
-		return MarshalString(v.StringValue(), opts), nil
+		s := v.StringValue()
+		if !utf8.ValidString(s) {
+			if !opts.KeepByteString {
+				return nil, fmt.Errorf(
+					"the value of property %q is a string that contains non-UTF8 bytes, which the receiver does not support",
+					key)
+			}
+			raw := resource.NewProperty(resource.PropertyMap{
+				resource.SigKey: resource.NewProperty(resource.ByteStringSig),
+				"value":         resource.NewProperty(base64.StdEncoding.EncodeToString([]byte(s))),
+			})
+			return MarshalPropertyValue(key, raw, opts)
+		}
+		return MarshalString(s, opts), nil
 	} else if v.IsArray() {
 		var elems []*structpb.Value
 		for _, elem := range v.ArrayValue() {
@@ -456,6 +476,20 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				return nil, fmt.Errorf("malformed RPC secret: missing value for %q", key)
 			}
 			return unmarshalSecretPropertyValue(value, opts), nil
+		case resource.ByteStringSig:
+			value, ok := obj["value"]
+			if !ok {
+				return nil, fmt.Errorf("malformed byte string for %q: missing value", key)
+			}
+			if !value.IsString() {
+				return nil, fmt.Errorf("malformed byte string for %q: value is not a string", key)
+			}
+			decoded, err := base64.StdEncoding.DecodeString(value.StringValue())
+			if err != nil {
+				return nil, fmt.Errorf("malformed byte string for %q: value is not valid base64: %w", key, err)
+			}
+			m := resource.NewProperty(string(decoded))
+			return &m, nil
 		case resource.ResourceReferenceSig:
 			urn, ok := obj["urn"]
 			if !ok {

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -1943,5 +1944,110 @@ func TestUpgradeToOutputValues(t *testing.T) {
 		assert.Equal(t, resource.URN(urn), propU.ResourceReferenceValue().URN)
 		id := propU.ResourceReferenceValue().ID
 		assert.True(t, id.IsComputed())
+	}
+}
+
+func TestByteStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = "\x00hello \x80\xfe\xff world\xf0\x28"
+	pk := resource.PropertyKey("pk")
+	opts := MarshalOptions{KeepByteString: true}
+
+	prop, err := MarshalPropertyValue(pk, resource.NewProperty(raw), opts)
+	require.NoError(t, err)
+	assert.Equal(t, &structpb.Value{
+		Kind: &structpb.Value_StructValue{
+			StructValue: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					resource.SigKey: structpb.NewStringValue(resource.ByteStringSig),
+					"value":         structpb.NewStringValue("AGhlbGxvIID+/yB3b3JsZPAo"),
+				},
+			},
+		},
+	}, prop)
+
+	// The whole point of the encoding is that the resulting protobuf value is valid on the wire.
+	_, err = proto.Marshal(prop)
+	require.NoError(t, err)
+
+	val, err := UnmarshalPropertyValue(pk, prop, opts)
+	require.NoError(t, err)
+	assert.Equal(t, resource.NewProperty(raw), *val)
+}
+
+func TestByteStringValidUTF8Unchanged(t *testing.T) {
+	t.Parallel()
+
+	pk := resource.PropertyKey("pk")
+	opts := MarshalOptions{KeepByteString: true}
+
+	prop, err := MarshalPropertyValue(pk, resource.NewProperty("héllo wörld"), opts)
+	require.NoError(t, err)
+	assert.Equal(t, structpb.NewStringValue("héllo wörld"), prop)
+}
+
+func TestByteStringUnsupported(t *testing.T) {
+	t.Parallel()
+
+	pk := resource.PropertyKey("pk")
+	_, err := MarshalPropertyValue(pk, resource.NewProperty("\x80"), MarshalOptions{})
+	assert.EqualError(t, err,
+		"the value of property \"pk\" is a string that contains non-UTF8 bytes, which the receiver does not support")
+}
+
+func TestByteStringInSecretRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = "\x80\xfe\xff"
+	pk := resource.PropertyKey("pk")
+	opts := MarshalOptions{KeepSecrets: true, KeepByteString: true}
+
+	prop, err := MarshalPropertyValue(pk, resource.MakeSecret(resource.NewProperty(raw)), opts)
+	require.NoError(t, err)
+	_, err = proto.Marshal(prop)
+	require.NoError(t, err)
+
+	val, err := UnmarshalPropertyValue(pk, prop, opts)
+	require.NoError(t, err)
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty(raw)), *val)
+}
+
+func TestByteStringMalformed(t *testing.T) {
+	t.Parallel()
+
+	pk := resource.PropertyKey("pk")
+
+	cases := []struct {
+		name string
+		obj  map[string]any
+		want string
+	}{
+		{
+			name: "missing value",
+			obj:  map[string]any{resource.SigKey: resource.ByteStringSig},
+			want: "malformed byte string for \"pk\": missing value",
+		},
+		{
+			name: "value not a string",
+			obj:  map[string]any{resource.SigKey: resource.ByteStringSig, "value": true},
+			want: "malformed byte string for \"pk\": value is not a string",
+		},
+		{
+			name: "value not base64",
+			obj:  map[string]any{resource.SigKey: resource.ByteStringSig, "value": "!!!"},
+			want: "malformed byte string for \"pk\": value is not valid base64: illegal base64 data at input byte 0",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			prop, err := MarshalPropertyValue(pk,
+				resource.NewProperty(resource.NewPropertyMapFromMap(c.obj)), MarshalOptions{})
+			require.NoError(t, err)
+			_, err = UnmarshalPropertyValue(pk, prop, MarshalOptions{})
+			assert.EqualError(t, err, c.want)
+		})
 	}
 }

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -722,6 +722,9 @@ const ResourceReferenceSig = sig.ResourceReference
 // OutputValueSig is the unique output value signature.
 const OutputValueSig = sig.OutputValue
 
+// ByteStringSig is the unique signature for strings containing bytes that are not valid UTF-8.
+const ByteStringSig = sig.ByteString
+
 // IsInternalPropertyKey returns true if the given property key is an internal key that should not be displayed to
 // users.
 func IsInternalPropertyKey(key PropertyKey) bool {

--- a/sdk/go/common/resource/sig/sig.go
+++ b/sdk/go/common/resource/sig/sig.go
@@ -29,6 +29,11 @@ const (
 	// OutputValueSig is the unique output value signature.
 	OutputValue = "d0e6a833031e9bbcd3f4e8bde6ca49a4"
 
+	// ByteString is the unique signature for string values that contain bytes which are not
+	// valid UTF-8. Such strings cannot be transported as protobuf string fields, so they are
+	// encoded as an object carrying the base64 encoding of the string's bytes.
+	ByteString = "803fd3297a5875dc03ca845dda5d2a98"
+
 	// a randomly assigned type hash for assets.
 	AssetSig = "c44067f5952c0a294b673a41bacd8c17"
 


### PR DESCRIPTION
Strings containing bytes that are not valid UTF-8 cannot be transported
as protobuf string fields: proto3 enforces UTF-8 at encode time, so such
values previously failed deep inside gRPC with an opaque error.

Introduce a new special signature, ByteString. When the new
MarshalOptions.KeepByteString flag is set, such strings marshal as an
object carrying the signature and a base64 encoding of the string's
bytes; unmarshaling decodes the object back into a plain string. When the
flag is not set, marshaling fails with a clear error naming the property
instead of corrupting the value or failing at the transport layer.

Nothing sets the flag yet; subsequent changes thread it through providers,
the resource monitor, SDKs, and callbacks, gated on capability
negotiation.
