### PR TITLE
Translate Neo UI events into ACP session updates

### DIFF
--- a/pkg/cmd/pulumi/neo/acp_pumpqueue.go
+++ b/pkg/cmd/pulumi/neo/acp_pumpqueue.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"sync"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+)
+
+// pumpAction is one ordered step the writer performs: emit a session/update
+// notification, launch a permission request, or resolve the active turn. Exactly
+// one field is set. Routing all three through a single ordered queue keeps them
+// in the order the agent produced them — in particular a turn resolves only
+// after the updates that preceded it have been written — while letting the pump
+// drain UIEvents without blocking on the editor.
+type pumpAction struct {
+	notify   acp.SessionUpdate  //nolint:unused // consumed by the ACP adapter, next in this stack
+	approval *UIApprovalRequest //nolint:unused // consumed by the ACP adapter, next in this stack
+	finish   *turnResult
+}
+
+// turnResult is how the event pump signals the waiting Prompt call that the
+// current turn ended: with a stop reason, or a fatal error.
+type turnResult struct {
+	reason acp.StopReason
+	err    error //nolint:unused // consumed by the ACP adapter, next in this stack
+}
+
+// pumpQueue is an unbounded, ordered, single-consumer queue of pumpActions. The
+// pump pushes without ever blocking on the editor; drainPumpQueue pops in FIFO
+// order. close stops intake, but actions already queued are still delivered —
+// in particular the turn result the pump queues on teardown, so a waiting
+// Prompt always resolves.
+type pumpQueue struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	items  []pumpAction
+	closed bool
+}
+
+func newPumpQueue() *pumpQueue {
+	q := &pumpQueue{}
+	q.cond = sync.NewCond(&q.mu)
+	return q
+}
+
+func (q *pumpQueue) push(a pumpAction) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	q.items = append(q.items, a)
+	q.cond.Signal()
+}
+
+// pop blocks until an action is available, returning ok=false once the queue is
+// closed and everything queued before the close has been delivered.
+func (q *pumpQueue) pop() (pumpAction, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.items) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if len(q.items) == 0 {
+		return pumpAction{}, false
+	}
+	a := q.items[0]
+	q.items = q.items[1:]
+	return a, true
+}
+
+// close stops intake: later pushes are dropped, and pop reports done once the
+// already-queued actions have been delivered.
+func (q *pumpQueue) close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	q.cond.Broadcast()
+}

--- a/pkg/cmd/pulumi/neo/acp_pumpqueue.go
+++ b/pkg/cmd/pulumi/neo/acp_pumpqueue.go
@@ -41,9 +41,9 @@ type turnResult struct {
 
 // pumpQueue is an unbounded, ordered, single-consumer queue of pumpActions. The
 // pump pushes without ever blocking on the editor; drainPumpQueue pops in FIFO
-// order. close stops intake, but actions already queued are still delivered —
-// in particular the turn result the pump queues on teardown, so a waiting
-// Prompt always resolves.
+// order. close stops intake and delivers the final turn result in the same
+// step, so a waiting Prompt always resolves no matter which path tears the
+// queue down.
 type pumpQueue struct {
 	mu     sync.Mutex
 	cond   *sync.Cond
@@ -83,11 +83,19 @@ func (q *pumpQueue) pop() (pumpAction, bool) {
 	return a, true
 }
 
-// close stops intake: later pushes are dropped, and pop reports done once the
-// already-queued actions have been delivered.
-func (q *pumpQueue) close() {
+// close stops intake, delivering final (when non-nil) as the last action —
+// folding the finish into close makes it impossible to close the queue without
+// resolving a waiting Prompt. Later pushes are dropped, pop reports done once
+// everything queued has been delivered, and a second close is a no-op.
+func (q *pumpQueue) close(final *turnResult) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	if final != nil {
+		q.items = append(q.items, pumpAction{finish: final})
+	}
 	q.closed = true
 	q.cond.Broadcast()
 }

--- a/pkg/cmd/pulumi/neo/acp_pumpqueue_test.go
+++ b/pkg/cmd/pulumi/neo/acp_pumpqueue_test.go
@@ -86,7 +86,7 @@ func TestPumpQueueCloseDeliversQueued(t *testing.T) {
 	q := newPumpQueue()
 	q.push(finishAction("before1"))
 	q.push(finishAction("before2"))
-	q.close()
+	q.close(nil)
 	q.push(finishAction("after"))
 
 	a, ok := q.pop()
@@ -100,6 +100,28 @@ func TestPumpQueueCloseDeliversQueued(t *testing.T) {
 	assert.False(t, ok, "a push after close must be dropped and pop must report done")
 }
 
+// TestPumpQueueCloseDeliversFinal is the structural guarantee close provides:
+// the final turn result passed to close is delivered after everything already
+// queued, and a second close cannot enqueue another.
+func TestPumpQueueCloseDeliversFinal(t *testing.T) {
+	t.Parallel()
+
+	q := newPumpQueue()
+	q.push(finishAction("queued"))
+	q.close(&turnResult{reason: "final"})
+	q.close(&turnResult{reason: "again"})
+
+	a, ok := q.pop()
+	require.True(t, ok)
+	assert.Equal(t, acp.StopReason("queued"), a.finish.reason)
+	a, ok = q.pop()
+	require.True(t, ok)
+	assert.Equal(t, acp.StopReason("final"), a.finish.reason)
+
+	_, ok = q.pop()
+	assert.False(t, ok, "a second close must not deliver another turn result")
+}
+
 func TestPumpQueueCloseUnblocksWaitingPop(t *testing.T) {
 	t.Parallel()
 
@@ -110,7 +132,7 @@ func TestPumpQueueCloseUnblocksWaitingPop(t *testing.T) {
 		done <- ok
 	}()
 
-	q.close()
+	q.close(nil)
 	select {
 	case ok := <-done:
 		assert.False(t, ok, "close must wake a blocked pop and report done")

--- a/pkg/cmd/pulumi/neo/acp_pumpqueue_test.go
+++ b/pkg/cmd/pulumi/neo/acp_pumpqueue_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+)
+
+// finishAction builds a pumpAction whose turn result carries reason, used as a
+// distinguishable payload in queue-ordering assertions.
+func finishAction(reason acp.StopReason) pumpAction {
+	return pumpAction{finish: &turnResult{reason: reason}}
+}
+
+func TestPumpQueueFIFO(t *testing.T) {
+	t.Parallel()
+
+	q := newPumpQueue()
+	q.push(finishAction("a"))
+	q.push(finishAction("b"))
+	q.push(finishAction("c"))
+
+	for _, want := range []acp.StopReason{"a", "b", "c"} {
+		a, ok := q.pop()
+		require.True(t, ok)
+		require.NotNil(t, a.finish)
+		assert.Equal(t, want, a.finish.reason)
+	}
+}
+
+func TestPumpQueuePopBlocksUntilPush(t *testing.T) {
+	t.Parallel()
+
+	type popResult struct {
+		a  pumpAction
+		ok bool
+	}
+	q := newPumpQueue()
+	got := make(chan popResult, 1)
+	go func() {
+		a, ok := q.pop()
+		got <- popResult{a, ok}
+	}()
+
+	// The pop above must be blocked: nothing has been pushed yet.
+	select {
+	case <-got:
+		t.Fatal("pop returned before anything was pushed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	q.push(finishAction("x"))
+	select {
+	case r := <-got:
+		require.True(t, r.ok)
+		assert.Equal(t, acp.StopReason("x"), r.a.finish.reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("pop did not observe the push")
+	}
+}
+
+// TestPumpQueueCloseDeliversQueued is the teardown guarantee the pump relies
+// on: close stops intake, but everything queued ahead of it — in particular the
+// final turn result — is still delivered before pop reports done.
+func TestPumpQueueCloseDeliversQueued(t *testing.T) {
+	t.Parallel()
+
+	q := newPumpQueue()
+	q.push(finishAction("before1"))
+	q.push(finishAction("before2"))
+	q.close()
+	q.push(finishAction("after"))
+
+	a, ok := q.pop()
+	require.True(t, ok)
+	assert.Equal(t, acp.StopReason("before1"), a.finish.reason)
+	a, ok = q.pop()
+	require.True(t, ok)
+	assert.Equal(t, acp.StopReason("before2"), a.finish.reason)
+
+	_, ok = q.pop()
+	assert.False(t, ok, "a push after close must be dropped and pop must report done")
+}
+
+func TestPumpQueueCloseUnblocksWaitingPop(t *testing.T) {
+	t.Parallel()
+
+	q := newPumpQueue()
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := q.pop()
+		done <- ok
+	}()
+
+	q.close()
+	select {
+	case ok := <-done:
+		assert.False(t, ok, "close must wake a blocked pop and report done")
+	case <-time.After(2 * time.Second):
+		t.Fatal("close did not unblock the waiting pop")
+	}
+}

--- a/pkg/cmd/pulumi/neo/acp_translate.go
+++ b/pkg/cmd/pulumi/neo/acp_translate.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
@@ -143,13 +144,17 @@ func textContent(s string) []acp.ToolCallContent {
 	return []acp.ToolCallContent{{Type: "content", Content: acp.ContentBlock{Type: "text", Text: s}}}
 }
 
-// planEntries maps Neo todo items to ACP plan entries. Neo's priority and status
+// planEntries maps Neo todo items to ACP plan entries, sorted by Index so the
+// agent's intended ordering survives JSON round-tripping (the same contract the
+// TUI's renderTodoLines applies to this slice). Neo's priority and status
 // vocabularies match ACP today, but ACP requires a valid value from its enums on
 // every entry, so we clamp on egress: a backend that drifts (an empty priority, a
 // new status) can't make us emit a spec-invalid plan that the editor may reject.
 func planEntries(items []UITodoItem) []acp.PlanEntry {
-	out := make([]acp.PlanEntry, 0, len(items))
-	for _, it := range items {
+	sorted := append([]UITodoItem(nil), items...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Index < sorted[j].Index })
+	out := make([]acp.PlanEntry, 0, len(sorted))
+	for _, it := range sorted {
 		out = append(out, acp.PlanEntry{
 			Content:  it.Content,
 			Priority: clampPlanPriority(it.Priority),

--- a/pkg/cmd/pulumi/neo/acp_translate.go
+++ b/pkg/cmd/pulumi/neo/acp_translate.go
@@ -1,0 +1,319 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+)
+
+// toolTracker assigns synthetic tool-call ids and carries the "current" id used
+// to correlate a UIToolStarted with the progress/completed events that follow.
+// This relies on the Session dispatching tool calls serially (the same
+// assumption the TUI's pulumi blocks make). cwd is the session working
+// directory, used to render file paths in tool titles relative to it.
+type toolTracker struct {
+	seq     int
+	current string
+	cwd     string
+}
+
+// translate maps a streaming UIEvent to the ACP session/update payload to send,
+// reporting false for events that produce no notification. Turn-boundary events
+// (idle/cancelled/error) and approvals are handled by the pump, not here. The
+// payload types inject their own "sessionUpdate" discriminator on marshal.
+func (t *toolTracker) translate(evt UIEvent) (acp.SessionUpdate, bool) {
+	switch e := evt.(type) {
+	case UIAssistantMessage:
+		if e.Content == "" {
+			return nil, false
+		}
+		// Each backend assistant_message is a complete message, not a token
+		// delta, and the editor concatenates the chunks it receives. Append a
+		// newline so successive messages in a turn don't run together (a trailing
+		// newline on the final message is invisible once rendered).
+		return acp.AgentMessageChunk{Content: acp.ContentBlock{Type: "text", Text: e.Content + "\n"}}, true
+	case UIToolStarted:
+		t.seq++
+		t.current = fmt.Sprintf("tc_%d", t.seq)
+		args := parseToolArgs(e.Args)
+		return acp.ToolCallStart{
+			ToolCallID: t.current,
+			Title:      toolTitle(e.Name, args, t.cwd),
+			Kind:       toolKind(e.Name),
+			Status:     acp.ToolStatusInProgress,
+			Locations:  toolLocations(args, t.cwd),
+			RawInput:   e.Args,
+		}, true
+	case UIToolProgress:
+		if t.current == "" {
+			return nil, false
+		}
+		return acp.ToolCallProgress{
+			ToolCallID: t.current,
+			Status:     acp.ToolStatusInProgress,
+			Content:    textContent(e.Message),
+		}, true
+	case UIToolCompleted:
+		// A completion with no tracked start (e.g. events replayed across a
+		// reconnect) has no call id to attach to, and ACP requires one.
+		if t.current == "" {
+			return nil, false
+		}
+		status := acp.ToolStatusCompleted
+		if e.IsError {
+			status = acp.ToolStatusFailed
+		}
+		update := acp.ToolCallProgress{
+			ToolCallID: t.current,
+			Status:     status,
+			Content:    textContent(string(e.Result)),
+			RawOutput:  e.Result,
+		}
+		// The call is finished; clear current so a stray progress event after
+		// completion doesn't attach to it (tool calls dispatch serially).
+		t.current = ""
+		return update, true
+	case UITodoList:
+		return acp.PlanUpdate{Entries: planEntries(e.Items)}, true
+	case UIWarning:
+		if e.Message == "" {
+			return nil, false
+		}
+		// ACP has no dedicated warning update, so surface it in the message
+		// stream (the TUI renders these in the transcript too). The prefix marks
+		// it as the CLI speaking rather than the model.
+		return acp.AgentMessageChunk{Content: acp.ContentBlock{Type: "text", Text: "Warning: " + e.Message + "\n"}}, true
+	}
+	return nil, false
+}
+
+// promptText renders a prompt's content blocks into the plain text forwarded to
+// Neo. Text blocks pass through verbatim. Resource links — which a client may
+// send regardless of prompt capabilities, typically for an @-mentioned file —
+// are materialized inline as their URI so the reference reaches the model rather
+// than being silently dropped. Capability-gated blocks (image/audio/embedded
+// resource) are ignored, since we don't advertise those capabilities.
+func promptText(blocks []acp.ContentBlock) string {
+	var b strings.Builder
+	for _, blk := range blocks {
+		switch blk.Type {
+		case "text":
+			b.WriteString(blk.Text)
+		case "resource_link":
+			b.WriteString(resourceLinkText(blk))
+		}
+	}
+	return b.String()
+}
+
+// resourceLinkText renders a resource_link block as text. The URI is what lets
+// the model (and its tools) locate the resource, so it always appears. The
+// optional Title — a human-readable description distinct from the file path — is
+// appended for context when set; Name is intentionally not appended, as it's
+// typically just the basename already present in the URI.
+func resourceLinkText(blk acp.ContentBlock) string {
+	if blk.Title == "" || blk.Title == blk.URI {
+		return "@" + blk.URI
+	}
+	return fmt.Sprintf("@%s (%s)", blk.URI, blk.Title)
+}
+
+// textContent wraps a non-empty string as a single ACP tool-call content block.
+func textContent(s string) []acp.ToolCallContent {
+	if s == "" {
+		return nil
+	}
+	return []acp.ToolCallContent{{Type: "content", Content: acp.ContentBlock{Type: "text", Text: s}}}
+}
+
+// planEntries maps Neo todo items to ACP plan entries. Neo's priority and status
+// vocabularies match ACP today, but ACP requires a valid value from its enums on
+// every entry, so we clamp on egress: a backend that drifts (an empty priority, a
+// new status) can't make us emit a spec-invalid plan that the editor may reject.
+func planEntries(items []UITodoItem) []acp.PlanEntry {
+	out := make([]acp.PlanEntry, 0, len(items))
+	for _, it := range items {
+		out = append(out, acp.PlanEntry{
+			Content:  it.Content,
+			Priority: clampPlanPriority(it.Priority),
+			Status:   clampPlanStatus(it.Status),
+		})
+	}
+	return out
+}
+
+// clampPlanPriority maps a Neo todo priority to an ACP-allowed priority,
+// defaulting unknown or empty values to "medium" (the neutral middle).
+func clampPlanPriority(priority string) string {
+	switch priority {
+	case acp.PlanPriorityHigh, acp.PlanPriorityMedium, acp.PlanPriorityLow:
+		return priority
+	default:
+		return acp.PlanPriorityMedium
+	}
+}
+
+// clampPlanStatus maps a Neo todo status to an ACP-allowed status, defaulting
+// unknown or empty values to "pending" so an unrecognized status reads as
+// not-yet-done rather than silently completed.
+func clampPlanStatus(status string) string {
+	switch status {
+	case acp.PlanStatusPending, acp.PlanStatusInProgress, acp.PlanStatusCompleted:
+		return status
+	default:
+		return acp.PlanStatusPending
+	}
+}
+
+// toolArgs is the subset of a tool call's JSON arguments used to enrich its ACP
+// presentation. The three fields cover every shape the title/location helpers
+// care about: filesystem calls carry file_path (read/write/edit) or path
+// (grep/content_replace/directory_tree); shell calls carry command. A tool call
+// is decoded once (see parseToolArgs) and the decoded value flows to both the
+// title and location helpers, rather than each re-parsing the raw arguments.
+type toolArgs struct {
+	FilePath string `json:"file_path"`
+	Path     string `json:"path"`
+	Command  string `json:"command"`
+}
+
+// parseToolArgs decodes a tool call's raw arguments into the display subset.
+// Decoding is best-effort: the result is presentation-only, so malformed or
+// absent arguments yield the zero value rather than an error.
+func parseToolArgs(raw json.RawMessage) toolArgs {
+	var a toolArgs
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &a)
+	}
+	return a
+}
+
+// file returns the file a filesystem tool call touches, preferring file_path
+// over path; tools without a file target (shell, pulumi) yield "".
+func (a toolArgs) file() string {
+	if a.FilePath != "" {
+		return a.FilePath
+	}
+	return a.Path
+}
+
+// command returns a shell call's command flattened to a single line so it reads
+// cleanly as a tool-call title; non-shell calls yield "".
+func (a toolArgs) command() string {
+	return strings.Join(strings.Fields(a.Command), " ")
+}
+
+// toolTitle turns a Neo tool name ("<server>__<method>") into a human-readable
+// tool-call title for the editor, enriched from the call's arguments so the
+// editor shows what the call operates on rather than a bare verb:
+//
+//   - filesystem calls append the file they touch, e.g.
+//     "filesystem__read" with {"file_path":"/work/pyproject.toml"} ->
+//     "Read ./pyproject.toml" (relative to cwd when possible).
+//   - shell calls render the command itself, e.g.
+//     "shell__shell_execute" with {"command":"git status"} -> "git status",
+//     so the editor shows the command instead of just "Shell execute".
+//
+// Falls back to the humanized method name (and then the raw name) when the
+// arguments carry nothing useful.
+func toolTitle(name string, args toolArgs, cwd string) string {
+	server, method, ok := strings.Cut(name, "__")
+	if !ok || method == "" {
+		return name
+	}
+	base := strings.ReplaceAll(method, "_", " ")
+	base = strings.ToUpper(base[:1]) + base[1:]
+
+	switch server {
+	case "shell":
+		// The command is the useful thing to show; the execute icon already
+		// conveys that it's a shell call.
+		if cmd := args.command(); cmd != "" {
+			return cmd
+		}
+	case "filesystem":
+		if path := args.file(); path != "" {
+			return base + " " + displayPath(path, cwd)
+		}
+	}
+	return base
+}
+
+// absToolPath renders a tool-call path as absolute: relative arguments are joined
+// against cwd (the session working directory), matching how the filesystem tool
+// resolves them before it reads or writes. Absolute arguments, or any path when cwd
+// is unknown, are returned unchanged. Both the title and the location derive from
+// this single normalized value so they can't disagree about the same file.
+func absToolPath(path, cwd string) string {
+	if cwd == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(cwd, path)
+}
+
+// displayPath renders a tool-call path for a title: relative to cwd with a
+// leading "./" (and forward slashes) when it sits inside the working directory,
+// otherwise the path as given. Paths outside cwd, or any path when cwd is unknown,
+// are returned as the absolute path.
+func displayPath(path, cwd string) string {
+	path = absToolPath(path, cwd)
+	if cwd == "" || !filepath.IsAbs(path) {
+		return path
+	}
+	rel, err := filepath.Rel(cwd, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return "./" + filepath.ToSlash(rel)
+}
+
+// toolLocations reports the file a tool call touches, so the editor can render
+// the call against that file natively — a clickable target or follow-along
+// highlighting. ACP locations must be absolute, so the path is normalized through
+// absToolPath; the editor can only resolve a path that points at a real on-disk
+// location. Tools without a file target (shell, pulumi) yield none.
+func toolLocations(args toolArgs, cwd string) []acp.ToolCallLocation {
+	path := args.file()
+	if path == "" {
+		return nil
+	}
+	return []acp.ToolCallLocation{{Path: absToolPath(path, cwd)}}
+}
+
+// toolKind maps a Neo tool name ("<server>__<method>") to an ACP ToolKind for
+// display. The method names mirror tools.Filesystem.Invoke; they're display-only
+// and any unrecognized name falls back to "other", so drift is harmless.
+func toolKind(name string) string {
+	server, method, _ := strings.Cut(name, "__")
+	switch server {
+	case "shell", "pulumi":
+		return acp.ToolKindExecute
+	case "filesystem":
+		switch method {
+		case "read", "directory_tree":
+			return acp.ToolKindRead
+		case "write", "edit", "content_replace":
+			return acp.ToolKindEdit
+		case "grep":
+			return acp.ToolKindSearch
+		}
+	}
+	return acp.ToolKindOther
+}

--- a/pkg/cmd/pulumi/neo/acp_translate_test.go
+++ b/pkg/cmd/pulumi/neo/acp_translate_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+)
+
+func TestPromptText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		blocks []acp.ContentBlock
+		want   string
+	}{
+		{
+			name:   "empty",
+			blocks: nil,
+			want:   "",
+		},
+		{
+			name:   "text only",
+			blocks: []acp.ContentBlock{{Type: "text", Text: "hello"}},
+			want:   "hello",
+		},
+		{
+			name: "concatenates text blocks",
+			blocks: []acp.ContentBlock{
+				{Type: "text", Text: "hello "},
+				{Type: "text", Text: "world"},
+			},
+			want: "hello world",
+		},
+		{
+			name: "resource link renders its uri",
+			blocks: []acp.ContentBlock{
+				{Type: "resource_link", URI: "file:///repo/main.go", Name: "main.go"},
+			},
+			want: "@file:///repo/main.go",
+		},
+		{
+			name: "resource link shows label when it differs from uri",
+			blocks: []acp.ContentBlock{
+				{Type: "resource_link", URI: "file:///repo/main.go", Name: "main.go", Title: "Entry point"},
+			},
+			want: "@file:///repo/main.go (Entry point)",
+		},
+		{
+			name: "resource link falls back to name when no title",
+			blocks: []acp.ContentBlock{
+				{Type: "resource_link", URI: "file:///repo/main.go", Name: "main.go"},
+			},
+			want: "@file:///repo/main.go",
+		},
+		{
+			name: "text interleaved with a resource link",
+			blocks: []acp.ContentBlock{
+				{Type: "text", Text: "look at "},
+				{Type: "resource_link", URI: "file:///repo/main.go", Name: "main.go"},
+				{Type: "text", Text: " please"},
+			},
+			want: "look at @file:///repo/main.go please",
+		},
+		{
+			name: "capability-gated blocks are ignored",
+			blocks: []acp.ContentBlock{
+				{Type: "text", Text: "keep"},
+				{Type: "image"},
+				{Type: "audio"},
+				{Type: "resource"},
+			},
+			want: "keep",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, promptText(tt.blocks))
+		})
+	}
+}
+
+func TestToolTrackerTranslate(t *testing.T) {
+	t.Parallel()
+
+	var tr toolTracker
+
+	u, ok := tr.translate(UIAssistantMessage{Content: "hi"})
+	require.True(t, ok)
+	require.IsType(t, acp.AgentMessageChunk{}, u)
+	assert.Equal(t, "hi\n", u.(acp.AgentMessageChunk).Content.Text,
+		"each complete message gets a trailing newline so successive messages don't run together")
+
+	_, ok = tr.translate(UIAssistantMessage{})
+	assert.False(t, ok, "empty assistant message produces no update")
+
+	u, ok = tr.translate(UIToolStarted{Name: "filesystem__edit", Args: json.RawMessage(`{"x":1}`)})
+	require.True(t, ok)
+	start := u.(acp.ToolCallStart)
+	assert.Equal(t, "tc_1", start.ToolCallID)
+	assert.Equal(t, acp.ToolKindEdit, start.Kind)
+	assert.Equal(t, acp.ToolStatusInProgress, start.Status)
+
+	u, ok = tr.translate(UIToolCompleted{Name: "filesystem__edit", Result: json.RawMessage(`{"ok":true}`)})
+	require.True(t, ok)
+	upd := u.(acp.ToolCallProgress)
+	assert.Equal(t, "tc_1", upd.ToolCallID, "completed update reuses the started call id")
+	assert.Equal(t, acp.ToolStatusCompleted, upd.Status)
+
+	// After completion the current id is cleared, so a stray progress or
+	// completion event no longer correlates to the finished call.
+	_, ok = tr.translate(UIToolProgress{Message: "late"})
+	assert.False(t, ok, "progress after completion produces no update")
+	_, ok = tr.translate(UIToolCompleted{})
+	assert.False(t, ok, "completion with no tracked start produces no update")
+
+	_, ok = tr.translate(UIToolStarted{Name: "shell__shell_execute"})
+	require.True(t, ok)
+	u, ok = tr.translate(UIToolCompleted{IsError: true})
+	require.True(t, ok)
+	assert.Equal(t, acp.ToolStatusFailed, u.(acp.ToolCallProgress).Status)
+
+	u, ok = tr.translate(UITodoList{Items: []UITodoItem{{Content: "do", Status: "pending", Priority: "high"}}})
+	require.True(t, ok)
+	plan := u.(acp.PlanUpdate)
+	require.Len(t, plan.Entries, 1)
+	assert.Equal(t, acp.PlanEntry{Content: "do", Status: "pending", Priority: "high"}, plan.Entries[0])
+}
+
+// TestToolTrackerOverlappingStarts pins the serial-dispatch assumption's
+// behavior at the edge: if a second tool start arrives before the first
+// completes, the tracker moves to the new call — the completion attaches to the
+// latest start, and the earlier call simply never completes (it is not
+// mis-attributed).
+func TestToolTrackerOverlappingStarts(t *testing.T) {
+	t.Parallel()
+
+	var tr toolTracker
+
+	u, ok := tr.translate(UIToolStarted{Name: "filesystem__read"})
+	require.True(t, ok)
+	assert.Equal(t, "tc_1", u.(acp.ToolCallStart).ToolCallID)
+
+	u, ok = tr.translate(UIToolStarted{Name: "shell__shell_execute"})
+	require.True(t, ok)
+	assert.Equal(t, "tc_2", u.(acp.ToolCallStart).ToolCallID)
+
+	u, ok = tr.translate(UIToolCompleted{})
+	require.True(t, ok)
+	assert.Equal(t, "tc_2", u.(acp.ToolCallProgress).ToolCallID,
+		"a completion attaches to the latest start")
+
+	_, ok = tr.translate(UIToolCompleted{})
+	assert.False(t, ok, "the overlapped first call has no id left to complete against")
+}
+
+// TestTranslateWarning verifies warnings reach the editor as message-stream
+// chunks (ACP has no dedicated warning update) and empty ones are dropped.
+func TestTranslateWarning(t *testing.T) {
+	t.Parallel()
+
+	var tr toolTracker
+	u, ok := tr.translate(UIWarning{Message: "stack was dropped"})
+	require.True(t, ok)
+	chunk := u.(acp.AgentMessageChunk)
+	assert.Equal(t, "Warning: stack was dropped\n", chunk.Content.Text)
+
+	_, ok = tr.translate(UIWarning{})
+	assert.False(t, ok, "an empty warning produces no update")
+}
+
+// TestPlanEntriesClampVocabulary verifies the ACP egress path keeps plan entries
+// within ACP's enums even if the backend drifts: empty or unknown priority falls
+// back to "medium", empty or unknown status falls back to "pending".
+func TestPlanEntriesClampVocabulary(t *testing.T) {
+	t.Parallel()
+
+	var tr toolTracker
+	u, ok := tr.translate(UITodoList{Items: []UITodoItem{
+		{Content: "valid", Status: "in_progress", Priority: "low"},
+		{Content: "empty", Status: "", Priority: ""},
+		{Content: "unknown", Status: "cancelled", Priority: "urgent"},
+	}})
+	require.True(t, ok)
+	plan := u.(acp.PlanUpdate)
+	require.Len(t, plan.Entries, 3)
+	assert.Equal(t, acp.PlanEntry{Content: "valid", Status: "in_progress", Priority: "low"}, plan.Entries[0])
+	assert.Equal(t, acp.PlanEntry{Content: "empty", Status: "pending", Priority: "medium"}, plan.Entries[1])
+	assert.Equal(t, acp.PlanEntry{Content: "unknown", Status: "pending", Priority: "medium"}, plan.Entries[2])
+}
+
+func TestToolStartHasReadableTitleAndLocation(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	main := filepath.Join(cwd, "main.go")
+
+	tr := toolTracker{cwd: cwd}
+	u, ok := tr.translate(UIToolStarted{
+		Name: "filesystem__read",
+		Args: mustJSON(t, map[string]string{"file_path": main}),
+	})
+	require.True(t, ok)
+	start := u.(acp.ToolCallStart)
+
+	assert.Equal(t, "Read ./main.go", start.Title, "title should name the file, relative to cwd")
+	assert.Equal(t, acp.ToolKindRead, start.Kind)
+	require.Len(t, start.Locations, 1)
+	assert.Equal(t, main, start.Locations[0].Path)
+}
+
+func TestToolTitleAndLocations(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	fsArgs := func(field, path string) toolArgs { return parseToolArgs(mustJSON(t, map[string]string{field: path})) }
+
+	// Filesystem calls name the file they touch, relative to cwd when possible.
+	assert.Equal(t, "Read ./pyproject.toml",
+		toolTitle("filesystem__read", fsArgs("file_path", filepath.Join(cwd, "pyproject.toml")), cwd))
+	assert.Equal(t, "Content replace ./src/a.go",
+		toolTitle("filesystem__content_replace", fsArgs("path", filepath.Join(cwd, "src", "a.go")), cwd))
+	assert.Equal(t, "Read ./src/a.go",
+		toolTitle("filesystem__read", fsArgs("file_path", "src/a.go"), cwd),
+		"relative paths absolutize against cwd, then relativize — matching the location")
+	outside := filepath.Join(filepath.Dir(cwd), "elsewhere", "hosts")
+	assert.Equal(t, "Read "+outside,
+		toolTitle("filesystem__read", fsArgs("file_path", outside), cwd),
+		"paths outside cwd stay absolute")
+	assert.Equal(t, "Read",
+		toolTitle("filesystem__read", toolArgs{}, cwd), "no path falls back to the verb")
+
+	// Shell calls render the command itself, flattened to one line.
+	assert.Equal(t, "git status",
+		toolTitle("shell__shell_execute", parseToolArgs(json.RawMessage(`{"command":"git status"}`)), cwd))
+	assert.Equal(t, "go build ./...",
+		toolTitle("shell__shell_execute", parseToolArgs(json.RawMessage(`{"command":"go build\n  ./..."}`)), cwd),
+		"multi-line commands collapse to a single line")
+	assert.Equal(t, "Shell execute",
+		toolTitle("shell__shell_execute", toolArgs{}, cwd), "no command falls back to the verb")
+
+	assert.Equal(t, "weird", toolTitle("weird", toolArgs{}, ""), "names without a server prefix pass through")
+
+	assert.Nil(t, toolLocations(toolArgs{}, cwd))
+	assert.Nil(t, toolLocations(parseToolArgs(json.RawMessage(`{"command":"ls"}`)), cwd), "no file target -> no location")
+	locs := toolLocations(parseToolArgs(json.RawMessage(`{"path":"/work/src"}`)), cwd)
+	require.Len(t, locs, 1)
+	assert.Equal(t, "/work/src", locs[0].Path, "absolute paths pass through unchanged")
+
+	// Relative arguments are absolutized against cwd: ACP locations must be
+	// absolute or the editor can't resolve the file.
+	rel := toolLocations(fsArgs("file_path", "src/a.go"), cwd)
+	require.Len(t, rel, 1)
+	assert.Equal(t, filepath.Join(cwd, "src", "a.go"), rel[0].Path)
+}
+
+// mustJSON marshals v to a json.RawMessage, failing the test on error. Used to
+// build tool-call args with OS-correct (cross-platform) file paths.
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/pkg/cmd/pulumi/neo/acp_translate_test.go
+++ b/pkg/cmd/pulumi/neo/acp_translate_test.go
@@ -210,6 +210,26 @@ func TestPlanEntriesClampVocabulary(t *testing.T) {
 	assert.Equal(t, acp.PlanEntry{Content: "unknown", Status: "pending", Priority: "medium"}, plan.Entries[2])
 }
 
+// TestPlanEntriesSortedByIndex verifies plan entries are emitted in the
+// agent's intended order even when the items arrive out of Index order, the
+// same contract the TUI's renderTodoLines applies to this slice.
+func TestPlanEntriesSortedByIndex(t *testing.T) {
+	t.Parallel()
+
+	var tr toolTracker
+	u, ok := tr.translate(UITodoList{Items: []UITodoItem{
+		{Content: "third", Status: "pending", Priority: "low", Index: 2},
+		{Content: "first", Status: "completed", Priority: "high", Index: 0},
+		{Content: "second", Status: "in_progress", Priority: "medium", Index: 1},
+	}})
+	require.True(t, ok)
+	plan := u.(acp.PlanUpdate)
+	require.Len(t, plan.Entries, 3)
+	assert.Equal(t, acp.PlanEntry{Content: "first", Status: "completed", Priority: "high"}, plan.Entries[0])
+	assert.Equal(t, acp.PlanEntry{Content: "second", Status: "in_progress", Priority: "medium"}, plan.Entries[1])
+	assert.Equal(t, acp.PlanEntry{Content: "third", Status: "pending", Priority: "low"}, plan.Entries[2])
+}
+
 func TestToolStartHasReadableTitleAndLocation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Two building blocks for the Neo ACP adapter's event pump:

- `acp_translate.go` maps streaming `UIEvent`s to ACP `session/update` payloads: agent message chunks, tool-call lifecycle (titles, locations, kinds), and plan entries clamped to the ACP vocabulary.
- `acp_pumpqueue.go` is an unbounded ordered queue that delivers updates, approval requests, and turn results in the order the agent produced them, without blocking on the editor.

Not yet wired to anything; the adapter that drives these is the next PR. Part 4/5 of the ACP stack (replaces #23669).

🤖 Generated with [Claude Code](https://claude.com/claude-code)