### PR TITLE
Add an application-agnostic Agent Client Protocol package

### DIFF
--- a/pkg/cmd/pulumi/neo/acp/agent.go
+++ b/pkg/cmd/pulumi/neo/acp/agent.go
@@ -1,0 +1,255 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// ErrAuthRequired is the sentinel a Delegate returns (directly or wrapped) when
+// there is no usable session. The agent maps it to the ACP "Authentication
+// required" error (code -32000) so the editor can prompt the user to
+// authenticate. A Delegate may wrap it with an application-specific message
+// (e.g. "run `pulumi login`") that the editor then surfaces.
+var ErrAuthRequired = errors.New("authentication required")
+
+// codeAuthRequired is the JSON-RPC error code ACP uses for "Authentication
+// required". It lies in the implementation-defined server-error range.
+const codeAuthRequired int64 = -32000
+
+// Delegate supplies the application-specific behavior behind the ACP session
+// methods, keeping this package free of application dependencies. The neo
+// package implements it over the Pulumi Cloud backend and the Neo Session event
+// loop.
+type Delegate interface {
+	// CheckAuth reports whether a usable session is available from the existing
+	// credentials, returning ErrAuthRequired when none is. It never prompts. The
+	// agent calls it from the `authenticate` handler so the editor learns at that
+	// point whether the user still needs to authenticate, rather than only when
+	// the first session is created. (For Neo this checks the CLI's Pulumi Cloud
+	// login.)
+	CheckAuth(ctx context.Context) error
+
+	// NewSession resolves auth and the session target for a session rooted at
+	// params.Cwd, builds the session's tool handlers — routing filesystem writes
+	// through client (as an editor fs/write_text_file request) when caps
+	// advertises fs.writeTextFile — and returns the new session id. It returns
+	// ErrAuthRequired when no usable credentials are available. client is retained
+	// for the session's lifetime to push session/update notifications and request
+	// permissions.
+	NewSession(
+		ctx context.Context, params NewSessionParams, caps ClientCapabilities, client Client,
+	) (NewSessionResult, error)
+
+	// Prompt runs one prompt turn for params.SessionID and returns the reason it
+	// ended. It streams session/update notifications through the Client retained
+	// at NewSession, and blocks until the turn completes (or ctx is done).
+	Prompt(ctx context.Context, params PromptParams) (PromptResult, error)
+
+	// Cancel asks the agent to stop the in-flight turn for params.SessionID. It
+	// corresponds to the session/cancel notification, so it returns promptly; the
+	// turn itself ends with StopCancelled once the backend acknowledges.
+	Cancel(ctx context.Context, params CancelParams) error
+
+	// SetConfigOption applies a session config option change (params.ConfigID =
+	// params.Value) for params.SessionID and returns the complete, updated option
+	// list. The agent may clamp or ignore a change it cannot honor; the returned
+	// current values are authoritative.
+	SetConfigOption(ctx context.Context, params SetConfigOptionParams) (SetConfigOptionResult, error)
+}
+
+// Identity is the agent's self-description, advertised to the editor on
+// initialize. The embedding application supplies it so this package carries no
+// application-specific branding.
+type Identity struct {
+	Name        string       // agentInfo.name (e.g. "pulumi-neo")
+	Title       string       // agentInfo.title (e.g. "Pulumi Neo")
+	AuthMethods []AuthMethod // advertised authenticate methods
+}
+
+// Agent is the ACP agent side of the adapter. It holds the state that spans the
+// connection's lifetime — the negotiated client capabilities and the Delegate —
+// and implements the client→agent methods dispatched by handle. The Client used
+// to reach back to the editor is not stored here: handle derives it from the
+// connection on each dispatch.
+//
+// Agent owns only the protocol handshake (initialize/authenticate) and request
+// routing; the application-specific session behavior (for Neo: the Cloud client,
+// org/stack resolution, and the Neo Session event loop) lives behind the
+// Delegate supplied at construction.
+type Agent struct {
+	// identity is reported as agentInfo and the advertised auth methods on
+	// initialize.
+	identity Identity
+	// version is reported as agentInfo.version on initialize.
+	version string
+	// delegate supplies the application-specific session behavior.
+	delegate Delegate
+
+	mu sync.Mutex
+	// clientCaps is captured from the initialize request and consulted when
+	// building per-session tool handlers (filesystem/shell routing).
+	clientCaps ClientCapabilities
+}
+
+// NewAgent constructs an Agent. identity is advertised to the editor as agentInfo
+// and the available auth methods, and version is surfaced as agentInfo.version,
+// both during initialize. delegate supplies the application-specific session
+// behavior and must be non-nil.
+func NewAgent(identity Identity, version string, delegate Delegate) *Agent {
+	return &Agent{identity: identity, version: version, delegate: delegate}
+}
+
+// initialize handles the `initialize` request: it records the client's
+// capabilities and reports the agent's. Per the spec we echo the client's
+// protocol version when we support it, otherwise our latest; since v1 is the
+// only version we implement, we always answer ProtocolVersion.
+func (a *Agent) initialize(req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[InitializeParams](req)
+	if err != nil {
+		return nil, err
+	}
+
+	a.mu.Lock()
+	a.clientCaps = params.ClientCapabilities
+	a.mu.Unlock()
+
+	return InitializeResult{
+		ProtocolVersion: ProtocolVersion,
+		AgentCapabilities: AgentCapabilities{
+			// session/load and non-text prompt content are not yet supported.
+			LoadSession:        false,
+			PromptCapabilities: PromptCapabilities{},
+		},
+		AgentInfo: &Implementation{
+			Name:    a.identity.Name,
+			Title:   a.identity.Title,
+			Version: a.version,
+		},
+		AuthMethods: advertisedAuthMethods(a.identity.AuthMethods, params.ClientCapabilities),
+	}, nil
+}
+
+// advertisedAuthMethods tailors the identity's auth methods to the client's
+// capabilities. A terminal-typed method is advertised as-is only when the
+// client declared the auth.terminal capability; otherwise it is degraded to the
+// untyped (agent-default) form — Type/Args/Env cleared, ID/Name/Description
+// kept — so the editor still surfaces the method's description telling the user
+// how to authenticate out of band. IDs are stable across the two forms. Meta is
+// kept even on degrade: clients ignore unrecognized "_meta" keys by spec, and
+// editors that support only the pre-stabilization terminal-auth meta (see
+// MetaKeyTerminalAuth) may not declare the auth.terminal capability.
+func advertisedAuthMethods(methods []AuthMethod, caps ClientCapabilities) []AuthMethod {
+	if caps.Auth.Terminal {
+		return methods
+	}
+	degraded := make([]AuthMethod, len(methods))
+	for i, m := range methods {
+		if m.Type == AuthMethodTypeTerminal {
+			m.Type, m.Args, m.Env = "", nil, nil
+		}
+		degraded[i] = m
+	}
+	return degraded
+}
+
+// authenticate handles the `authenticate` request. Login itself happens outside
+// this channel — for a terminal-typed method the client runs the agent's setup
+// command (for Neo: `pulumi login`) in a real terminal, since an interactive
+// login cannot run over the stdio JSON-RPC stream. authenticate then verifies
+// via the Delegate that a usable session exists, mapping its absence to the ACP
+// "Authentication required" error so the editor can tell the user how to
+// authenticate at the point it asked. session/new performs the same check, so
+// auth stays gated even if credentials lapse between calls. Returns null on
+// success.
+func (a *Agent) authenticate(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[AuthenticateParams](req)
+	if err != nil {
+		return nil, err
+	}
+	// Method IDs survive capability degrading (see advertisedAuthMethods), so
+	// validate against the identity list directly.
+	if !slices.ContainsFunc(a.identity.AuthMethods, func(m AuthMethod) bool { return m.ID == params.MethodID }) {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("unknown auth method id %q", params.MethodID),
+		}
+	}
+	if err := a.delegate.CheckAuth(ctx); err != nil {
+		return nil, mapDelegateErr(err)
+	}
+	return nil, nil
+}
+
+// mapDelegateErr converts a Delegate error into the response the editor should
+// see, translating ErrAuthRequired to the ACP "Authentication required" code so
+// the editor can prompt for login. Other errors pass through unchanged.
+func mapDelegateErr(err error) error {
+	if errors.Is(err, ErrAuthRequired) {
+		return &jsonrpc2.Error{Code: codeAuthRequired, Message: err.Error()}
+	}
+	return err
+}
+
+// newSession handles the `session/new` request. client is the connection-backed
+// Client handle supplied by handle; the Delegate retains it for the session's
+// lifetime to build editor-backed tool handlers (e.g. ClientFS) and to stream
+// session/update notifications.
+func (a *Agent) newSession(ctx context.Context, client Client, req *jsonrpc2.Request) (any, error) {
+	a.mu.Lock()
+	caps := a.clientCaps
+	a.mu.Unlock()
+	params, err := decodeParams[NewSessionParams](req)
+	if err != nil {
+		return nil, err
+	}
+	res, err := a.delegate.NewSession(ctx, params, caps, client)
+	if err != nil {
+		return nil, mapDelegateErr(err)
+	}
+	return res, nil
+}
+
+func (a *Agent) prompt(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[PromptParams](req)
+	if err != nil {
+		return nil, err
+	}
+	return a.delegate.Prompt(ctx, params)
+}
+
+func (a *Agent) setConfigOption(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[SetConfigOptionParams](req)
+	if err != nil {
+		return nil, err
+	}
+	return a.delegate.SetConfigOption(ctx, params)
+}
+
+// cancel handles the session/cancel notification. As a notification it has no
+// response; HandlerWithError logs any returned error.
+func (a *Agent) cancel(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	params, err := decodeParams[CancelParams](req)
+	if err != nil {
+		return nil, err
+	}
+	return nil, a.delegate.Cancel(ctx, params)
+}

--- a/pkg/cmd/pulumi/neo/acp/agent_test.go
+++ b/pkg/cmd/pulumi/neo/acp/agent_test.go
@@ -1,0 +1,370 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testAuthMethod is the auth-method id advertised by testIdentity. The package
+// itself carries no auth-method constant — identity is injected — so tests
+// supply their own.
+const testAuthMethod = "test-login"
+
+// testIdentity is the agent identity used across these tests, standing in for
+// whatever an embedding application (e.g. neo) injects via NewAgent. The auth
+// method is terminal-typed so initialize tests can observe capability-based
+// degradation.
+var testIdentity = Identity{
+	Name:  "test-agent",
+	Title: "Test Agent",
+	AuthMethods: []AuthMethod{{
+		ID:   testAuthMethod,
+		Name: "Test login",
+		Type: AuthMethodTypeTerminal,
+		Args: []string{"login"},
+		Env:  map[string]string{"TEST_LOGIN": "1"},
+		Meta: map[string]any{MetaKeyTerminalAuth: map[string]any{
+			"label": "test login", "command": "test-agent", "args": []any{"login"},
+		}},
+	}},
+}
+
+// newTestPeers wires an agent connection to a client connection over an
+// in-memory pipe, returning the client side to drive requests against. Both
+// connections are closed via t.Cleanup.
+func newTestPeers(t *testing.T, a *Agent) *jsonrpc2.Conn {
+	return newTestPeersWithClient(t, a, noopHandler{})
+}
+
+// newTestPeersWithClient is like newTestPeers but lets the caller supply the
+// client-side handler so a test can answer the agent's outbound requests (e.g.
+// fs/read_text_file). The agent side is wrapped in AsyncHandler exactly as Serve
+// does, so the wiring under test matches production — in particular, an inbound
+// request handler may block on an outbound request without deadlocking the read
+// loop.
+func newTestPeersWithClient(t *testing.T, a *Agent, clientHandler jsonrpc2.Handler) *jsonrpc2.Conn {
+	t.Helper()
+	agentEnd, clientEnd := net.Pipe()
+
+	agentConn := jsonrpc2.NewConn(t.Context(),
+		jsonrpc2.NewPlainObjectStream(agentEnd), jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(a.handle)))
+
+	clientConn := jsonrpc2.NewConn(t.Context(),
+		jsonrpc2.NewPlainObjectStream(clientEnd), clientHandler)
+
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = agentConn.Close()
+	})
+	return clientConn
+}
+
+// noopHandler is the client-side handler for tests that only make outbound
+// calls and expect no agent→client requests.
+type noopHandler struct{}
+
+func (noopHandler) Handle(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request) {}
+
+func TestInitializeNegotiatesAndCapturesCapabilities(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.999.0", &fakeDelegate{})
+	client := newTestPeers(t, agent)
+
+	var res InitializeResult
+	err := client.Call(t.Context(), "initialize", InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		ClientCapabilities: ClientCapabilities{
+			FS:       FileSystemCapability{ReadTextFile: true, WriteTextFile: true},
+			Terminal: true,
+			Auth:     AuthCapability{Terminal: true},
+		},
+		ClientInfo: &Implementation{Name: "test-editor", Version: "1.0"},
+	}, &res)
+	require.NoError(t, err)
+
+	assert.Equal(t, ProtocolVersion, res.ProtocolVersion)
+	require.NotNil(t, res.AgentInfo)
+	assert.Equal(t, "v3.999.0", res.AgentInfo.Version)
+	// The client supports terminal auth, so the method is advertised as-is.
+	require.Len(t, res.AuthMethods, 1)
+	assert.Equal(t, testIdentity.AuthMethods[0], res.AuthMethods[0])
+
+	// The editor's capabilities are captured for later tool routing. (The Call
+	// above completing gives the necessary happens-before for this direct read.)
+	agent.mu.Lock()
+	caps := agent.clientCaps
+	agent.mu.Unlock()
+	assert.True(t, caps.FS.WriteTextFile)
+	assert.True(t, caps.FS.ReadTextFile)
+	assert.True(t, caps.Terminal)
+	assert.True(t, caps.Auth.Terminal)
+}
+
+func TestInitializeDegradesTerminalAuthMethods(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.999.0", &fakeDelegate{})
+	client := newTestPeers(t, agent)
+
+	// Without auth.terminal, expect the degraded (untyped) form.
+	var res InitializeResult
+	err := client.Call(t.Context(), "initialize", InitializeParams{
+		ProtocolVersion:    ProtocolVersion,
+		ClientCapabilities: ClientCapabilities{Terminal: true},
+	}, &res)
+	require.NoError(t, err)
+
+	require.Len(t, res.AuthMethods, 1)
+	got := res.AuthMethods[0]
+	assert.Equal(t, testAuthMethod, got.ID)
+	assert.Equal(t, "Test login", got.Name)
+	assert.Empty(t, got.Type)
+	assert.Empty(t, got.Args)
+	assert.Empty(t, got.Env)
+	// Meta survives degrade: pre-stabilization terminal-auth clients may not
+	// declare auth.terminal, and others ignore unknown "_meta" keys by spec.
+	assert.Contains(t, got.Meta, MetaKeyTerminalAuth)
+	// The identity itself is not mutated by degradation.
+	assert.Equal(t, AuthMethodTypeTerminal, testIdentity.AuthMethods[0].Type)
+}
+
+func TestAuthenticateAcknowledgesWhenLoggedIn(t *testing.T) {
+	t.Parallel()
+
+	// authErr nil: a usable session exists.
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{})
+	client := newTestPeers(t, agent)
+
+	err := client.Call(t.Context(), "authenticate", AuthenticateParams{MethodID: testAuthMethod}, nil)
+	require.NoError(t, err)
+}
+
+func TestAuthenticateAuthRequiredMapsToCode(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{authErr: ErrAuthRequired})
+	client := newTestPeers(t, agent)
+
+	err := client.Call(t.Context(), "authenticate", AuthenticateParams{MethodID: testAuthMethod}, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, codeAuthRequired, rpcErr.Code)
+}
+
+func TestAuthenticateUnknownMethodIDIsInvalidParams(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{})
+	client := newTestPeers(t, agent)
+
+	err := client.Call(t.Context(), "authenticate", AuthenticateParams{MethodID: "bogus"}, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, jsonrpc2.CodeInvalidParams, rpcErr.Code)
+}
+
+func TestUnknownMethodIsMethodNotFound(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPeers(t, NewAgent(testIdentity, "v3.0.0", &fakeDelegate{}))
+
+	err := client.Call(t.Context(), "does/not/exist", nil, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, jsonrpc2.CodeMethodNotFound, rpcErr.Code)
+}
+
+// fakeDelegate records what the session methods were called with and returns
+// canned results, so the agent's delegation and error mapping can be tested
+// without a Pulumi Cloud backend.
+type fakeDelegate struct {
+	result       NewSessionResult
+	err          error
+	authErr      error
+	gotParams    NewSessionParams
+	gotCaps      ClientCapabilities
+	gotClient    Client
+	promptResult PromptResult
+	promptErr    error
+	gotPrompt    PromptParams
+	gotCancel    CancelParams
+	configResult SetConfigOptionResult
+	configErr    error
+	gotConfig    SetConfigOptionParams
+}
+
+func (f *fakeDelegate) CheckAuth(context.Context) error { return f.authErr }
+
+func (f *fakeDelegate) NewSession(
+	_ context.Context, params NewSessionParams, caps ClientCapabilities, client Client,
+) (NewSessionResult, error) {
+	f.gotParams, f.gotCaps, f.gotClient = params, caps, client
+	return f.result, f.err
+}
+
+func (f *fakeDelegate) Prompt(_ context.Context, params PromptParams) (PromptResult, error) {
+	f.gotPrompt = params
+	return f.promptResult, f.promptErr
+}
+
+func (f *fakeDelegate) Cancel(_ context.Context, params CancelParams) error {
+	f.gotCancel = params
+	return nil
+}
+
+func (f *fakeDelegate) SetConfigOption(
+	_ context.Context, params SetConfigOptionParams,
+) (SetConfigOptionResult, error) {
+	f.gotConfig = params
+	return f.configResult, f.configErr
+}
+
+func TestNewSessionDelegatesWithCapturedCapabilities(t *testing.T) {
+	t.Parallel()
+
+	fd := &fakeDelegate{result: NewSessionResult{SessionID: "sess_42"}}
+	agent := NewAgent(testIdentity, "v3.0.0", fd)
+	client := newTestPeers(t, agent)
+
+	// initialize first so the agent captures the client's fs capability and
+	// forwards it to the delegate.
+	require.NoError(t, client.Call(t.Context(), "initialize", InitializeParams{
+		ProtocolVersion:    ProtocolVersion,
+		ClientCapabilities: ClientCapabilities{FS: FileSystemCapability{WriteTextFile: true}},
+	}, &InitializeResult{}))
+
+	var res NewSessionResult
+	err := client.Call(t.Context(), "session/new", NewSessionParams{Cwd: "/work"}, &res)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sess_42", res.SessionID)
+	assert.Equal(t, "/work", fd.gotParams.Cwd)
+	assert.True(t, fd.gotCaps.FS.WriteTextFile, "client fs capability should reach the delegate")
+	require.NotNil(t, fd.gotClient, "the delegate should receive a Client for editor-backed writes")
+}
+
+// readingDelegate's Prompt reads a file back through the editor, exercising the
+// outbound-request-during-an-inbound-request path that previously deadlocked.
+type readingDelegate struct {
+	client    Client
+	readPath  string
+	gotResult string
+}
+
+func (d *readingDelegate) CheckAuth(context.Context) error { return nil }
+
+func (d *readingDelegate) NewSession(
+	_ context.Context, _ NewSessionParams, _ ClientCapabilities, client Client,
+) (NewSessionResult, error) {
+	d.client = client
+	return NewSessionResult{SessionID: "sess_read"}, nil
+}
+
+func (d *readingDelegate) Prompt(ctx context.Context, _ PromptParams) (PromptResult, error) {
+	cfs := &ClientFS{Caller: d.client, SessionID: "sess_read"}
+	content, err := cfs.ReadTextFile(ctx, d.readPath)
+	if err != nil {
+		return PromptResult{}, err
+	}
+	d.gotResult = content
+	return PromptResult{StopReason: StopEndTurn}, nil
+}
+
+func (d *readingDelegate) Cancel(context.Context, CancelParams) error { return nil }
+
+func (d *readingDelegate) SetConfigOption(
+	context.Context, SetConfigOptionParams,
+) (SetConfigOptionResult, error) {
+	return SetConfigOptionResult{}, nil
+}
+
+// replyingClient answers fs/read_text_file with canned content. It models the
+// editor satisfying the agent's read while the agent's prompt handler is blocked
+// waiting for it.
+type replyingClient struct{ content string }
+
+func (c replyingClient) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	if req.Method == "fs/read_text_file" {
+		_ = conn.Reply(ctx, req.ID, readTextFileResult{Content: c.content})
+	}
+}
+
+// TestPromptCanReadFileBackThroughClient is the regression test for the deadlock
+// where a prompt turn that issued an outbound fs/read_text_file hung forever: the
+// agent's single JSON-RPC read loop was parked inside the synchronous prompt
+// handler and could never deliver the editor's response. With AsyncHandler the
+// turn completes. The test uses its own timeout so a regression shows up as a
+// failure, not a hung test.
+func TestPromptCanReadFileBackThroughClient(t *testing.T) {
+	t.Parallel()
+
+	fd := &readingDelegate{readPath: "/abs/file.txt"}
+	agent := NewAgent(testIdentity, "v3.0.0", fd)
+	client := newTestPeersWithClient(t, agent, replyingClient{content: "hello"})
+
+	require.NoError(t, client.Call(t.Context(), "session/new", NewSessionParams{Cwd: "/work"}, &NewSessionResult{}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var res PromptResult
+	err := client.Call(ctx, "session/prompt", PromptParams{SessionID: "sess_read"}, &res)
+	require.NoError(t, err, "prompt that reads a file back through the editor must not deadlock")
+	assert.Equal(t, StopEndTurn, res.StopReason)
+	assert.Equal(t, "hello", fd.gotResult)
+}
+
+func TestSetConfigOptionDelegates(t *testing.T) {
+	t.Parallel()
+
+	fd := &fakeDelegate{configResult: SetConfigOptionResult{
+		ConfigOptions: []ConfigOption{{ID: "permission", Type: ConfigOptionTypeSelect, CurrentValue: "read-only"}},
+	}}
+	agent := NewAgent(testIdentity, "v3.0.0", fd)
+	client := newTestPeers(t, agent)
+
+	var res SetConfigOptionResult
+	err := client.Call(t.Context(), "session/set_config_option", SetConfigOptionParams{
+		SessionID: "sess_1", ConfigID: "permission", Value: "read-only",
+	}, &res)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sess_1", fd.gotConfig.SessionID)
+	assert.Equal(t, "permission", fd.gotConfig.ConfigID)
+	assert.Equal(t, "read-only", fd.gotConfig.Value)
+	require.Len(t, res.ConfigOptions, 1)
+	assert.Equal(t, "read-only", res.ConfigOptions[0].CurrentValue)
+}
+
+func TestNewSessionAuthRequiredMapsToCode(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{err: ErrAuthRequired})
+	client := newTestPeers(t, agent)
+
+	err := client.Call(t.Context(), "session/new", NewSessionParams{Cwd: "/work"}, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, codeAuthRequired, rpcErr.Code)
+}

--- a/pkg/cmd/pulumi/neo/acp/conn.go
+++ b/pkg/cmd/pulumi/neo/acp/conn.go
@@ -1,0 +1,130 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+// Serve runs the ACP agent over the given stdio streams, speaking newline-framed
+// JSON-RPC 2.0, until the peer disconnects or ctx is cancelled. The embedding
+// command calls this with its stdin/stdout (for Neo, `pulumi neo acp`); nothing
+// else may write to the output stream or it will corrupt the protocol.
+func Serve(ctx context.Context, a *Agent, in io.Reader, out io.Writer) error {
+	stream := jsonrpc2.NewPlainObjectStream(stdio{Reader: in, Writer: out})
+	// AsyncHandler runs each inbound request in its own goroutine. This is
+	// required, not just an optimization: a session/prompt turn issues outbound
+	// requests back to the editor (fs/read_text_file, terminal/*,
+	// session/request_permission) and blocks on their responses. Those responses
+	// arrive on this same connection and are dispatched by jsonrpc2's single read
+	// loop — which, with a synchronous handler, would still be parked inside the
+	// prompt handler and could never deliver them, deadlocking on the first such
+	// call. Async handling also lets a session/cancel be processed while its
+	// session/prompt is still in flight.
+	handler := jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(a.handle))
+	conn := jsonrpc2.NewConn(ctx, stream, handler)
+
+	select {
+	case <-ctx.Done():
+		_ = conn.Close()
+		return ctx.Err()
+	case <-conn.DisconnectNotify():
+		return nil
+	}
+}
+
+// handle dispatches a single client→agent request by method name. It is wrapped
+// in jsonrpc2.HandlerWithError, which turns the (result, error) return into a
+// JSON-RPC response: a *jsonrpc2.Error becomes a structured error response,
+// any other error becomes a generic one, and notifications drop the result.
+// The Client handed to session/new is derived from conn here, so it exists the
+// moment a request can be dispatched — there is no wiring step to race.
+func (a *Agent) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	switch req.Method {
+	case "initialize":
+		return a.initialize(req)
+	case "authenticate":
+		return a.authenticate(ctx, req)
+	case "session/new":
+		return a.newSession(ctx, connCaller{conn: conn}, req)
+	case "session/prompt":
+		return a.prompt(ctx, req)
+	case "session/cancel":
+		return a.cancel(ctx, req)
+	case "session/set_config_option":
+		return a.setConfigOption(ctx, req)
+	default:
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeMethodNotFound,
+			Message: fmt.Sprintf("method %q is not supported", req.Method),
+		}
+	}
+}
+
+// decodeParams unmarshals a request's params into T, returning a CodeInvalidParams
+// JSON-RPC error on failure. Absent params decode to the zero value of T.
+func decodeParams[T any](req *jsonrpc2.Request) (T, error) {
+	var v T
+	if req.Params == nil {
+		return v, nil
+	}
+	if err := json.Unmarshal(*req.Params, &v); err != nil {
+		return v, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: fmt.Sprintf("decoding %s params: %v", req.Method, err),
+		}
+	}
+	return v, nil
+}
+
+// Client is the agent's handle to the editor for the connection: it adds
+// fire-and-forget notifications (session/update) on top of the request/response
+// Caller (session/request_permission, fs/*, terminal/*).
+type Client interface {
+	Caller
+	// Notify sends a JSON-RPC notification (no response expected).
+	Notify(ctx context.Context, method string, params any) error
+}
+
+// connCaller adapts a *jsonrpc2.Conn to the Client (and Caller) interface so
+// outbound helpers (e.g. ClientFS) and the session translator can issue requests
+// and notifications without depending on jsonrpc2 directly.
+type connCaller struct {
+	conn *jsonrpc2.Conn
+}
+
+func (c connCaller) Call(ctx context.Context, method string, params, result any) error {
+	return c.conn.Call(ctx, method, params, result)
+}
+
+func (c connCaller) Notify(ctx context.Context, method string, params any) error {
+	return c.conn.Notify(ctx, method, params)
+}
+
+// stdio adapts a separate reader and writer (stdin/stdout) into the single
+// io.ReadWriteCloser that jsonrpc2.NewPlainObjectStream expects. Close is a no-op:
+// the process owns the underlying file descriptors and closing them here would
+// race the runtime's own teardown.
+type stdio struct {
+	io.Reader
+	io.Writer
+}
+
+func (stdio) Close() error { return nil }

--- a/pkg/cmd/pulumi/neo/acp/fs.go
+++ b/pkg/cmd/pulumi/neo/acp/fs.go
@@ -14,7 +14,13 @@
 
 package acp
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
 
 // Caller issues an outbound JSON-RPC request to the ACP client (the editor) and
 // decodes the response into result, which may be nil when the method returns no
@@ -53,9 +59,9 @@ type readTextFileResult struct {
 // ClientFS routes filesystem reads and writes to the ACP client so the editor
 // performs them — surfacing writes as native diffs and serving reads from the
 // editor's (possibly unsaved) buffer — rather than the CLI touching disk
-// directly. It is wired into a tools.Filesystem via its OnRead/OnWrite hooks;
-// gate that wiring on the client having advertised the corresponding fs
-// capability during initialize.
+// directly. It is wired into a tools.Filesystem via its ReadFileOverride and
+// WriteFileOverride fields; gate that wiring on the client having advertised
+// the corresponding fs capability during initialize.
 type ClientFS struct {
 	// Caller issues the outbound fs/* requests to the editor.
 	Caller Caller
@@ -65,7 +71,8 @@ type ClientFS struct {
 
 // WriteTextFile sends the full content of an absolute path to the editor via the
 // ACP `fs/write_text_file` request. Its signature matches
-// tools.Filesystem.OnWrite, so it can be assigned to that hook directly.
+// tools.Filesystem.WriteFileOverride, so it can be assigned to that field
+// directly.
 func (c *ClientFS) WriteTextFile(ctx context.Context, path, content string) error {
 	return c.Caller.Call(ctx, "fs/write_text_file", writeTextFileParams{
 		SessionID: c.SessionID,
@@ -76,13 +83,23 @@ func (c *ClientFS) WriteTextFile(ctx context.Context, path, content string) erro
 
 // ReadTextFile fetches the full content of an absolute path from the editor via
 // the ACP `fs/read_text_file` request. Its signature matches
-// tools.Filesystem.OnRead, so it can be assigned to that hook directly.
+// tools.Filesystem.ReadFileOverride, so it can be assigned to that field
+// directly, and it honors that field's contract of reporting missing files
+// with an error satisfying errors.Is(err, fs.ErrNotExist).
 func (c *ClientFS) ReadTextFile(ctx context.Context, path string) (string, error) {
 	var res readTextFileResult
 	if err := c.Caller.Call(ctx, "fs/read_text_file", readTextFileParams{
 		SessionID: c.SessionID,
 		Path:      path,
 	}, &res); err != nil {
+		// ACP doesn't standardize a "file not found" error code, but the
+		// ReadFileOverride contract requires missing files to surface as
+		// fs.ErrNotExist (the edit tool's creation mode depends on it). The
+		// editor's view is local disk plus its open buffers, so when the editor
+		// couldn't read the file and it isn't on disk either, it doesn't exist.
+		if _, statErr := os.Stat(path); errors.Is(statErr, fs.ErrNotExist) {
+			return "", fmt.Errorf("%w: %w", fs.ErrNotExist, err)
+		}
 		return "", err
 	}
 	return res.Content, nil

--- a/pkg/cmd/pulumi/neo/acp/fs.go
+++ b/pkg/cmd/pulumi/neo/acp/fs.go
@@ -1,0 +1,89 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import "context"
+
+// Caller issues an outbound JSON-RPC request to the ACP client (the editor) and
+// decodes the response into result, which may be nil when the method returns no
+// payload. The session connection (*jsonrpc2.Conn) satisfies this via a thin
+// adapter; tests supply a fake.
+type Caller interface {
+	Call(ctx context.Context, method string, params, result any) error
+}
+
+// writeTextFileParams is the request body for the ACP `fs/write_text_file`
+// client method. Field names mirror the ACP schema exactly. path must be
+// absolute; the client creates the file (and any missing parents) if needed and
+// responds with null.
+//
+// https://agentclientprotocol.com/protocol/file-system
+type writeTextFileParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+}
+
+// readTextFileParams is the request body for the ACP `fs/read_text_file` client
+// method. path must be absolute. The response carries the file's full content.
+//
+// https://agentclientprotocol.com/protocol/file-system
+type readTextFileParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+}
+
+// readTextFileResult is the response to fs/read_text_file.
+type readTextFileResult struct {
+	Content string `json:"content"`
+}
+
+// ClientFS routes filesystem reads and writes to the ACP client so the editor
+// performs them — surfacing writes as native diffs and serving reads from the
+// editor's (possibly unsaved) buffer — rather than the CLI touching disk
+// directly. It is wired into a tools.Filesystem via its OnRead/OnWrite hooks;
+// gate that wiring on the client having advertised the corresponding fs
+// capability during initialize.
+type ClientFS struct {
+	// Caller issues the outbound fs/* requests to the editor.
+	Caller Caller
+	// SessionID is the ACP session the operation belongs to.
+	SessionID string
+}
+
+// WriteTextFile sends the full content of an absolute path to the editor via the
+// ACP `fs/write_text_file` request. Its signature matches
+// tools.Filesystem.OnWrite, so it can be assigned to that hook directly.
+func (c *ClientFS) WriteTextFile(ctx context.Context, path, content string) error {
+	return c.Caller.Call(ctx, "fs/write_text_file", writeTextFileParams{
+		SessionID: c.SessionID,
+		Path:      path,
+		Content:   content,
+	}, nil)
+}
+
+// ReadTextFile fetches the full content of an absolute path from the editor via
+// the ACP `fs/read_text_file` request. Its signature matches
+// tools.Filesystem.OnRead, so it can be assigned to that hook directly.
+func (c *ClientFS) ReadTextFile(ctx context.Context, path string) (string, error) {
+	var res readTextFileResult
+	if err := c.Caller.Call(ctx, "fs/read_text_file", readTextFileParams{
+		SessionID: c.SessionID,
+		Path:      path,
+	}, &res); err != nil {
+		return "", err
+	}
+	return res.Content, nil
+}

--- a/pkg/cmd/pulumi/neo/acp/fs_test.go
+++ b/pkg/cmd/pulumi/neo/acp/fs_test.go
@@ -17,6 +17,9 @@ package acp
 import (
 	"context"
 	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,11 +89,33 @@ func TestClientFSReadTextFile(t *testing.T) {
 func TestClientFSReadTextFilePropagatesError(t *testing.T) {
 	t.Parallel()
 
-	wantErr := errors.New("not found")
-	fs := &ClientFS{Caller: &recordingCaller{err: wantErr}, SessionID: "sess_123"}
+	// The file exists on disk, so the editor's failure is not a missing file:
+	// the RPC error must come through unchanged, without fs.ErrNotExist.
+	path := filepath.Join(t.TempDir(), "main.go")
+	require.NoError(t, os.WriteFile(path, []byte("package main"), 0o600))
 
-	_, err := fs.ReadTextFile(t.Context(), "/abs/path/main.go")
+	wantErr := errors.New("editor went away")
+	cfs := &ClientFS{Caller: &recordingCaller{err: wantErr}, SessionID: "sess_123"}
+
+	_, err := cfs.ReadTextFile(t.Context(), path)
 	assert.ErrorIs(t, err, wantErr)
+	assert.NotErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestClientFSReadTextFileMapsMissingFileToErrNotExist(t *testing.T) {
+	t.Parallel()
+
+	// ACP has no standard "file not found" error code, so when the editor's
+	// read fails and the file isn't on disk either, ReadTextFile must classify
+	// the failure as fs.ErrNotExist — tools.Filesystem.ReadFileOverride's
+	// contract, which the edit tool's creation mode relies on — while keeping
+	// the original RPC error in the chain.
+	rpcErr := errors.New("editor: no such file")
+	cfs := &ClientFS{Caller: &recordingCaller{err: rpcErr}, SessionID: "sess_123"}
+
+	_, err := cfs.ReadTextFile(t.Context(), filepath.Join(t.TempDir(), "missing.go"))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.ErrorIs(t, err, rpcErr)
 }
 
 func TestClientFSWriteTextFilePropagatesError(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/acp/fs_test.go
+++ b/pkg/cmd/pulumi/neo/acp/fs_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCaller captures the single outbound request a test makes so the
+// method name and decoded params can be asserted. err is returned from Call;
+// readContent is served back for fs/read_text_file responses.
+type recordingCaller struct {
+	calls       int
+	method      string
+	params      any
+	err         error
+	readContent string
+}
+
+func (c *recordingCaller) Call(_ context.Context, method string, params, result any) error {
+	c.calls++
+	c.method = method
+	c.params = params
+	if c.err != nil {
+		return c.err
+	}
+	if r, ok := result.(*readTextFileResult); ok {
+		r.Content = c.readContent
+	}
+	return nil
+}
+
+func TestClientFSWriteTextFile(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingCaller{}
+	fs := &ClientFS{Caller: caller, SessionID: "sess_123"}
+
+	require.NoError(t, fs.WriteTextFile(t.Context(), "/abs/path/main.go", "package main"))
+
+	assert.Equal(t, 1, caller.calls)
+	assert.Equal(t, "fs/write_text_file", caller.method)
+	require.IsType(t, writeTextFileParams{}, caller.params)
+	got := caller.params.(writeTextFileParams)
+	assert.Equal(t, writeTextFileParams{
+		SessionID: "sess_123",
+		Path:      "/abs/path/main.go",
+		Content:   "package main",
+	}, got)
+}
+
+func TestClientFSReadTextFile(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingCaller{readContent: "package main"}
+	fs := &ClientFS{Caller: caller, SessionID: "sess_123"}
+
+	got, err := fs.ReadTextFile(t.Context(), "/abs/path/main.go")
+	require.NoError(t, err)
+	assert.Equal(t, "package main", got)
+
+	assert.Equal(t, "fs/read_text_file", caller.method)
+	require.IsType(t, readTextFileParams{}, caller.params)
+	assert.Equal(t,
+		readTextFileParams{SessionID: "sess_123", Path: "/abs/path/main.go"},
+		caller.params.(readTextFileParams))
+}
+
+func TestClientFSReadTextFilePropagatesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("not found")
+	fs := &ClientFS{Caller: &recordingCaller{err: wantErr}, SessionID: "sess_123"}
+
+	_, err := fs.ReadTextFile(t.Context(), "/abs/path/main.go")
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestClientFSWriteTextFilePropagatesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("permission denied")
+	fs := &ClientFS{Caller: &recordingCaller{err: wantErr}, SessionID: "sess_123"}
+
+	err := fs.WriteTextFile(t.Context(), "/abs/path/main.go", "x")
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/pkg/cmd/pulumi/neo/acp/terminal.go
+++ b/pkg/cmd/pulumi/neo/acp/terminal.go
@@ -1,0 +1,142 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"context"
+	"errors"
+)
+
+// ClientTerminal runs a command in the editor's terminal via the ACP terminal/*
+// methods, so shell tool calls execute in the editor (with its own UI and
+// environment) instead of as a local child process. Gate its use on the client
+// having advertised the terminal capability during initialize.
+//
+// https://agentclientprotocol.com/protocol/terminals
+type ClientTerminal struct {
+	Caller    Caller
+	SessionID string
+}
+
+// TerminalResult is the outcome of running a command in the editor's terminal.
+// The editor merges stdout and stderr into a single Output stream. ExitCode is
+// 0 when the process was terminated by a signal (Signal is then set). TimedOut
+// is true when the run was killed because the caller's context expired.
+type TerminalResult struct {
+	Output    string
+	ExitCode  int
+	Signal    string
+	Truncated bool
+	TimedOut  bool
+}
+
+type createTerminalParams struct {
+	SessionID       string   `json:"sessionId"`
+	Command         string   `json:"command"`
+	Args            []string `json:"args,omitempty"`
+	Cwd             string   `json:"cwd,omitempty"`
+	OutputByteLimit int      `json:"outputByteLimit,omitempty"`
+}
+
+type createTerminalResult struct {
+	TerminalID string `json:"terminalId"`
+}
+
+// terminalRef identifies a created terminal for the output/wait/kill/release
+// methods.
+type terminalRef struct {
+	SessionID  string `json:"sessionId"`
+	TerminalID string `json:"terminalId"`
+}
+
+// exitStatus is the process termination status. ExitCode is null when the
+// process was terminated by a signal.
+type exitStatus struct {
+	ExitCode *int   `json:"exitCode"`
+	Signal   string `json:"signal,omitempty"`
+}
+
+type terminalOutputResult struct {
+	Output     string      `json:"output"`
+	Truncated  bool        `json:"truncated"`
+	ExitStatus *exitStatus `json:"exitStatus,omitempty"`
+}
+
+// Run creates a terminal for command (with args, in cwd), waits for it to exit,
+// collects its output, and releases the terminal. outputByteLimit caps the
+// captured output (0 means the client's default). If ctx expires while waiting,
+// the command is killed, whatever output it produced is returned with TimedOut
+// set, and ctx's error is returned. The terminal is always released.
+func (c *ClientTerminal) Run(
+	ctx context.Context, command string, args []string, cwd string, outputByteLimit int,
+) (TerminalResult, error) {
+	var created createTerminalResult
+	if err := c.Caller.Call(ctx, "terminal/create", createTerminalParams{
+		SessionID:       c.SessionID,
+		Command:         command,
+		Args:            args,
+		Cwd:             cwd,
+		OutputByteLimit: outputByteLimit,
+	}, &created); err != nil {
+		return TerminalResult{}, err
+	}
+
+	ref := terminalRef{SessionID: c.SessionID, TerminalID: created.TerminalID}
+	// Always release, even on timeout/cancel, so the editor frees the terminal.
+	defer func() { _ = c.Caller.Call(context.WithoutCancel(ctx), "terminal/release", ref, nil) }()
+
+	var exit exitStatus
+	if err := c.Caller.Call(ctx, "terminal/wait_for_exit", ref, &exit); err != nil {
+		// The wait failed. Usually ctx expired (the caller's timeout fired);
+		// it can also be a transport error. Either way, kill the command and
+		// return whatever output it produced so the agent sees partial results.
+		// Only flag TimedOut when ctx actually hit its deadline — matching the
+		// local shell tool — so a transport failure isn't mislabeled as a timeout.
+		_ = c.Caller.Call(context.WithoutCancel(ctx), "terminal/kill", ref, nil)
+		out, _ := c.fetchOutput(context.WithoutCancel(ctx), ref)
+		out.TimedOut = errors.Is(err, context.DeadlineExceeded)
+		return out, err
+	}
+
+	out, err := c.fetchOutput(ctx, ref)
+	if err != nil {
+		return TerminalResult{}, err
+	}
+	out.ExitCode = derefInt(exit.ExitCode)
+	out.Signal = exit.Signal
+	return out, nil
+}
+
+// fetchOutput reads the terminal's accumulated output and (if it has exited) its
+// exit status.
+func (c *ClientTerminal) fetchOutput(ctx context.Context, ref terminalRef) (TerminalResult, error) {
+	var o terminalOutputResult
+	if err := c.Caller.Call(ctx, "terminal/output", ref, &o); err != nil {
+		return TerminalResult{}, err
+	}
+	res := TerminalResult{Output: o.Output, Truncated: o.Truncated}
+	if o.ExitStatus != nil {
+		res.ExitCode = derefInt(o.ExitStatus.ExitCode)
+		res.Signal = o.ExitStatus.Signal
+	}
+	return res, nil
+}
+
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/pkg/cmd/pulumi/neo/acp/terminal_test.go
+++ b/pkg/cmd/pulumi/neo/acp/terminal_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedCaller answers the terminal/* methods with canned results and records
+// the order they were called in.
+type scriptedCaller struct {
+	methods   []string
+	exitCode  int
+	signal    string
+	output    string
+	truncated bool
+	waitErr   error
+}
+
+func (c *scriptedCaller) Call(_ context.Context, method string, _, result any) error {
+	c.methods = append(c.methods, method)
+	switch method {
+	case "terminal/create":
+		if r, ok := result.(*createTerminalResult); ok {
+			r.TerminalID = "term_1"
+		}
+	case "terminal/wait_for_exit":
+		if c.waitErr != nil {
+			return c.waitErr
+		}
+		if r, ok := result.(*exitStatus); ok {
+			// A signal-terminated process reports a null exit code (no ExitCode)
+			// alongside the signal, matching the editor's wire shape.
+			if c.signal != "" {
+				r.Signal = c.signal
+			} else {
+				ec := c.exitCode
+				r.ExitCode = &ec
+			}
+		}
+	case "terminal/output":
+		if r, ok := result.(*terminalOutputResult); ok {
+			r.Output = c.output
+			r.Truncated = c.truncated
+		}
+	}
+	return nil
+}
+
+func TestClientTerminalRun(t *testing.T) {
+	t.Parallel()
+
+	sc := &scriptedCaller{exitCode: 0, output: "hello\n"}
+	ct := &ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	res, err := ct.Run(t.Context(), "sh", []string{"-c", "echo hello"}, "/work", 1024)
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", res.Output)
+	assert.Equal(t, 0, res.ExitCode)
+	assert.False(t, res.TimedOut)
+
+	assert.Equal(t,
+		[]string{"terminal/create", "terminal/wait_for_exit", "terminal/output", "terminal/release"},
+		sc.methods)
+}
+
+func TestClientTerminalRunReportsExitCode(t *testing.T) {
+	t.Parallel()
+
+	sc := &scriptedCaller{exitCode: 2, output: "boom"}
+	ct := &ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	res, err := ct.Run(t.Context(), "sh", []string{"-c", "exit 2"}, "/work", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.ExitCode)
+	assert.Equal(t, "boom", res.Output)
+}
+
+func TestClientTerminalRunKillsOnWaitError(t *testing.T) {
+	t.Parallel()
+
+	sc := &scriptedCaller{waitErr: context.DeadlineExceeded, output: "partial"}
+	ct := &ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	res, err := ct.Run(t.Context(), "sh", []string{"-c", "sleep 100"}, "/work", 0)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, res.TimedOut)
+	assert.Equal(t, "partial", res.Output, "partial output is collected after the kill")
+	assert.Contains(t, sc.methods, "terminal/kill")
+	assert.Contains(t, sc.methods, "terminal/release")
+}
+
+func TestClientTerminalRunWaitErrorNotMislabeledAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	// A non-deadline wait failure (e.g. the editor's terminal went away) must
+	// not be reported as a timeout; only a real deadline sets TimedOut.
+	sc := &scriptedCaller{waitErr: errors.New("terminal vanished"), output: "partial"}
+	ct := &ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	res, err := ct.Run(t.Context(), "sh", []string{"-c", "sleep 100"}, "/work", 0)
+	require.Error(t, err)
+	assert.False(t, res.TimedOut, "transport error must not be labeled a timeout")
+	assert.Contains(t, sc.methods, "terminal/kill")
+}
+
+func TestClientTerminalRunReportsSignal(t *testing.T) {
+	t.Parallel()
+
+	// A signal-terminated process reports a null exit code; Signal carries the
+	// cause and ExitCode decodes to 0 at this layer.
+	sc := &scriptedCaller{signal: "SIGKILL", output: "killed"}
+	ct := &ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	res, err := ct.Run(t.Context(), "sh", []string{"-c", "sleep 100"}, "/work", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "SIGKILL", res.Signal)
+}
+
+func TestClientTerminalRunPropagatesCreateError(t *testing.T) {
+	t.Parallel()
+
+	rc := &recordingCaller{err: errors.New("no terminal")}
+	ct := &ClientTerminal{Caller: rc, SessionID: "sess_1"}
+	_, err := ct.Run(t.Context(), "sh", []string{"-c", "true"}, "/work", 0)
+	require.Error(t, err)
+	// No terminal was created, so there is nothing to kill or release: the
+	// failed create must be the only call issued.
+	assert.Equal(t, 1, rc.calls)
+	assert.Equal(t, "terminal/create", rc.method)
+}

--- a/pkg/cmd/pulumi/neo/acp/types.go
+++ b/pkg/cmd/pulumi/neo/acp/types.go
@@ -1,0 +1,494 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package acp is a self-contained implementation of the Agent Client Protocol
+// (https://agentclientprotocol.com) wire layer: the JSON-RPC plumbing, the
+// method router, the protocol types, and the fs/terminal callback hooks an
+// agent exposes to its editor. It is application-neutral: the embedding
+// application supplies its identity (see NewAgent) and behavior (see Delegate).
+//
+// It has no dependencies on Pulumi or Neo — its only external dependency is the
+// jsonrpc2 transport. The Neo-specific glue that wires this protocol to Neo's
+// session, config, and backend lives in the parent neo package (the acp_*.go
+// files), which imports this package; the dependency only ever points inward.
+// Keep it that way: nothing here should import anything under pkg/cmd/pulumi/neo.
+package acp
+
+import "encoding/json"
+
+// ProtocolVersion is the ACP MAJOR version this agent implements. The wire field
+// is a single integer; on initialize we negotiate down to a version the client
+// also understands (see Agent.initialize).
+//
+// https://agentclientprotocol.com/protocol/initialization
+const ProtocolVersion = 1
+
+// Implementation identifies a client or agent: free-form name/title/version
+// metadata exchanged on initialize.
+type Implementation struct {
+	Name    string `json:"name,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// InitializeParams is the client→agent `initialize` request. protocolVersion is
+// the latest MAJOR version the client supports.
+type InitializeParams struct {
+	ProtocolVersion    int                `json:"protocolVersion"`
+	ClientCapabilities ClientCapabilities `json:"clientCapabilities"`
+	ClientInfo         *Implementation    `json:"clientInfo,omitempty"`
+}
+
+// ClientCapabilities describes the optional features the editor (client) offers
+// the agent. We consult these in session/new to decide whether filesystem and
+// shell tool calls are routed to the editor or executed locally.
+type ClientCapabilities struct {
+	// FS reports the editor's filesystem read/write support.
+	FS FileSystemCapability `json:"fs"`
+	// Terminal reports whether the editor can run commands via the terminal/*
+	// methods on the agent's behalf. Distinct from Auth.Terminal, which is about
+	// running the agent's login flow in an editor terminal.
+	Terminal bool `json:"terminal,omitempty"`
+	// Auth reports which typed auth methods the editor can execute.
+	Auth AuthCapability `json:"auth"`
+}
+
+// AuthCapability reports the editor's support for typed authentication methods
+// (https://agentclientprotocol.com/rfds/auth-methods).
+type AuthCapability struct {
+	// Terminal reports whether the editor can run a terminal-typed auth method:
+	// re-launching the agent binary in a real terminal with the method's
+	// args/env for an interactive setup flow.
+	Terminal bool `json:"terminal,omitempty"`
+}
+
+// FileSystemCapability reports which filesystem operations the editor exposes to
+// the agent. Each gates the correspondingly-named fs/* client method.
+type FileSystemCapability struct {
+	ReadTextFile  bool `json:"readTextFile,omitempty"`
+	WriteTextFile bool `json:"writeTextFile,omitempty"`
+}
+
+// InitializeResult is the agent→client `initialize` response. protocolVersion is
+// the agreed version (the same value the client sent when we support it, else
+// our latest).
+type InitializeResult struct {
+	ProtocolVersion   int               `json:"protocolVersion"`
+	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
+	AgentInfo         *Implementation   `json:"agentInfo,omitempty"`
+	AuthMethods       []AuthMethod      `json:"authMethods,omitempty"`
+}
+
+// AgentCapabilities describes the optional features this agent supports. For the
+// initial slice we support neither session loading nor non-text prompt content.
+type AgentCapabilities struct {
+	// LoadSession reports support for the session/load method (resumption).
+	LoadSession bool `json:"loadSession,omitempty"`
+	// PromptCapabilities reports which non-text content blocks may appear in a
+	// session/prompt request.
+	PromptCapabilities PromptCapabilities `json:"promptCapabilities"`
+}
+
+// PromptCapabilities reports which optional content block types the agent
+// accepts in a prompt. All default false: text-only for now.
+type PromptCapabilities struct {
+	Image           bool `json:"image,omitempty"`
+	Audio           bool `json:"audio,omitempty"`
+	EmbeddedContext bool `json:"embeddedContext,omitempty"`
+}
+
+// AuthMethodTypeTerminal marks an AuthMethod whose setup is an interactive
+// terminal flow: the client re-launches the agent binary in a real terminal,
+// with the method's Args and Env replacing the configured launch values for
+// that run only. Only advertised to clients that declare the auth.terminal
+// capability (see AuthCapability).
+const AuthMethodTypeTerminal = "terminal"
+
+// AuthMethod is one authentication option the agent advertises on initialize.
+type AuthMethod struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// Type identifies how the client executes the method
+	// (https://agentclientprotocol.com/rfds/auth-methods). Empty means the
+	// spec-default "agent": the agent authenticates by itself when the client
+	// calls `authenticate`.
+	Type string `json:"type,omitempty"`
+	// Args and Env apply to terminal-typed methods: they replace the agent's
+	// configured launch arguments and extend its environment for the setup run.
+	Args []string          `json:"args,omitempty"`
+	Env  map[string]string `json:"env,omitempty"`
+	// Meta is the spec's implementation-specific extension point; clients
+	// ignore keys they don't recognize. See MetaKeyTerminalAuth.
+	Meta map[string]any `json:"_meta,omitempty"`
+}
+
+// MetaKeyTerminalAuth is the AuthMethod.Meta key carrying a TerminalAuthMeta.
+const MetaKeyTerminalAuth = "terminal-auth"
+
+// TerminalAuthMeta is the pre-stabilization form of terminal auth, honored by
+// editors (e.g. current stable Zed) that predate the typed AuthMethod fields:
+// the client runs Command with Args/Env in a real terminal. Unlike the typed
+// form, Command names the binary explicitly — the client substitutes nothing
+// into its configured launch command. Advertise it under MetaKeyTerminalAuth
+// alongside the typed fields until the RFD stabilizes.
+type TerminalAuthMeta struct {
+	Label   string            `json:"label"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// AuthenticateParams is the client→agent `authenticate` request, naming the
+// method (by AuthMethod.ID) the client chose.
+type AuthenticateParams struct {
+	MethodID string `json:"methodId"`
+}
+
+// NewSessionParams is the client→agent `session/new` request. Cwd is the
+// absolute working directory the session is rooted at; tool file and shell
+// operations resolve against it. Other fields the spec defines (e.g.
+// mcpServers) are accepted but ignored for now.
+type NewSessionParams struct {
+	Cwd string `json:"cwd"`
+}
+
+// NewSessionResult is the agent→client `session/new` response carrying the id
+// the client passes on subsequent session/prompt and session/cancel requests.
+// ConfigOptions advertises the session settings the editor may change (see
+// ConfigOption); it is omitted when the agent exposes none.
+type NewSessionResult struct {
+	SessionID     string         `json:"sessionId"`
+	ConfigOptions []ConfigOption `json:"configOptions,omitempty"`
+}
+
+// ConfigOptionTypeSelect is the only ConfigOption.Type the spec defines so far: a
+// choice among a fixed set of values.
+const ConfigOptionTypeSelect = "select"
+
+// ConfigCategoryMode is the ConfigOption.Category hint for options that change how
+// the agent behaves (vs. e.g. "model"). Editors may surface these prominently.
+const ConfigCategoryMode = "mode"
+
+// ConfigOption is one session configuration setting the agent advertises and the
+// editor can change via session/set_config_option. It supersedes the older
+// Session Modes API and, unlike modes, lets the agent expose several independent
+// settings at once. Today every option is a "select" (Type) over Options, with
+// CurrentValue naming the active one.
+//
+// https://agentclientprotocol.com/protocol/v1/session-config-options
+type ConfigOption struct {
+	ID           string              `json:"id"`
+	Name         string              `json:"name"`
+	Description  string              `json:"description,omitempty"`
+	Category     string              `json:"category,omitempty"`
+	Type         string              `json:"type"`
+	CurrentValue string              `json:"currentValue"`
+	Options      []ConfigOptionValue `json:"options"`
+}
+
+// ConfigOptionValue is one selectable value of a select ConfigOption.
+type ConfigOptionValue struct {
+	Value       string `json:"value"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// SetConfigOptionParams is the client→agent `session/set_config_option` request:
+// set the option ConfigID to Value for SessionID.
+type SetConfigOptionParams struct {
+	SessionID string `json:"sessionId"`
+	ConfigID  string `json:"configId"`
+	Value     string `json:"value"`
+}
+
+// SetConfigOptionResult is the agent→client response: the complete, updated option
+// list (current values reflect the change, including any the agent clamped or
+// adjusted as a side effect).
+type SetConfigOptionResult struct {
+	ConfigOptions []ConfigOption `json:"configOptions"`
+}
+
+// ContentBlock is a single piece of prompt or message content. We produce text
+// blocks and consume "text" and "resource_link" blocks: text and resource links
+// are baseline content a client may send regardless of prompt capabilities (an
+// editor emits a resource_link when the user @-mentions a file). The capability-
+// gated blocks (image/audio and the embedded "resource") are not yet advertised,
+// so a conforming client won't send them.
+type ContentBlock struct {
+	Type string `json:"type"` // "text" | "resource_link"
+	Text string `json:"text,omitempty"`
+
+	// Resource link fields, set when Type == "resource_link". URI and Name are
+	// required by the spec for that type; the rest are optional metadata we keep
+	// so the reference survives translation to Neo's text-only prompt input.
+	URI         string `json:"uri,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Title       string `json:"title,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// PromptParams is the client→agent `session/prompt` request: the user's message
+// for sessionId, as an ordered list of content blocks.
+type PromptParams struct {
+	SessionID string         `json:"sessionId"`
+	Prompt    []ContentBlock `json:"prompt"`
+}
+
+// PromptResult is the agent→client `session/prompt` response, returned when the
+// turn ends.
+type PromptResult struct {
+	StopReason StopReason `json:"stopReason"`
+}
+
+// StopReason explains why a prompt turn ended.
+type StopReason string
+
+const (
+	// StopEndTurn is the normal completion: the model finished without
+	// requesting more tools.
+	StopEndTurn StopReason = "end_turn"
+	// StopCancelled is returned when the client cancelled the turn.
+	StopCancelled StopReason = "cancelled"
+	// StopRefusal is returned when the agent declined to continue.
+	StopRefusal StopReason = "refusal"
+	// StopMaxTokens is returned when the token limit was reached.
+	StopMaxTokens StopReason = "max_tokens"
+	// StopMaxTurnRequests is returned when the model-call limit was reached.
+	StopMaxTurnRequests StopReason = "max_turn_requests"
+)
+
+// CancelParams is the client→agent `session/cancel` notification, asking the
+// agent to stop the in-flight turn for sessionId.
+type CancelParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// SessionNotification is the params of a `session/update` notification. Update
+// is one of the SessionUpdate payload types below, distinguished by its
+// sessionUpdate discriminator injected on marshal.
+type SessionNotification struct {
+	SessionID string        `json:"sessionId"`
+	Update    SessionUpdate `json:"update"`
+}
+
+// SessionUpdate is the sealed set of session/update payloads. The marker method
+// is unexported so only this package's payload types satisfy it, keeping the
+// notification stream typed end to end rather than passing an open any.
+type SessionUpdate interface {
+	isSessionUpdate()
+}
+
+func (AgentMessageChunk) isSessionUpdate()  {}
+func (ToolCallStart) isSessionUpdate()      {}
+func (ToolCallProgress) isSessionUpdate()   {}
+func (PlanUpdate) isSessionUpdate()         {}
+func (ConfigOptionUpdate) isSessionUpdate() {}
+
+// The session/update payload types below each marshal with a constant
+// "sessionUpdate" discriminator injected by MarshalJSON, so the wire tag is
+// owned here (by the type) rather than set by hand at every call site.
+
+// AgentMessageChunk is the session/update payload carrying a piece of the
+// agent's response text.
+type AgentMessageChunk struct {
+	Content ContentBlock `json:"content"`
+}
+
+// MarshalJSON tags the payload as "agent_message_chunk".
+func (u AgentMessageChunk) MarshalJSON() ([]byte, error) {
+	type alias AgentMessageChunk
+	return json.Marshal(struct {
+		SessionUpdate string `json:"sessionUpdate"`
+		alias
+	}{"agent_message_chunk", alias(u)})
+}
+
+// ToolCallStart is the session/update payload announcing a new tool call.
+type ToolCallStart struct {
+	ToolCallID string             `json:"toolCallId"`
+	Title      string             `json:"title"`
+	Kind       string             `json:"kind,omitempty"`
+	Status     string             `json:"status,omitempty"`
+	Locations  []ToolCallLocation `json:"locations,omitempty"`
+	RawInput   json.RawMessage    `json:"rawInput,omitempty"`
+}
+
+// ToolCallLocation is a file (optionally a line) a tool call touches. Editors
+// use it to render the call against the file natively — a clickable path, a
+// read/edit affordance, follow-along highlighting.
+type ToolCallLocation struct {
+	Path string `json:"path"`
+	Line *int   `json:"line,omitempty"`
+}
+
+// MarshalJSON tags the payload as "tool_call".
+func (u ToolCallStart) MarshalJSON() ([]byte, error) {
+	type alias ToolCallStart
+	return json.Marshal(struct {
+		SessionUpdate string `json:"sessionUpdate"`
+		alias
+	}{"tool_call", alias(u)})
+}
+
+// ToolCallProgress is the session/update payload reporting a status or output
+// change for an in-flight tool call.
+type ToolCallProgress struct {
+	ToolCallID string            `json:"toolCallId"`
+	Status     string            `json:"status,omitempty"`
+	Content    []ToolCallContent `json:"content,omitempty"`
+	RawOutput  json.RawMessage   `json:"rawOutput,omitempty"`
+}
+
+// MarshalJSON tags the payload as "tool_call_update".
+func (u ToolCallProgress) MarshalJSON() ([]byte, error) {
+	type alias ToolCallProgress
+	return json.Marshal(struct {
+		SessionUpdate string `json:"sessionUpdate"`
+		alias
+	}{"tool_call_update", alias(u)})
+}
+
+// ToolCallContent wraps a content block produced by a tool call. Only the
+// "content" form is produced for now (diff and terminal forms exist in ACP).
+type ToolCallContent struct {
+	Type    string       `json:"type"` // "content"
+	Content ContentBlock `json:"content"`
+}
+
+// PlanUpdate is the session/update payload carrying the agent's task list.
+type PlanUpdate struct {
+	Entries []PlanEntry `json:"entries"`
+}
+
+// MarshalJSON tags the payload as "plan".
+func (u PlanUpdate) MarshalJSON() ([]byte, error) {
+	type alias PlanUpdate
+	return json.Marshal(struct {
+		SessionUpdate string `json:"sessionUpdate"`
+		alias
+	}{"plan", alias(u)})
+}
+
+// ConfigOptionUpdate is the session/update payload announcing that one or more
+// config options changed value out of band (e.g. the agent left plan mode on its
+// own). It carries the complete, current option list, mirroring the
+// session/set_config_option response.
+type ConfigOptionUpdate struct {
+	ConfigOptions []ConfigOption `json:"configOptions"`
+}
+
+// MarshalJSON tags the payload as "config_option_update".
+func (u ConfigOptionUpdate) MarshalJSON() ([]byte, error) {
+	type alias ConfigOptionUpdate
+	return json.Marshal(struct {
+		SessionUpdate string `json:"sessionUpdate"`
+		alias
+	}{"config_option_update", alias(u)})
+}
+
+// PlanEntry is one item in a PlanUpdate. Field values match ACP: priority is
+// "high"|"medium"|"low"; status is "pending"|"in_progress"|"completed".
+type PlanEntry struct {
+	Content  string `json:"content"`
+	Priority string `json:"priority"`
+	Status   string `json:"status"`
+}
+
+// Plan entry priorities and statuses (ACP enums). ACP requires a valid value
+// from these sets on every entry, so the adapter clamps to them on egress.
+const (
+	PlanPriorityHigh   = "high"
+	PlanPriorityMedium = "medium"
+	PlanPriorityLow    = "low"
+
+	PlanStatusPending    = "pending"
+	PlanStatusInProgress = "in_progress"
+	PlanStatusCompleted  = "completed"
+)
+
+// Tool call kinds and statuses (ACP enums).
+const (
+	ToolKindRead    = "read"
+	ToolKindEdit    = "edit"
+	ToolKindSearch  = "search"
+	ToolKindExecute = "execute"
+	ToolKindOther   = "other"
+
+	ToolStatusInProgress = "in_progress"
+	ToolStatusCompleted  = "completed"
+	ToolStatusFailed     = "failed"
+)
+
+// RequestPermissionParams is the agent→client `session/request_permission`
+// request, asking the user to approve a tool call. The client replies by
+// selecting one of options.
+type RequestPermissionParams struct {
+	SessionID string             `json:"sessionId"`
+	ToolCall  PermissionToolCall `json:"toolCall"`
+	Options   []PermissionOption `json:"options"`
+}
+
+// PermissionToolCall identifies (and briefly describes) the tool call awaiting
+// approval.
+type PermissionToolCall struct {
+	ToolCallID string `json:"toolCallId"`
+	Title      string `json:"title,omitempty"`
+}
+
+// PermissionOption is one choice the user can pick in a permission request. Kind
+// is one of "allow_once"|"allow_always"|"reject_once"|"reject_always".
+type PermissionOption struct {
+	OptionID string `json:"optionId"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+}
+
+// RequestPermissionResult is the client→agent response to a permission request.
+type RequestPermissionResult struct {
+	Outcome PermissionOutcome `json:"outcome"`
+}
+
+// PermissionOutcome reports the user's decision. Outcome is "selected" (with
+// OptionID set) or "cancelled".
+type PermissionOutcome struct {
+	Outcome  string `json:"outcome"`
+	OptionID string `json:"optionId,omitempty"`
+}
+
+// Permission option ids and kinds we offer for each approval request.
+const (
+	permissionOptionAllow  = "allow"
+	permissionOptionReject = "reject"
+	permissionKindAllow    = "allow_once"
+	permissionKindReject   = "reject_once"
+	permissionSelected     = "selected"
+)
+
+// ApprovalOptions returns the standard allow/reject choices to present in a
+// permission request. Callers interpret the response with
+// RequestPermissionResult.Approved.
+func ApprovalOptions() []PermissionOption {
+	return []PermissionOption{
+		{OptionID: permissionOptionAllow, Name: "Allow", Kind: permissionKindAllow},
+		{OptionID: permissionOptionReject, Name: "Reject", Kind: permissionKindReject},
+	}
+}
+
+// Approved reports whether the user selected the allow option. A cancelled
+// outcome, a missing selection, or the reject option all count as not approved.
+func (r RequestPermissionResult) Approved() bool {
+	return r.Outcome.Outcome == permissionSelected && r.Outcome.OptionID == permissionOptionAllow
+}

--- a/pkg/cmd/pulumi/neo/acp/types_test.go
+++ b/pkg/cmd/pulumi/neo/acp/types_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionUpdateDiscriminators verifies each update payload injects its
+// constant "sessionUpdate" tag on marshal (and still emits its own fields), so
+// the wire discriminator stays owned by the type rather than the call site.
+func TestSessionUpdateDiscriminators(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		update any
+		tag    string
+		field  string // a payload field that must survive alongside the tag
+	}{
+		{"agent_message_chunk", AgentMessageChunk{Content: ContentBlock{Type: "text"}}, "agent_message_chunk", "content"},
+		{"tool_call", ToolCallStart{ToolCallID: "tc_1", Title: "shell"}, "tool_call", "toolCallId"},
+		{"tool_call_update", ToolCallProgress{ToolCallID: "tc_1", Status: "completed"}, "tool_call_update", "toolCallId"},
+		{"plan", PlanUpdate{Entries: []PlanEntry{{Content: "do"}}}, "plan", "entries"},
+		{
+			"config_option_update",
+			ConfigOptionUpdate{ConfigOptions: []ConfigOption{{ID: "permission"}}},
+			"config_option_update", "configOptions",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			raw, err := json.Marshal(tt.update)
+			require.NoError(t, err)
+
+			var m map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(raw, &m))
+			assert.JSONEq(t, `"`+tt.tag+`"`, string(m["sessionUpdate"]))
+			assert.Contains(t, m, tt.field, "payload fields must marshal alongside the discriminator")
+		})
+	}
+}
+
+// TestAuthMethodWireShape verifies the typed-auth fields marshal when set and
+// disappear when zero, so a degraded (untyped) method advertises exactly the
+// pre-typed-auth wire shape.
+func TestAuthMethodWireShape(t *testing.T) {
+	t.Parallel()
+
+	terminal := AuthMethod{
+		ID:   "m1",
+		Name: "Terminal login",
+		Type: AuthMethodTypeTerminal,
+		Args: []string{"login"},
+		Env:  map[string]string{"A": "1"},
+		Meta: map[string]any{MetaKeyTerminalAuth: TerminalAuthMeta{
+			Label:   "log in",
+			Command: "agent",
+			Args:    []string{"login"},
+		}},
+	}
+	raw, err := json.Marshal(terminal)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"id":"m1","name":"Terminal login","type":"terminal","args":["login"],"env":{"A":"1"},
+		"_meta":{"terminal-auth":{"label":"log in","command":"agent","args":["login"]}}
+	}`, string(raw))
+
+	degraded := AuthMethod{ID: "m1", Name: "Terminal login"}
+	raw, err = json.Marshal(degraded)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"m1","name":"Terminal login"}`, string(raw))
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -104,6 +104,7 @@ require (
 	github.com/rivo/uniseg v0.4.7
 	github.com/segmentio/encoding v0.3.5
 	github.com/shirou/gopsutil/v3 v3.22.3
+	github.com/sourcegraph/jsonrpc2 v0.2.1
 	github.com/spf13/afero v1.15.0
 	github.com/texttheater/golang-levenshtein v1.0.1
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -313,6 +313,8 @@ github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
@@ -525,6 +527,8 @@ github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 h1:pXY9qYc/MP5zdvq
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 h1:8ZnTA26bBOoPkAbbitKPgNlpw0Bwt7ZlpYgZWHWJR/w=
 github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:tNZjgbYncKL5HxvDULAr/mWDmFz4B7H8yrXEDlnoIiw=
+github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFRh6zSQ=
+github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=


### PR DESCRIPTION
`pkg/cmd/pulumi/neo/acp` implements the agent side of the [Agent Client Protocol](https://agentclientprotocol.com) over stdio JSON-RPC: the initialize/session handshake and prompt loop, the protocol types, and proxies for editor-owned filesystem and terminal capabilities.

The package has no Pulumi imports and can be reviewed against the ACP spec alone; its only new dependency is `github.com/sourcegraph/jsonrpc2`. Unused until the Neo ACP adapter lands on top of it. Part 3/5 of the ACP stack (replaces #23669).

🤖 Generated with [Claude Code](https://claude.com/claude-code)