### PR TITLE
Add delegation hooks to Neo's filesystem and shell tools

### DIFF
--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -57,6 +57,14 @@ const nonInteractivePromptPreamble = "<details><summary>non-interactive mode</su
 	"explicit and return a complete final answer.\n\n" +
 	"</details>"
 
+// neoTaskCreator is the slice of the cloud client that creates Neo tasks.
+// *client.Client satisfies it; tests fake it.
+type neoTaskCreator interface {
+	CreateNeoTask(
+		ctx context.Context, orgName, content, stackName, projectName string, opts client.CreateNeoTaskOptions,
+	) (*client.NeoTaskResponse, error)
+}
+
 // createNeoTaskWithEntityRetry creates a Neo task; if the backend rejects the
 // attached stack with "invalid entities" (typically a permissions issue) it retries
 // once without the stack so the task is still created. onEntityDropped, if non-nil,
@@ -64,7 +72,7 @@ const nonInteractivePromptPreamble = "<details><summary>non-interactive mode</su
 // surface a warning.
 func createNeoTaskWithEntityRetry(
 	ctx context.Context,
-	pc *client.Client,
+	pc neoTaskCreator,
 	orgName, prompt, stackName, projectName string,
 	opts client.CreateNeoTaskOptions,
 	onEntityDropped func(error),
@@ -77,6 +85,17 @@ func createNeoTaskWithEntityRetry(
 		return pc.CreateNeoTask(ctx, orgName, prompt, "", "", opts)
 	}
 	return resp, err
+}
+
+// entityDroppedWarning renders the user-facing warning for
+// createNeoTaskWithEntityRetry's stack-dropped fallback. The TUI and the ACP
+// adapter both surface it, so the wording lives here rather than at each call
+// site.
+func entityDroppedWarning(orgName, projectName, stackRefName string, err error) string {
+	return fmt.Sprintf(
+		"could not attach stack %s/%s/%s to Neo task: %s; creating task without stack context",
+		orgName, projectName, stackRefName, err,
+	)
 }
 
 // isInvalidEntitiesError reports whether err is the Neo backend's "invalid entities"
@@ -331,30 +350,13 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 		opts.prompt = buildDebugPrompt(ctx, cloudBe, target, opts.debugKind, opts.debugID, opts.prompt)
 	}
 
-	// Allow tools to read/write under temp directories in addition to cwd: the agent
-	// stages scratch files there (downloads, intermediate state) and the CLI sandbox
-	// would otherwise reject those paths. See pulumi/pulumi-service#42027.
-	extraRoots := dedupeExistingRoots("/tmp", os.TempDir())
-	fs, err := tools.NewFilesystem(opts.cwdFlag, extraRoots...)
+	// pu's sink stays nil here so live events are dropped in non-interactive mode;
+	// the interactive path below sets pu.Sink to push UIEvents onto uiCh.
+	lt, err := buildLocalToolHandlers(opts.cwdFlag, ws)
 	if err != nil {
 		return err
 	}
-	sh, err := tools.NewShell(opts.cwdFlag, extraRoots...)
-	if err != nil {
-		return err
-	}
-	handlers := map[string]ToolHandler{
-		"filesystem": fs,
-		"shell":      sh,
-	}
-
-	// In non-interactive mode the sink stays nil and live events are dropped; the
-	// interactive path below sets pu.Sink to push UIEvents onto uiCh.
-	pu, err := tools.NewPulumi(opts.cwdFlag, ws, nil)
-	if err != nil {
-		return err
-	}
-	handlers["pulumi"] = pu
+	pu, handlers := lt.pu, lt.handlers
 
 	if opts.printMode || !isInteractive() {
 		if opts.prompt == "" {
@@ -460,11 +462,9 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 						PlanMode:            planMode,
 						EnabledIntegrations: enabledIntegrations,
 					}, func(originalErr error) {
-						sendUI(uiCh, UIWarning{Message: fmt.Sprintf(
-							"could not attach stack %s/%s/%s to Neo task: %s; "+
-								"creating task without stack context",
-							orgName, projectName, stackRefName, originalErr,
-						)})
+						sendUI(uiCh, UIWarning{
+							Message: entityDroppedWarning(orgName, projectName, stackRefName, originalErr),
+						})
 					})
 				if err != nil {
 					sendUI(uiCh, UIError{Message: "failed to create Neo task: " + err.Error()})
@@ -726,6 +726,49 @@ func resolveTaskTarget(
 		return taskTarget{}, errors.New("could not determine an organization for the Neo task; pass --org")
 	}
 	return t, nil
+}
+
+// localTools are the CLI-local tool handlers shared by every Neo entrypoint. The
+// concrete fs/sh/pu handles are exposed alongside the assembled handler map so
+// callers can layer on extras without re-deriving the shared construction or the
+// temp-root policy: the interactive path sets pu.Sink, and the ACP adapter routes
+// fs/sh through the editor. handlers already contains fs/sh/pu under their tool
+// names.
+type localTools struct {
+	fs       *tools.Filesystem
+	sh       *tools.Shell
+	pu       *tools.Pulumi
+	handlers map[string]ToolHandler
+}
+
+// buildLocalToolHandlers constructs the CLI-local tool handlers shared by every
+// Neo entrypoint (interactive TUI, non-interactive, ACP): the filesystem, shell,
+// and pulumi tools rooted at cwd. The filesystem and shell additionally allow
+// tools to read/write under temp directories in addition to cwd: the agent
+// stages scratch files there (downloads, intermediate state) and the CLI sandbox
+// would otherwise reject those paths (see pulumi/pulumi-service#42027).
+func buildLocalToolHandlers(cwd string, ws pkgWorkspace.Context) (localTools, error) {
+	extraRoots := dedupeExistingRoots("/tmp", os.TempDir())
+	fs, err := tools.NewFilesystem(cwd, extraRoots...)
+	if err != nil {
+		return localTools{}, err
+	}
+	sh, err := tools.NewShell(cwd, extraRoots...)
+	if err != nil {
+		return localTools{}, err
+	}
+	pu, err := tools.NewPulumi(cwd, ws, nil)
+	if err != nil {
+		return localTools{}, err
+	}
+	return localTools{
+		fs: fs, sh: sh, pu: pu,
+		handlers: map[string]ToolHandler{
+			"filesystem": fs,
+			"shell":      sh,
+			"pulumi":     pu,
+		},
+	}, nil
 }
 
 // dedupeExistingRoots returns candidates with duplicates removed by canonical path,

--- a/pkg/cmd/pulumi/neo/tools/filesystem.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem.go
@@ -47,14 +47,29 @@ import (
 // The remaining filesystem method (grep_ast) returns a structured "not yet implemented"
 // error so the agent can degrade gracefully.
 //
-// All paths in incoming requests are absolute (the cloud agent assumes a sandboxed VM).
-// We resolve them and reject anything that lands outside the allowed roots, so the agent
-// can never read or write files outside Root or the configured extras (e.g. /tmp).
+// Incoming paths may be absolute or relative; relative paths are resolved against Root.
+// Either way we canonicalize the result and reject anything that lands outside the allowed
+// roots, so the agent can never read or write files outside Root or the configured extras
+// (e.g. /tmp).
 type Filesystem struct {
 	// Root is the user's working directory. Relative paths are joined against it.
 	Root string
 	// allowedRoots is Root followed by any extra roots passed to NewFilesystem.
 	allowedRoots []string
+	// OnWrite, when non-nil, performs the actual file write for the tool's
+	// mutating methods (write, edit, content_replace) in place of writing to
+	// local disk. path is the resolved absolute path; content is the full new
+	// file contents. The Neo ACP adapter sets this to route writes through the
+	// editor's fs/write_text_file request, so changes surface as native diffs
+	// and the editor (not the CLI) owns the on-disk mutation. A nil OnWrite
+	// writes straight to disk, creating parent directories as needed.
+	OnWrite func(ctx context.Context, path, content string) error
+	// OnRead, when non-nil, supplies the full contents of path in place of
+	// reading local disk for the read method. The Neo ACP adapter sets this to
+	// fetch via the editor's fs/read_text_file request, so reads see the
+	// editor's unsaved buffer. The tool still applies its own offset/limit
+	// slicing to the returned content. A nil OnRead reads from disk.
+	OnRead func(ctx context.Context, path string) (string, error)
 }
 
 // NewFilesystem creates a Filesystem handler rooted at the given absolute directory.
@@ -91,7 +106,7 @@ func NewFilesystem(root string, extraRoots ...string) (*Filesystem, error) {
 }
 
 // Invoke dispatches a single filesystem method call.
-func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessage) (any, error) {
+func (f *Filesystem) Invoke(ctx context.Context, method string, args json.RawMessage) (any, error) {
 	switch method {
 	case "read":
 		var p struct {
@@ -102,7 +117,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding read args: %w", err)
 		}
-		return nilOnError(f.read(p.FilePath, p.Offset, p.Limit))
+		return nilOnError(f.read(ctx, p.FilePath, p.Offset, p.Limit))
 	case "write":
 		var p struct {
 			FilePath string `json:"file_path"`
@@ -111,7 +126,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding write args: %w", err)
 		}
-		return nilOnError(f.write(p.FilePath, p.Content))
+		return nilOnError(f.write(ctx, p.FilePath, p.Content))
 	case "directory_tree":
 		var p struct {
 			Path  string `json:"path"`
@@ -126,7 +141,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding edit args: %w", err)
 		}
-		return nilOnError(f.edit(p))
+		return nilOnError(f.edit(ctx, p))
 	case "grep":
 		var p struct {
 			Pattern string `json:"pattern"`
@@ -148,7 +163,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding content_replace args: %w", err)
 		}
-		return nilOnError(f.contentReplace(p.Pattern, p.Replacement, p.Path, p.FilePattern, p.DryRun))
+		return nilOnError(f.contentReplace(ctx, p.Pattern, p.Replacement, p.Path, p.FilePattern, p.DryRun))
 	case "grep_ast":
 		return nil, fmt.Errorf("filesystem method %q is not yet implemented in pulumi neo CLI mode", method)
 	default:
@@ -168,9 +183,9 @@ func nilOnError[T any](v T, err error) (any, error) {
 	return v, nil
 }
 
-// resolve safely interprets a path supplied by the agent. The agent sends absolute paths
-// (they were absolute inside its sandboxed VM); we accept those but require they resolve
-// to a location under one of the allowed roots. Relative paths are resolved against Root.
+// resolve safely interprets a path supplied by the agent, which may be absolute or
+// relative. Relative paths are resolved against Root; absolute paths are accepted as given.
+// Either way we require the result resolve to a location under one of the allowed roots.
 func (f *Filesystem) resolve(p string) (string, error) {
 	if p == "" {
 		return "", errors.New("path is required")
@@ -186,16 +201,15 @@ type readResult struct {
 	Content string `json:"content"`
 }
 
-func (f *Filesystem) read(p string, offset, limit int) (readResult, error) {
+func (f *Filesystem) read(ctx context.Context, p string, offset, limit int) (readResult, error) {
 	abs, err := f.resolve(p)
 	if err != nil {
 		return readResult{}, err
 	}
-	b, err := os.ReadFile(abs)
+	content, err := f.getFile(ctx, abs)
 	if err != nil {
 		return readResult{}, err
 	}
-	content := string(b)
 	if offset > 0 || limit > 0 {
 		// Apply line-based slicing matching the upstream tool's offset/limit semantics.
 		lines := strings.Split(content, "\n")
@@ -218,18 +232,43 @@ type writeResult struct {
 	BytesWritten int `json:"bytes_written"`
 }
 
-func (f *Filesystem) write(p, content string) (writeResult, error) {
+func (f *Filesystem) write(ctx context.Context, p, content string) (writeResult, error) {
 	abs, err := f.resolve(p)
 	if err != nil {
 		return writeResult{}, err
 	}
-	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-		return writeResult{}, err
-	}
-	if err := os.WriteFile(abs, []byte(content), 0o600); err != nil {
+	if err := f.putFile(ctx, abs, content); err != nil {
 		return writeResult{}, err
 	}
 	return writeResult{BytesWritten: len(content)}, nil
+}
+
+// getFile returns the full contents of the resolved absolute path abs. When
+// OnRead is set the read is delegated to it (the ACP adapter fetches via the
+// editor's fs/read_text_file); otherwise it reads from local disk.
+func (f *Filesystem) getFile(ctx context.Context, abs string) (string, error) {
+	if f.OnRead != nil {
+		return f.OnRead(ctx, abs)
+	}
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// putFile commits content to the resolved absolute path abs. When OnWrite is set
+// the write is delegated to it (the ACP adapter forwards it to the editor as
+// fs/write_text_file, which creates missing parents itself); otherwise it writes
+// to local disk, creating parent directories as needed.
+func (f *Filesystem) putFile(ctx context.Context, abs, content string) error {
+	if f.OnWrite != nil {
+		return f.OnWrite(ctx, abs, content)
+	}
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(abs, []byte(content), 0o600)
 }
 
 // editArgs is the JSON shape for the `edit` tool. ExpectedReplacements is a pointer so
@@ -245,7 +284,7 @@ type editArgs struct {
 // edit performs a single exact-string replacement. The response string and error wording
 // are deliberately kept byte-identical to the upstream mcp-claude-code `edit` tool so the
 // agent sees the same output whether the call ran on Cloud or CLI.
-func (f *Filesystem) edit(p editArgs) (string, error) {
+func (f *Filesystem) edit(ctx context.Context, p editArgs) (string, error) {
 	abs, err := f.resolve(p.FilePath)
 	if err != nil {
 		return "", err
@@ -267,10 +306,7 @@ func (f *Filesystem) edit(p editArgs) (string, error) {
 
 	// Creation mode: file doesn't exist and old_string is empty.
 	if !fileExists && p.OldString == "" {
-		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-			return "", err
-		}
-		if err := os.WriteFile(abs, []byte(p.NewString), 0o600); err != nil {
+		if err := f.putFile(ctx, abs, p.NewString); err != nil {
 			return "", err
 		}
 		return fmt.Sprintf("Successfully created file: %s (%d bytes)", p.FilePath, len(p.NewString)), nil
@@ -289,14 +325,15 @@ func (f *Filesystem) edit(p editArgs) (string, error) {
 		return "Error: Parameter 'old_string' cannot be empty for existing files", nil
 	}
 
-	raw, err := os.ReadFile(abs)
+	// Read through getFile so an ACP-backed edit matches and diffs against the
+	// same content it will write back (the editor's buffer), not stale disk.
+	original, err := f.getFile(ctx, abs)
 	if err != nil {
 		return "", err
 	}
-	if !utf8.Valid(raw) {
+	if !utf8.ValidString(original) {
 		return "Error: Cannot edit binary file: " + p.FilePath, nil
 	}
-	original := string(raw)
 
 	occurrences := strings.Count(original, p.OldString)
 	if occurrences == 0 {
@@ -321,7 +358,7 @@ func (f *Filesystem) edit(p editArgs) (string, error) {
 		return "No changes made to file: " + p.FilePath, nil
 	}
 
-	if err := os.WriteFile(abs, []byte(modified), 0o600); err != nil {
+	if err := f.putFile(ctx, abs, modified); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf(
@@ -546,7 +583,7 @@ func (f *Filesystem) grep(pattern, searchPath, include string) (grepResult, erro
 	for _, m := range matches {
 		fmt.Fprintf(&buf, "%s:%d: %s\n", m.path, m.lineno, m.content)
 	}
-	body, truncated := capString(buf.String(), maxOutputBytes)
+	body, truncated := capString(buf.String(), MaxOutputBytes)
 	return grepResult{Content: body, Truncated: truncated}, nil
 }
 
@@ -563,7 +600,7 @@ type contentReplaceResult struct {
 // output summarizes what would change. Mirrors the upstream mcp-claude-code
 // `content_replace` tool.
 func (f *Filesystem) contentReplace(
-	pattern, replacement, searchPath, filePattern string, dryRun bool,
+	ctx context.Context, pattern, replacement, searchPath, filePattern string, dryRun bool,
 ) (contentReplaceResult, error) {
 	if pattern == "" {
 		return contentReplaceResult{}, errors.New("pattern is required")
@@ -590,14 +627,16 @@ func (f *Filesystem) contentReplace(
 	totalReplacements := 0
 
 	processFile := func(path string) error {
-		b, readErr := os.ReadFile(path)
+		// Read and write through getFile/putFile so an ACP-backed replace operates
+		// on the editor's view of each file rather than mixing a disk read with an
+		// editor write.
+		before, readErr := f.getFile(ctx, path)
 		if readErr != nil {
 			return nil //nolint:nilerr // skip unreadable files (same stance as grep)
 		}
-		if isBinary(b) {
+		if isBinary([]byte(before)) {
 			return nil
 		}
-		before := string(b)
 		count := strings.Count(before, pattern)
 		if count == 0 {
 			return nil
@@ -608,7 +647,7 @@ func (f *Filesystem) contentReplace(
 			return nil
 		}
 		after := strings.ReplaceAll(before, pattern, replacement)
-		return os.WriteFile(path, []byte(after), 0o600)
+		return f.putFile(ctx, path, after)
 	}
 
 	if err := walkMatching(abs, filePattern, processFile); err != nil {
@@ -632,7 +671,7 @@ func (f *Filesystem) contentReplace(
 	for _, r := range results {
 		fmt.Fprintf(&buf, "%s: %d replacements\n", r.path, r.count)
 	}
-	body, truncated := capString(buf.String(), maxOutputBytes)
+	body, truncated := capString(buf.String(), MaxOutputBytes)
 	return contentReplaceResult{
 		Content:          body,
 		ReplacementsMade: totalReplacements,

--- a/pkg/cmd/pulumi/neo/tools/filesystem.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem.go
@@ -51,25 +51,35 @@ import (
 // Either way we canonicalize the result and reject anything that lands outside the allowed
 // roots, so the agent can never read or write files outside Root or the configured extras
 // (e.g. /tmp).
+//
+// ReadFileOverride and WriteFileOverride divert per-file content I/O (see their docs), but
+// directory enumeration has no override: directory_tree, grep, and the file-discovery walk
+// in content_replace always list local disk, because the ACP protocol the overrides exist
+// for offers file read/write requests only — no directory listing or stat. With overrides
+// set, those methods therefore discover files on disk while reading and writing their
+// contents through the overrides.
 type Filesystem struct {
 	// Root is the user's working directory. Relative paths are joined against it.
 	Root string
 	// allowedRoots is Root followed by any extra roots passed to NewFilesystem.
 	allowedRoots []string
-	// OnWrite, when non-nil, performs the actual file write for the tool's
-	// mutating methods (write, edit, content_replace) in place of writing to
-	// local disk. path is the resolved absolute path; content is the full new
-	// file contents. The Neo ACP adapter sets this to route writes through the
-	// editor's fs/write_text_file request, so changes surface as native diffs
-	// and the editor (not the CLI) owns the on-disk mutation. A nil OnWrite
-	// writes straight to disk, creating parent directories as needed.
-	OnWrite func(ctx context.Context, path, content string) error
-	// OnRead, when non-nil, supplies the full contents of path in place of
-	// reading local disk for the read method. The Neo ACP adapter sets this to
-	// fetch via the editor's fs/read_text_file request, so reads see the
-	// editor's unsaved buffer. The tool still applies its own offset/limit
-	// slicing to the returned content. A nil OnRead reads from disk.
-	OnRead func(ctx context.Context, path string) (string, error)
+	// WriteFileOverride, when non-nil, replaces the default local-disk write for
+	// the tool's mutating methods (write, edit, content_replace). path is the
+	// resolved absolute path; content is the full new file contents. The Neo ACP
+	// adapter sets this to route writes through the editor's fs/write_text_file
+	// request, so changes surface as native diffs and the editor (not the CLI)
+	// owns the on-disk mutation. When nil, writes go straight to disk, creating
+	// parent directories as needed.
+	WriteFileOverride func(ctx context.Context, path, content string) error
+	// ReadFileOverride, when non-nil, replaces the default local-disk read
+	// wherever the tool needs file contents (read, and the read-modify-write in
+	// edit and content_replace). The Neo ACP adapter sets this to fetch via the
+	// editor's fs/read_text_file request, so reads see the editor's unsaved
+	// buffer. The tool still applies its own offset/limit slicing to the
+	// returned content. A missing file must be reported with an error satisfying
+	// errors.Is(err, fs.ErrNotExist) — edit relies on that to decide between
+	// editing and creating a file. When nil, reads come from disk.
+	ReadFileOverride func(ctx context.Context, path string) (string, error)
 }
 
 // NewFilesystem creates a Filesystem handler rooted at the given absolute directory.
@@ -244,11 +254,11 @@ func (f *Filesystem) write(ctx context.Context, p, content string) (writeResult,
 }
 
 // getFile returns the full contents of the resolved absolute path abs. When
-// OnRead is set the read is delegated to it (the ACP adapter fetches via the
-// editor's fs/read_text_file); otherwise it reads from local disk.
+// ReadFileOverride is set the read is delegated to it (the ACP adapter fetches
+// via the editor's fs/read_text_file); otherwise it reads from local disk.
 func (f *Filesystem) getFile(ctx context.Context, abs string) (string, error) {
-	if f.OnRead != nil {
-		return f.OnRead(ctx, abs)
+	if f.ReadFileOverride != nil {
+		return f.ReadFileOverride(ctx, abs)
 	}
 	b, err := os.ReadFile(abs)
 	if err != nil {
@@ -257,13 +267,14 @@ func (f *Filesystem) getFile(ctx context.Context, abs string) (string, error) {
 	return string(b), nil
 }
 
-// putFile commits content to the resolved absolute path abs. When OnWrite is set
-// the write is delegated to it (the ACP adapter forwards it to the editor as
-// fs/write_text_file, which creates missing parents itself); otherwise it writes
-// to local disk, creating parent directories as needed.
+// putFile commits content to the resolved absolute path abs. When
+// WriteFileOverride is set the write is delegated to it (the ACP adapter
+// forwards it to the editor as fs/write_text_file, which creates missing
+// parents itself); otherwise it writes to local disk, creating parent
+// directories as needed.
 func (f *Filesystem) putFile(ctx context.Context, abs, content string) error {
-	if f.OnWrite != nil {
-		return f.OnWrite(ctx, abs, content)
+	if f.WriteFileOverride != nil {
+		return f.WriteFileOverride(ctx, abs, content)
 	}
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 		return err
@@ -298,38 +309,26 @@ func (f *Filesystem) edit(ctx context.Context, p editArgs) (string, error) {
 		return "Error: Parameter 'expected_replacements' must be a non-negative number", nil
 	}
 
-	info, statErr := os.Stat(abs)
-	fileExists := statErr == nil
-	if statErr != nil && !os.IsNotExist(statErr) {
-		return "", statErr
-	}
-
-	// Creation mode: file doesn't exist and old_string is empty.
-	if !fileExists && p.OldString == "" {
-		if err := f.putFile(ctx, abs, p.NewString); err != nil {
-			return "", err
+	// Read through getFile so an ACP-backed edit matches and diffs against the
+	// same content it will write back (the editor's buffer), not stale disk.
+	// Existence is derived from the read rather than a local stat so a file that
+	// exists only in the editor is edited, not clobbered by creation mode.
+	original, readErr := f.getFile(ctx, abs)
+	if readErr != nil {
+		// Creation mode: file doesn't exist and old_string is empty.
+		if p.OldString == "" && errors.Is(readErr, fs.ErrNotExist) {
+			if err := f.putFile(ctx, abs, p.NewString); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Successfully created file: %s (%d bytes)", p.FilePath, len(p.NewString)), nil
 		}
-		return fmt.Sprintf("Successfully created file: %s (%d bytes)", p.FilePath, len(p.NewString)), nil
-	}
-
-	if !fileExists {
-		return "", statErr
-	}
-	if info.IsDir() {
-		return "", fmt.Errorf("path %q is a directory, not a file", p.FilePath)
+		return "", readErr
 	}
 
 	// Whitespace-only old_string on an existing file is ambiguous — reject it rather
 	// than silently matching every run of whitespace in the file.
 	if strings.TrimSpace(p.OldString) == "" {
 		return "Error: Parameter 'old_string' cannot be empty for existing files", nil
-	}
-
-	// Read through getFile so an ACP-backed edit matches and diffs against the
-	// same content it will write back (the editor's buffer), not stale disk.
-	original, err := f.getFile(ctx, abs)
-	if err != nil {
-		return "", err
 	}
 	if !utf8.ValidString(original) {
 		return "Error: Cannot edit binary file: " + p.FilePath, nil

--- a/pkg/cmd/pulumi/neo/tools/filesystem_test.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem_test.go
@@ -17,7 +17,9 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,10 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFilesystem_OnWriteHookDivertsWrites verifies that, when OnWrite is set,
-// the mutating methods commit through the hook instead of touching disk. This
-// is the seam the Neo ACP adapter uses to forward writes to the editor.
-func TestFilesystem_OnWriteHookDivertsWrites(t *testing.T) {
+// TestFilesystem_WriteFileOverrideDivertsWrites verifies that, when
+// WriteFileOverride is set, the mutating methods commit through it instead of
+// touching disk. This is the seam the Neo ACP adapter uses to forward writes
+// to the editor.
+func TestFilesystem_WriteFileOverrideDivertsWrites(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -43,7 +46,7 @@ func TestFilesystem_OnWriteHookDivertsWrites(t *testing.T) {
 		content string
 	}
 	var writes []captured
-	fs.OnWrite = func(_ context.Context, path, content string) error {
+	fs.WriteFileOverride = func(_ context.Context, path, content string) error {
 		writes = append(writes, captured{path: path, content: content})
 		return nil
 	}
@@ -53,17 +56,99 @@ func TestFilesystem_OnWriteHookDivertsWrites(t *testing.T) {
 		json.RawMessage(fmt.Sprintf(`{"file_path":%q,"content":"hello"}`, target)))
 	require.NoError(t, err)
 
-	// resolve canonicalizes the path (symlink-evaluated root), so the hook sees
-	// the resolved absolute path rather than the raw temp path.
+	// resolve canonicalizes the path (symlink-evaluated root), so the override
+	// sees the resolved absolute path rather than the raw temp path.
 	realRoot, err := filepath.EvalSymlinks(root)
 	require.NoError(t, err)
 	require.Len(t, writes, 1)
 	assert.Equal(t, filepath.Join(realRoot, "new.txt"), writes[0].path)
 	assert.Equal(t, "hello", writes[0].content)
 
-	// The hook owns the write; nothing was created on disk.
+	// The override owns the write; nothing was created on disk.
 	_, statErr := os.Stat(target)
 	assert.True(t, os.IsNotExist(statErr), "expected no file on disk, stat err: %v", statErr)
+}
+
+// TestFilesystem_EditThroughOverridesEditsBufferOnlyFile verifies that edit
+// derives existence from ReadFileOverride rather than a local stat: a file
+// that exists only in the editor (nothing on disk) is edited in place through
+// the overrides.
+func TestFilesystem_EditThroughOverridesEditsBufferOnlyFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	buffer := "hello world\n"
+	fs.ReadFileOverride = func(_ context.Context, _ string) (string, error) {
+		return buffer, nil
+	}
+	var wrote string
+	fs.WriteFileOverride = func(_ context.Context, _, content string) error {
+		wrote = content
+		return nil
+	}
+
+	target := filepath.Join(root, "buffer-only.txt")
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"world","new_string":"there"}`, target))
+	assert.Contains(t, res, "Successfully edited file")
+	assert.Equal(t, "hello there\n", wrote)
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "edit must not touch disk when overrides are set")
+}
+
+// TestFilesystem_EditCreationThroughOverrides verifies creation mode with
+// overrides set: ReadFileOverride reporting fs.ErrNotExist plus an empty
+// old_string creates the file through WriteFileOverride.
+func TestFilesystem_EditCreationThroughOverrides(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	fs.ReadFileOverride = func(_ context.Context, path string) (string, error) {
+		return "", fmt.Errorf("editor: %q: %w", path, iofs.ErrNotExist)
+	}
+	var wrote string
+	fs.WriteFileOverride = func(_ context.Context, _, content string) error {
+		wrote = content
+		return nil
+	}
+
+	target := filepath.Join(root, "new.txt")
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"","new_string":"seeded"}`, target))
+	assert.Contains(t, res, "Successfully created file")
+	assert.Equal(t, "seeded", wrote)
+}
+
+// TestFilesystem_EditReadOverrideGenericErrorDoesNotCreate verifies that only
+// fs.ErrNotExist enables creation mode: any other read failure surfaces as an
+// error instead of clobbering a file whose contents simply couldn't be read.
+func TestFilesystem_EditReadOverrideGenericErrorDoesNotCreate(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	readErr := errors.New("editor went away")
+	fs.ReadFileOverride = func(_ context.Context, _ string) (string, error) {
+		return "", readErr
+	}
+	fs.WriteFileOverride = func(_ context.Context, _, _ string) error {
+		t.Fatal("a failed read must not trigger a write")
+		return nil
+	}
+
+	_, err = fs.Invoke(t.Context(), "edit", json.RawMessage(fmt.Sprintf(
+		`{"file_path":%q,"old_string":"","new_string":"seeded"}`,
+		filepath.Join(root, "new.txt"))))
+	require.ErrorIs(t, err, readErr)
 }
 
 func TestFilesystem_WriteThenReadAbsolutePath(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tools/filesystem_test.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem_test.go
@@ -15,6 +15,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -26,6 +27,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestFilesystem_OnWriteHookDivertsWrites verifies that, when OnWrite is set,
+// the mutating methods commit through the hook instead of touching disk. This
+// is the seam the Neo ACP adapter uses to forward writes to the editor.
+func TestFilesystem_OnWriteHookDivertsWrites(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	type captured struct {
+		path    string
+		content string
+	}
+	var writes []captured
+	fs.OnWrite = func(_ context.Context, path, content string) error {
+		writes = append(writes, captured{path: path, content: content})
+		return nil
+	}
+
+	target := filepath.Join(root, "new.txt")
+	_, err = fs.Invoke(t.Context(), "write",
+		json.RawMessage(fmt.Sprintf(`{"file_path":%q,"content":"hello"}`, target)))
+	require.NoError(t, err)
+
+	// resolve canonicalizes the path (symlink-evaluated root), so the hook sees
+	// the resolved absolute path rather than the raw temp path.
+	realRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	require.Len(t, writes, 1)
+	assert.Equal(t, filepath.Join(realRoot, "new.txt"), writes[0].path)
+	assert.Equal(t, "hello", writes[0].content)
+
+	// The hook owns the write; nothing was created on disk.
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "expected no file on disk, stat err: %v", statErr)
+}
 
 func TestFilesystem_WriteThenReadAbsolutePath(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -41,12 +41,12 @@ type Shell struct {
 	DefaultTimeout time.Duration
 	// allowedRoots is Cwd followed by any extra roots passed to NewShell.
 	allowedRoots []string
-	// OnExec, when non-nil, runs the command in place of local execution. dir is
-	// the already-resolved, root-validated working directory and timeout the
+	// ExecOverride, when non-nil, replaces local execution of the command. dir
+	// is the already-resolved, root-validated working directory and timeout the
 	// effective timeout. The Neo ACP adapter sets this to run the command in the
 	// editor's terminal (terminal/*). It returns the same ShellResult this tool
-	// produces locally. A nil OnExec runs the command on this machine.
-	OnExec func(ctx context.Context, command, dir string, timeout time.Duration) (ShellResult, error)
+	// produces locally. When nil, the command runs on this machine.
+	ExecOverride func(ctx context.Context, command, dir string, timeout time.Duration) (ShellResult, error)
 }
 
 // NewShell creates a Shell handler with sensible defaults. The working directory is
@@ -103,8 +103,8 @@ func (s *Shell) Invoke(ctx context.Context, method string, args json.RawMessage)
 	if err != nil {
 		return nil, err
 	}
-	if s.OnExec != nil {
-		return s.OnExec(ctx, p.Command, dir, timeout)
+	if s.ExecOverride != nil {
+		return s.ExecOverride(ctx, p.Command, dir, timeout)
 	}
 	return s.run(ctx, p.Command, dir, timeout)
 }

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -41,6 +41,12 @@ type Shell struct {
 	DefaultTimeout time.Duration
 	// allowedRoots is Cwd followed by any extra roots passed to NewShell.
 	allowedRoots []string
+	// OnExec, when non-nil, runs the command in place of local execution. dir is
+	// the already-resolved, root-validated working directory and timeout the
+	// effective timeout. The Neo ACP adapter sets this to run the command in the
+	// editor's terminal (terminal/*). It returns the same ShellResult this tool
+	// produces locally. A nil OnExec runs the command on this machine.
+	OnExec func(ctx context.Context, command, dir string, timeout time.Duration) (ShellResult, error)
 }
 
 // NewShell creates a Shell handler with sensible defaults. The working directory is
@@ -97,6 +103,9 @@ func (s *Shell) Invoke(ctx context.Context, method string, args json.RawMessage)
 	if err != nil {
 		return nil, err
 	}
+	if s.OnExec != nil {
+		return s.OnExec(ctx, p.Command, dir, timeout)
+	}
 	return s.run(ctx, p.Command, dir, timeout)
 }
 
@@ -121,9 +130,46 @@ func childEnvWithAgent(parent []string) []string {
 	return append(out, "AI_AGENT=neo")
 }
 
-// maxOutputBytes is the maximum number of bytes captured from stdout or stderr.
-// Output beyond this limit is silently discarded and "truncated" is set in the result.
-const maxOutputBytes = 1 << 20 // 1 MiB
+// ShellInvocation wraps a shell command string in the platform shell used to run
+// it: `sh -c` on Unix, `cmd /C` on Windows. Both the local runner here and the
+// Neo ACP editor-terminal runner call this so the two paths invoke commands
+// identically.
+func ShellInvocation(command string) (program string, args []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/C", command}
+	}
+	return "sh", []string{"-c", command}
+}
+
+// ShellResult is the structured outcome of running a shell command and the
+// canonical shape the `shell` tool returns to the agent. Both the local runner
+// and the ACP editor-terminal runner return it directly, so the wire shape can't
+// drift between them. Its JSON tags define that wire shape: stdout, stderr, and
+// exit_code are always present; error and the boolean flags appear only when set.
+type ShellResult struct {
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exit_code"`
+	// Err is a transport/exec failure that isn't an exit code (e.g. the command
+	// could not be started). Omitted when empty.
+	Err       string `json:"error,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+	TimedOut  bool   `json:"timed_out,omitempty"`
+}
+
+// TimeoutError is the error the shell tool returns when a command exceeds its
+// timeout. Both the local runner and the Neo ACP editor-terminal runner return
+// it, so the agent sees the same failure whichever path ran the command.
+func TimeoutError(timeout time.Duration) error {
+	return fmt.Errorf("shell command timed out after %s", timeout)
+}
+
+// MaxOutputBytes is the maximum number of bytes captured from stdout or stderr.
+// Output beyond this limit is silently discarded and "truncated" is set in the
+// result. It is the canonical capture cap for the shell tool: the Neo ACP
+// adapter passes it to editor-run terminals too, so truncation behaves
+// identically on both paths.
+const MaxOutputBytes = 1 << 20 // 1 MiB
 
 // cappedBuffer is a bytes.Buffer that stops accepting writes after a limit.
 type cappedBuffer struct {
@@ -145,16 +191,12 @@ func (c *cappedBuffer) Write(p []byte) (int, error) {
 	return c.buf.Write(p)
 }
 
-func (s *Shell) run(ctx context.Context, command string, dir string, timeout time.Duration) (any, error) {
+func (s *Shell) run(ctx context.Context, command string, dir string, timeout time.Duration) (ShellResult, error) {
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(runCtx, "cmd", "/C", command)
-	} else {
-		cmd = exec.CommandContext(runCtx, "sh", "-c", command)
-	}
+	program, args := ShellInvocation(command)
+	cmd := exec.CommandContext(runCtx, program, args...)
 	cmd.Dir = dir
 	cmd.Env = childEnvWithAgent(os.Environ())
 
@@ -171,32 +213,29 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 	// grace period instead of blocking forever on the inherited pipes.
 	cmd.WaitDelay = 5 * time.Second
 
-	stdout := &cappedBuffer{limit: maxOutputBytes}
-	stderr := &cappedBuffer{limit: maxOutputBytes}
+	stdout := &cappedBuffer{limit: MaxOutputBytes}
+	stderr := &cappedBuffer{limit: MaxOutputBytes}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
 	err := cmd.Run()
 
-	result := map[string]any{
-		"stdout":    stdout.buf.String(),
-		"stderr":    stderr.buf.String(),
-		"exit_code": 0,
+	res := ShellResult{
+		Stdout:    stdout.buf.String(),
+		Stderr:    stderr.buf.String(),
+		Truncated: stdout.truncated || stderr.truncated,
 	}
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			result["exit_code"] = exitErr.ExitCode()
+			res.ExitCode = exitErr.ExitCode()
 		} else {
-			result["error"] = err.Error()
+			res.Err = err.Error()
 		}
 	}
-	if stdout.truncated || stderr.truncated {
-		result["truncated"] = true
-	}
 	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-		result["timed_out"] = true
-		return result, fmt.Errorf("shell command timed out after %s", timeout)
+		res.TimedOut = true
+		return res, TimeoutError(timeout)
 	}
-	return result, nil
+	return res, nil
 }

--- a/pkg/cmd/pulumi/neo/tools/shell_test.go
+++ b/pkg/cmd/pulumi/neo/tools/shell_test.go
@@ -38,9 +38,9 @@ func TestShell_ExecuteCapturesStdout(t *testing.T) {
 	require.NoError(t, err)
 	res, err := sh.Invoke(t.Context(), "shell_execute", json.RawMessage(`{"command":"echo hi"}`))
 	require.NoError(t, err)
-	m := res.(map[string]any)
-	assert.Equal(t, "hi\n", m["stdout"])
-	assert.Equal(t, 0, m["exit_code"])
+	r := res.(ShellResult)
+	assert.Equal(t, "hi\n", r.Stdout)
+	assert.Equal(t, 0, r.ExitCode)
 }
 
 func TestShell_ExecuteHonorsTimeout(t *testing.T) {
@@ -56,7 +56,7 @@ func TestShell_ExecuteHonorsTimeout(t *testing.T) {
 	require.Error(t, err, "timeout must surface as a non-nil error so the TUI marks the call failed")
 	assert.Contains(t, err.Error(), "timed out")
 	require.NotNil(t, res, "partial result must still be returned alongside the timeout error")
-	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	assert.True(t, res.(ShellResult).TimedOut)
 }
 
 func TestShell_ExecuteHonorsAgentTimeout(t *testing.T) {
@@ -72,7 +72,7 @@ func TestShell_ExecuteHonorsAgentTimeout(t *testing.T) {
 		json.RawMessage(`{"command":"sleep 5","timeout":0.1}`))
 	require.Error(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	assert.True(t, res.(ShellResult).TimedOut)
 	assert.Less(t, time.Since(start), 5*time.Second, "agent-supplied timeout was ignored")
 }
 
@@ -90,7 +90,7 @@ func TestShell_ExecuteAgentTimeoutOverridesDefault(t *testing.T) {
 		json.RawMessage(`{"command":"sleep 5","timeout":0.1}`))
 	require.Error(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	assert.True(t, res.(ShellResult).TimedOut)
 	assert.Less(t, time.Since(start), 5*time.Second, "agent timeout did not override DefaultTimeout")
 }
 
@@ -111,7 +111,7 @@ func TestShell_ExecuteUnblocksOnOrphanedChild(t *testing.T) {
 		json.RawMessage(`{"command":"sleep 30 & wait","timeout":0.2}`))
 	require.Error(t, err)
 	require.NotNil(t, res)
-	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	assert.True(t, res.(ShellResult).TimedOut)
 	// Allow generous slack for the WaitDelay grace period (5s) plus CI noise.
 	assert.Less(t, time.Since(start), 15*time.Second, "shell hung on orphaned child")
 }
@@ -137,7 +137,7 @@ func TestShell_ExecuteCapturesNonZeroExit(t *testing.T) {
 	require.NoError(t, err)
 	res, err := sh.Invoke(t.Context(), "shell_execute", json.RawMessage(`{"command":"exit 3"}`))
 	require.NoError(t, err)
-	assert.Equal(t, 3, res.(map[string]any)["exit_code"])
+	assert.Equal(t, 3, res.(ShellResult).ExitCode)
 }
 
 func TestShell_ExecuteHonorsCwdSubdirectory(t *testing.T) {
@@ -159,7 +159,7 @@ func TestShell_ExecuteHonorsCwdSubdirectory(t *testing.T) {
 	res, err := sh.Invoke(t.Context(), "shell_execute",
 		json.RawMessage(`{"command":"pwd","cwd":"`+sub+`"}`))
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(res.(map[string]any)["stdout"].(string), resolvedSub))
+	assert.True(t, strings.HasPrefix(res.(ShellResult).Stdout, resolvedSub))
 }
 
 func TestShell_ExecuteRejectsCwdOutsideRoot(t *testing.T) {
@@ -208,13 +208,13 @@ func TestShell_TruncatesLargeOutput(t *testing.T) {
 
 	sh, err := NewShell(t.TempDir())
 	require.NoError(t, err)
-	// Generate more than maxOutputBytes of stdout.
+	// Generate more than MaxOutputBytes of stdout.
 	res, err := sh.Invoke(t.Context(), "shell_execute",
 		json.RawMessage(`{"command":"dd if=/dev/zero bs=1048576 count=2 2>/dev/null | tr '\\0' 'A'"}`))
 	require.NoError(t, err)
-	m := res.(map[string]any)
-	assert.True(t, m["truncated"].(bool))
-	assert.LessOrEqual(t, len(m["stdout"].(string)), maxOutputBytes)
+	r := res.(ShellResult)
+	assert.True(t, r.Truncated)
+	assert.LessOrEqual(t, len(r.Stdout), MaxOutputBytes)
 }
 
 func TestShell_RejectsUnknownMethod(t *testing.T) {
@@ -246,7 +246,7 @@ func TestShell_AcceptsCwdUnderExtraRoot(t *testing.T) {
 	res, err := sh.Invoke(t.Context(), "shell_execute",
 		json.RawMessage(fmt.Sprintf(`{"command":"pwd","cwd":%q}`, scratch)))
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(res.(map[string]any)["stdout"].(string), resolvedScratch))
+	assert.True(t, strings.HasPrefix(res.(ShellResult).Stdout, resolvedScratch))
 }
 
 func TestShell_RejectsCwdOutsideRootAndExtras(t *testing.T) {
@@ -299,7 +299,7 @@ func TestShell_InjectsAIAgent(t *testing.T) {
 	res, err := sh.Invoke(t.Context(), "shell_execute",
 		json.RawMessage(`{"command":"printenv AI_AGENT"}`))
 	require.NoError(t, err)
-	assert.Equal(t, "neo\n", res.(map[string]any)["stdout"])
+	assert.Equal(t, "neo\n", res.(ShellResult).Stdout)
 }
 
 func TestChildEnvWithAgent(t *testing.T) {


### PR DESCRIPTION
Let callers reroute the Neo tools' I/O without changing their wire shape:

- `Filesystem` gains `OnRead`/`OnWrite` hooks (nil means local disk, as before) and now accepts relative paths, resolved against its root.
- `Shell` gains an `OnExec` hook and exports `ShellResult`/`ShellInvocation` so an alternate runner produces identical results.
- `neo.go`: extract `buildLocalToolHandlers`, the `neoTaskCreator` interface, and `entityDroppedWarning` for reuse by other Neo entrypoints.

No behavior change with the hooks unset. Part 2/5 of the ACP stack (replaces #23669); the adapter uses these to route reads/writes/exec through the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)