### PR TITLE
Serialize strings containing non-UTF8 bytes losslessly in state

### DIFF
--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -293,7 +293,7 @@ func getPreviewMetadataStep(
 	ctx := context.TODO()
 	if m.Old != nil {
 		oldState := stateForJSONOutput(m.Old.State, opts)
-		res, err := stack.SerializeResource(ctx, oldState, config.NewPanicCrypter(), false /* showSecrets */)
+		res, _, err := stack.SerializeResource(ctx, oldState, config.NewPanicCrypter(), false /* showSecrets */)
 		if err == nil {
 			step.OldState = &res
 		} else {
@@ -302,7 +302,7 @@ func getPreviewMetadataStep(
 	}
 	if m.New != nil {
 		newState := stateForJSONOutput(m.New.State, opts)
-		res, err := stack.SerializeResource(ctx, newState, config.NewPanicCrypter(), false /* showSecrets */)
+		res, _, err := stack.SerializeResource(ctx, newState, config.NewPanicCrypter(), false /* showSecrets */)
 		if err == nil {
 			step.NewState = &res
 		} else {

--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -45,22 +45,25 @@ func SerializeJournalEntry(
 	ctx context.Context, je engine.JournalEntry, enc config.Encrypter,
 ) (apitype.JournalEntry, error) {
 	var state *apitype.ResourceV3
+	var requiresByteString bool
 
 	if je.State != nil {
-		s, err := stack.SerializeResource(ctx, je.State, enc, false)
+		s, encodedByteString, err := stack.SerializeResource(ctx, je.State, enc, false)
 		if err != nil {
 			return apitype.JournalEntry{}, fmt.Errorf("serializing resource state: %w", err)
 		}
 		state = &s
+		requiresByteString = requiresByteString || encodedByteString
 	}
 
 	var operation *apitype.OperationV2
 	if je.Operation != nil {
-		op, err := stack.SerializeOperation(ctx, *je.Operation, enc, false)
+		op, encodedByteString, err := stack.SerializeOperation(ctx, *je.Operation, enc, false)
 		if err != nil {
 			return apitype.JournalEntry{}, fmt.Errorf("serializing operation: %w", err)
 		}
 		operation = &op
+		requiresByteString = requiresByteString || encodedByteString
 	}
 	var secretsManager *apitype.SecretsProvidersV1
 	if je.SecretsManager != nil {
@@ -72,11 +75,13 @@ func SerializeJournalEntry(
 
 	var snapshot *apitype.DeploymentV3
 	if je.NewSnapshot != nil {
+		var features []string
 		var err error
-		snapshot, err = stack.SerializeDeployment(ctx, je.NewSnapshot, false)
+		snapshot, _, features, err = stack.SerializeDeploymentWithMetadata(ctx, je.NewSnapshot, false)
 		if err != nil {
 			return apitype.JournalEntry{}, fmt.Errorf("serializing new snapshot: %w", err)
 		}
+		requiresByteString = requiresByteString || slices.Contains(features, "byteString")
 	}
 	var snippets []apitype.SnippetV1
 	if je.Snippets != nil {
@@ -105,6 +110,8 @@ func SerializeJournalEntry(
 		ExtensionRef:          je.ExtensionRef,
 		Extension:             je.Extension,
 		Snippets:              snippets,
+
+		RequiresByteString: requiresByteString,
 	}
 
 	return serializedEntry, nil
@@ -131,6 +138,11 @@ type JournalReplayer struct {
 
 	// hasRefresh indicates whether any of the journal entries were part of a refresh operation.
 	hasRefresh bool
+
+	// requiresByteString indicates whether any applied journal entry encoded strings containing
+	// non-UTF8 bytes. It is tracked here because such strings inside secrets cannot be detected from
+	// the serialized resources this replayer holds.
+	requiresByteString bool
 
 	// index is the current index in the new resource list.
 	index int64
@@ -163,6 +175,9 @@ func NewJournalReplayer(base *apitype.DeploymentV3) *JournalReplayer {
 }
 
 func (r *JournalReplayer) Add(entry apitype.JournalEntry) error {
+	if entry.RequiresByteString {
+		r.requiresByteString = true
+	}
 	switch entry.Kind {
 	case apitype.JournalEntryKindBegin:
 		r.incompleteOps[entry.OperationID] = entry
@@ -336,7 +351,7 @@ func (r *JournalReplayer) GenerateDeployment() (apitype.TypedDeployment, error) 
 	for i, res := range r.newResources {
 		if _, ok := removeIndices[int64(i)]; !ok {
 			resources = append(resources, *res)
-			stack.ApplyFeatures(*res, features)
+			stack.ApplyFeatures(*res, r.requiresByteString, features)
 		}
 	}
 
@@ -356,13 +371,13 @@ func (r *JournalReplayer) GenerateDeployment() (apitype.TypedDeployment, error) 
 					// we're supposed to replace the resource), and then a
 					// delete happens (so we're supposed to delete the resource).
 					resources = append(resources, *state)
-					stack.ApplyFeatures(*state, features)
+					stack.ApplyFeatures(*state, r.requiresByteString, features)
 				} else {
 					if _, ok := r.markAsDeletion[int64(i)]; ok {
 						res.Delete = true
 					}
 					resources = append(resources, res)
-					stack.ApplyFeatures(res, features)
+					stack.ApplyFeatures(res, r.requiresByteString, features)
 				}
 			}
 		}
@@ -373,7 +388,7 @@ func (r *JournalReplayer) GenerateDeployment() (apitype.TypedDeployment, error) 
 	for _, op := range r.incompleteOps {
 		if op.Operation != nil {
 			operations = append(operations, *op.Operation)
-			stack.ApplyFeatures(op.Operation.Resource, features)
+			stack.ApplyFeatures(op.Operation.Resource, r.requiresByteString, features)
 		}
 	}
 
@@ -384,7 +399,7 @@ func (r *JournalReplayer) GenerateDeployment() (apitype.TypedDeployment, error) 
 		for _, pendingOperation := range base.PendingOperations {
 			if pendingOperation.Type == apitype.OperationTypeCreating {
 				operations = append(operations, pendingOperation)
-				stack.ApplyFeatures(pendingOperation.Resource, features)
+				stack.ApplyFeatures(pendingOperation.Resource, r.requiresByteString, features)
 			}
 		}
 	}

--- a/pkg/backend/journal_byte_string_test.go
+++ b/pkg/backend/journal_byte_string_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that a journal entry whose state holds a string containing non-UTF8 bytes inside a secret
+// records that fact, and that a deployment rebuilt from the journal is gated on the byteString
+// feature. The secret is encrypted in the serialized entry, so replay cannot detect this on its own.
+func TestJournalByteStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = "\x00hello \x80\xfe\xff world\xf0\x28"
+
+	state := &pkgresource.State{
+		Type:    tokens.Type("pkgA:index:res"),
+		URN:     resource.NewURN("dev", "proj", "", tokens.Type("pkgA:index:res"), "r1"),
+		Custom:  true,
+		Inputs:  resource.PropertyMap{},
+		Outputs: resource.PropertyMap{"out": resource.MakeSecret(resource.NewProperty(raw))},
+	}
+
+	engineEntry := engine.JournalEntry{
+		Kind:        engine.JournalEntrySuccess,
+		SequenceID:  1,
+		OperationID: 1,
+		State:       state,
+	}
+
+	serialized, err := SerializeJournalEntry(t.Context(), engineEntry, b64.NewBase64SecretsManager().Encrypter())
+	require.NoError(t, err)
+	assert.True(t, serialized.RequiresByteString)
+
+	replayer := NewJournalReplayer(&apitype.DeploymentV3{})
+	require.NoError(t, replayer.Add(serialized))
+
+	deployment, err := replayer.GenerateDeployment()
+	require.NoError(t, err)
+	assert.Contains(t, deployment.Features, "byteString")
+	assert.Equal(t, apitype.DeploymentSchemaVersionLatest, deployment.Version)
+}

--- a/pkg/backend/journaler_snapshot_test.go
+++ b/pkg/backend/journaler_snapshot_test.go
@@ -343,7 +343,7 @@ func TestSamesWithOtherMeaningfulChangesJournaling(t *testing.T) {
 		inSnapshot := sp.SavedSnapshots[0].Resources[2]
 		// The snapshot might edit the URN so don't check against that
 		c.URN = inSnapshot.URN
-		sres, err := stack.SerializeResource(
+		sres, _, err := stack.SerializeResource(
 			t.Context(), c, b64.NewBase64SecretsManager().Encrypter(), false)
 		require.NoError(t, err)
 
@@ -373,7 +373,7 @@ func TestSamesWithOtherMeaningfulChangesJournaling(t *testing.T) {
 	assert.NotEmpty(t, sp.SavedSnapshots)
 	assert.NotEmpty(t, sp.SavedSnapshots[0].Resources)
 	inSnapshot := sp.SavedSnapshots[0].Resources[0]
-	sres, err := stack.SerializeResource(
+	sres, _, err := stack.SerializeResource(
 		t.Context(), sourceUpdated, b64.NewBase64SecretsManager().Encrypter(), false)
 	require.NoError(t, err)
 	assert.Equal(t, sres, inSnapshot)
@@ -435,7 +435,7 @@ func TestSamesWithOtherMeaningfulChangesJournaling(t *testing.T) {
 		assert.NotEmpty(t, sp.SavedSnapshots[0].Resources)
 
 		inSnapshot := sp.SavedSnapshots[0].Resources[2]
-		sres, err := stack.SerializeResource(
+		sres, _, err := stack.SerializeResource(
 			t.Context(), c, b64.NewBase64SecretsManager().Encrypter(), false)
 		require.NoError(t, err)
 		assert.Equal(t, sres, inSnapshot)

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -395,7 +395,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		inSnapshot := sp.SavedSnapshots[0].Resources[2]
 		// The snapshot might edit the URN so don't check against that
 		c.URN = inSnapshot.URN
-		sres, err := stack.SerializeResource(
+		sres, _, err := stack.SerializeResource(
 			t.Context(), c, b64.NewBase64SecretsManager().Encrypter(), false)
 		require.NoError(t, err)
 		assert.Equal(t, sres, inSnapshot)
@@ -425,7 +425,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 	assert.NotEmpty(t, sp.SavedSnapshots)
 	assert.NotEmpty(t, sp.SavedSnapshots[0].Resources)
 	inSnapshot := sp.SavedSnapshots[0].Resources[0]
-	sres, err := stack.SerializeResource(
+	sres, _, err := stack.SerializeResource(
 		t.Context(), sourceUpdated, b64.NewBase64SecretsManager().Encrypter(), false)
 	require.NoError(t, err)
 	assert.Equal(t, sres, inSnapshot)
@@ -487,7 +487,7 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 		assert.NotEmpty(t, sp.SavedSnapshots[0].Resources)
 
 		inSnapshot := sp.SavedSnapshots[0].Resources[2]
-		sres, err := stack.SerializeResource(
+		sres, _, err := stack.SerializeResource(
 			t.Context(), c, b64.NewBase64SecretsManager().Encrypter(), false)
 		require.NoError(t, err)
 		assert.Equal(t, sres, inSnapshot)

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -412,7 +412,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			}
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
-				actual, err := stack.SerializeResource(t.Context(), actualState, config.NopEncrypter, false)
+				actual, _, err := stack.SerializeResource(t.Context(), actualState, config.NopEncrypter, false)
 				contract.IgnoreError(err)
 
 				sb, err := json.MarshalIndent(s, "", "    ")

--- a/pkg/importer/language_test.go
+++ b/pkg/importer/language_test.go
@@ -95,7 +95,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 			}
 			assert.Equal(t, state.Protect, actualState.Protect)
 			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
-				actual, err := stack.SerializeResource(t.Context(), actualState, config.NopEncrypter, false)
+				actual, _, err := stack.SerializeResource(t.Context(), actualState, config.NopEncrypter, false)
 				contract.IgnoreError(err)
 
 				sb, err := json.MarshalIndent(s, "", "    ")

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -16,6 +16,7 @@ package stack
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,6 +27,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	fxs "github.com/pgavlin/fx/v2/slices"
 	"go.opentelemetry.io/otel"
@@ -75,6 +77,7 @@ const (
 	replaceWithFeature               = "replaceWith"
 	snippetsFeature                  = "snippets-prototype"
 	extensionParameterizationFeature = "extensionParameterization"
+	byteStringFeature                = "byteString"
 )
 
 var (
@@ -133,6 +136,7 @@ var supportedFeatures = map[string]bool{
 	replaceWithFeature:               true,
 	snippetsFeature:                  true,
 	extensionParameterizationFeature: true,
+	byteStringFeature:                true,
 }
 
 // validateSupportedFeatures validates that the features used in a deployment are supported.
@@ -150,7 +154,13 @@ func validateSupportedFeatures(features []string) error {
 }
 
 // ApplyFeatures applies the features used by a resource to the feature map.
-func ApplyFeatures(res apitype.ResourceV3, features map[string]bool) {
+//
+// Byte string inside secrets are encrypted away by serialization, so they cannot be detected from
+// the serialized resource; callers must pass encodedByteString as reported by SerializeResource.
+func ApplyFeatures(res apitype.ResourceV3, encodedByteString bool, features map[string]bool) {
+	if encodedByteString {
+		features[byteStringFeature] = true
+	}
 	if res.RefreshBeforeUpdate {
 		features[refreshBeforeUpdateFeature] = true
 	}
@@ -172,6 +182,40 @@ func ApplyFeatures(res apitype.ResourceV3, features map[string]bool) {
 	if res.SnippetID != "" {
 		features[snippetsFeature] = true
 	}
+}
+
+// propertyValueNeedsByteString reports whether the value contains a string with bytes that are not
+// valid UTF-8. Such strings serialize with the byte string signature, which requires the
+// byteString feature so that older engines refuse to read state they would corrupt.
+func propertyValueNeedsByteString(v resource.PropertyValue) bool {
+	switch {
+	case v.IsString():
+		return !utf8.ValidString(v.StringValue())
+	case v.IsArray():
+		for _, elem := range v.ArrayValue() {
+			if propertyValueNeedsByteString(elem) {
+				return true
+			}
+		}
+	case v.IsObject():
+		return propertyMapNeedsByteString(v.ObjectValue())
+	case v.IsSecret():
+		return propertyValueNeedsByteString(v.SecretValue().Element)
+	case v.IsOutput():
+		return propertyValueNeedsByteString(v.OutputValue().Element)
+	case v.IsComputed():
+		return propertyValueNeedsByteString(v.Input().Element)
+	}
+	return false
+}
+
+func propertyMapNeedsByteString(m resource.PropertyMap) bool {
+	for _, v := range m {
+		if propertyValueNeedsByteString(v) {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateUntypedDeployment validates a deployment against the Deployment JSON schema.
@@ -226,19 +270,22 @@ func SerializeDeploymentWithMetadata(
 	// Serialize all vertices and only include a vertex section if non-empty.
 	resources := slice.Prealloc[apitype.ResourceV3](len(snap.Resources))
 	for _, res := range snap.Resources {
-		sres, err := SerializeResource(ctx, res, enc, showSecrets)
+		sres, encodedByteString, err := SerializeResource(ctx, res, enc, showSecrets)
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("serializing resources: %w", err)
 		}
-		ApplyFeatures(sres, featureMap)
+		ApplyFeatures(sres, encodedByteString, featureMap)
 		resources = append(resources, sres)
 	}
 
 	operations := slice.Prealloc[apitype.OperationV2](len(snap.PendingOperations))
 	for _, op := range snap.PendingOperations {
-		sop, err := SerializeOperation(ctx, op, enc, showSecrets)
+		sop, encodedByteString, err := SerializeOperation(ctx, op, enc, showSecrets)
 		if err != nil {
 			return nil, 0, nil, err
+		}
+		if encodedByteString {
+			featureMap[byteStringFeature] = true
 		}
 		operations = append(operations, sop)
 	}
@@ -610,22 +657,28 @@ func initializeSecretsManager(
 	return secretsManager, nil
 }
 
-// SerializeResource turns a resource into a structure suitable for serialization.
+// SerializeResource turns a resource into a structure suitable for serialization. The returned bool
+// reports whether serialization encoded strings containing non-UTF8 bytes: encoding inside secrets is
+// invisible once they are encrypted, so this must be reported here, while the plaintext is still visible.
 func SerializeResource(
 	ctx context.Context, res *pkgresource.State, enc config.Encrypter, showSecrets bool,
-) (apitype.ResourceV3, error) {
+) (apitype.ResourceV3, bool, error) {
 	contract.Requiref(res != nil, "res", "must not be nil")
 	contract.Requiref(res.URN != "", "res", "must have a URN")
 
 	res.Lock.Lock()
 	defer res.Lock.Unlock()
 
+	encodedByteString := propertyMapNeedsByteString(res.Inputs) ||
+		propertyMapNeedsByteString(res.Outputs) ||
+		propertyValueNeedsByteString(res.ReplacementTrigger)
+
 	// Serialize all input and output properties recursively, and add them if non-empty.
 	var inputs map[string]any
 	if inp := res.Inputs; inp != nil {
 		sinp, err := SerializeProperties(ctx, inp, enc, showSecrets)
 		if err != nil {
-			return apitype.ResourceV3{}, err
+			return apitype.ResourceV3{}, false, err
 		}
 		inputs = sinp
 	}
@@ -633,14 +686,14 @@ func SerializeResource(
 	if outp := res.Outputs; outp != nil {
 		soutp, err := SerializeProperties(ctx, outp, enc, showSecrets)
 		if err != nil {
-			return apitype.ResourceV3{}, err
+			return apitype.ResourceV3{}, false, err
 		}
 		outputs = soutp
 	}
 
 	trigger, err := SerializePropertyValue(ctx, res.ReplacementTrigger, enc, showSecrets)
 	if err != nil {
-		return apitype.ResourceV3{}, err
+		return apitype.ResourceV3{}, false, err
 	}
 
 	stackTrace := slices.Collect(fxs.Map(res.StackTrace, func(frame pkgresource.StackFrame) apitype.StackFrameV1 {
@@ -689,21 +742,21 @@ func SerializeResource(
 		v3Resource.CustomTimeouts = &res.CustomTimeouts
 	}
 
-	return v3Resource, nil
+	return v3Resource, encodedByteString, nil
 }
 
 // SerializeOperation serializes a resource in a pending state.
 func SerializeOperation(
 	ctx context.Context, op pkgresource.Operation, enc config.Encrypter, showSecrets bool,
-) (apitype.OperationV2, error) {
-	res, err := SerializeResource(ctx, op.Resource, enc, showSecrets)
+) (apitype.OperationV2, bool, error) {
+	res, encodedByteString, err := SerializeResource(ctx, op.Resource, enc, showSecrets)
 	if err != nil {
-		return apitype.OperationV2{}, fmt.Errorf("serializing resource: %w", err)
+		return apitype.OperationV2{}, false, fmt.Errorf("serializing resource: %w", err)
 	}
 	return apitype.OperationV2{
 		Resource: res,
 		Type:     apitype.OperationType(op.Type),
-	}, nil
+	}, encodedByteString, nil
 }
 
 // SerializeProperties serializes a resource property bag so that it's suitable for serialization.
@@ -829,6 +882,15 @@ func SerializePropertyValue(ctx context.Context, prop resource.PropertyValue, en
 		}
 
 		return &secret, nil
+	}
+
+	// Strings containing bytes that are not valid UTF-8 would be corrupted by JSON encoding, so they are
+	// serialized with a signature carrying the base64 encoding of their bytes.
+	if prop.IsString() && !utf8.ValidString(prop.StringValue()) {
+		return map[string]any{
+			resource.SigKey: resource.ByteStringSig,
+			"value":         base64.StdEncoding.EncodeToString([]byte(prop.StringValue())),
+		}, nil
 	}
 
 	// Floats need special handling for Inf and NaN.
@@ -1103,6 +1165,18 @@ func DeserializePropertyValue(v any, dec config.Decrypter,
 						return resource.MakeCustomResourceReference(urn, resource.ID(id), packageVersion), nil
 					}
 					return resource.MakeComponentResourceReference(urn, packageVersion), nil
+				case resource.ByteStringSig:
+					encoded, ok := objmap["value"].(string)
+					if !ok {
+						return resource.PropertyValue{},
+							errors.New("malformed byte string: missing or non-string 'value' field")
+					}
+					decoded, err := base64.StdEncoding.DecodeString(encoded)
+					if err != nil {
+						return resource.PropertyValue{},
+							fmt.Errorf("malformed byte string: unable to parse 'value' field: %w", err)
+					}
+					return resource.NewProperty(string(decoded)), nil
 				case floatSignature:
 					hex, ok := objmap["value"].(string)
 					if !ok {

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -125,7 +125,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		},
 		SnippetID: "",
 	}.Make()
-	dep, err := SerializeResource(t.Context(), res, config.NopEncrypter, false /* showSecrets */)
+	dep, _, err := SerializeResource(t.Context(), res, config.NopEncrypter, false /* showSecrets */)
 	require.NoError(t, err)
 
 	// assert some things about the deployment record:
@@ -1135,7 +1135,7 @@ func TestSecretInputRoundTrip(t *testing.T) {
 
 	sm := b64.NewBase64SecretsManager()
 
-	serialized, err := SerializeResource(ctx, res, sm.Encrypter(), false /* showSecrets */)
+	serialized, _, err := SerializeResource(ctx, res, sm.Encrypter(), false /* showSecrets */)
 	require.NoError(t, err)
 
 	deserialized, err := DeserializeResource(serialized, sm.Decrypter())
@@ -1248,4 +1248,95 @@ func TestDeserializeStackOutputs_SecretsInStackOutputs_Decrypted(t *testing.T) {
 		"hello":  resource.NewProperty("world"),
 		"secret": resource.MakeSecret(resource.NewProperty("super secret")),
 	}, outputs)
+}
+
+func TestSerializeByteString(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const raw = "\x00hello \x80\xfe\xff world\xf0\x28"
+
+	serialized, err := SerializePropertyValue(ctx, resource.NewProperty(raw), config.NopEncrypter, false)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		resource.SigKey: resource.ByteStringSig,
+		"value":         "AGhlbGxvIID+/yB3b3JsZPAo",
+	}, serialized)
+
+	// The serialized form must survive a JSON round trip, which plain strings containing invalid
+	// UTF-8 do not (encoding/json replaces invalid bytes with U+FFFD).
+	wire, err := wireValue(ctx, resource.NewProperty(raw))
+	require.NoError(t, err)
+	require.NoError(t, propertyValueSchema.Validate(wire))
+
+	deserialized, err := DeserializePropertyValue(wire, config.NopDecrypter)
+	require.NoError(t, err)
+	assert.Equal(t, resource.NewProperty(raw), deserialized)
+}
+
+// TestByteStringDeploymentRoundTrip verifies that a resource with a property containing non-UTF8
+// bytes round-trips through an untyped deployment and that the deployment is gated by the
+// "byteString" feature.
+func TestByteStringDeploymentRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const raw = "\x00hello \x80\xfe\xff world\xf0\x28"
+	res := &pkgresource.State{
+		Type:    tokens.Type("pkgA:index:res"),
+		URN:     resource.NewURN("dev", "proj", "", tokens.Type("pkgA:index:res"), "r1"),
+		Custom:  true,
+		Inputs:  resource.PropertyMap{"propA": resource.NewProperty(raw)},
+		Outputs: resource.PropertyMap{"propA": resource.MakeSecret(resource.NewProperty(raw))},
+	}
+
+	snap := &deploy.Snapshot{
+		Resources:      []*pkgresource.State{res},
+		SecretsManager: b64.NewBase64SecretsManager(),
+	}
+
+	untyped, err := SerializeUntypedDeployment(ctx, snap, nil)
+	require.NoError(t, err)
+	require.Equal(t, DeploymentSchemaVersionLatest, untyped.Version,
+		"presence of a non-UTF8 string should trigger the latest schema version")
+	require.Equal(t, []string{byteStringFeature}, untyped.Features,
+		"presence of a non-UTF8 string should advertise the byteString feature")
+	require.NoError(t, ValidateUntypedDeployment(untyped))
+
+	roundTripped, err := DeserializeUntypedDeployment(ctx, untyped, b64.Base64SecretsProvider)
+	require.NoError(t, err)
+	require.Len(t, roundTripped.Resources, 1)
+	assert.Equal(t, res.Inputs, roundTripped.Resources[0].Inputs)
+	assert.Equal(t, res.Outputs, roundTripped.Resources[0].Outputs)
+}
+
+func TestSerializeResourceReportsByteString(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const raw = "\x00hello \x80\xfe\xff world\xf0\x28"
+
+	makeState := func(outputs resource.PropertyMap) *pkgresource.State {
+		return &pkgresource.State{
+			Type:    tokens.Type("pkgA:index:res"),
+			URN:     resource.NewURN("dev", "proj", "", tokens.Type("pkgA:index:res"), "r1"),
+			Custom:  true,
+			Inputs:  resource.PropertyMap{},
+			Outputs: outputs,
+		}
+	}
+
+	// A raw byte string hidden inside a secret must still be reported: once serialized the secret is
+	// encrypted and the encoding is invisible to callers.
+	_, encoded, err := SerializeResource(ctx,
+		makeState(resource.PropertyMap{"out": resource.MakeSecret(resource.NewProperty(raw))}),
+		b64.NewBase64SecretsManager().Encrypter(), false)
+	require.NoError(t, err)
+	assert.True(t, encoded)
+
+	_, encoded, err = SerializeResource(ctx,
+		makeState(resource.PropertyMap{"out": resource.NewProperty("plain")}),
+		config.NopEncrypter, false)
+	require.NoError(t, err)
+	assert.False(t, encoded)
 }

--- a/sdk/go/common/apitype/journal.go
+++ b/sdk/go/common/apitype/journal.go
@@ -101,6 +101,11 @@ type JournalEntry struct {
 	// Only set for JournalEntryKindExtensionParameterize entries.
 	ExtensionRef *ExtensionRef `json:"extensionRef,omitempty"`
 	Extension    *Extension    `json:"extension,omitempty"`
+
+	// True if serializing this entry's State, Operation, or NewSnapshot encoded strings containing
+	// non-UTF8 bytes. Such strings inside secrets are invisible after encryption, so the fact must be
+	// recorded at serialization time for replay to gate rebuilt deployments on the byteString feature.
+	RequiresByteString bool `json:"requiresByteString,omitempty"`
 }
 
 func (e JournalEntry) String() string {

--- a/sdk/go/common/apitype/property-values.json
+++ b/sdk/go/common/apitype/property-values.json
@@ -243,6 +243,22 @@
                 }
             },
             "required": ["4dabf18193072939515e22adb298388d", "value"]
+        },
+        {
+            "title": "Byte string property values",
+            "description": "Serialized representation of string values containing bytes that are not valid UTF-8, which cannot be represented directly in JSON.",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Byte string signature",
+                    "const": "803fd3297a5875dc03ca845dda5d2a98"
+                },
+                "value": {
+                    "description": "The base64 encoding of the string's bytes.",
+                    "type": "string"
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d", "value"]
         }
     ]
 }


### PR DESCRIPTION
encoding/json silently replaces bytes that are not valid UTF-8 with
U+FFFD, so such strings were corrupted by a round trip through state.
Serialize them with the byte string signature instead, and gate
their presence behind a new byteString deployment feature (schema
version 4) so that older engines refuse to read state they would corrupt.

The feature is emitted only when a resource or pending operation actually
contains such a string. Detection scans the pre-serialization state under
the resource's lock, so raw bytes inside secrets are counted even though
they are encrypted in the serialized form.
