### PR TITLE
Make workspace Context.New and ReadProject take an explicit directory

### DIFF
--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -52,7 +52,12 @@ func getCurrentStackName(ws pkgWorkspace.Context) (string, error) {
 		return stackName, nil
 	}
 
-	w, err := ws.New()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	w, err := ws.New(cwd)
 	if err != nil {
 		return "", err
 	}
@@ -83,8 +88,13 @@ func getStackNameWithLegacyOrgNameIfNeeded(b backend.Backend, stackName string) 
 
 // SetCurrentStack changes the current stack to the given stack name.
 func SetCurrentStack(ws pkgWorkspace.Context, name string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current working directory: %w", err)
+	}
+
 	// Switch the current workspace to that stack.
-	w, err := ws.New()
+	w, err := ws.New(cwd)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -99,9 +99,11 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"The name of the stack to get info on. Defaults to the current stack")
+		"The name of the stack to get info on. Defaults to the current stack",
+	)
 	cmd.PersistentFlags().BoolVarP(
-		&transitiveDependencies, "transitive", "t", false, "Include transitive dependencies")
+		&transitiveDependencies, "transitive", "t", false, "Include transitive dependencies",
+	)
 
 	return cmd
 }
@@ -149,9 +151,15 @@ func getSummaryAbout(
 		result.Host = &host
 	}
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		addError(err, "Failed to get current working directory")
+		return result
+	}
+
 	var proj *workspace.Project
 	var pwd string
-	if proj, pwd, err = ws.ReadProject(); err != nil {
+	if proj, pwd, err = ws.ReadProject(cwd); err != nil {
 		addError(err, "Failed to read project")
 	} else {
 		projinfo := &engine.Projinfo{Proj: proj, Root: pwd}
@@ -159,11 +167,13 @@ func getSummaryAbout(
 		pluginHost, hostErr := pkghost.New(
 			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
 			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext,
-			packageworkspace.NewResolverServer(reg))
+			packageworkspace.NewResolverServer(reg),
+		)
 		if hostErr != nil {
 			addError(hostErr, "Failed to create plugin host")
 		} else if pwd, program, pluginContext, err := engine.ProjectInfoContext(
-			ctx, projinfo, pluginHost, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil); err != nil {
+			ctx, projinfo, pluginHost, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil,
+		); err != nil {
 			addError(err, "Failed to create plugin context")
 			contract.IgnoreClose(pluginHost)
 		} else {

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -140,8 +140,13 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env
 				cloudURL = filepath.ToSlash(cloudURL)
 			}
 
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
 			// Try to read the current project
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -172,7 +177,8 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env
 					cloudURL = "https://api.pulumi.com"
 				}
 			} else if url := strings.TrimPrefix(strings.TrimPrefix(
-				cloudURL, "https://"), "http://"); strings.HasPrefix(url, "app.pulumi.com/") ||
+				cloudURL, "https://",
+			), "http://"); strings.HasPrefix(url, "app.pulumi.com/") ||
 				strings.HasPrefix(url, "pulumi.com") {
 				return fmt.Errorf("%s is not a valid self-hosted backend, "+
 					"use `pulumi login` without arguments to log into the Pulumi Cloud backend", cloudURL)
@@ -202,21 +208,25 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env
 			if oidcToken != "" {
 				// Extract defaults from JWT token before creating auth context
 				resolvedOrg, resolvedTeam, resolvedUser, innerErr := extractOIDCDefaults(
-					oidcOrg, oidcTeam, oidcUser, oidcToken)
+					oidcOrg, oidcTeam, oidcUser, oidcToken,
+				)
 				if innerErr != nil {
 					return fmt.Errorf("problem logging in: %w", innerErr)
 				}
 
 				authContext, innerErr := workspace.NewAuthContextForTokenExchange(
-					resolvedOrg, resolvedTeam, resolvedUser, oidcToken, oidcExpiration)
+					resolvedOrg, resolvedTeam, resolvedUser, oidcToken, oidcExpiration,
+				)
 				if innerErr != nil {
 					return fmt.Errorf("problem logging in: %w", innerErr)
 				}
 				be, err = lm.LoginFromAuthContext(
-					ctx, cmdutil.Diag(), cloudURL, project, true /* setCurrent */, insecure, authContext)
+					ctx, cmdutil.Diag(), cloudURL, project, true /* setCurrent */, insecure, authContext,
+				)
 			} else {
 				be, err = lm.Login(
-					ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent */, insecure, displayOptions.Color)
+					ctx, ws, cmdutil.Diag(), cloudURL, project, true /* setCurrent */, insecure, displayOptions.Color,
+				)
 			}
 
 			if err != nil {
@@ -270,7 +280,8 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env
 	cmd.PersistentFlags().StringVar(&oidcUser, "oidc-user", "", "The user when exchanging for a personal token")
 	cmd.PersistentFlags().StringVar(
 		&oidcExpiration, "oidc-expiration", "",
-		"The expiration for the cloud backend access token in duration format (e.g. '15m', '24h')")
+		"The expiration for the cloud backend access token in duration format (e.g. '15m', '24h')",
+	)
 
 	return cmd
 }
@@ -381,7 +392,8 @@ func extractOIDCDefaults(organization, team, user, token string) (string, string
 		return "", "", "", fmt.Errorf(
 			"JWT scope contains both team '%s' and user '%s'. "+
 				"Only one of team or user may be specified for token exchange",
-			jwtTeam, jwtUser)
+			jwtTeam, jwtUser,
+		)
 	}
 
 	// Validate that explicit flags don't conflict with JWT claims
@@ -390,21 +402,24 @@ func extractOIDCDefaults(organization, team, user, token string) (string, string
 			"--oidc-org '%s' conflicts with JWT aud claim organization '%s'. "+
 				"The JWT aud claim takes precedence during token exchange. "+
 				"Either omit --oidc-org to use the JWT value, or ensure they match",
-			organization, jwtOrg)
+			organization, jwtOrg,
+		)
 	}
 	if team != "" && jwtTeam != "" && team != jwtTeam {
 		return "", "", "", fmt.Errorf(
 			"--oidc-team '%s' conflicts with JWT scope team '%s'. "+
 				"The JWT scope takes precedence during token exchange. "+
 				"Either omit --oidc-team to use the JWT value, or ensure they match",
-			team, jwtTeam)
+			team, jwtTeam,
+		)
 	}
 	if user != "" && jwtUser != "" && user != jwtUser {
 		return "", "", "", fmt.Errorf(
 			"--oidc-user '%s' conflicts with JWT scope user '%s'. "+
 				"The JWT scope takes precedence during token exchange. "+
 				"Either omit --oidc-user to use the JWT value, or ensure they match",
-			user, jwtUser)
+			user, jwtUser,
+		)
 	}
 
 	// Use JWT values if explicit flags not provided

--- a/pkg/cmd/pulumi/auth/login_test.go
+++ b/pkg/cmd/pulumi/auth/login_test.go
@@ -111,7 +111,7 @@ func TestLoginURLResolution(t *testing.T) {
 		{
 			name: "project backend URL used when no env var",
 			ws: &pkgWorkspace.MockContext{
-				ReadProjectF: func() (*workspace.Project, string, error) {
+				ReadProjectF: func(string) (*workspace.Project, string, error) {
 					return &workspace.Project{
 						Backend: &workspace.ProjectBackend{URL: "https://project-backend.example.com"},
 					}, "", nil
@@ -433,7 +433,8 @@ func TestExtractOIDCDefaults(t *testing.T) {
 			t.Parallel()
 
 			gotOrg, gotTeam, gotUser, err := extractOIDCDefaults(
-				tt.organization, tt.team, tt.user, tt.token)
+				tt.organization, tt.team, tt.user, tt.token,
+			)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -17,6 +17,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -68,8 +69,13 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "Logged out of everything")
 			} else {
 				if cloudURL == "" {
+					cwd, err := os.Getwd()
+					if err != nil {
+						return fmt.Errorf("getting current working directory: %w", err)
+					}
+
 					// Try to read the current project
-					project, _, err := ws.ReadProject()
+					project, _, err := ws.ReadProject(cwd)
 					if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 						return err
 					}

--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -30,8 +31,13 @@ import (
 )
 
 func IsDIYBackend(ws pkgWorkspace.Context, opts display.Options) (bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, fmt.Errorf("getting current working directory: %w", err)
+	}
+
 	// Try to read the current project
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return false, err
 	}

--- a/pkg/cmd/pulumi/cloud/resolve.go
+++ b/pkg/cmd/pulumi/cloud/resolve.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	pkgBackend "github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -64,9 +65,13 @@ type ResolvedContext struct {
 // LoggedIn=false rather than prompting or failing. Callers that require
 // authentication should check LoggedIn and surface their own error.
 func ResolveContext(ctx context.Context) (*ResolvedContext, error) {
-	ws := pkgWorkspace.Instance
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getting current working directory: %w", err)
+	}
 
-	project, _, err := ws.ReadProject()
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, fmt.Errorf("reading project: %w", err)
 	}

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -77,7 +77,12 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -130,20 +135,25 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
-		"Show secret values when listing config instead of displaying blinded values")
+		"Show secret values when listing config instead of displaying blinded values",
+	)
 	cmd.Flags().BoolVar(
 		&open, "open", false,
 		"Open and resolve any environments listed in the stack configuration. "+
-			"Defaults to true if --show-secrets is set, false otherwise")
+			"Defaults to true if --show-secrets is set, false otherwise",
+	)
 	cmd.Flags().BoolVarP(
 		&jsonOut, "json", "j", false,
-		"Emit output as JSON")
+		"Emit output as JSON",
+	)
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
+		"The name of the stack to operate on. Defaults to the current stack",
+	)
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
-		"Use the configuration values in the specified file rather than detecting the file name")
+		"Use the configuration values in the specified file rather than detecting the file name",
+	)
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
@@ -176,7 +186,12 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -218,7 +233,8 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				return err
 			}
 			destinationProjectStack, err := cmdStack.LoadProjectStack(
-				ctx, cmdutil.Diag(), project, destinationStack, *configFile)
+				ctx, cmdutil.Diag(), project, destinationStack, *configFile,
+			)
 			if err != nil {
 				return err
 			}
@@ -284,10 +300,12 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 
 	copyCommand.PersistentFlags().BoolVar(
 		&path, "path", false,
-		"The key contains a path to a property in a map or list to set")
+		"The key contains a path to a property in a map or list to set",
+	)
 	copyCommand.PersistentFlags().StringVarP(
 		&destinationStackName, "dest", "d", "",
-		"The name of the new stack to copy the config to")
+		"The name of the new stack to copy the config to",
+	)
 
 	return copyCommand
 }
@@ -344,13 +362,16 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 
 	getCmd.Flags().BoolVarP(
 		&jsonOut, "json", "j", false,
-		"Emit output as JSON")
+		"Emit output as JSON",
+	)
 	getCmd.Flags().BoolVar(
 		&open, "open", true,
-		"Open and resolve any environments listed in the stack configuration")
+		"Open and resolve any environments listed in the stack configuration",
+	)
 	getCmd.PersistentFlags().BoolVar(
 		&path, "path", false,
-		"The key contains a path to a property in a map or list to get")
+		"The key contains a path to a property in a map or list to get",
+	)
 
 	return getCmd
 }
@@ -374,7 +395,12 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -429,7 +455,8 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 
 	rmCmd.PersistentFlags().BoolVar(
 		&path, "path", false,
-		"The key contains a path to a property in a map or list to remove")
+		"The key contains a path to a property in a map or list to remove",
+	)
 
 	return rmCmd
 }
@@ -453,7 +480,12 @@ func newConfigRemoveAllCmd(ws pkgWorkspace.Context, stack *string, configFile *s
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -511,7 +543,8 @@ func newConfigRemoveAllCmd(ws pkgWorkspace.Context, stack *string, configFile *s
 
 	rmAllCmd.PersistentFlags().BoolVar(
 		&path, "path", false,
-		"Parse the keys as paths in a map or list rather than raw strings")
+		"Parse the keys as paths in a map or list rather than raw strings",
+	)
 
 	return rmAllCmd
 }
@@ -529,7 +562,12 @@ func newConfigRefreshCmd(
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -649,7 +687,8 @@ func newConfigRefreshCmd(
 	constrictor.AttachArguments(refreshCmd, constrictor.NoArgs)
 
 	refreshCmd.PersistentFlags().BoolVarP(
-		&force, "force", "f", false, "Overwrite configuration file, if it exists, without creating a backup")
+		&force, "force", "f", false, "Overwrite configuration file, if it exists, without creating a backup",
+	)
 
 	return refreshCmd
 }
@@ -693,7 +732,12 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -729,19 +773,24 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 
 	setCmd.PersistentFlags().BoolVar(
 		&configSetCmd.Path, "path", false,
-		"The key contains a path to a property in a map or list to set")
+		"The key contains a path to a property in a map or list to set",
+	)
 	setCmd.PersistentFlags().BoolVar(
 		&configSetCmd.Plaintext, "plaintext", false,
-		"Save the value as plaintext (unencrypted)")
+		"Save the value as plaintext (unencrypted)",
+	)
 	setCmd.PersistentFlags().BoolVar(
 		&configSetCmd.Secret, "secret", false,
-		"Encrypt the value instead of storing it in plaintext")
+		"Encrypt the value instead of storing it in plaintext",
+	)
 	setCmd.PersistentFlags().StringVar(
-		&configSetCmd.Type, "type", "", "Save the value as the given type.  Allowed values are string, bool, int, and float")
+		&configSetCmd.Type, "type", "", "Save the value as the given type.  Allowed values are string, bool, int, and float",
+	)
 	setCmd.MarkFlagsMutuallyExclusive("secret", "plaintext", "type")
 	setCmd.PersistentFlags().BoolVar(
 		&configSetCmd.Raw, "raw", false,
-		"When setting the value through stdin, do not trim trailing newlines from the value")
+		"When setting the value through stdin, do not trim trailing newlines from the value",
+	)
 	setCmd.DisableFlagsInUseLine = true
 
 	return setCmd
@@ -895,7 +944,12 @@ func newConfigSetAllCmd(
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil {
 				return err
 			}
@@ -1035,13 +1089,16 @@ func newConfigSetAllCmd(
 
 	setCmd.PersistentFlags().BoolVar(
 		&path, "path", false,
-		"Parse the keys as paths in a map or list rather than raw strings")
+		"Parse the keys as paths in a map or list rather than raw strings",
+	)
 	setCmd.PersistentFlags().StringArrayVar(
 		&plaintextArgs, "plaintext", []string{},
-		"Marks a value as plaintext (unencrypted)")
+		"Marks a value as plaintext (unencrypted)",
+	)
 	setCmd.PersistentFlags().StringArrayVar(
 		&secretArgs, "secret", []string{},
-		"Marks a value as secret to be encrypted")
+		"Marks a value as secret to be encrypted",
+	)
 	setCmd.PersistentFlags().StringVar(
 		&jsonArg, "json", "",
 		"Read values from a JSON string in the format produced by 'pulumi config --json'",
@@ -1247,7 +1304,12 @@ func getConfig(
 	openEnvironment bool,
 	configFile string,
 ) error {
-	project, _, err := ws.ReadProject()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	project, _, err := ws.ReadProject(cwd)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -127,7 +127,12 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 ) (*workspace.ProjectStack, *workspace.Project, *backend.Stack, error) {
 	opts := display.Options{Color: cmd.color}
 
-	project, _, err := cmd.ws.ReadProject()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	project, _, err := cmd.ws.ReadProject(cwd)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"text/template"
 
@@ -64,16 +65,20 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 
 	cmd.Flags().StringVar(
 		&impl.envName, "env", "",
-		`The name of the environment to create. Defaults to "<project name>/<stack name>"`)
+		`The name of the environment to create. Defaults to "<project name>/<stack name>"`,
+	)
 	cmd.Flags().BoolVar(
 		&impl.showSecrets, "show-secrets", false,
-		"Show secret values in plaintext instead of ciphertext")
+		"Show secret values in plaintext instead of ciphertext",
+	)
 	cmd.Flags().BoolVar(
 		&impl.keepConfig, "keep-config", false,
-		"Do not remove configuration values from the stack after creating the environment")
+		"Do not remove configuration values from the stack after creating the environment",
+	)
 	cmd.Flags().BoolVarP(
 		&impl.yes, "yes", "y", false,
-		"True to save the created environment without prompting")
+		"True to save the created environment without prompting",
+	)
 
 	return cmd
 }
@@ -105,7 +110,12 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 
 	opts := display.Options{Color: cmd.parent.color}
 
-	project, _, err := cmd.parent.ws.ReadProject()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	project, _, err := cmd.parent.ws.ReadProject(cwd)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -99,7 +99,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		},
 
 		ws: &pkgWorkspace.MockContext{
-			ReadProjectF: func() (*workspace.Project, string, error) {
+			ReadProjectF: func(string) (*workspace.Project, string, error) {
 				p, err := workspace.LoadProjectBytes([]byte(projectYAML), "Pulumi.yaml", encoding.YAML)
 				if err != nil {
 					return nil, "", err

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -797,7 +797,7 @@ func TestConfigSetAll(t *testing.T) {
 			configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
 
 			ws := &pkgWorkspace.MockContext{
-				ReadProjectF: func() (*workspace.Project, string, error) {
+				ReadProjectF: func(string) (*workspace.Project, string, error) {
 					return &workspace.Project{
 						Name: "testProject",
 					}, "", nil
@@ -955,7 +955,7 @@ func TestConfigRefresh(t *testing.T) {
 		}
 
 		ws := &pkgWorkspace.MockContext{
-			ReadProjectF: func() (*workspace.Project, string, error) {
+			ReadProjectF: func(string) (*workspace.Project, string, error) {
 				return &workspace.Project{Name: "testProject"}, "", nil
 			},
 			GetStoredCredentialsF: func() (workspace.Credentials, error) {
@@ -1423,7 +1423,7 @@ func TestConfigPathOperations(t *testing.T) {
 			configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
 
 			ws := &pkgWorkspace.MockContext{
-				ReadProjectF: func() (*workspace.Project, string, error) {
+				ReadProjectF: func(string) (*workspace.Project, string, error) {
 					return &project, tmpdir, nil
 				},
 			}

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -74,7 +74,8 @@ func GetStackConfigurationOrLatest(
 			}
 			return nil, err
 		},
-		configFile)
+		configFile,
+	)
 }
 
 func getStackConfigurationWithFallback(
@@ -95,7 +96,8 @@ func getStackConfigurationWithFallback(
 		cfg, err := fallbackGetConfig(err)
 		if err != nil {
 			return backend.StackConfiguration{}, nil, fmt.Errorf(
-				"stack configuration could not be loaded from either Pulumi.yaml or the backend: %w", err)
+				"stack configuration could not be loaded from either Pulumi.yaml or the backend: %w", err,
+			)
 		}
 		workspaceStack = &workspace.ProjectStack{
 			Config: cfg,
@@ -351,7 +353,12 @@ func ParseConfigKey(ws pkgWorkspace.Context, key string, path bool) (config.Key,
 	// As a convenience, we'll treat any key with no delimiter as if:
 	// <program-name>:<key> had been written instead
 	if !strings.Contains(key, tokens.TokenDelimiter) {
-		proj, _, err := ws.ReadProject()
+		cwd, err := os.Getwd()
+		if err != nil {
+			return config.Key{}, fmt.Errorf("getting current working directory: %w", err)
+		}
+
+		proj, _, err := ws.ReadProject(cwd)
 		if err != nil {
 			return config.Key{}, err
 		}

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -447,7 +447,8 @@ func TestStackEnvConfig(t *testing.T) {
 	cfg.Config = config.Map{}
 
 	err = workspace.ApplyProjectConfig(
-		ctx, "mystack", &project, cfg.Environment, cfg.Config, config.NopEncrypter, config.NopDecrypter)
+		ctx, "mystack", &project, cfg.Environment, cfg.Config, config.NopEncrypter, config.NopDecrypter,
+	)
 	require.NoError(t, err)
 
 	assert.Equal(t, config.Map{
@@ -729,7 +730,7 @@ func TestParseConfigKey(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "test-project",
 			}, "/test/path", nil

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -44,8 +45,13 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
 			// Try to read the current project
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -108,7 +114,8 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 	cmd.PersistentFlags().StringVarP(
-		&stackName, "stack", "s", "", "The name of the stack to view")
+		&stackName, "stack", "s", "", "The name of the stack to view",
+	)
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -511,7 +511,7 @@ func runConvert(
 			return fmt.Errorf("changing the working directory: %w", err)
 		}
 
-		proj, root, err := ws.ReadProject(cwd)
+		proj, root, err := ws.ReadProject(outDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -123,28 +123,35 @@ func NewConvertCmd(lm cmdBackend.LoginManager, ws pkgWorkspace.Context) *cobra.C
 	constrictor.AttachArguments(cmd, constrictor.UnrestrictedArgs)
 
 	cmd.PersistentFlags().StringVar(
-		&language, "language", "", "Which language plugin to use to generate the Pulumi project")
+		&language, "language", "", "Which language plugin to use to generate the Pulumi project",
+	)
 	if err := cmd.MarkPersistentFlagRequired("language"); err != nil {
 		panic("failed to mark 'language' as a required flag")
 	}
 
 	cmd.PersistentFlags().StringVar(
-		&from, "from", "yaml", "Which converter plugin to use to read the source program")
+		&from, "from", "yaml", "Which converter plugin to use to read the source program",
+	)
 
 	cmd.PersistentFlags().StringVar(
-		&outDir, "out", ".", "The output directory to write the converted project to")
+		&outDir, "out", ".", "The output directory to write the converted project to",
+	)
 
 	cmd.PersistentFlags().BoolVar(
-		&generateOnly, "generate-only", false, "Generate the converted program(s) only; do not install dependencies")
+		&generateOnly, "generate-only", false, "Generate the converted program(s) only; do not install dependencies",
+	)
 
 	cmd.PersistentFlags().StringSliceVar(
-		&mappings, "mappings", []string{}, "Any mapping files to use in the conversion")
+		&mappings, "mappings", []string{}, "Any mapping files to use in the conversion",
+	)
 
 	cmd.PersistentFlags().BoolVar(
-		&strict, "strict", false, "Fail the conversion on errors such as missing variables")
+		&strict, "strict", false, "Fail the conversion on errors such as missing variables",
+	)
 
 	cmd.PersistentFlags().StringVar(
-		&name, "name", "", "The name to use for the converted project; defaults to the directory of the source project")
+		&name, "name", "", "The name to use for the converted project; defaults to the directory of the source project",
+	)
 
 	return cmd
 }
@@ -504,7 +511,7 @@ func runConvert(
 			return fmt.Errorf("changing the working directory: %w", err)
 		}
 
-		proj, root, err := ws.ReadProject()
+		proj, root, err := ws.ReadProject(cwd)
 		if err != nil {
 			return err
 		}
@@ -513,13 +520,15 @@ func runConvert(
 		pluginHost, err := pkghost.New(
 			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
 			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext,
-			packageworkspace.NewResolverServer(reg))
+			packageworkspace.NewResolverServer(reg),
+		)
 		if err != nil {
 			return err
 		}
 		defer contract.IgnoreClose(pluginHost) // host is owned here, closed after the context
 		_, main, pctx, err := engine.ProjectInfoContext(
-			ctx, projinfo, pluginHost, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
+			ctx, projinfo, pluginHost, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/deployment/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment/deployment_run.go
@@ -17,6 +17,7 @@ package deployment
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -63,7 +64,11 @@ func newDeploymentRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 				SuppressPermalink: suppressPermalink,
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -113,11 +118,13 @@ func newDeploymentRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(
 		&suppressPermalink, "suppress-permalink", false,
-		"Suppress display of the state permalink")
+		"Suppress display of the state permalink",
+	)
 
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
+		"The name of the stack to operate on. Defaults to the current stack",
+	)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -80,7 +80,12 @@ func initializeDeploymentSettingsCmd(
 		IsInteractive: interactive,
 	}
 
-	project, _, err := ws.ReadProject()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/deployment/remote.go
+++ b/pkg/cmd/pulumi/deployment/remote.go
@@ -186,64 +186,82 @@ type RemoteArgs struct {
 func (r *RemoteArgs) ApplyFlagsForDeploymentCommand(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&r.InheritSettings, "inherit-settings", true,
-		"Inherit deployment settings from the current stack")
+		"Inherit deployment settings from the current stack",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&r.SuppressStreamLogs, "suppress-stream-logs", true,
-		"Suppress log streaming of the deployment job")
+		"Suppress log streaming of the deployment job",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&r.EnvVars, "env", []string{},
 		"Environment variables to use in the remote operation of the form NAME=value "+
-			"(e.g. `--env FOO=bar`)")
+			"(e.g. `--env FOO=bar`)",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&r.SecretEnvVars, "env-secret", []string{},
 		"Environment variables with secret values to use in the remote operation of the form "+
-			"NAME=secretvalue (e.g. `--env FOO=secret`)")
+			"NAME=secretvalue (e.g. `--env FOO=secret`)",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&r.PreRunCommands, "pre-run-command", []string{},
-		"Commands to run before the remote operation")
+		"Commands to run before the remote operation",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&r.SkipInstallDependencies, "skip-install-dependencies", false,
-		"Whether to skip the default dependency installation step")
+		"Whether to skip the default dependency installation step",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitBranch, "git-branch", "",
 		"Git branch to deploy; this is mutually exclusive with --git-commit; "+
-			"either value needs to be specified")
+			"either value needs to be specified",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitCommit, "git-commit", "",
 		"Git commit hash of the commit to deploy (if used, HEAD will be in detached mode); "+
-			"this is mutually exclusive with --git-branch; either value needs to be specified")
+			"this is mutually exclusive with --git-branch; either value needs to be specified",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitRepoDir, "git-repo-dir", "",
 		"The directory to work from in the project's source repository "+
-			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root")
+			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthAccessToken, "git-auth-access-token", "",
-		"Git personal access token")
+		"Git personal access token",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthSSHPrivateKey, "git-auth-ssh-private-key", "",
-		"Git SSH private key; use --git-auth-password for the password, if needed")
+		"Git SSH private key; use --git-auth-password for the password, if needed",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthSSHPrivateKeyPath, "git-auth-ssh-private-key-path", "",
-		"Git SSH private key path; use --git-auth-password for the password, if needed")
+		"Git SSH private key path; use --git-auth-password for the password, if needed",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthPassword, "git-auth-password", "",
-		"Git password; for use with username or with an SSH private key")
+		"Git password; for use with username or with an SSH private key",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthUsername, "git-auth-username", "",
-		"Git username")
+		"Git username",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.ExecutorImage, "executor-image", "",
-		"The Docker image to use for the executor")
+		"The Docker image to use for the executor",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.ExecutorImageUsername, "executor-image-username", "",
-		"The username for the credentials with access to the Docker image to use for the executor")
+		"The username for the credentials with access to the Docker image to use for the executor",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.ExecutorImagePassword, "executor-image-password", "",
-		"The password for the credentials with access to the Docker image to use for the executor")
+		"The password for the credentials with access to the Docker image to use for the executor",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.AgentPoolID, "agent-pool-id", "",
 		"The agent pool to use to run the deployment job. When empty, the Pulumi Cloud shared queue "+
-			"will be used.")
+			"will be used.",
+	)
 }
 
 // Add flags to support remote operations
@@ -254,67 +272,86 @@ func (r *RemoteArgs) ApplyFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVar(
 		&r.Remote, "remote", false,
-		"[EXPERIMENTAL] Run the operation remotely")
+		"[EXPERIMENTAL] Run the operation remotely",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&r.SuppressStreamLogs, "suppress-stream-logs", false,
-		"[EXPERIMENTAL] Suppress log streaming of the deployment job")
+		"[EXPERIMENTAL] Suppress log streaming of the deployment job",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&r.InheritSettings, "remote-inherit-settings", false,
-		"[EXPERIMENTAL] Inherit deployment settings from the current stack")
+		"[EXPERIMENTAL] Inherit deployment settings from the current stack",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&r.EnvVars, "remote-env", []string{},
 		"[EXPERIMENTAL] Environment variables to use in the remote operation of the form NAME=value "+
-			"(e.g. `--remote-env FOO=bar`)")
+			"(e.g. `--remote-env FOO=bar`)",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&r.SecretEnvVars, "remote-env-secret", []string{},
 		"[EXPERIMENTAL] Environment variables with secret values to use in the remote operation of the form "+
-			"NAME=secretvalue (e.g. `--remote-env FOO=secret`)")
+			"NAME=secretvalue (e.g. `--remote-env FOO=secret`)",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&r.PreRunCommands, "remote-pre-run-command", []string{},
-		"[EXPERIMENTAL] Commands to run before the remote operation")
+		"[EXPERIMENTAL] Commands to run before the remote operation",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&r.SkipInstallDependencies, "remote-skip-install-dependencies", false,
-		"[EXPERIMENTAL] Whether to skip the default dependency installation step")
+		"[EXPERIMENTAL] Whether to skip the default dependency installation step",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitBranch, "remote-git-branch", "",
 		"[EXPERIMENTAL] Git branch to deploy; this is mutually exclusive with --remote-git-commit; "+
-			"either value needs to be specified")
+			"either value needs to be specified",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitCommit, "remote-git-commit", "",
 		"[EXPERIMENTAL] Git commit hash of the commit to deploy (if used, HEAD will be in detached mode); "+
-			"this is mutually exclusive with --remote-git-branch; either value needs to be specified")
+			"this is mutually exclusive with --remote-git-branch; either value needs to be specified",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitRepoDir, "remote-git-repo-dir", "",
 		"[EXPERIMENTAL] The directory to work from in the project's source repository "+
-			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root")
+			"where Pulumi.yaml is located; used when Pulumi.yaml is not in the project source root",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthAccessToken, "remote-git-auth-access-token", "",
-		"[EXPERIMENTAL] Git personal access token")
+		"[EXPERIMENTAL] Git personal access token",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthSSHPrivateKey, "remote-git-auth-ssh-private-key", "",
-		"[EXPERIMENTAL] Git SSH private key; use --remote-git-auth-password for the password, if needed")
+		"[EXPERIMENTAL] Git SSH private key; use --remote-git-auth-password for the password, if needed",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthSSHPrivateKeyPath, "remote-git-auth-ssh-private-key-path", "",
-		"[EXPERIMENTAL] Git SSH private key path; use --remote-git-auth-password for the password, if needed")
+		"[EXPERIMENTAL] Git SSH private key path; use --remote-git-auth-password for the password, if needed",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthPassword, "remote-git-auth-password", "",
-		"[EXPERIMENTAL] Git password; for use with username or with an SSH private key")
+		"[EXPERIMENTAL] Git password; for use with username or with an SSH private key",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.GitAuthUsername, "remote-git-auth-username", "",
-		"[EXPERIMENTAL] Git username")
+		"[EXPERIMENTAL] Git username",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.ExecutorImage, "remote-executor-image", "",
-		"[EXPERIMENTAL] The Docker image to use for the executor")
+		"[EXPERIMENTAL] The Docker image to use for the executor",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.ExecutorImageUsername, "remote-executor-image-username", "",
-		"[EXPERIMENTAL] The username for the credentials with access to the Docker image to use for the executor")
+		"[EXPERIMENTAL] The username for the credentials with access to the Docker image to use for the executor",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.ExecutorImagePassword, "remote-executor-image-password", "",
-		"[EXPERIMENTAL] The password for the credentials with access to the Docker image to use for the executor")
+		"[EXPERIMENTAL] The password for the credentials with access to the Docker image to use for the executor",
+	)
 	cmd.PersistentFlags().StringVar(
 		&r.AgentPoolID, "remote-agent-pool-id", "",
 		"[EXPERIMENTAL] The agent pool to use to run the deployment job. When empty, the Pulumi Cloud shared queue "+
-			"will be used.")
+			"will be used.",
+	)
 }
 
 func ValidateRemoteDeploymentFlags(url string, args RemoteArgs) error {
@@ -396,13 +433,19 @@ func RunDeployment(ctx context.Context, ws pkgWorkspace.Context, cmd *cobra.Comm
 		key, err := os.ReadFile(args.GitAuthSSHPrivateKeyPath)
 		if err != nil {
 			return fmt.Errorf(
-				"reading SSH private key path %q: %w", args.GitAuthSSHPrivateKeyPath, err)
+				"reading SSH private key path %q: %w", args.GitAuthSSHPrivateKeyPath, err,
+			)
 		}
 		sshPrivateKey = string(key)
 	}
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current working directory: %w", err)
+	}
+
 	// Try to read the current project
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -141,7 +141,7 @@ func NewDoCmd(
 			Color: cmdutil.GetGlobalColorization(),
 		})
 
-		proj, root, err := ws.ReadProject()
+		proj, root, err := ws.ReadProject("")
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 			return nil, nil, fmt.Errorf("read project: %w", err)
 		}
@@ -473,7 +473,7 @@ to use another format.`,
 // Errors reading the workspace are swallowed: the stack identity is best-effort context for PCL
 // evaluation, not a hard requirement, and `do` must stay usable when no workspace is configured.
 func currentStackIdentity(ws pkgWorkspace.Context) (organization, stack string) {
-	w, err := ws.New()
+	w, err := ws.New("")
 	if err != nil {
 		return "", ""
 	}

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -1305,7 +1305,7 @@ func TestDoCmdFunctionInvokeWithProjectContext(t *testing.T) {
 
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name:    tokens.PackageName("my-project"),
 				Runtime: workspace.NewProjectRuntimeInfo("yaml", nil),

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -925,13 +925,13 @@ func providerFlagStackContext(
 
 	proj := &workspace.Project{Name: tokens.PackageName("proj")}
 	mws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return proj, t.TempDir(), nil
 		},
-		// `do` populates evalContext.Stack from ws.New().Settings().Stack via currentStackIdentity;
+		// `do` populates evalContext.Stack from ws.New("").Settings().Stack via currentStackIdentity;
 		// that determines whether configureProvider considers us "in a stack context". PULUMI_STACK
 		// above only feeds the parallel path used by state.CurrentStack — both have to agree.
-		NewF: func() (pkgWorkspace.W, error) {
+		NewF: func(_ string) (pkgWorkspace.W, error) {
 			return &pkgWorkspace.MockW{
 				SettingsF: func() *pkgWorkspace.Settings {
 					return &pkgWorkspace.Settings{Stack: "myorg/proj/dev"}

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -878,7 +878,7 @@ func TestCurrentStackIdentity(t *testing.T) {
 
 	mockWS := func(stack string, newErr error) *pkgWorkspace.MockContext {
 		return &pkgWorkspace.MockContext{
-			NewF: func() (pkgWorkspace.W, error) {
+			NewF: func(_ string) (pkgWorkspace.W, error) {
 				if newErr != nil {
 					return nil, newErr
 				}
@@ -926,13 +926,13 @@ func TestDoCmdFunctionInvokeWithStackContext(t *testing.T) {
 
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name:    tokens.PackageName("my-project"),
 				Runtime: workspace.NewProjectRuntimeInfo("yaml", nil),
 			}, root, nil
 		},
-		NewF: func() (pkgWorkspace.W, error) {
+		NewF: func(_ string) (pkgWorkspace.W, error) {
 			return &pkgWorkspace.MockW{
 				SettingsF: func() *pkgWorkspace.Settings {
 					return &pkgWorkspace.Settings{Stack: "acme/my-project/dev"}
@@ -1002,7 +1002,7 @@ func TestDoCmdFunctionInvokeWithoutStackContext(t *testing.T) {
 
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name:    tokens.PackageName("my-project"),
 				Runtime: workspace.NewProjectRuntimeInfo("yaml", nil),

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -122,7 +122,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			}
 
 			// Load the project
-			proj, root, err := ws.ReadProject()
+			proj, root, err := ws.ReadProject("")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/logs/decrypt.go
+++ b/pkg/cmd/pulumi/logs/decrypt.go
@@ -203,7 +203,7 @@ func secretsManagerFromStack(ctx context.Context, s backend.Stack) (secrets.Mana
 }
 
 func currentStackName(ws pkgWorkspace.Context) string {
-	w, err := ws.New()
+	w, err := ws.New("")
 	if err != nil {
 		return ""
 	}

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -62,7 +62,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 			}
 
 			// Fetch the project.
-			proj, _, err := ws.ReadProject()
+			proj, _, err := ws.ReadProject("")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -300,7 +300,7 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 	ws := pkgWorkspace.Instance
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -580,7 +580,7 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 
 	// Override the workspace to surface a non-NotFound error from ReadProject.
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return nil, "", errors.New("synthetic ReadProject failure")
 		},
 	}

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -326,7 +326,7 @@ func TestResolveTaskTarget_WorkspaceStackOwnerWinsOverDefaultOrg(t *testing.T) {
 	}
 
 	wsCtx := &pkgWorkspace.MockContext{
-		NewF: func() (pkgWorkspace.W, error) {
+		NewF: func(_ string) (pkgWorkspace.W, error) {
 			return &pkgWorkspace.MockW{
 				SettingsF: func() *pkgWorkspace.Settings {
 					return &pkgWorkspace.Settings{Stack: "otherorg/proj/dev"}

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -232,7 +232,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	}
 	defer func() { _ = os.Chdir(prevDir) }()
 
-	proj, root, err := p.Workspace.ReadProject()
+	proj, root, err := p.Workspace.ReadProject("")
 	if err != nil {
 		return failedResult(a, "", fmt.Errorf("reading project: %w", err))
 	}

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -411,7 +411,7 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 	t.Cleanup(func() { cmdBackend.DefaultLoginManager = prev })
 
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return &workspace.Project{Name: "p"}, dir, nil
 		},
 	}
@@ -472,7 +472,7 @@ func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 			t.Cleanup(func() { cmdBackend.DefaultLoginManager = prev })
 
 			ws := &pkgWorkspace.MockContext{
-				ReadProjectF: func() (*workspace.Project, string, error) {
+				ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 					return &workspace.Project{Name: "p"}, dir, nil
 				},
 			}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -782,7 +782,7 @@ func NewImportCmd() *cobra.Command {
 
 			ws := pkgWorkspace.Instance
 
-			proj, root, err := ws.ReadProject()
+			proj, root, err := ws.ReadProject("")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/operations/io.go
+++ b/pkg/cmd/pulumi/operations/io.go
@@ -66,7 +66,7 @@ func parseAndSaveConfigArray(
 // client address is present, the returned project will always have the runtime set to "client"
 // with the address option set to the client address.
 func readProjectForUpdate(ws pkgWorkspace.Context, clientAddress string) (*workspace.Project, string, error) {
-	proj, root, err := ws.ReadProject()
+	proj, root, err := ws.ReadProject("")
 	if err != nil {
 		oerr := err
 		if errors.Is(err, workspace.ErrProjectNotFound) {

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -408,7 +408,7 @@ func NewUpCmd() *cobra.Command {
 		}
 
 		// Load the project, update the name & description, remove the template section, and save it.
-		proj, root, err := ws.ReadProject()
+		proj, root, err := ws.ReadProject("")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -118,7 +118,7 @@ func NewWatchCmd() *cobra.Command {
 				return err
 			}
 
-			proj, root, err := ws.ReadProject()
+			proj, root, err := ws.ReadProject("")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/org/org.go
+++ b/pkg/cmd/pulumi/org/org.go
@@ -45,7 +45,7 @@ func NewOrgCmd() *cobra.Command {
 
 			// Try to read the current project
 			ws := pkgWorkspace.Instance
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -115,7 +115,7 @@ func newOrgSetDefaultCmd() *cobra.Command {
 
 			// Try to read the current project
 			ws := pkgWorkspace.Instance
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -166,7 +166,7 @@ func newOrgGetDefaultCmd() *cobra.Command {
 
 			// Try to read the current project
 			ws := pkgWorkspace.Instance
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/org/org_member_list.go
+++ b/pkg/cmd/pulumi/org/org_member_list.go
@@ -133,7 +133,7 @@ func defaultOrgMemberListClientFactory(
 	ws := pkgWorkspace.Instance
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, "", err
 	}

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -73,7 +73,7 @@ func defaultOrgRoleClientFactory(ctx context.Context, orgFlag string) (orgRoleCl
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
 	ws := pkgWorkspace.Instance
 
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, "", err
 	}

--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -119,7 +119,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	}
 	// Try to read the current project
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -53,7 +53,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	}
 	// Try to read the current project
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
@@ -96,7 +96,7 @@ func newOrgWebhookDeliveryListCmd() *cobra.Command {
 }
 
 func (c *orgWebhookDeliveryListCmd) run(ctx context.Context, webhookName string) error {
-	project, _, err := c.ws.ReadProject()
+	project, _, err := c.ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_edit.go
+++ b/pkg/cmd/pulumi/org/org_webhook_edit.go
@@ -129,7 +129,7 @@ func newOrgWebhookEditCmd() *cobra.Command {
 }
 
 func (c *orgWebhookEditCmd) run(ctx context.Context, cobraCmd *cobra.Command, webhookName string) error {
-	project, _, err := c.ws.ReadProject()
+	project, _, err := c.ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_list.go
@@ -122,7 +122,7 @@ func newOrgWebhookListCmdWith(
 }
 
 func (c *orgWebhookListCmd) run(ctx context.Context) error {
-	project, _, err := c.ws.ReadProject()
+	project, _, err := c.ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_new.go
+++ b/pkg/cmd/pulumi/org/org_webhook_new.go
@@ -178,7 +178,7 @@ func (c *orgWebhookNewCmd) run(ctx context.Context) error {
 	}
 
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_ping.go
+++ b/pkg/cmd/pulumi/org/org_webhook_ping.go
@@ -92,7 +92,7 @@ func newOrgWebhookPingCmd() *cobra.Command {
 }
 
 func (c *orgWebhookPingCmd) run(ctx context.Context, webhookName string) error {
-	project, _, err := c.ws.ReadProject()
+	project, _, err := c.ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -96,7 +96,7 @@ func (c *orgWebhookRemoveCmd) run(ctx context.Context, webhookName string) error
 	}
 
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_delete.go
+++ b/pkg/cmd/pulumi/packagecmd/package_delete.go
@@ -69,7 +69,7 @@ You must have publish permissions for the package to delete it.`,
 				return backenderr.ErrNonInteractiveRequiresYes
 			}
 
-			project, _, err := pkgWorkspace.Instance.ReadProject()
+			project, _, err := pkgWorkspace.Instance.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return fmt.Errorf("failed to determine current project: %w", err)
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -151,7 +151,7 @@ func (cmd *packagePublishCmd) Run(
 	if cmd.stdout == nil {
 		cmd.stdout = io.Discard
 	}
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	project, _, err := pkgWorkspace.Instance.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return fmt.Errorf("failed to determine current project: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -551,8 +551,8 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 
 func newMockTemplateWorkspace(readProjectErr error) pkgWorkspace.Context {
 	return &pkgWorkspace.MockContext{
-		NewF: func() (pkgWorkspace.W, error) { return nil, readProjectErr },
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		NewF: func(_ string) (pkgWorkspace.W, error) { return nil, readProjectErr },
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return nil, "", readProjectErr
 		},
 	}

--- a/pkg/cmd/pulumi/packageinstallation/invariant_test.go
+++ b/pkg/cmd/pulumi/packageinstallation/invariant_test.go
@@ -286,11 +286,11 @@ func (w invariantWorkspace) DownloadPlugin(
 	return p, func(success bool) {}, nil
 }
 
-func (w invariantWorkspace) New() (pkgWorkspace.W, error) {
+func (w invariantWorkspace) New(string) (pkgWorkspace.W, error) {
 	return nil, assert.AnError
 }
 
-func (w invariantWorkspace) ReadProject() (*workspace.Project, string, error) {
+func (w invariantWorkspace) ReadProject(string) (*workspace.Project, string, error) {
 	return nil, "", assert.AnError
 }
 

--- a/pkg/cmd/pulumi/packageinstallation/record_test.go
+++ b/pkg/cmd/pulumi/packageinstallation/record_test.go
@@ -159,16 +159,16 @@ func (w *recordingWorkspace) DownloadPlugin(
 	}, err
 }
 
-func (w *recordingWorkspace) New() (pkgWorkspace.W, error) {
-	w.start("New")
-	result, err := w.w.New()
+func (w *recordingWorkspace) New(dir string) (pkgWorkspace.W, error) {
+	w.start("New", dir)
+	result, err := w.w.New(dir)
 	w.finish(result, err)
 	return result, err
 }
 
-func (w *recordingWorkspace) ReadProject() (*workspace.Project, string, error) {
-	w.start("ReadProject")
-	project, path, err := w.w.ReadProject()
+func (w *recordingWorkspace) ReadProject(dir string) (*workspace.Project, string, error) {
+	w.start("ReadProject", dir)
+	project, path, err := w.w.ReadProject(dir)
 	w.finish(project, path, err)
 	return project, path, err
 }

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -70,12 +70,12 @@ func (mockInstallContext) GetPlugins(context.Context) ([]workspace.PluginInfo, e
 	return nil, nil
 }
 
-func (m mockInstallContext) New() (pkgWorkspace.W, error) {
+func (m mockInstallContext) New(string) (pkgWorkspace.W, error) {
 	m.t.Error("New should not be called")
 	return nil, assert.AnError
 }
 
-func (m mockInstallContext) ReadProject() (*workspace.Project, string, error) {
+func (m mockInstallContext) ReadProject(string) (*workspace.Project, string, error) {
 	m.t.Error("ReadProject should not be called")
 	return nil, "", assert.AnError
 }
@@ -178,13 +178,15 @@ func TestProviderFromSource(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, pluginHost.Close()) }()
 		pctx, err := plugin.NewContext(
-			t.Context(), nil, nil, pluginHost, nil, t.TempDir(), nil, false, nil)
+			t.Context(), nil, nil, pluginHost, nil, t.TempDir(), nil, false, nil,
+		)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, pctx.Close()) }()
 
 		provider, spec, err := providerFromSource(
 			pctx, inputSource, nil,
-			env.NewEnv(env.MapStore{"PULUMI_EXPERIMENTAL": "true"}), 0, installCtx)
+			env.NewEnv(env.MapStore{"PULUMI_EXPERIMENTAL": "true"}), 0, installCtx,
+		)
 		require.NoError(t, err)
 		return provider, spec
 	}

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -68,7 +68,7 @@ func NewPluginCmd() *cobra.Command {
 
 // getProjectPlugins fetches a list of plugins used by this project.
 func getProjectPlugins(ctx context.Context) ([]workspace.PluginDescriptor, error) {
-	proj, root, err := pkgWorkspace.Instance.ReadProject()
+	proj, root, err := pkgWorkspace.Instance.ReadProject("")
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func getProjectPlugins(ctx context.Context) ([]workspace.PluginDescriptor, error
 }
 
 func resolvePlugins(ctx context.Context, plugins []workspace.PluginDescriptor) ([]workspace.PluginInfo, error) {
-	proj, root, err := pkgWorkspace.Instance.ReadProject()
+	proj, root, err := pkgWorkspace.Instance.ReadProject("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/policy/policy_analyze_test.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze_test.go
@@ -85,7 +85,7 @@ func newMockBackendForAnalyze() (*backend.MockBackend, *backend.MockStack) {
 // newMockWsAndLm returns a MockContext and MockLoginManager that route through be.
 func newMockWsAndLm(be backend.Backend) (pkgWorkspace.Context, cmdBackend.LoginManager) {
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return nil, "", workspace.ErrProjectNotFound
 		},
 	}

--- a/pkg/cmd/pulumi/policy/policy_group_list.go
+++ b/pkg/cmd/pulumi/policy/policy_group_list.go
@@ -68,7 +68,7 @@ func newPolicyGroupListCmd() *cobra.Command {
 
 			// Try to read the current project
 			ws := pkgWorkspace.Instance
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy/policy_list.go
+++ b/pkg/cmd/pulumi/policy/policy_list.go
@@ -52,7 +52,7 @@ func newPolicyListCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobr
 			ctx := cmd.Context()
 
 			// Try to read the current project
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy/policy_list_test.go
+++ b/pkg/cmd/pulumi/policy/policy_list_test.go
@@ -52,7 +52,7 @@ func TestPolicyLsCmd_QueriesPolicyPacksByOrgNameNotUserName(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return nil, "", workspace.ErrProjectNotFound
 		},
 	}

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -173,7 +173,7 @@ func loginToCloudBackend(
 ) (backend.Backend, error) {
 	// Try to read the current project
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -336,7 +336,7 @@ func ParseConfig(configArray []string, path bool) (config.Map, error) {
 func SaveConfig(
 	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stack backend.Stack, c config.Map, configFile string,
 ) error {
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -348,7 +348,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	fmt.Fprintln(args.stdout)
 
 	// Load the project, update the name & description, remove the template section, and save it.
-	proj, root, err := ws.ReadProject()
+	proj, root, err := ws.ReadProject("")
 	if err != nil {
 		return err
 	}
@@ -849,7 +849,7 @@ func promptForAIProjectURL(ctx context.Context, ws pkgWorkspace.Context, args ne
 	opts display.Options,
 ) (string, error) {
 	// Try to read the current project
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return "", err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_acceptance_test.go
@@ -322,7 +322,7 @@ func currentUser(t *testing.T) string {
 }
 
 func loadStackName(t *testing.T) string {
-	w, err := pkgWorkspace.Instance.New()
+	w, err := pkgWorkspace.Instance.New("")
 	require.NoError(t, err)
 	return w.Settings().Stack
 }

--- a/pkg/cmd/pulumi/project/project_list.go
+++ b/pkg/cmd/pulumi/project/project_list.go
@@ -72,7 +72,7 @@ func newProjectListCmd() *cobra.Command {
 			ws := pkgWorkspace.Instance
 			var err error
 			var currentProject *workspace.Project
-			currentProject, _, err = ws.ReadProject()
+			currentProject, _, err = ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -127,7 +127,7 @@ func RequireStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, 
 	}
 
 	// Try to read the current project
-	project, root, err := ws.ReadProject()
+	project, root, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func requireCurrentStack(
 	lm cmdBackend.LoginManager, lopt LoadOption, opts display.Options, configFile string,
 ) (backend.Stack, error) {
 	// Try to read the current project
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 		return nil, errors.New(chooseStackErr)
 	}
 
-	proj, root, err := ws.ReadProject()
+	proj, root, err := ws.ReadProject("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -59,7 +59,7 @@ func CreateSecretsManagerForExistingStack(
 		}
 	}
 
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func readStackConfiguration(ctx context.Context, sink diag.Sink, ws pkgWorkspace
 	// Attempt to read a stack configuration, since it's possible that the user may have supplied one even though the
 	// stack has not actually been created yet. If we fail to read one, that's OK -- we'll just create a new one and
 	// populate it as we go.
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil {
 		return &workspace.ProjectStack{}, nil
 	}

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -108,7 +108,7 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		return err
 	}
 
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -93,7 +93,7 @@ This command displays data about previous updates for a stack.`,
 			}
 			var decrypter config.Decrypter
 			if showSecrets {
-				project, _, err := ws.ReadProject()
+				project, _, err := ws.ReadProject("")
 				if err != nil {
 					return fmt.Errorf("loading project: %w", err)
 				}

--- a/pkg/cmd/pulumi/stack/stack_import.go
+++ b/pkg/cmd/pulumi/stack/stack_import.go
@@ -97,7 +97,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 			// reconfigure it for the target stack we're importing into.
 			if snapshot.SecretsManager != nil && snapshot.SecretsManager.Type() == service.Type {
 				var loadErr error
-				project, _, loadErr := ws.ReadProject()
+				project, _, loadErr := ws.ReadProject("")
 				var ps *workspace.ProjectStack
 				if loadErr == nil {
 					ps, loadErr = LoadProjectStack(ctx, diag, project, s, "")

--- a/pkg/cmd/pulumi/stack/stack_import_test.go
+++ b/pkg/cmd/pulumi/stack/stack_import_test.go
@@ -94,7 +94,7 @@ func TestStackImport_ChangeServiceSecrets(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		NewF: func() (pkgWorkspace.W, error) {
+		NewF: func(_ string) (pkgWorkspace.W, error) {
 			return w, nil
 		},
 	}
@@ -221,10 +221,10 @@ func TestStackImport_ServiceSecrets_DefaultSecretManagerMutatesProjectStack(t *t
 	}
 
 	ws := &pkgWorkspace.MockContext{
-		NewF: func() (pkgWorkspace.W, error) {
+		NewF: func(_ string) (pkgWorkspace.W, error) {
 			return w, nil
 		},
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
 			return &workspace.Project{Name: "proj"}, "Pulumi.yaml", nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_list.go
+++ b/pkg/cmd/pulumi/stack/stack_list.go
@@ -160,7 +160,7 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 
 	// Try to read the current project
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -148,7 +148,7 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 	ws := pkgWorkspace.Instance
 
 	// Try to read the current project
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject("")
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
@@ -198,7 +198,7 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	proj, root, projectErr := ws.ReadProject()
+	proj, root, projectErr := ws.ReadProject("")
 	if projectErr != nil && !errors.Is(projectErr, workspace.ErrProjectNotFound) {
 		return projectErr
 	}

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -54,7 +54,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// Try to read the current project
-			project, root, err := ws.ReadProject()
+			project, root, err := ws.ReadProject("")
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -34,7 +34,7 @@ func newStackUnselectCmd() *cobra.Command {
 			"This way, next time pulumi needs to execute an operation, the user is prompted with one of the stacks to select\n" +
 			"from.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			currentWorkspace, err := pkgWorkspace.Instance.New()
+			currentWorkspace, err := pkgWorkspace.Instance.New("")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -74,7 +74,7 @@ func TestStateDeleteMultipleURNs(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil
@@ -143,7 +143,7 @@ func TestStateDeleteMultipleURNsResolvesDependencyOrder(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil
@@ -208,7 +208,7 @@ func TestStateDeleteParentAndChild(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil
@@ -261,7 +261,7 @@ func TestStateDeleteInvalidURN(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{Name: "proj"}, "/testing/project", nil
 		},
 	}
@@ -305,7 +305,7 @@ func TestStateDeleteURNNotFound(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{Name: "proj"}, "/testing/project", nil
 		},
 	}
@@ -392,7 +392,7 @@ func TestStateDeleteURN(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil
@@ -446,7 +446,7 @@ func TestStateDeleteDependency(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil
@@ -505,7 +505,7 @@ func TestStateDeleteProtected(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil
@@ -578,7 +578,7 @@ func TestStateDeleteAll(t *testing.T) {
 		},
 	}
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{
 				Name: "proj",
 			}, "/testing/project", nil

--- a/pkg/cmd/pulumi/state/state_repair_test.go
+++ b/pkg/cmd/pulumi/state/state_repair_test.go
@@ -309,7 +309,7 @@ func newStateRepairCmdFixture(
 	}
 
 	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{Backend: &workspace.ProjectBackend{URL: "file://url"}}, "", nil
 		},
 	}

--- a/pkg/cmd/pulumi/state/state_upgrade.go
+++ b/pkg/cmd/pulumi/state/state_upgrade.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -56,7 +57,12 @@ This only has an effect on DIY backends.
 				Stdout: stdout,
 			}
 
-			project, _, err := ws.ReadProject()
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}

--- a/pkg/cmd/pulumi/templatecmd/template_publish.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish.go
@@ -69,13 +69,16 @@ func newTemplatePublishCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(
 		&args.version, "version", "",
-		"The version of the template (required, semver format)")
+		"The version of the template (required, semver format)",
+	)
 	cmd.Flags().StringVar(
 		&args.name, "name", "",
-		"The name of the template (required)")
+		"The name of the template (required)",
+	)
 	cmd.Flags().StringVar(
 		&args.publisher, "publisher", "",
-		"The publisher of the template (e.g., 'pulumi'). Defaults to the default organization in your pulumi config.")
+		"The publisher of the template (e.g., 'pulumi'). Defaults to the default organization in your pulumi config.",
+	)
 	contract.AssertNoErrorf(cmd.MarkFlagRequired("version"), "Could not mark \"version\" as required")
 	contract.AssertNoErrorf(cmd.MarkFlagRequired("name"), "Could not mark \"name\" as required")
 
@@ -102,14 +105,20 @@ func (tplCmd *templatePublishCmd) Run(
 		return fmt.Errorf("invalid version format: %w", err)
 	}
 
-	project, _, err := pkgWorkspace.Instance.ReadProject()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	project, _, err := pkgWorkspace.Instance.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return fmt.Errorf("failed to determine current project: %w", err)
 	}
 
 	b, err := cmdBackend.CurrentBackend(
 		ctx, pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, project,
-		display.Options{Color: cmdutil.GetGlobalColorization()})
+		display.Options{Color: cmdutil.GetGlobalColorization()},
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/templatecmd/template_publish_test.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish_test.go
@@ -347,8 +347,8 @@ runtime: nodejs
 
 func newMockTemplateWorkspace(readProjectErr error) pkgWorkspace.Context {
 	return &pkgWorkspace.MockContext{
-		NewF: func() (pkgWorkspace.W, error) { return nil, readProjectErr },
-		ReadProjectF: func() (*workspace.Project, string, error) {
+		NewF: func(string) (pkgWorkspace.W, error) { return nil, readProjectErr },
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return nil, "", readProjectErr
 		},
 	}

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -203,7 +203,8 @@ func (s *Source) getRegistryTemplateByVersion(
 	if template.Source == "github" && strings.HasPrefix(template.Name, "pulumi/templates/") {
 		s.addError(fmt.Errorf(
 			"template '%s' is VCS-backed and does not support specific versions",
-			displayName))
+			displayName,
+		))
 		return
 	}
 
@@ -306,8 +307,14 @@ func (s *Source) getOrgTemplates(
 	ctx context.Context, templateName string,
 	wg *sync.WaitGroup, e env.Env,
 ) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		s.addError(fmt.Errorf("getting current working directory: %w", err))
+		return
+	}
+
 	ws := pkgWorkspace.Instance
-	project, _, err := ws.ReadProject()
+	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		s.addError(fmt.Errorf("could not read the current project: %w", err))
 		return

--- a/pkg/cmd/pulumi/whoami/whoami.go
+++ b/pkg/cmd/pulumi/whoami/whoami.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -71,8 +72,13 @@ func NewWhoAmICmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Co
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current working directory: %w", err)
+			}
+
 			// Try to read the current project
-			project, _, err := ws.ReadProject()
+			project, _, err := ws.ReadProject(cwd)
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
 			}
@@ -97,7 +103,8 @@ func NewWhoAmICmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Co
 
 	cmd.PersistentFlags().BoolVarP(
 		&verbose, "verbose", "v", false,
-		"Print detailed whoami information")
+		"Print detailed whoami information",
+	)
 
 	return cmd
 }

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -24,13 +24,15 @@ import (
 // Context is an interface that represents the context of a workspace. It provides access to loading projects and
 // plugins.
 type Context interface {
-	// New creates a new workspace using the current working directory. Requires a Pulumi.yaml file be present
-	// in the folder hierarchy between the current working directory and the .pulumi folder.
+	// New creates a new workspace rooted at the given directory. Requires a Pulumi.yaml file be present
+	// in the folder hierarchy between dir and the .pulumi folder. If dir is empty or relative, it is
+	// resolved against the process working directory.
 	New(dir string) (W, error)
 
-	// ReadProject attempts to detect and read a Pulumi project for the current workspace. If the
-	// project is successfully detected and read, it is returned along with the path to its containing
-	// directory, which will be used as the root of the project's Pulumi program.
+	// ReadProject attempts to detect and read a Pulumi project by searching upwards from the given
+	// directory. If the project is successfully detected and read, it is returned along with the path
+	// to its containing directory, which will be used as the root of the project's Pulumi program.
+	// If dir is empty or relative, it is resolved against the process working directory.
 	ReadProject(dir string) (*workspace.Project, string, error)
 
 	// LoadPluginProjectAt reads a plugin project definition in the given directory. If no project is found,

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -16,7 +16,6 @@ package workspace
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -27,12 +26,12 @@ import (
 type Context interface {
 	// New creates a new workspace using the current working directory. Requires a Pulumi.yaml file be present
 	// in the folder hierarchy between the current working directory and the .pulumi folder.
-	New() (W, error)
+	New(dir string) (W, error)
 
 	// ReadProject attempts to detect and read a Pulumi project for the current workspace. If the
 	// project is successfully detected and read, it is returned along with the path to its containing
 	// directory, which will be used as the root of the project's Pulumi program.
-	ReadProject() (*workspace.Project, string, error)
+	ReadProject(dir string) (*workspace.Project, string, error)
 
 	// LoadPluginProjectAt reads a plugin project definition in the given directory. If no project is found,
 	// [workspace.ErrPluginNotFound] is returned.
@@ -56,39 +55,16 @@ type Context interface {
 
 var Instance Context = &workspaceContext{}
 
-// NewContextFrom returns a Context rooted at dir: project detection and
-// workspace settings resolve by searching upwards from dir rather than from
-// the process working directory. Path-explicit and machine-global operations
-// (plugin loading, stored credentials) behave identically to Instance. Use it
-// when the effective working directory is supplied by a caller — e.g. an
-// ACP editor handing the CLI a session cwd — instead of the process's own.
-func NewContextFrom(dir string) Context {
-	return &workspaceContext{dir: dir}
-}
-
 // workspaceContext implements Context. dir, when non-empty, roots project and
 // workspace-settings detection; when empty, the process working directory is
 // used.
-type workspaceContext struct {
-	dir string
+type workspaceContext struct{}
+
+func (c *workspaceContext) New(dir string) (W, error) {
+	return newW(dir)
 }
 
-func (c *workspaceContext) New() (W, error) {
-	if c.dir != "" {
-		return newWFrom(c.dir)
-	}
-	return newW()
-}
-
-func (c *workspaceContext) ReadProject() (*workspace.Project, string, error) {
-	dir := c.dir
-	if dir == "" {
-		var err error
-		dir, err = os.Getwd()
-		if err != nil {
-			return nil, "", err
-		}
-	}
+func (c *workspaceContext) ReadProject(dir string) (*workspace.Project, string, error) {
 	path, err := workspace.DetectProjectPathFrom(dir)
 	if err != nil {
 		return nil, "", err

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -16,6 +16,7 @@ package workspace
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -55,14 +56,44 @@ type Context interface {
 
 var Instance Context = &workspaceContext{}
 
-type workspaceContext struct{}
+// NewContextFrom returns a Context rooted at dir: project detection and
+// workspace settings resolve by searching upwards from dir rather than from
+// the process working directory. Path-explicit and machine-global operations
+// (plugin loading, stored credentials) behave identically to Instance. Use it
+// when the effective working directory is supplied by a caller — e.g. an
+// ACP editor handing the CLI a session cwd — instead of the process's own.
+func NewContextFrom(dir string) Context {
+	return &workspaceContext{dir: dir}
+}
 
-func (*workspaceContext) New() (W, error) {
+// workspaceContext implements Context. dir, when non-empty, roots project and
+// workspace-settings detection; when empty, the process working directory is
+// used.
+type workspaceContext struct {
+	dir string
+}
+
+func (c *workspaceContext) New() (W, error) {
+	if c.dir != "" {
+		return newWFrom(c.dir)
+	}
 	return newW()
 }
 
-func (*workspaceContext) ReadProject() (*workspace.Project, string, error) {
-	proj, path, err := workspace.DetectProjectAndPath()
+func (c *workspaceContext) ReadProject() (*workspace.Project, string, error) {
+	dir := c.dir
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	path, err := workspace.DetectProjectPathFrom(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	proj, err := workspace.LoadProject(path)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/workspace/context.go
+++ b/pkg/workspace/context.go
@@ -55,16 +55,13 @@ type Context interface {
 
 var Instance Context = &workspaceContext{}
 
-// workspaceContext implements Context. dir, when non-empty, roots project and
-// workspace-settings detection; when empty, the process working directory is
-// used.
 type workspaceContext struct{}
 
-func (c *workspaceContext) New(dir string) (W, error) {
+func (*workspaceContext) New(dir string) (W, error) {
 	return newW(dir)
 }
 
-func (c *workspaceContext) ReadProject(dir string) (*workspace.Project, string, error) {
+func (*workspaceContext) ReadProject(dir string) (*workspace.Project, string, error) {
 	path, err := workspace.DetectProjectPathFrom(dir)
 	if err != nil {
 		return nil, "", err

--- a/pkg/workspace/context_test.go
+++ b/pkg/workspace/context_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// TestNewContextFromReadsProjectAtDir verifies a dir-scoped Context detects the
+// project by searching upwards from its directory, independent of the process
+// working directory (the test never chdirs into the project).
+func TestNewContextFromReadsProjectAtDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "Pulumi.yaml"),
+		[]byte("name: ctx-test\nruntime: yaml\n"), 0o600))
+	nested := filepath.Join(root, "sub", "dir")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	proj, dir, err := NewContextFrom(nested).ReadProject()
+	require.NoError(t, err)
+	assert.Equal(t, "ctx-test", string(proj.Name))
+	// The project root is where Pulumi.yaml lives, possibly symlink-resolved on
+	// platforms where the temp dir is behind a symlink.
+	realRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	realDir, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	assert.Equal(t, realRoot, realDir)
+}
+
+func TestNewContextFromNoProject(t *testing.T) {
+	t.Parallel()
+
+	// An empty directory (outside any Pulumi project) yields ErrProjectNotFound,
+	// matching Instance's sentinel so callers' errors.Is checks behave the same.
+	_, _, err := NewContextFrom(t.TempDir()).ReadProject()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, workspace.ErrProjectNotFound))
+}

--- a/pkg/workspace/context_test.go
+++ b/pkg/workspace/context_test.go
@@ -29,7 +29,7 @@ import (
 // TestNewContextFromReadsProjectAtDir verifies a dir-scoped Context detects the
 // project by searching upwards from its directory, independent of the process
 // working directory (the test never chdirs into the project).
-func TestNewContextFromReadsProjectAtDir(t *testing.T) {
+func TestReadProjectReadsProjectAtDir(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -52,7 +52,7 @@ func TestNewContextFromReadsProjectAtDir(t *testing.T) {
 	assert.Equal(t, realRoot, realDir)
 }
 
-func TestNewContextFromNoProject(t *testing.T) {
+func TestReadProjectNoProject(t *testing.T) {
 	t.Parallel()
 
 	// An empty directory (outside any Pulumi project) yields ErrProjectNotFound,

--- a/pkg/workspace/context_test.go
+++ b/pkg/workspace/context_test.go
@@ -35,11 +35,12 @@ func TestNewContextFromReadsProjectAtDir(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(root, "Pulumi.yaml"),
-		[]byte("name: ctx-test\nruntime: yaml\n"), 0o600))
+		[]byte("name: ctx-test\nruntime: yaml\n"), 0o600,
+	))
 	nested := filepath.Join(root, "sub", "dir")
 	require.NoError(t, os.MkdirAll(nested, 0o755))
 
-	proj, dir, err := NewContextFrom(nested).ReadProject()
+	proj, dir, err := Instance.ReadProject(nested)
 	require.NoError(t, err)
 	assert.Equal(t, "ctx-test", string(proj.Name))
 	// The project root is where Pulumi.yaml lives, possibly symlink-resolved on
@@ -56,7 +57,7 @@ func TestNewContextFromNoProject(t *testing.T) {
 
 	// An empty directory (outside any Pulumi project) yields ErrProjectNotFound,
 	// matching Instance's sentinel so callers' errors.Is checks behave the same.
-	_, _, err := NewContextFrom(t.TempDir()).ReadProject()
+	_, _, err := Instance.ReadProject(t.TempDir())
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, workspace.ErrProjectNotFound))
 }

--- a/pkg/workspace/mock.go
+++ b/pkg/workspace/mock.go
@@ -21,23 +21,23 @@ import (
 )
 
 type MockContext struct {
-	NewF                  func() (W, error)
-	ReadProjectF          func() (*workspace.Project, string, error)
+	NewF                  func(dir string) (W, error)
+	ReadProjectF          func(dir string) (*workspace.Project, string, error)
 	GetStoredCredentialsF func() (workspace.Credentials, error)
 	LoadPluginProjectAtF  func(ctx context.Context, path string) (*workspace.PluginProject, string, error)
 	LoadBaseProjectFromF  func(ctx context.Context, path string) (workspace.BaseProject, string, error)
 }
 
-func (c *MockContext) New() (W, error) {
+func (c *MockContext) New(dir string) (W, error) {
 	if c.NewF != nil {
-		return c.NewF()
+		return c.NewF(dir)
 	}
 	return nil, workspace.ErrProjectNotFound
 }
 
-func (c *MockContext) ReadProject() (*workspace.Project, string, error) {
+func (c *MockContext) ReadProject(dir string) (*workspace.Project, string, error) {
 	if c.ReadProjectF != nil {
-		return c.ReadProjectF()
+		return c.ReadProjectF(dir)
 	}
 	return nil, "", workspace.ErrProjectNotFound
 }

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -70,23 +70,28 @@ func newW() (W, error) {
 	if err != nil {
 		return nil, err
 	}
+	return newWFrom(cwd)
+}
 
-	absDir, err := filepath.Abs(cwd)
+// newWFrom creates a new workspace rooted at dir. Requires a Pulumi.yaml file be present in the
+// folder hierarchy between dir and the .pulumi folder.
+func newWFrom(dir string) (W, error) {
+	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
 	}
-	cwd = absDir
+	dir = absDir
 
-	if w, ok := loadFromCache(cwd); ok {
+	if w, ok := loadFromCache(dir); ok {
 		return w, nil
 	}
 
-	path, err := workspace.DetectProjectPathFrom(cwd)
+	path, err := workspace.DetectProjectPathFrom(dir)
 	if err != nil {
 		return nil, err
 	} else if path == "" {
 		return nil, fmt.Errorf("no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
-			"created a project yet, use `pulumi new` to do so", cwd)
+			"created a project yet, use `pulumi new` to do so", dir)
 	}
 
 	proj, err := workspace.LoadProject(path)
@@ -104,7 +109,7 @@ func newW() (W, error) {
 		return nil, fmt.Errorf("unable to read workspace settings: %w", err)
 	}
 
-	upsertIntoCache(cwd, w)
+	upsertIntoCache(dir, w)
 	return w, nil
 }
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -63,19 +63,9 @@ func upsertIntoCache(key string, w W) {
 	cache[key] = w
 }
 
-// newW creates a new workspace using the current working directory. Requires a Pulumi.yaml file be present in the
-// folder hierarchy between the current working directory and the .pulumi folder.
-func newW() (W, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	return newWFrom(cwd)
-}
-
-// newWFrom creates a new workspace rooted at dir. Requires a Pulumi.yaml file be present in the
+// newW creates a new workspace rooted at dir. Requires a Pulumi.yaml file be present in the
 // folder hierarchy between dir and the .pulumi folder.
-func newWFrom(dir string) (W, error) {
+func newW(dir string) (W, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Changes the `pkgWorkspace.Context` interface so `New` and `ReadProject` take an explicit directory to search upwards from, instead of implicitly using the process working directory. All CLI callers now pass `os.Getwd()`, so behavior is unchanged.

Groundwork for the Neo ACP adapter, where the editor supplies the session working directory. Part 1/5 of the ACP stack (replaces #23669).

🤖 Generated with [Claude Code](https://claude.com/claude-code)