### PR TITLE
Add `pulumi neo acp` Agent Client Protocol adapter

### DIFF
--- a/changelog/pending/cli-feat-20260623-150000.yaml
+++ b/changelog/pending/cli-feat-20260623-150000.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: feat
+body: Add `pulumi neo acp` to run Neo as an Agent Client Protocol agent over stdio for ACP-capable editors, with read-only and plan mode exposed as session config options
+time: 2026-06-23T15:00:00.000000+01:00
+custom:
+    PR: "23886"

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -61,14 +61,7 @@ func getCurrentStackName(ws pkgWorkspace.Context, dir string) (string, error) {
 		return stackName, nil
 	}
 
-	if dir == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("getting current working directory: %w", err)
-		}
-		dir = cwd
-	}
-
+	// An empty dir resolves to the process working directory inside ws.New.
 	w, err := ws.New(dir)
 	if err != nil {
 		return "", err

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -26,7 +26,16 @@ import (
 
 // CurrentStack reads the current stack and returns an instance connected to its backend provider.
 func CurrentStack(ctx context.Context, ws pkgWorkspace.Context, b backend.Backend) (backend.Stack, error) {
-	stackName, err := getCurrentStackName(ws)
+	return CurrentStackAt(ctx, ws, b, "")
+}
+
+// CurrentStackAt is like CurrentStack, but resolves the workspace (and thus the selected stack)
+// from dir instead of the process working directory. An empty dir means the process working
+// directory.
+func CurrentStackAt(
+	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, dir string,
+) (backend.Stack, error) {
+	stackName, err := getCurrentStackName(ws, dir)
 	if err != nil {
 		return nil, err
 	} else if stackName == "" {
@@ -46,18 +55,21 @@ func CurrentStack(ctx context.Context, ws pkgWorkspace.Context, b backend.Backen
 	return b.GetStack(ctx, ref)
 }
 
-func getCurrentStackName(ws pkgWorkspace.Context) (string, error) {
+func getCurrentStackName(ws pkgWorkspace.Context, dir string) (string, error) {
 	// PULUMI_STACK environment variable overrides any stack name in the workspace settings
 	if stackName, ok := os.LookupEnv("PULUMI_STACK"); ok {
 		return stackName, nil
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("getting current working directory: %w", err)
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getting current working directory: %w", err)
+		}
+		dir = cwd
 	}
 
-	w, err := ws.New(cwd)
+	w, err := ws.New(dir)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/pulumi/neo/acp/agent.go
+++ b/pkg/cmd/pulumi/neo/acp/agent.go
@@ -233,7 +233,11 @@ func (a *Agent) prompt(ctx context.Context, req *jsonrpc2.Request) (any, error) 
 	if err != nil {
 		return nil, err
 	}
-	return a.delegate.Prompt(ctx, params)
+	res, err := a.delegate.Prompt(ctx, params)
+	if err != nil {
+		return nil, mapDelegateErr(err)
+	}
+	return res, nil
 }
 
 func (a *Agent) setConfigOption(ctx context.Context, req *jsonrpc2.Request) (any, error) {
@@ -241,7 +245,11 @@ func (a *Agent) setConfigOption(ctx context.Context, req *jsonrpc2.Request) (any
 	if err != nil {
 		return nil, err
 	}
-	return a.delegate.SetConfigOption(ctx, params)
+	res, err := a.delegate.SetConfigOption(ctx, params)
+	if err != nil {
+		return nil, mapDelegateErr(err)
+	}
+	return res, nil
 }
 
 // cancel handles the session/cancel notification. As a notification it has no

--- a/pkg/cmd/pulumi/neo/acp/agent_test.go
+++ b/pkg/cmd/pulumi/neo/acp/agent_test.go
@@ -67,7 +67,8 @@ func newTestPeersWithClient(t *testing.T, a *Agent, clientHandler jsonrpc2.Handl
 	agentEnd, clientEnd := net.Pipe()
 
 	agentConn := jsonrpc2.NewConn(t.Context(),
-		jsonrpc2.NewPlainObjectStream(agentEnd), jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(a.handle)))
+		jsonrpc2.NewPlainObjectStream(agentEnd),
+		jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(a.handleWithRecover)))
 
 	clientConn := jsonrpc2.NewConn(t.Context(),
 		jsonrpc2.NewPlainObjectStream(clientEnd), clientHandler)
@@ -207,6 +208,7 @@ type fakeDelegate struct {
 	gotClient    Client
 	promptResult PromptResult
 	promptErr    error
+	promptFn     func(PromptParams) (PromptResult, error)
 	gotPrompt    PromptParams
 	gotCancel    CancelParams
 	configResult SetConfigOptionResult
@@ -225,6 +227,9 @@ func (f *fakeDelegate) NewSession(
 
 func (f *fakeDelegate) Prompt(_ context.Context, params PromptParams) (PromptResult, error) {
 	f.gotPrompt = params
+	if f.promptFn != nil {
+		return f.promptFn(params)
+	}
 	return f.promptResult, f.promptErr
 }
 
@@ -367,4 +372,54 @@ func TestNewSessionAuthRequiredMapsToCode(t *testing.T) {
 	var rpcErr *jsonrpc2.Error
 	require.ErrorAs(t, err, &rpcErr)
 	assert.EqualValues(t, codeAuthRequired, rpcErr.Code)
+}
+
+func TestPromptAuthRequiredMapsToCode(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{promptErr: ErrAuthRequired})
+	client := newTestPeers(t, agent)
+
+	err := client.Call(t.Context(), "session/prompt", PromptParams{SessionID: "sess_1"}, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, codeAuthRequired, rpcErr.Code)
+}
+
+func TestSetConfigOptionAuthRequiredMapsToCode(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{configErr: ErrAuthRequired})
+	client := newTestPeers(t, agent)
+
+	err := client.Call(t.Context(), "session/set_config_option", SetConfigOptionParams{
+		SessionID: "sess_1", ConfigID: "permission", Value: "read-only",
+	}, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, codeAuthRequired, rpcErr.Code)
+}
+
+func TestHandlerPanicMapsToInternalErrorAndConnectionSurvives(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(testIdentity, "v3.0.0", &fakeDelegate{
+		promptFn: func(PromptParams) (PromptResult, error) { panic("boom in prompt") },
+	})
+	client := newTestPeers(t, agent)
+
+	// The panicking request fails with an internal error rather than tearing
+	// down the connection.
+	err := client.Call(t.Context(), "session/prompt", PromptParams{SessionID: "sess_1"}, nil)
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.EqualValues(t, jsonrpc2.CodeInternalError, rpcErr.Code)
+	assert.Contains(t, rpcErr.Message, "boom in prompt")
+
+	// The same connection still serves subsequent requests.
+	var res InitializeResult
+	require.NoError(t, client.Call(t.Context(), "initialize", InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+	}, &res))
+	assert.Equal(t, ProtocolVersion, res.ProtocolVersion)
 }

--- a/pkg/cmd/pulumi/neo/acp/conn.go
+++ b/pkg/cmd/pulumi/neo/acp/conn.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"runtime/debug"
 
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -38,7 +40,7 @@ func Serve(ctx context.Context, a *Agent, in io.Reader, out io.Writer) error {
 	// prompt handler and could never deliver them, deadlocking on the first such
 	// call. Async handling also lets a session/cancel be processed while its
 	// session/prompt is still in flight.
-	handler := jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(a.handle))
+	handler := jsonrpc2.AsyncHandler(jsonrpc2.HandlerWithError(a.handleWithRecover))
 	conn := jsonrpc2.NewConn(ctx, stream, handler)
 
 	select {
@@ -48,6 +50,38 @@ func Serve(ctx context.Context, a *Agent, in io.Reader, out io.Writer) error {
 	case <-conn.DisconnectNotify():
 		return nil
 	}
+}
+
+// PanicError logs a recovered panic value and its stack to stderr — stdout
+// carries the JSON-RPC protocol and must stay clean — and returns an error
+// describing the panic (without the stack, which stays out of responses).
+// Shared by the per-request recovery below and the adapter's session
+// goroutines.
+func PanicError(where string, r any) error {
+	err := fmt.Errorf("panic in %s: %v", where, r)
+	//nolint:forbidigo // panics surface on goroutines with no cobra command in
+	// scope, and stderr is the ACP log channel (stdout carries the protocol).
+	fmt.Fprintf(os.Stderr, "%v\n%s", err, debug.Stack())
+	return err
+}
+
+// handleWithRecover wraps handle so a panic while serving one request becomes
+// an internal-error response for that request instead of crashing the process:
+// jsonrpc2's AsyncHandler gives each request its own goroutine and nothing
+// above us recovers on it. For notifications HandlerWithError logs the error
+// instead, which is the right degradation.
+func (a *Agent) handleWithRecover(
+	ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request,
+) (result any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			result, err = nil, &jsonrpc2.Error{
+				Code:    jsonrpc2.CodeInternalError,
+				Message: PanicError("handling "+req.Method, r).Error(),
+			}
+		}
+	}()
+	return a.handle(ctx, conn, req)
 }
 
 // handle dispatches a single client→agent request by method name. It is wrapped

--- a/pkg/cmd/pulumi/neo/acp_adapter.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter.go
@@ -1,0 +1,355 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/tools"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// neoACPIdentity is how the adapter introduces itself to the editor on the ACP
+// initialize handshake: the agent name/title and the single auth method we
+// advertise. The method is terminal-typed: an editor that supports terminal
+// auth runs `pulumi login` (our launch command with Args swapped in) in a real
+// terminal, since an interactive login cannot run over the stdio JSON-RPC
+// channel. The same flow is duplicated as pre-stabilization terminal-auth meta
+// for editors (e.g. current stable Zed) that execute that instead of the typed
+// fields; there the command is explicit, so we name our own binary. For editors
+// without either mechanism the agent degrades the method to the untyped form
+// and the description tells the user to run `pulumi login` themselves; in
+// every case `authenticate` only verifies that a login session exists (see
+// acpDelegate.CheckAuth).
+func neoACPIdentity() acp.Identity {
+	// Fall back to resolution via PATH if we can't name our own binary.
+	command := "pulumi"
+	if exe, err := os.Executable(); err == nil {
+		command = exe
+	}
+	return acp.Identity{
+		Name:  "pulumi-neo",
+		Title: "Pulumi Neo",
+		AuthMethods: []acp.AuthMethod{{
+			ID:   "pulumi-login",
+			Name: "Pulumi login",
+			Description: "Authenticate by running `pulumi login` in a terminal. " +
+				"Neo uses your existing Pulumi Cloud session.",
+			Type: acp.AuthMethodTypeTerminal,
+			Args: []string{"login"},
+			Meta: map[string]any{acp.MetaKeyTerminalAuth: acp.TerminalAuthMeta{
+				Label:   "pulumi login",
+				Command: command,
+				Args:    []string{"login"},
+			}},
+		}},
+	}
+}
+
+// errNeoAuthRequired wraps acp.ErrAuthRequired with the Pulumi-specific message
+// the editor surfaces to the user. Wrapping keeps errors.Is(err,
+// acp.ErrAuthRequired) true so the agent still maps it to the ACP
+// "Authentication required" code, while err.Error() carries the login hint.
+var errNeoAuthRequired = fmt.Errorf(
+	"not authenticated with Pulumi Cloud; run `pulumi login`: %w", acp.ErrAuthRequired)
+
+// newNeoACPCmd is the hidden `pulumi neo acp` subcommand. It speaks the Agent
+// Client Protocol (https://agentclientprotocol.com) over stdio so ACP-capable
+// editors can drive Neo as a subprocess. It is hidden because it is launched by
+// editors via their configured command string, not run by hand.
+//
+// Authentication defaults to the CLI's existing Pulumi Cloud session, exactly
+// like `pulumi neo`: the agent never prompts interactively (that would corrupt
+// the JSON-RPC stream on stdout) and instead surfaces an auth-required error
+// the editor can act on when no login is present — by running the advertised
+// terminal auth method (`pulumi login`) when it supports that, or by showing
+// the method's description otherwise.
+func newNeoACPCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "acp",
+		Short:  "Run Pulumi Neo as an Agent Client Protocol (ACP) agent over stdio",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			agent := acp.NewAgent(neoACPIdentity(), version.Version, &acpDelegate{
+				ws:       pkgWorkspace.Instance,
+				baseCtx:  ctx,
+				sessions: map[string]*acpSession{},
+			})
+			// stdin/stdout carry the JSON-RPC stream; nothing else may write to
+			// stdout. cmd.OutOrStdout()/InOrStdin() resolve to the real fds.
+			return acp.Serve(ctx, agent, cmd.InOrStdin(), cmd.OutOrStdout())
+		},
+	}
+}
+
+// acpDelegate implements acp.Delegate over the Pulumi Cloud backend. It owns the
+// live ACP sessions for the connection; the per-session runtime lives in
+// acp_session.go.
+type acpDelegate struct {
+	ws pkgWorkspace.Context
+	// baseCtx is the connection-lifetime context (cmd.Context()). Per-session
+	// background work (the Neo Session event loop) derives from it so it
+	// outlives the request that started it and is torn down when the connection
+	// closes.
+	baseCtx context.Context //nolint:containedctx // session loops outlive requests; see comment
+
+	mu       sync.Mutex
+	sessions map[string]*acpSession
+}
+
+// currentBackend resolves the Pulumi Cloud backend from the stored CLI
+// credentials, returning errNeoAuthRequired (which wraps acp.ErrAuthRequired)
+// when the user is not logged in. It never prompts, so it is safe to call on the
+// JSON-RPC channel. dir determines where the project is detected from (the
+// session cwd in NewSession, the process cwd — "" — in CheckAuth); the project
+// (if any) is returned alongside so callers needing it for target resolution
+// don't re-read it.
+func (d *acpDelegate) currentBackend(
+	ctx context.Context, dir string,
+) (backend.Backend, *workspace.Project, error) {
+	project, _, err := d.ws.ReadProject(dir)
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, nil, err
+	}
+	// NonInteractiveCurrentBackend uses the stored CLI credentials and never
+	// prompts, so it returns a nil backend when the user is not logged in.
+	be, err := cmdBackend.NonInteractiveCurrentBackend(ctx, d.ws, cmdBackend.DefaultLoginManager, project)
+	if err != nil {
+		return nil, nil, err
+	}
+	if be == nil {
+		return nil, nil, errNeoAuthRequired
+	}
+	return be, project, nil
+}
+
+// CheckAuth reports whether a usable Pulumi Cloud session exists. See
+// acp.Delegate; the agent calls it from the `authenticate` handler. The
+// authenticate request carries no working directory, so the project (which only
+// influences backend selection here) is detected from the process cwd.
+func (d *acpDelegate) CheckAuth(ctx context.Context) error {
+	_, _, err := d.currentBackend(ctx, "")
+	return err
+}
+
+// NewSession resolves CLI auth and the task target, builds the session's tool
+// handlers, registers the session, and returns its id. See acp.Delegate.
+func (d *acpDelegate) NewSession(
+	ctx context.Context, params acp.NewSessionParams, caps acp.ClientCapabilities, client acp.Client,
+) (acp.NewSessionResult, error) {
+	cwd := params.Cwd
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return acp.NewSessionResult{}, fmt.Errorf("resolving working directory: %w", err)
+		}
+	}
+	// Root the whole session at cwd: project detection, current-stack lookup,
+	// and the tool sandboxes all resolve from the editor-supplied directory, not
+	// from wherever the editor happened to launch the CLI process.
+	be, project, err := d.currentBackend(ctx, cwd)
+	if err != nil {
+		return acp.NewSessionResult{}, err
+	}
+	cloudBe, ok := be.(httpstate.Backend)
+	if !ok {
+		return acp.NewSessionResult{}, errors.New("`pulumi neo` requires the Pulumi Cloud backend")
+	}
+	if msg := neoUpgradeMessage(cloudBe.Capabilities(ctx), version.Version); msg != "" {
+		return acp.NewSessionResult{}, errors.New(msg)
+	}
+
+	target, err := resolveTaskTarget(ctx, d.ws, cloudBe, project, "", "", cwd)
+	if err != nil {
+		return acp.NewSessionResult{}, err
+	}
+
+	sessionID, err := newACPSessionID()
+	if err != nil {
+		return acp.NewSessionResult{}, err
+	}
+
+	handlers, err := buildACPHandlers(cwd, sessionID, caps, client, d.ws)
+	if err != nil {
+		return acp.NewSessionResult{}, err
+	}
+
+	sess := &acpSession{
+		acpID:        sessionID,
+		api:          cloudBe.Client(),
+		orgName:      target.org,
+		projectName:  target.project,
+		stackRefName: target.stackName(),
+		cwd:          cwd,
+		handlers:     handlers,
+		client:       client,
+	}
+	d.mu.Lock()
+	d.sessions[sessionID] = sess
+	d.mu.Unlock()
+
+	// Advertise the read-only and plan-mode config options at their defaults so
+	// the editor can change them before (or, for read-only, during) the session.
+	return acp.NewSessionResult{
+		SessionID:     sessionID,
+		ConfigOptions: sess.configOptionsSnapshot(),
+	}, nil
+}
+
+// Prompt runs one prompt turn for the session, blocking until it ends and
+// reporting the stop reason. The turn lifecycle itself lives on acpSession
+// (see runTurn). See acp.Delegate.
+func (d *acpDelegate) Prompt(ctx context.Context, params acp.PromptParams) (acp.PromptResult, error) {
+	s, ok := d.session(params.SessionID)
+	if !ok {
+		return acp.PromptResult{}, fmt.Errorf("unknown session %q", params.SessionID)
+	}
+	return s.runTurn(ctx, d.baseCtx, promptText(params.Prompt))
+}
+
+// Cancel posts a cancel user event for the session's task, if one is running.
+// The turn ends with StopCancelled once the backend acknowledges. See
+// acp.Delegate.
+func (d *acpDelegate) Cancel(ctx context.Context, params acp.CancelParams) error {
+	s, ok := d.session(params.SessionID)
+	if !ok {
+		return nil
+	}
+	return s.cancel(ctx)
+}
+
+// SetConfigOption applies a `permission` or `plan` config-option change for the
+// session and returns the full, updated option list. Read-only takes effect
+// immediately (PATCHing a running task); plan mode only applies before the task
+// is created and is otherwise clamped. See acp.Delegate.
+func (d *acpDelegate) SetConfigOption(
+	ctx context.Context, params acp.SetConfigOptionParams,
+) (acp.SetConfigOptionResult, error) {
+	s, ok := d.session(params.SessionID)
+	if !ok {
+		return acp.SetConfigOptionResult{}, fmt.Errorf("unknown session %q", params.SessionID)
+	}
+	if err := s.setConfigOption(ctx, params.ConfigID, params.Value); err != nil {
+		return acp.SetConfigOptionResult{}, err
+	}
+	return acp.SetConfigOptionResult{ConfigOptions: s.configOptionsSnapshot()}, nil
+}
+
+// session returns the registered session for id. Used by Prompt and Cancel to
+// find the state established by NewSession.
+func (d *acpDelegate) session(id string) (*acpSession, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	s, ok := d.sessions[id]
+	return s, ok
+}
+
+// buildACPHandlers constructs the CLI-local tool handlers for a session rooted
+// at cwd. When the editor advertised the matching fs/terminal capability, the
+// filesystem and shell tools are routed through the editor (so writes appear as
+// native diffs, reads see unsaved buffers, and commands run in the editor's
+// terminal); otherwise they run locally. The pulumi tool always runs locally.
+func buildACPHandlers(
+	cwd, sessionID string, caps acp.ClientCapabilities, caller acp.Caller, ws pkgWorkspace.Context,
+) (map[string]ToolHandler, error) {
+	lt, err := buildLocalToolHandlers(cwd, ws)
+	if err != nil {
+		return nil, err
+	}
+	if caps.FS.WriteTextFile || caps.FS.ReadTextFile {
+		cfs := &acp.ClientFS{Caller: caller, SessionID: sessionID}
+		if caps.FS.WriteTextFile {
+			lt.fs.OnWrite = cfs.WriteTextFile
+		}
+		if caps.FS.ReadTextFile {
+			lt.fs.OnRead = cfs.ReadTextFile
+		}
+	}
+	if caps.Terminal {
+		ct := &acp.ClientTerminal{Caller: caller, SessionID: sessionID}
+		lt.sh.OnExec = func(
+			ctx context.Context, command, dir string, timeout time.Duration,
+		) (tools.ShellResult, error) {
+			return runInEditorTerminal(ctx, ct, command, dir, timeout)
+		}
+	}
+	return lt.handlers, nil
+}
+
+// runInEditorTerminal runs a shell command in the editor's terminal and shapes
+// the result like the local shell tool, through the shared tools.ShellResult so
+// the wire shape stays identical. The editor merges stdout and stderr, so the
+// combined stream is reported as stdout and stderr is left empty. It is wired
+// into tools.Shell.OnExec by buildACPHandlers.
+func runInEditorTerminal(
+	ctx context.Context, ct *acp.ClientTerminal, command, dir string, timeout time.Duration,
+) (tools.ShellResult, error) {
+	program, args := tools.ShellInvocation(command)
+	tctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Cap the captured output at the same limit as the local shell tool, so
+	// truncation behaves identically on both paths.
+	res, err := ct.Run(tctx, program, args, dir, tools.MaxOutputBytes)
+
+	exitCode := res.ExitCode
+	if res.Signal != "" {
+		// A signal-terminated process carries no exit code (the editor reports
+		// null, which decodes to 0). Surface it as -1 to match the local shell
+		// tool, so a signal-killed command isn't reported as a clean exit 0.
+		exitCode = -1
+	}
+	out := tools.ShellResult{
+		Stdout:    res.Output,
+		ExitCode:  exitCode,
+		Truncated: res.Truncated,
+		TimedOut:  res.TimedOut,
+	}
+	if res.TimedOut {
+		return out, tools.TimeoutError(timeout)
+	}
+	if err != nil {
+		// A non-timeout transport error means we can't trust the result.
+		return tools.ShellResult{}, err
+	}
+	return out, nil
+}
+
+// newACPSessionID returns a random, opaque ACP session id.
+func newACPSessionID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generating session id: %w", err)
+	}
+	return "sess_" + hex.EncodeToString(b[:]), nil
+}

--- a/pkg/cmd/pulumi/neo/acp_adapter.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter.go
@@ -289,15 +289,15 @@ func buildACPHandlers(
 	if caps.FS.WriteTextFile || caps.FS.ReadTextFile {
 		cfs := &acp.ClientFS{Caller: caller, SessionID: sessionID}
 		if caps.FS.WriteTextFile {
-			lt.fs.OnWrite = cfs.WriteTextFile
+			lt.fs.WriteFileOverride = cfs.WriteTextFile
 		}
 		if caps.FS.ReadTextFile {
-			lt.fs.OnRead = cfs.ReadTextFile
+			lt.fs.ReadFileOverride = cfs.ReadTextFile
 		}
 	}
 	if caps.Terminal {
 		ct := &acp.ClientTerminal{Caller: caller, SessionID: sessionID}
-		lt.sh.OnExec = func(
+		lt.sh.ExecOverride = func(
 			ctx context.Context, command, dir string, timeout time.Duration,
 		) (tools.ShellResult, error) {
 			return runInEditorTerminal(ctx, ct, command, dir, timeout)
@@ -310,7 +310,7 @@ func buildACPHandlers(
 // the result like the local shell tool, through the shared tools.ShellResult so
 // the wire shape stays identical. The editor merges stdout and stderr, so the
 // combined stream is reported as stdout and stderr is left empty. It is wired
-// into tools.Shell.OnExec by buildACPHandlers.
+// into tools.Shell.ExecOverride by buildACPHandlers.
 func runInEditorTerminal(
 	ctx context.Context, ct *acp.ClientTerminal, command, dir string, timeout time.Duration,
 ) (tools.ShellResult, error) {

--- a/pkg/cmd/pulumi/neo/acp_adapter.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -27,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/tools"
@@ -116,10 +114,10 @@ func newNeoACPCmd() *cobra.Command {
 // acp_session.go.
 type acpDelegate struct {
 	ws pkgWorkspace.Context
-	// baseCtx is the connection-lifetime context (cmd.Context()). Per-session
-	// background work (the Neo Session event loop) derives from it so it
-	// outlives the request that started it and is torn down when the connection
-	// closes.
+	// baseCtx is the connection-lifetime context (cmd.Context()), stashed on
+	// each session at creation so its background work (the Neo Session event
+	// loop) outlives the request that started it and is torn down when the
+	// connection closes.
 	baseCtx context.Context //nolint:containedctx // session loops outlive requests; see comment
 
 	mu       sync.Mutex
@@ -136,8 +134,8 @@ type acpDelegate struct {
 func (d *acpDelegate) currentBackend(
 	ctx context.Context, dir string,
 ) (backend.Backend, *workspace.Project, error) {
-	project, _, err := d.ws.ReadProject(dir)
-	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+	project, err := readNeoProject(d.ws, dir)
+	if err != nil {
 		return nil, nil, err
 	}
 	// NonInteractiveCurrentBackend uses the stored CLI credentials and never
@@ -181,15 +179,12 @@ func (d *acpDelegate) NewSession(
 	if err != nil {
 		return acp.NewSessionResult{}, err
 	}
-	cloudBe, ok := be.(httpstate.Backend)
-	if !ok {
-		return acp.NewSessionResult{}, errors.New("`pulumi neo` requires the Pulumi Cloud backend")
-	}
-	if msg := neoUpgradeMessage(cloudBe.Capabilities(ctx), version.Version); msg != "" {
-		return acp.NewSessionResult{}, errors.New(msg)
+	cloudBe, err := resolveNeoCloudBackend(ctx, be)
+	if err != nil {
+		return acp.NewSessionResult{}, err
 	}
 
-	target, err := resolveTaskTarget(ctx, d.ws, cloudBe, project, "", "", cwd)
+	target, err := resolveTaskTarget(ctx, d.ws, cloudBe, project, taskTargetOpts{dir: cwd})
 	if err != nil {
 		return acp.NewSessionResult{}, err
 	}
@@ -213,6 +208,7 @@ func (d *acpDelegate) NewSession(
 		cwd:          cwd,
 		handlers:     handlers,
 		client:       client,
+		baseCtx:      d.baseCtx,
 	}
 	d.mu.Lock()
 	d.sessions[sessionID] = sess
@@ -234,7 +230,7 @@ func (d *acpDelegate) Prompt(ctx context.Context, params acp.PromptParams) (acp.
 	if !ok {
 		return acp.PromptResult{}, fmt.Errorf("unknown session %q", params.SessionID)
 	}
-	return s.runTurn(ctx, d.baseCtx, promptText(params.Prompt))
+	return s.runTurn(ctx, promptText(params.Prompt))
 }
 
 // Cancel posts a cancel user event for the session's task, if one is running.

--- a/pkg/cmd/pulumi/neo/acp_adapter_test.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter_test.go
@@ -81,8 +81,8 @@ func TestBuildACPHandlersRoutesWritesToEditor(t *testing.T) {
 
 	fs, ok := handlers["filesystem"].(*tools.Filesystem)
 	require.True(t, ok)
-	require.NotNil(t, fs.OnWrite, "fs.writeTextFile capability should route writes through the editor")
-	assert.Nil(t, fs.OnRead, "fs.readTextFile was not advertised, so reads stay local")
+	require.NotNil(t, fs.WriteFileOverride, "fs.writeTextFile capability should route writes through the editor")
+	assert.Nil(t, fs.ReadFileOverride, "fs.readTextFile was not advertised, so reads stay local")
 }
 
 func TestBuildACPHandlersRoutesReadsToEditor(t *testing.T) {
@@ -96,8 +96,8 @@ func TestBuildACPHandlersRoutesReadsToEditor(t *testing.T) {
 
 	fs, ok := handlers["filesystem"].(*tools.Filesystem)
 	require.True(t, ok)
-	require.NotNil(t, fs.OnRead, "fs.readTextFile capability should route reads through the editor")
-	assert.Nil(t, fs.OnWrite, "fs.writeTextFile was not advertised, so writes stay local")
+	require.NotNil(t, fs.ReadFileOverride, "fs.readTextFile capability should route reads through the editor")
+	assert.Nil(t, fs.WriteFileOverride, "fs.writeTextFile was not advertised, so writes stay local")
 }
 
 func TestBuildACPHandlersLocalWhenNoFSCapability(t *testing.T) {
@@ -110,12 +110,12 @@ func TestBuildACPHandlersLocalWhenNoFSCapability(t *testing.T) {
 
 	fs, ok := handlers["filesystem"].(*tools.Filesystem)
 	require.True(t, ok)
-	assert.Nil(t, fs.OnWrite, "without the capability, writes stay local")
-	assert.Nil(t, fs.OnRead, "without the capability, reads stay local")
+	assert.Nil(t, fs.WriteFileOverride, "without the capability, writes stay local")
+	assert.Nil(t, fs.ReadFileOverride, "without the capability, reads stay local")
 
 	sh, ok := handlers["shell"].(*tools.Shell)
 	require.True(t, ok)
-	assert.Nil(t, sh.OnExec, "without the terminal capability, shell stays local")
+	assert.Nil(t, sh.ExecOverride, "without the terminal capability, shell stays local")
 }
 
 func TestBuildACPHandlersRoutesShellToTerminal(t *testing.T) {
@@ -128,7 +128,7 @@ func TestBuildACPHandlersRoutesShellToTerminal(t *testing.T) {
 
 	sh, ok := handlers["shell"].(*tools.Shell)
 	require.True(t, ok)
-	require.NotNil(t, sh.OnExec, "terminal capability should route shell commands through the editor")
+	require.NotNil(t, sh.ExecOverride, "terminal capability should route shell commands through the editor")
 }
 
 // recordingFSCaller answers the agent's outbound fs/* requests: it records the

--- a/pkg/cmd/pulumi/neo/acp_adapter_test.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter_test.go
@@ -1,0 +1,518 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/tools"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// fakeACPCaller is a no-op acp.Caller; buildACPHandlers only needs a non-nil
+// value to wire the editor-backed write path.
+type fakeACPCaller struct{}
+
+func (fakeACPCaller) Call(context.Context, string, any, any) error { return nil }
+
+func TestNeoACPIdentityAdvertisesTerminalLogin(t *testing.T) {
+	t.Parallel()
+
+	// The single advertised auth method is terminal-typed: editors run our
+	// launch binary with these args (`pulumi login`) in a real terminal. The id
+	// is wire-visible and must stay stable for editors that persist it.
+	identity := neoACPIdentity()
+	require.Len(t, identity.AuthMethods, 1)
+	m := identity.AuthMethods[0]
+	assert.Equal(t, "pulumi-login", m.ID)
+	assert.Equal(t, acp.AuthMethodTypeTerminal, m.Type)
+	assert.Equal(t, []string{"login"}, m.Args)
+	assert.Empty(t, m.Env)
+	assert.NotEmpty(t, m.Description, "description doubles as the degraded-method guidance")
+
+	// The pre-stabilization terminal-auth meta mirrors the typed fields with an
+	// explicit command (our own binary) for editors that only execute the meta
+	// form (e.g. current stable Zed).
+	meta, ok := m.Meta[acp.MetaKeyTerminalAuth].(acp.TerminalAuthMeta)
+	require.True(t, ok, "terminal-auth meta must be advertised")
+	assert.Equal(t, "pulumi login", meta.Label)
+	assert.NotEmpty(t, meta.Command)
+	assert.Equal(t, []string{"login"}, meta.Args)
+}
+
+func TestBuildACPHandlersRoutesWritesToEditor(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	handlers, err := buildACPHandlers(cwd, "sess_1",
+		acp.ClientCapabilities{FS: acp.FileSystemCapability{WriteTextFile: true}},
+		fakeACPCaller{}, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	for _, name := range []string{"filesystem", "shell", "pulumi"} {
+		assert.Contains(t, handlers, name)
+	}
+
+	fs, ok := handlers["filesystem"].(*tools.Filesystem)
+	require.True(t, ok)
+	require.NotNil(t, fs.OnWrite, "fs.writeTextFile capability should route writes through the editor")
+	assert.Nil(t, fs.OnRead, "fs.readTextFile was not advertised, so reads stay local")
+}
+
+func TestBuildACPHandlersRoutesReadsToEditor(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	handlers, err := buildACPHandlers(cwd, "sess_1",
+		acp.ClientCapabilities{FS: acp.FileSystemCapability{ReadTextFile: true}},
+		fakeACPCaller{}, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	fs, ok := handlers["filesystem"].(*tools.Filesystem)
+	require.True(t, ok)
+	require.NotNil(t, fs.OnRead, "fs.readTextFile capability should route reads through the editor")
+	assert.Nil(t, fs.OnWrite, "fs.writeTextFile was not advertised, so writes stay local")
+}
+
+func TestBuildACPHandlersLocalWhenNoFSCapability(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	handlers, err := buildACPHandlers(cwd, "sess_1",
+		acp.ClientCapabilities{}, fakeACPCaller{}, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	fs, ok := handlers["filesystem"].(*tools.Filesystem)
+	require.True(t, ok)
+	assert.Nil(t, fs.OnWrite, "without the capability, writes stay local")
+	assert.Nil(t, fs.OnRead, "without the capability, reads stay local")
+
+	sh, ok := handlers["shell"].(*tools.Shell)
+	require.True(t, ok)
+	assert.Nil(t, sh.OnExec, "without the terminal capability, shell stays local")
+}
+
+func TestBuildACPHandlersRoutesShellToTerminal(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	handlers, err := buildACPHandlers(cwd, "sess_1",
+		acp.ClientCapabilities{Terminal: true}, fakeACPCaller{}, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	sh, ok := handlers["shell"].(*tools.Shell)
+	require.True(t, ok)
+	require.NotNil(t, sh.OnExec, "terminal capability should route shell commands through the editor")
+}
+
+// recordingFSCaller answers the agent's outbound fs/* requests: it records the
+// last method and params (re-encoded as JSON so assertions don't need acp's
+// unexported wire structs) and serves readContent for fs/read_text_file.
+type recordingFSCaller struct {
+	calls       int
+	method      string
+	params      json.RawMessage
+	readContent string
+}
+
+func (c *recordingFSCaller) Call(_ context.Context, method string, params, result any) error {
+	c.calls++
+	c.method = method
+	c.params, _ = json.Marshal(params)
+	if method == "fs/read_text_file" && result != nil {
+		return json.Unmarshal([]byte(`{"content":`+strconv.Quote(c.readContent)+`}`), result)
+	}
+	return nil
+}
+
+// fsParams is the wire shape of the fs/read_text_file and fs/write_text_file
+// params, decoded from the recorded JSON for assertions.
+type fsParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+}
+
+// TestACPFilesystemReadUsesEditorContent: with fs.readTextFile advertised, a
+// filesystem read is served by the editor — returning its (possibly unsaved)
+// buffer, with the tool's offset/limit slicing still applied — ignoring
+// whatever is on local disk.
+func TestACPFilesystemReadUsesEditorContent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "main.go")
+	require.NoError(t, os.WriteFile(target, []byte("ON DISK\n"), 0o600))
+
+	caller := &recordingFSCaller{readContent: "line1\nline2\nline3\n"}
+	handlers, err := buildACPHandlers(root, "sess_abc",
+		acp.ClientCapabilities{FS: acp.FileSystemCapability{ReadTextFile: true}},
+		caller, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	res, err := handlers["filesystem"].Invoke(t.Context(), "read",
+		mustJSON(t, map[string]any{"file_path": target, "offset": 1}))
+	require.NoError(t, err)
+	assert.Equal(t, "fs/read_text_file", caller.method)
+
+	// The result reflects the editor's content (sliced from offset 1), not disk.
+	raw, err := json.Marshal(res)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "line2")
+	assert.NotContains(t, string(raw), "ON DISK")
+	assert.NotContains(t, string(raw), "line1", "offset slicing should still apply to editor content")
+}
+
+// TestACPFilesystemEditUsesEditorBufferOverDisk guards that an ACP-backed edit
+// matches and writes against the editor's buffer (via the read routing), not
+// stale disk: the on-disk content here would not contain old_string at all.
+func TestACPFilesystemEditUsesEditorBufferOverDisk(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "main.go")
+	require.NoError(t, os.WriteFile(target, []byte("STALE DISK CONTENT\n"), 0o600))
+
+	caller := &recordingFSCaller{readContent: "func target() {}\n"}
+	handlers, err := buildACPHandlers(root, "sess_abc",
+		acp.ClientCapabilities{FS: acp.FileSystemCapability{ReadTextFile: true, WriteTextFile: true}},
+		caller, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	res, err := handlers["filesystem"].Invoke(t.Context(), "edit", mustJSON(t, map[string]string{
+		"file_path":  target,
+		"old_string": "func target()",
+		"new_string": "func renamed()",
+	}))
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(res)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "Successfully edited", "edit should match against the editor buffer")
+
+	// The write carried the buffer-derived content, and disk was left untouched.
+	var wrote fsParams
+	require.NoError(t, json.Unmarshal(caller.params, &wrote))
+	assert.Equal(t, "func renamed() {}\n", wrote.Content)
+	onDisk, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "STALE DISK CONTENT\n", string(onDisk))
+}
+
+// TestACPFilesystemEditRoutesThroughEditorWrite is the end-to-end check for the
+// edit-as-ACP-write path: with only fs.writeTextFile advertised, a filesystem
+// edit reads and computes the modified content locally but commits it through
+// the editor's fs/write_text_file, leaving the on-disk file untouched (the
+// editor owns the write).
+func TestACPFilesystemEditRoutesThroughEditorWrite(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "main.go")
+	const original = "package main\n\nfunc foo() {}\n"
+	require.NoError(t, os.WriteFile(target, []byte(original), 0o600))
+
+	caller := &recordingFSCaller{}
+	handlers, err := buildACPHandlers(root, "sess_abc",
+		acp.ClientCapabilities{FS: acp.FileSystemCapability{WriteTextFile: true}},
+		caller, pkgWorkspace.Instance)
+	require.NoError(t, err)
+
+	_, err = handlers["filesystem"].Invoke(t.Context(), "edit", mustJSON(t, map[string]string{
+		"file_path":  target,
+		"old_string": "func foo()",
+		"new_string": "func bar()",
+	}))
+	require.NoError(t, err)
+
+	// The write was diverted to the editor with the fully-modified content.
+	require.Equal(t, 1, caller.calls)
+	require.Equal(t, "fs/write_text_file", caller.method)
+	var wrote fsParams
+	require.NoError(t, json.Unmarshal(caller.params, &wrote))
+	// The filesystem tool canonicalizes the path before writing, so the editor
+	// receives the symlink-evaluated absolute path.
+	realRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(realRoot, "main.go"), wrote.Path)
+	assert.Equal(t, "sess_abc", wrote.SessionID)
+	assert.Equal(t, "package main\n\nfunc bar() {}\n", wrote.Content)
+
+	// Disk is untouched: the CLI did not perform the write itself.
+	onDisk, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(onDisk))
+}
+
+// scriptedTermCaller records the terminal/* methods invoked and can fail the
+// wait step to exercise the timeout path, or report a signal exit to exercise
+// the signal-mapping path. It otherwise leaves results at their zero value.
+type scriptedTermCaller struct {
+	mu      sync.Mutex
+	methods []string
+	waitErr error
+	signal  string
+}
+
+func (c *scriptedTermCaller) Call(_ context.Context, method string, _, result any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.methods = append(c.methods, method)
+	if method == "terminal/wait_for_exit" {
+		if c.waitErr != nil {
+			return c.waitErr
+		}
+		// A signal-terminated process reports a null exit code plus the signal.
+		// Decode into the caller-provided result so we don't name acp's
+		// unexported exitStatus type.
+		if c.signal != "" {
+			_ = json.Unmarshal([]byte(`{"exitCode":null,"signal":`+strconv.Quote(c.signal)+`}`), result)
+		}
+	}
+	return nil
+}
+
+func TestRunInEditorTerminalSuccess(t *testing.T) {
+	t.Parallel()
+
+	sc := &scriptedTermCaller{}
+	ct := &acp.ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	out, err := runInEditorTerminal(t.Context(), ct, "echo hi", "/work", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 0, out.ExitCode)
+	assert.Equal(t, "", out.Stderr)
+	assert.Equal(t,
+		[]string{"terminal/create", "terminal/wait_for_exit", "terminal/output", "terminal/release"},
+		sc.methods)
+}
+
+func TestRunInEditorTerminalTimeout(t *testing.T) {
+	t.Parallel()
+
+	sc := &scriptedTermCaller{waitErr: context.DeadlineExceeded}
+	ct := &acp.ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	out, err := runInEditorTerminal(t.Context(), ct, "sleep 100", "/work", time.Minute)
+	require.Error(t, err)
+	assert.True(t, out.TimedOut)
+	assert.Contains(t, sc.methods, "terminal/kill")
+}
+
+func TestRunInEditorTerminalSignalMapsToNonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	// A signal-terminated command has a null exit code over the wire; it must
+	// surface as a non-zero exit (-1, matching the local shell) rather than a
+	// clean exit 0.
+	sc := &scriptedTermCaller{signal: "SIGKILL"}
+	ct := &acp.ClientTerminal{Caller: sc, SessionID: "sess_1"}
+
+	out, err := runInEditorTerminal(t.Context(), ct, "sleep 100", "/work", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, -1, out.ExitCode)
+	assert.False(t, out.TimedOut)
+}
+
+func TestACPDelegateSessionLookup(t *testing.T) {
+	t.Parallel()
+
+	d := &acpDelegate{ws: pkgWorkspace.Instance, sessions: map[string]*acpSession{}}
+	d.sessions["sess_1"] = &acpSession{
+		orgName:      "acme",
+		projectName:  "proj",
+		stackRefName: "dev",
+		cwd:          "/work",
+		handlers:     map[string]ToolHandler{},
+	}
+
+	got, ok := d.session("sess_1")
+	require.True(t, ok)
+	assert.Equal(t, "acme", got.orgName)
+	assert.Equal(t, "proj", got.projectName)
+	assert.Equal(t, "dev", got.stackRefName)
+	assert.Equal(t, "/work", got.cwd)
+	require.NotNil(t, got.handlers)
+
+	_, ok = d.session("missing")
+	assert.False(t, ok)
+}
+
+func TestPromptRejectsOverlappingTurn(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeTaskAPI{}
+	d := &acpDelegate{ws: pkgWorkspace.Instance, baseCtx: t.Context(), sessions: map[string]*acpSession{}}
+	d.sessions["sess_1"] = &acpSession{
+		acpID:   "sess_1",
+		api:     api,
+		orgName: "acme",
+		started: true,
+		taskID:  "task_1",
+		// A turn is already registered; a second prompt must be rejected rather
+		// than overwrite it and orphan the prior waiter.
+		activeTurn: make(chan turnResult, 1),
+	}
+
+	_, err := d.Prompt(t.Context(), acp.PromptParams{
+		SessionID: "sess_1",
+		Prompt:    []acp.ContentBlock{{Type: "text", Text: "hi"}},
+	})
+	require.ErrorContains(t, err, "already in progress")
+	assert.Empty(t, api.posted, "overlapping prompt must not post to the backend")
+}
+
+func TestPromptRejectedAfterSessionEnded(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeTaskAPI{}
+	d := &acpDelegate{ws: pkgWorkspace.Instance, baseCtx: t.Context(), sessions: map[string]*acpSession{}}
+	d.sessions["sess_1"] = &acpSession{
+		acpID:   "sess_1",
+		api:     api,
+		orgName: "acme",
+		started: true,
+		taskID:  "task_1",
+		// The event loop exited with an error; a new turn could never complete.
+		ended:  true,
+		runErr: errors.New("event stream lost"),
+	}
+
+	_, err := d.Prompt(t.Context(), acp.PromptParams{
+		SessionID: "sess_1",
+		Prompt:    []acp.ContentBlock{{Type: "text", Text: "hi"}},
+	})
+	require.ErrorContains(t, err, "event stream lost")
+	assert.Empty(t, api.posted, "a prompt on an ended session must not post to the backend")
+}
+
+// createdTask records one CreateNeoTask call a session made against the fake
+// backend.
+type createdTask struct {
+	content     string
+	stackName   string
+	projectName string
+	opts        client.CreateNeoTaskOptions
+}
+
+// fakeTaskAPI is a fake neoSessionAPI: it records the task creations, user
+// events, and mode PATCHes a session sends to the (fake) Neo backend, and
+// serves stream (which may be nil: reads then block until ctx ends) as the
+// task's event stream. The *Err fields, when set, fail the corresponding call.
+type fakeTaskAPI struct {
+	stream    chan client.NeoStreamEvent
+	createErr error
+	postErr   error
+	updateErr error
+	// rejectStack, when true, fails any CreateNeoTask that names a stack with
+	// the backend's "invalid entities" rejection, driving the retry-without-
+	// stack fallback in createNeoTaskWithEntityRetry.
+	rejectStack bool
+
+	mu      sync.Mutex
+	created []createdTask
+	posted  []any
+	patches []client.UpdateNeoTaskOptions
+}
+
+func (p *fakeTaskAPI) CreateNeoTask(
+	_ context.Context, _, content, stackName, projectName string, opts client.CreateNeoTaskOptions,
+) (*client.NeoTaskResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.createErr != nil {
+		return nil, p.createErr
+	}
+	if p.rejectStack && stackName != "" {
+		return nil, &apitype.ErrorResponse{Code: 400, Message: "invalid entities for task"}
+	}
+	p.created = append(p.created, createdTask{
+		content: content, stackName: stackName, projectName: projectName, opts: opts,
+	})
+	return &client.NeoTaskResponse{TaskID: "task_1"}, nil
+}
+
+func (p *fakeTaskAPI) StreamNeoTaskEvents(
+	context.Context, string, string, string,
+) (<-chan client.NeoStreamEvent, error) {
+	return p.stream, nil
+}
+
+func (p *fakeTaskAPI) PostNeoTaskUserEvent(_ context.Context, _, _ string, body any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.postErr != nil {
+		return p.postErr
+	}
+	p.posted = append(p.posted, body)
+	return nil
+}
+
+func (p *fakeTaskAPI) UpdateNeoTask(
+	_ context.Context, _, _ string, opts client.UpdateNeoTaskOptions,
+) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.updateErr != nil {
+		return p.updateErr
+	}
+	p.patches = append(p.patches, opts)
+	return nil
+}
+
+func TestCancelPostsUserCancel(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{}
+	d := &acpDelegate{ws: pkgWorkspace.Instance, sessions: map[string]*acpSession{}}
+	d.sessions["sess_x"] = &acpSession{acpID: "sess_x", api: fp, orgName: "acme", taskID: "task_1", started: true}
+
+	require.NoError(t, d.Cancel(t.Context(), acp.CancelParams{SessionID: "sess_x"}))
+
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	require.Len(t, fp.posted, 1)
+	_, ok := fp.posted[0].(apitype.AgentUserEventCancel)
+	assert.True(t, ok)
+}
+
+func TestCancelNoopWhenUnknownOrNotStarted(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{}
+	d := &acpDelegate{ws: pkgWorkspace.Instance, sessions: map[string]*acpSession{}}
+	d.sessions["not_started"] = &acpSession{api: fp}
+
+	require.NoError(t, d.Cancel(t.Context(), acp.CancelParams{SessionID: "missing"}))
+	require.NoError(t, d.Cancel(t.Context(), acp.CancelParams{SessionID: "not_started"}))
+
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	assert.Empty(t, fp.posted)
+}

--- a/pkg/cmd/pulumi/neo/acp_adapter_test.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter_test.go
@@ -434,6 +434,9 @@ type fakeTaskAPI struct {
 	// the backend's "invalid entities" rejection, driving the retry-without-
 	// stack fallback in createNeoTaskWithEntityRetry.
 	rejectStack bool
+	// streamPanic, when true, panics in StreamNeoTaskEvents — a stand-in for a
+	// bug anywhere on the session event loop goroutine, driving its recover.
+	streamPanic bool
 
 	mu      sync.Mutex
 	created []createdTask
@@ -461,6 +464,9 @@ func (p *fakeTaskAPI) CreateNeoTask(
 func (p *fakeTaskAPI) StreamNeoTaskEvents(
 	context.Context, string, string, string,
 ) (<-chan client.NeoStreamEvent, error) {
+	if p.streamPanic {
+		panic("stream exploded")
+	}
 	return p.stream, nil
 }
 

--- a/pkg/cmd/pulumi/neo/acp_config.go
+++ b/pkg/cmd/pulumi/neo/acp_config.go
@@ -1,0 +1,186 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+)
+
+// The ACP session config options the adapter exposes, mirroring the user-facing
+// toggles of the `pulumi neo` TUI: a read-only permission mode (Ctrl+R) and plan
+// mode (Shift+Tab). Approval mode is intentionally not exposed — it stays
+// "manual" so every gated tool call surfaces as an editor permission request.
+const (
+	// acpConfigPermission selects between full access and read-only. Maps to
+	// client.NeoPermissionMode; its values equal the mode's wire strings.
+	acpConfigPermission = "permission"
+	// acpConfigPlan selects plan mode vs. building directly. Maps to PlanMode.
+	acpConfigPlan = "plan"
+
+	acpPermissionValueDefault  = string(client.NeoPermissionModeDefault)
+	acpPermissionValueReadOnly = string(client.NeoPermissionModeReadOnly)
+
+	acpPlanValueBuild = "build"
+	acpPlanValuePlan  = "plan"
+)
+
+// neoConfigOptions renders the adapter's config options with current values
+// reflecting permissionMode and planMode. The order is the agent's preferred
+// display priority (permission first).
+func neoConfigOptions(permissionMode client.NeoPermissionMode, planMode bool) []acp.ConfigOption {
+	permValue := string(permissionMode)
+	if permValue == "" {
+		permValue = acpPermissionValueDefault
+	}
+	planValue := acpPlanValueBuild
+	if planMode {
+		planValue = acpPlanValuePlan
+	}
+	return []acp.ConfigOption{
+		{
+			ID:           acpConfigPermission,
+			Name:         "Permissions",
+			Description:  "Limit Neo to read-only operations, or allow full access.",
+			Category:     acp.ConfigCategoryMode,
+			Type:         acp.ConfigOptionTypeSelect,
+			CurrentValue: permValue,
+			Options: []acp.ConfigOptionValue{
+				{
+					Value:       acpPermissionValueDefault,
+					Name:        "Full access",
+					Description: "Neo may change state, run `pulumi up`, and open PRs, subject to your role.",
+				},
+				{
+					Value:       acpPermissionValueReadOnly,
+					Name:        "Read-only",
+					Description: "Neo may only read; state changes, deployments, and PRs are blocked.",
+				},
+			},
+		},
+		{
+			ID:           acpConfigPlan,
+			Name:         "Plan mode",
+			Description:  "Have Neo explore and propose a plan before it makes any changes.",
+			Category:     acp.ConfigCategoryMode,
+			Type:         acp.ConfigOptionTypeSelect,
+			CurrentValue: planValue,
+			Options: []acp.ConfigOptionValue{
+				{
+					Value:       acpPlanValueBuild,
+					Name:        "Build",
+					Description: "Neo can make changes right away.",
+				},
+				{
+					Value:       acpPlanValuePlan,
+					Name:        "Plan",
+					Description: "Neo proposes a plan first. Set this before the first message.",
+				},
+			},
+		},
+	}
+}
+
+// configOptionsSnapshot renders the session's config options from its current
+// mode state, taking the lock.
+func (s *acpSession) configOptionsSnapshot() []acp.ConfigOption {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return neoConfigOptions(s.permissionMode, s.planMode)
+}
+
+// setConfigOption applies a single config-option change. The permission option is
+// live: once the task exists it is PATCHed so the cloud picks it up immediately;
+// before the task exists the stored value is applied at creation (start). The
+// plan option is fixed at task creation — PlanMode cannot change on a running task
+// — so a change after the task starts is clamped (kept at its current value),
+// mirroring the TUI, where Shift+Tab is frozen after the first message.
+//
+// startMu is held throughout so this cannot interleave with start's task
+// creation: a change lands either before it (start reads the new values) or
+// after it (started is true, so the permission change PATCHes the live task and
+// a plan change is clamped) — never in between, where it would be stored and
+// advertised but never applied.
+func (s *acpSession) setConfigOption(ctx context.Context, configID, value string) error {
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
+	switch configID {
+	case acpConfigPermission:
+		var mode client.NeoPermissionMode
+		switch value {
+		case acpPermissionValueDefault:
+			mode = client.NeoPermissionModeDefault
+		case acpPermissionValueReadOnly:
+			mode = client.NeoPermissionModeReadOnly
+		default:
+			return fmt.Errorf("invalid value %q for config option %q", value, configID)
+		}
+		s.mu.Lock()
+		started, taskID := s.started, s.taskID
+		s.mu.Unlock()
+		// Push to a live task first; only record the new value once the server has
+		// accepted it, so a failed PATCH doesn't leave us advertising a mode the
+		// task isn't actually in.
+		if started {
+			if err := s.api.UpdateNeoTask(ctx, s.orgName, taskID,
+				client.UpdateNeoTaskOptions{PermissionMode: &mode}); err != nil {
+				return err
+			}
+		}
+		s.mu.Lock()
+		s.permissionMode = mode
+		s.mu.Unlock()
+		return nil
+
+	case acpConfigPlan:
+		var plan bool
+		switch value {
+		case acpPlanValueBuild:
+			plan = false
+		case acpPlanValuePlan:
+			plan = true
+		default:
+			return fmt.Errorf("invalid value %q for config option %q", value, configID)
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		// Clamp once the task exists: plan mode is established at creation and the
+		// server's PlanModeTracker runs in lockstep from there.
+		if !s.started {
+			s.planMode = plan
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unknown config option %q", configID)
+	}
+}
+
+// noteExitedPlanMode records that the session left plan mode (the server clears
+// it when an exit_plan_mode approval is granted) and reports whether the local
+// state actually changed, so the caller can emit a single config_option_update.
+func (s *acpSession) noteExitedPlanMode() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.planMode {
+		return false
+	}
+	s.planMode = false
+	return true
+}

--- a/pkg/cmd/pulumi/neo/acp_config_test.go
+++ b/pkg/cmd/pulumi/neo/acp_config_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+)
+
+// findOption returns the config option with the given id, failing the test if it
+// is absent.
+func findOption(t *testing.T, opts []acp.ConfigOption, id string) acp.ConfigOption {
+	t.Helper()
+	for _, o := range opts {
+		if o.ID == id {
+			return o
+		}
+	}
+	t.Fatalf("config option %q not advertised", id)
+	return acp.ConfigOption{}
+}
+
+func TestConfigOptionsDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := &acpSession{}
+	opts := s.configOptionsSnapshot()
+
+	// permission first (the agent's preferred display priority), then plan.
+	require.Len(t, opts, 2)
+	assert.Equal(t, acpConfigPermission, opts[0].ID)
+	assert.Equal(t, acpConfigPlan, opts[1].ID)
+
+	perm := findOption(t, opts, acpConfigPermission)
+	assert.Equal(t, acp.ConfigOptionTypeSelect, perm.Type)
+	assert.Equal(t, acp.ConfigCategoryMode, perm.Category)
+	assert.Equal(t, acpPermissionValueDefault, perm.CurrentValue, "default is full access, not read-only")
+
+	plan := findOption(t, opts, acpConfigPlan)
+	assert.Equal(t, acpPlanValueBuild, plan.CurrentValue, "plan mode is off by default")
+}
+
+func TestSetConfigOptionPermission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("before start stores value without patching", func(t *testing.T) {
+		t.Parallel()
+		up := &fakeTaskAPI{}
+		s := &acpSession{api: up, orgName: "acme"}
+
+		require.NoError(t, s.setConfigOption(t.Context(), acpConfigPermission, acpPermissionValueReadOnly))
+
+		assert.Equal(t, client.NeoPermissionModeReadOnly, s.permissionMode)
+		up.mu.Lock()
+		assert.Empty(t, up.patches, "no task exists yet, so nothing to PATCH")
+		up.mu.Unlock()
+		assert.Equal(t, acpPermissionValueReadOnly,
+			findOption(t, s.configOptionsSnapshot(), acpConfigPermission).CurrentValue)
+	})
+
+	t.Run("after start patches the live task", func(t *testing.T) {
+		t.Parallel()
+		up := &fakeTaskAPI{}
+		s := &acpSession{api: up, orgName: "acme", taskID: "task_1", started: true}
+
+		require.NoError(t, s.setConfigOption(t.Context(), acpConfigPermission, acpPermissionValueReadOnly))
+
+		up.mu.Lock()
+		defer up.mu.Unlock()
+		require.Len(t, up.patches, 1)
+		require.NotNil(t, up.patches[0].PermissionMode)
+		assert.Equal(t, client.NeoPermissionModeReadOnly, *up.patches[0].PermissionMode)
+		assert.Nil(t, up.patches[0].ApprovalMode, "approval mode is never changed")
+	})
+
+	t.Run("failed patch keeps the old mode", func(t *testing.T) {
+		t.Parallel()
+		up := &fakeTaskAPI{updateErr: errors.New("PATCH rejected")}
+		s := &acpSession{api: up, orgName: "acme", taskID: "task_1", started: true}
+
+		// The documented ordering: push to the live task first, store only on
+		// success — a failed PATCH must not leave us advertising a mode the task
+		// isn't actually in.
+		err := s.setConfigOption(t.Context(), acpConfigPermission, acpPermissionValueReadOnly)
+		require.ErrorContains(t, err, "PATCH rejected")
+
+		assert.Empty(t, s.permissionMode, "a failed PATCH must not store the new mode")
+		assert.Equal(t, acpPermissionValueDefault,
+			findOption(t, s.configOptionsSnapshot(), acpConfigPermission).CurrentValue,
+			"the advertised options must still show the mode the task is in")
+	})
+}
+
+func TestSetConfigOptionPlan(t *testing.T) {
+	t.Parallel()
+
+	t.Run("before start stores value", func(t *testing.T) {
+		t.Parallel()
+		s := &acpSession{}
+
+		require.NoError(t, s.setConfigOption(t.Context(), acpConfigPlan, acpPlanValuePlan))
+
+		assert.True(t, s.planMode)
+		assert.Equal(t, acpPlanValuePlan,
+			findOption(t, s.configOptionsSnapshot(), acpConfigPlan).CurrentValue)
+	})
+
+	t.Run("after start is clamped", func(t *testing.T) {
+		t.Parallel()
+		s := &acpSession{started: true}
+
+		// PlanMode is fixed at task creation; a later switch must not change it.
+		require.NoError(t, s.setConfigOption(t.Context(), acpConfigPlan, acpPlanValuePlan))
+
+		assert.False(t, s.planMode, "plan mode cannot be enabled once the task exists")
+		assert.Equal(t, acpPlanValueBuild,
+			findOption(t, s.configOptionsSnapshot(), acpConfigPlan).CurrentValue)
+	})
+}
+
+func TestSetConfigOptionRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	s := &acpSession{}
+	require.Error(t, s.setConfigOption(t.Context(), acpConfigPermission, "bogus"))
+	require.Error(t, s.setConfigOption(t.Context(), acpConfigPlan, "bogus"))
+	require.Error(t, s.setConfigOption(t.Context(), "unknown", "x"))
+}
+
+func TestDelegateSetConfigOption(t *testing.T) {
+	t.Parallel()
+
+	up := &fakeTaskAPI{}
+	d := &acpDelegate{ws: pkgWorkspace.Instance, sessions: map[string]*acpSession{}}
+	d.sessions["sess_x"] = &acpSession{acpID: "sess_x", api: up, orgName: "acme"}
+
+	res, err := d.SetConfigOption(t.Context(), acp.SetConfigOptionParams{
+		SessionID: "sess_x", ConfigID: acpConfigPermission, Value: acpPermissionValueReadOnly,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, acpPermissionValueReadOnly,
+		findOption(t, res.ConfigOptions, acpConfigPermission).CurrentValue,
+		"the response carries the complete, updated option list")
+
+	_, err = d.SetConfigOption(t.Context(), acp.SetConfigOptionParams{SessionID: "missing"})
+	require.ErrorContains(t, err, "unknown session")
+}
+
+func TestRequestPermissionPlanExitEmitsConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeACPClient{permResult: acp.RequestPermissionResult{
+		Outcome: acp.PermissionOutcome{Outcome: "selected", OptionID: "allow"},
+	}}
+	fp := &fakeTaskAPI{}
+	s := &acpSession{acpID: "sess_x", client: fc, api: fp, orgName: "acme", taskID: "task_1", planMode: true}
+
+	s.requestPermission(t.Context(), UIApprovalRequest{
+		ApprovalID:   "appr_1",
+		ApprovalType: approvalTypePlanExit,
+		Message:      "approve the plan?",
+	})
+
+	assert.False(t, s.planMode, "approving an exit_plan_mode request clears plan mode")
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	var update *acp.ConfigOptionUpdate
+	for _, n := range fc.notifications {
+		if n.method != "session/update" {
+			continue
+		}
+		if sn, ok := n.params.(acp.SessionNotification); ok {
+			if u, ok := sn.Update.(acp.ConfigOptionUpdate); ok {
+				update = &u
+			}
+		}
+	}
+	require.NotNil(t, update, "a config_option_update must announce leaving plan mode")
+	assert.Equal(t, acpPlanValueBuild, findOption(t, update.ConfigOptions, acpConfigPlan).CurrentValue)
+}
+
+func TestRequestPermissionPlanExitRejectedKeepsPlanMode(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeACPClient{permResult: acp.RequestPermissionResult{
+		Outcome: acp.PermissionOutcome{Outcome: "selected", OptionID: "reject"},
+	}}
+	fp := &fakeTaskAPI{}
+	s := &acpSession{acpID: "sess_x", client: fc, api: fp, orgName: "acme", taskID: "task_1", planMode: true}
+
+	s.requestPermission(t.Context(), UIApprovalRequest{
+		ApprovalID:   "appr_1",
+		ApprovalType: approvalTypePlanExit,
+		Message:      "approve the plan?",
+	})
+
+	assert.True(t, s.planMode, "rejecting the plan keeps plan mode on")
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	for _, n := range fc.notifications {
+		if sn, ok := n.params.(acp.SessionNotification); ok {
+			_, isCfg := sn.Update.(acp.ConfigOptionUpdate)
+			assert.False(t, isCfg, "no config_option_update when plan mode is unchanged")
+		}
+	}
+}

--- a/pkg/cmd/pulumi/neo/acp_pumpqueue.go
+++ b/pkg/cmd/pulumi/neo/acp_pumpqueue.go
@@ -27,8 +27,8 @@ import (
 // after the updates that preceded it have been written — while letting the pump
 // drain UIEvents without blocking on the editor.
 type pumpAction struct {
-	notify   acp.SessionUpdate  //nolint:unused // consumed by the ACP adapter, next in this stack
-	approval *UIApprovalRequest //nolint:unused // consumed by the ACP adapter, next in this stack
+	notify   acp.SessionUpdate
+	approval *UIApprovalRequest
 	finish   *turnResult
 }
 
@@ -36,7 +36,7 @@ type pumpAction struct {
 // current turn ended: with a stop reason, or a fatal error.
 type turnResult struct {
 	reason acp.StopReason
-	err    error //nolint:unused // consumed by the ACP adapter, next in this stack
+	err    error
 }
 
 // pumpQueue is an unbounded, ordered, single-consumer queue of pumpActions. The

--- a/pkg/cmd/pulumi/neo/acp_session.go
+++ b/pkg/cmd/pulumi/neo/acp_session.go
@@ -140,13 +140,23 @@ func (s *acpSession) start(baseCtx context.Context, prompt string) error {
 	// When Run returns (stream ended, failed, or ctx cancelled), record that the
 	// event loop is gone — new prompts are rejected from then on — and tear down
 	// the derived context so the pump stops too and resolves any in-flight turn
-	// (see pump's teardown).
+	// (see pump's teardown). Run also executes every tool handler, so a panic
+	// anywhere in that code is recovered here into runErr — the session ends
+	// with an error instead of taking down the whole process; deferring cancel
+	// first (LIFO) means the pump unwinds only after the panic is recorded, so
+	// its teardown resolves a waiting turn with the panic error.
 	go func() {
+		var err error
 		defer cancel()
-		err := session.Run(sessCtx)
-		s.mu.Lock()
-		s.ended, s.runErr = true, err
-		s.mu.Unlock()
+		defer func() {
+			if r := recover(); r != nil {
+				err = acp.PanicError("Neo session event loop", r)
+			}
+			s.mu.Lock()
+			s.ended, s.runErr = true, err
+			s.mu.Unlock()
+		}()
+		err = session.Run(sessCtx)
 	}()
 	go s.pump(sessCtx, uiCh)
 	return nil

--- a/pkg/cmd/pulumi/neo/acp_session.go
+++ b/pkg/cmd/pulumi/neo/acp_session.go
@@ -1,0 +1,361 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// acpSession is the per-session state an ACP session carries: the resolved
+// Pulumi Cloud client and task target, the working directory, the tool
+// handlers, and the editor client used to stream updates. The Neo task and its
+// event loop are created lazily on the first prompt (matching the TUI).
+type acpSession struct {
+	acpID        string
+	api          neoSessionAPI
+	orgName      string
+	projectName  string
+	stackRefName string
+	cwd          string
+	handlers     map[string]ToolHandler
+	client       acp.Client
+
+	// startMu serializes task creation (start) with config-option changes
+	// (setConfigOption), spanning their network calls. Without it a mode change
+	// could land between start reading the modes and the task becoming
+	// PATCHable — stored and advertised, but never applied to the task. mu stays
+	// the short-lived field lock; never acquire startMu while holding mu.
+	startMu sync.Mutex
+
+	mu      sync.Mutex
+	taskID  string
+	started bool
+	// ended records that the Session event loop has exited (runErr says why;
+	// nil means a clean stream end or connection teardown). Set by the start
+	// goroutine when Run returns. Once ended, new prompts are rejected and the
+	// pump's teardown resolves any in-flight turn.
+	ended  bool
+	runErr error
+	// permissionMode and planMode are the config-option selections that feed the
+	// Neo task. They are mutated by SetConfigOption and read when the task is
+	// created (start) — permissionMode also live-PATCHes a running task, while
+	// planMode is fixed once the task exists. Default zero values mean the
+	// hardcoded baseline: full-access permissions, plan mode off.
+	permissionMode client.NeoPermissionMode
+	planMode       bool
+	activeTurn     chan turnResult
+}
+
+// neoSessionAPI is the slice of the cloud client an ACP session drives its Neo
+// task through: creating the task, streaming its events, posting user events
+// (chat messages, approvals, cancels), and PATCHing a live task's mode
+// settings. *client.Client satisfies it; tests fake it.
+type neoSessionAPI interface {
+	EventStreamer
+	neoTaskCreator
+	UpdateNeoTask(ctx context.Context, orgName, taskID string, opts client.UpdateNeoTaskOptions) error
+}
+
+// start creates the Neo task with the first prompt as the initial message and
+// launches the long-lived Session event loop plus the translation pump. Both run
+// on a context derived from the connection lifetime so they survive past the
+// prompt request that started them.
+func (s *acpSession) start(baseCtx context.Context, prompt string) error {
+	// Hold startMu across the whole creation window so a concurrent
+	// setConfigOption either happens-before (its values are read below) or
+	// happens-after (it sees started and PATCHes the live task).
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
+	s.mu.Lock()
+	permissionMode := s.permissionMode
+	if permissionMode == "" {
+		permissionMode = client.NeoPermissionModeDefault
+	}
+	planMode := s.planMode
+	s.mu.Unlock()
+
+	// If the backend drops the attached stack (createNeoTaskWithEntityRetry's
+	// fallback), collect the warning here — uiCh doesn't exist yet — and queue
+	// it below so it reaches the editor, mirroring the TUI.
+	var warnings []string
+	resp, err := createNeoTaskWithEntityRetry(baseCtx, s.api, s.orgName, prompt, s.stackRefName, s.projectName,
+		client.CreateNeoTaskOptions{
+			ToolExecutionMode: "cli",
+			// Manual approval routes every gated tool call to the editor as an ACP
+			// permission request; balanced/auto would resolve them server-side and
+			// bypass the editor. It is fixed (not a config option) for that reason.
+			ApprovalMode: client.NeoApprovalModeManual,
+			// PermissionMode (read-only) and PlanMode come from the editor's config
+			// option selections; see the `permission` and `plan` ACP config options.
+			PermissionMode: permissionMode,
+			PlanMode:       planMode,
+		}, func(originalErr error) {
+			warnings = append(warnings,
+				entityDroppedWarning(s.orgName, s.projectName, s.stackRefName, originalErr))
+		})
+	if err != nil {
+		return err
+	}
+
+	sessCtx, cancel := context.WithCancel(baseCtx)
+	uiCh := make(chan UIEvent, 64)
+	// Queue creation-time warnings ahead of any stream events so the pump
+	// forwards them to the editor first.
+	for _, w := range warnings {
+		sendUI(uiCh, UIWarning{Message: w})
+	}
+
+	s.mu.Lock()
+	s.taskID = resp.TaskID
+	s.started = true
+	s.mu.Unlock()
+
+	session := &Session{
+		Client:   s.api,
+		Handlers: s.handlers,
+		OrgName:  s.orgName,
+		TaskID:   resp.TaskID,
+		UIEvents: uiCh,
+	}
+	// When Run returns (stream ended, failed, or ctx cancelled), record that the
+	// event loop is gone — new prompts are rejected from then on — and tear down
+	// the derived context so the pump stops too and resolves any in-flight turn
+	// (see pump's teardown).
+	go func() {
+		defer cancel()
+		err := session.Run(sessCtx)
+		s.mu.Lock()
+		s.ended, s.runErr = true, err
+		s.mu.Unlock()
+	}()
+	go s.pump(sessCtx, uiCh)
+	return nil
+}
+
+// runTurn runs one prompt turn: on the first prompt it creates the Neo task and
+// starts the event loop (start); on later prompts it posts the user's message.
+// Either way it blocks until the turn ends (a final assistant message,
+// cancellation, or a fatal error) and reports the stop reason. baseCtx is the
+// connection-lifetime context the session's background loops run on; ctx is the
+// prompt request's own context.
+func (s *acpSession) runTurn(ctx, baseCtx context.Context, text string) (acp.PromptResult, error) {
+	// Register this turn before any work so the pump can signal it the moment
+	// the turn ends, even for a very fast turn. ACP drives one prompt at a time
+	// per session; reject an overlapping prompt rather than overwrite activeTurn,
+	// which would orphan the prior waiter (the pump only ever signals the latest).
+	done := make(chan turnResult, 1)
+	s.mu.Lock()
+	if s.ended {
+		// The Session event loop is gone (stream failure or clean end); a new
+		// turn could never complete, so fail it up front.
+		s.mu.Unlock()
+		return acp.PromptResult{}, s.endedError()
+	}
+	if s.activeTurn != nil {
+		s.mu.Unlock()
+		return acp.PromptResult{}, fmt.Errorf("a prompt turn is already in progress for session %q", s.acpID)
+	}
+	s.activeTurn = done
+	needStart := !s.started
+	taskID := s.taskID
+	s.mu.Unlock()
+
+	var startErr error
+	if needStart {
+		startErr = s.start(baseCtx, text)
+	} else {
+		startErr = s.api.PostNeoTaskUserEvent(ctx, s.orgName, taskID,
+			apitype.AgentUserEventUserMessage{Type: "user_message", Content: text})
+	}
+	if startErr != nil {
+		s.mu.Lock()
+		s.activeTurn = nil
+		s.mu.Unlock()
+		return acp.PromptResult{}, startErr
+	}
+
+	select {
+	case <-ctx.Done():
+		return acp.PromptResult{}, ctx.Err()
+	case tr := <-done:
+		if tr.err != nil {
+			return acp.PromptResult{}, tr.err
+		}
+		return acp.PromptResult{StopReason: tr.reason}, nil
+	}
+}
+
+// cancel posts a cancel user event for the session's task, if one is running.
+// The turn ends with StopCancelled once the backend acknowledges.
+func (s *acpSession) cancel(ctx context.Context) error {
+	s.mu.Lock()
+	started, taskID := s.started, s.taskID
+	s.mu.Unlock()
+	if !started || taskID == "" {
+		return nil
+	}
+	return s.api.PostNeoTaskUserEvent(ctx, s.orgName, taskID, apitype.AgentUserEventCancel{Type: "user_cancel"})
+}
+
+// endedError describes why the session can no longer run turns: the event loop
+// exited with runErr, or ended without error (a clean stream end or connection
+// teardown).
+func (s *acpSession) endedError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.runErr != nil {
+		return fmt.Errorf("Neo session ended: %w", s.runErr)
+	}
+	return errors.New("Neo session has ended")
+}
+
+// pump translates Session UIEvents into ordered actions (session/update
+// notifications, permission requests, turn resolutions) and hands them to a
+// dedicated writer goroutine. It runs until the session context is cancelled or
+// the event channel closes.
+//
+// Draining uiCh and writing to the editor are deliberately decoupled. uiCh is a
+// best-effort channel: Session.sendUI drops events when it is full (fine for the
+// TUI, which only renders them). But the pump also derives the turn-boundary
+// signals that resolve a waiting Prompt from this stream, and those must not be
+// lost. If the pump wrote session/update notifications inline it would block on
+// a slow editor stdout, let uiCh back up, and a dropped boundary event would
+// hang Prompt until cancellation. Routing everything through an unbounded,
+// ordered queue lets the pump keep draining uiCh at all times, while preserving
+// the order the agent produced events (so updates still precede the turn result).
+func (s *acpSession) pump(ctx context.Context, uiCh <-chan UIEvent) {
+	q := newPumpQueue()
+	go s.drainPumpQueue(ctx, q)
+	// Teardown must resolve a waiting Prompt: the event loop is gone, so no
+	// turn-boundary event will ever arrive. close delivers the final turn
+	// result — a no-op for the waiter if the turn already resolved (finishTurn
+	// without a waiter does nothing) — after everything queued ahead of it.
+	defer func() { q.close(&turnResult{err: s.endedError()}) }()
+
+	tracker := toolTracker{cwd: s.cwd}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-uiCh:
+			if !ok {
+				return
+			}
+			switch e := evt.(type) {
+			case UIApprovalRequest:
+				req := e
+				q.push(pumpAction{approval: &req})
+			case UICancelled:
+				q.push(pumpAction{finish: &turnResult{reason: acp.StopCancelled}})
+			case UIError:
+				q.push(pumpAction{finish: &turnResult{err: errors.New(e.Message)}})
+			case UITaskIdle:
+				q.push(pumpAction{finish: &turnResult{reason: acp.StopEndTurn}})
+			default:
+				if update, send := tracker.translate(evt); send {
+					q.push(pumpAction{notify: update})
+				}
+			}
+		}
+	}
+}
+
+// drainPumpQueue performs queued pump actions in order until the queue is closed
+// and drained. It is the only writer of stream-derived session/update
+// notifications, so a slow editor stalls it alone and never the pump that feeds
+// it. (requestPermission — already off this goroutine — sends its
+// config_option_update directly: that update is ordered by the permission
+// round-trip it follows, not by the event stream, and jsonrpc2 serializes
+// concurrent writes.)
+func (s *acpSession) drainPumpQueue(ctx context.Context, q *pumpQueue) {
+	for {
+		a, ok := q.pop()
+		if !ok {
+			return
+		}
+		switch {
+		case a.notify != nil:
+			s.notify(ctx, a.notify)
+		case a.approval != nil:
+			// Run the editor round-trip off the writer so later actions keep
+			// flowing while the user decides.
+			go s.requestPermission(ctx, *a.approval)
+		case a.finish != nil:
+			s.finishTurn(*a.finish)
+		}
+	}
+}
+
+// notify sends a session/update notification for this session, dropping errors:
+// a failed notification means the editor has gone away, which the connection
+// teardown handles.
+func (s *acpSession) notify(ctx context.Context, update acp.SessionUpdate) {
+	_ = s.client.Notify(ctx, "session/update", acp.SessionNotification{SessionID: s.acpID, Update: update})
+}
+
+// finishTurn delivers the turn's outcome to the waiting Prompt call, if any. The
+// channel is buffered so this never blocks the pump.
+func (s *acpSession) finishTurn(tr turnResult) {
+	s.mu.Lock()
+	ch := s.activeTurn
+	s.activeTurn = nil
+	s.mu.Unlock()
+	if ch != nil {
+		ch <- tr
+	}
+}
+
+// requestPermission forwards a Neo approval request to the editor as an ACP
+// permission request and relays the decision back to the backend as a user
+// confirmation. A failed/denied request is treated as a rejection.
+func (s *acpSession) requestPermission(ctx context.Context, e UIApprovalRequest) {
+	title := e.Message
+	if title == "" {
+		title = e.ToolName
+	}
+	var res acp.RequestPermissionResult
+	approved := false
+	if err := s.client.Call(ctx, "session/request_permission", acp.RequestPermissionParams{
+		SessionID: s.acpID,
+		ToolCall:  acp.PermissionToolCall{ToolCallID: e.ApprovalID, Title: title},
+		Options:   acp.ApprovalOptions(),
+	}, &res); err == nil {
+		approved = res.Approved()
+	}
+
+	// Approving an exit_plan_mode request exits plan mode server-side (the
+	// PlanModeTracker clears in lockstep). Reflect that to the editor with a
+	// config_option_update so its plan-mode indicator follows along.
+	if approved && e.ApprovalType == approvalTypePlanExit && s.noteExitedPlanMode() {
+		s.notify(ctx, acp.ConfigOptionUpdate{ConfigOptions: s.configOptionsSnapshot()})
+	}
+
+	s.mu.Lock()
+	taskID := s.taskID
+	s.mu.Unlock()
+	_ = s.api.PostNeoTaskUserEvent(ctx, s.orgName, taskID, apitype.AgentUserEventUserConfirmation{
+		Type:       "user_confirmation",
+		ApprovalID: e.ApprovalID,
+		Approved:   approved,
+	})
+}

--- a/pkg/cmd/pulumi/neo/acp_session.go
+++ b/pkg/cmd/pulumi/neo/acp_session.go
@@ -38,6 +38,10 @@ type acpSession struct {
 	cwd          string
 	handlers     map[string]ToolHandler
 	client       acp.Client
+	// baseCtx is the connection-lifetime context the session's background work
+	// (the Neo Session event loop and the pump) derives from, so it outlives the
+	// prompt request that starts it and is torn down when the connection closes.
+	baseCtx context.Context //nolint:containedctx // fixed at session creation; see comment
 
 	// startMu serializes task creation (start) with config-option changes
 	// (setConfigOption), spanning their network calls. Without it a mode change
@@ -77,9 +81,9 @@ type neoSessionAPI interface {
 
 // start creates the Neo task with the first prompt as the initial message and
 // launches the long-lived Session event loop plus the translation pump. Both run
-// on a context derived from the connection lifetime so they survive past the
-// prompt request that started them.
-func (s *acpSession) start(baseCtx context.Context, prompt string) error {
+// on a context derived from the connection lifetime (baseCtx) so they survive
+// past the prompt request that started them.
+func (s *acpSession) start(prompt string) error {
 	// Hold startMu across the whole creation window so a concurrent
 	// setConfigOption either happens-before (its values are read below) or
 	// happens-after (it sees started and PATCHes the live task).
@@ -98,7 +102,7 @@ func (s *acpSession) start(baseCtx context.Context, prompt string) error {
 	// fallback), collect the warning here — uiCh doesn't exist yet — and queue
 	// it below so it reaches the editor, mirroring the TUI.
 	var warnings []string
-	resp, err := createNeoTaskWithEntityRetry(baseCtx, s.api, s.orgName, prompt, s.stackRefName, s.projectName,
+	resp, err := createNeoTaskWithEntityRetry(s.baseCtx, s.api, s.orgName, prompt, s.stackRefName, s.projectName,
 		client.CreateNeoTaskOptions{
 			ToolExecutionMode: "cli",
 			// Manual approval routes every gated tool call to the editor as an ACP
@@ -117,7 +121,7 @@ func (s *acpSession) start(baseCtx context.Context, prompt string) error {
 		return err
 	}
 
-	sessCtx, cancel := context.WithCancel(baseCtx)
+	sessCtx, cancel := context.WithCancel(s.baseCtx)
 	uiCh := make(chan UIEvent, 64)
 	// Queue creation-time warnings ahead of any stream events so the pump
 	// forwards them to the editor first.
@@ -165,10 +169,9 @@ func (s *acpSession) start(baseCtx context.Context, prompt string) error {
 // runTurn runs one prompt turn: on the first prompt it creates the Neo task and
 // starts the event loop (start); on later prompts it posts the user's message.
 // Either way it blocks until the turn ends (a final assistant message,
-// cancellation, or a fatal error) and reports the stop reason. baseCtx is the
-// connection-lifetime context the session's background loops run on; ctx is the
+// cancellation, or a fatal error) and reports the stop reason. ctx is the
 // prompt request's own context.
-func (s *acpSession) runTurn(ctx, baseCtx context.Context, text string) (acp.PromptResult, error) {
+func (s *acpSession) runTurn(ctx context.Context, text string) (acp.PromptResult, error) {
 	// Register this turn before any work so the pump can signal it the moment
 	// the turn ends, even for a very fast turn. ACP drives one prompt at a time
 	// per session; reject an overlapping prompt rather than overwrite activeTurn,
@@ -192,7 +195,7 @@ func (s *acpSession) runTurn(ctx, baseCtx context.Context, text string) (acp.Pro
 
 	var startErr error
 	if needStart {
-		startErr = s.start(baseCtx, text)
+		startErr = s.start(text)
 	} else {
 		startErr = s.api.PostNeoTaskUserEvent(ctx, s.orgName, taskID,
 			apitype.AgentUserEventUserMessage{Type: "user_message", Content: text})
@@ -204,6 +207,11 @@ func (s *acpSession) runTurn(ctx, baseCtx context.Context, text string) (acp.Pro
 		return acp.PromptResult{}, startErr
 	}
 
+	// On ctx.Done we deliberately leave activeTurn registered: the backend turn
+	// is still in flight, and clearing the slot early would let a new prompt
+	// register a waiter that the old turn's boundary event then resolves. The
+	// slot clears on the next turn-boundary event (or the pump's teardown)
+	// instead — until then, new prompts are rejected as overlapping.
 	select {
 	case <-ctx.Done():
 		return acp.PromptResult{}, ctx.Err()

--- a/pkg/cmd/pulumi/neo/acp_session_test.go
+++ b/pkg/cmd/pulumi/neo/acp_session_test.go
@@ -250,6 +250,7 @@ func TestRunTurnFirstPromptCreatesTaskAndCompletes(t *testing.T) {
 		stackRefName:   "dev",
 		client:         fc,
 		handlers:       map[string]ToolHandler{},
+		baseCtx:        t.Context(),
 		permissionMode: client.NeoPermissionModeReadOnly,
 		planMode:       true,
 	}
@@ -261,7 +262,7 @@ func TestRunTurnFirstPromptCreatesTaskAndCompletes(t *testing.T) {
 		IsFinal: true,
 	})}
 
-	res, err := s.runTurn(t.Context(), t.Context(), "build it")
+	res, err := s.runTurn(t.Context(), "build it")
 	require.NoError(t, err)
 	assert.Equal(t, acp.StopEndTurn, res.StopReason)
 
@@ -298,9 +299,9 @@ func TestStartDefaultsModes(t *testing.T) {
 	t.Parallel()
 
 	fp := &fakeTaskAPI{}
-	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}}
+	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}, baseCtx: t.Context()}
 
-	require.NoError(t, s.start(t.Context(), "hello"))
+	require.NoError(t, s.start("hello"))
 
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
@@ -316,9 +317,9 @@ func TestRunTurnCreateErrorReleasesTurn(t *testing.T) {
 	t.Parallel()
 
 	fp := &fakeTaskAPI{createErr: errors.New("task quota exceeded")}
-	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}}
+	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}, baseCtx: t.Context()}
 
-	_, err := s.runTurn(t.Context(), t.Context(), "hello")
+	_, err := s.runTurn(t.Context(), "hello")
 	require.ErrorContains(t, err, "task quota exceeded")
 
 	s.mu.Lock()
@@ -339,7 +340,7 @@ func TestRunTurnPostErrorReleasesTurn(t *testing.T) {
 		started: true, taskID: "task_9",
 	}
 
-	_, err := s.runTurn(t.Context(), t.Context(), "again")
+	_, err := s.runTurn(t.Context(), "again")
 	require.ErrorContains(t, err, "backend rejected the message")
 
 	s.mu.Lock()
@@ -356,13 +357,13 @@ func TestRunTurnSurvivesEventLoopPanic(t *testing.T) {
 	t.Parallel()
 
 	fp := &fakeTaskAPI{streamPanic: true}
-	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}}
+	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}, baseCtx: t.Context()}
 
-	_, err := s.runTurn(t.Context(), t.Context(), "hello")
+	_, err := s.runTurn(t.Context(), "hello")
 	require.ErrorContains(t, err, "panic in Neo session event loop")
 	require.ErrorContains(t, err, "stream exploded")
 
-	_, err = s.runTurn(t.Context(), t.Context(), "again")
+	_, err = s.runTurn(t.Context(), "again")
 	require.ErrorContains(t, err, "panic in Neo session event loop")
 }
 
@@ -381,7 +382,7 @@ func TestRunTurnConcurrentPromptsExactlyOneWins(t *testing.T) {
 	errs := make(chan error, 2)
 	for range 2 {
 		go func() {
-			_, err := s.runTurn(t.Context(), t.Context(), "hi")
+			_, err := s.runTurn(t.Context(), "hi")
 			errs <- err
 		}()
 	}
@@ -421,10 +422,10 @@ func TestStartEntityDroppedWarningReachesEditor(t *testing.T) {
 	fc := &fakeACPClient{}
 	s := &acpSession{
 		acpID: "sess_x", api: fp, orgName: "acme", projectName: "proj", stackRefName: "dev",
-		client: fc, handlers: map[string]ToolHandler{},
+		client: fc, handlers: map[string]ToolHandler{}, baseCtx: t.Context(),
 	}
 
-	require.NoError(t, s.start(t.Context(), "hello"))
+	require.NoError(t, s.start("hello"))
 
 	// The task was still created, just without the stack attached.
 	fp.mu.Lock()
@@ -465,7 +466,7 @@ func TestRunTurnLaterPromptPostsUserMessage(t *testing.T) {
 	var err error
 	go func() {
 		defer close(turnDone)
-		res, err = s.runTurn(t.Context(), t.Context(), "again")
+		res, err = s.runTurn(t.Context(), "again")
 	}()
 
 	// Wait for the post, then resolve the turn the way the pump would.

--- a/pkg/cmd/pulumi/neo/acp_session_test.go
+++ b/pkg/cmd/pulumi/neo/acp_session_test.go
@@ -1,0 +1,509 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/acp"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// capturedNotif is one session/update the fake client received.
+type capturedNotif struct {
+	method string
+	params any
+}
+
+// fakeACPClient implements acp.Client, recording notifications and serving a
+// canned permission outcome for Call.
+type fakeACPClient struct {
+	mu            sync.Mutex
+	notifications []capturedNotif
+	callMethod    string
+	callParams    any
+	permResult    acp.RequestPermissionResult
+	callErr       error
+}
+
+func (c *fakeACPClient) Notify(_ context.Context, method string, params any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.notifications = append(c.notifications, capturedNotif{method: method, params: params})
+	return nil
+}
+
+func (c *fakeACPClient) Call(_ context.Context, method string, params, result any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.callMethod, c.callParams = method, params
+	if c.callErr != nil {
+		return c.callErr
+	}
+	if r, ok := result.(*acp.RequestPermissionResult); ok {
+		*r = c.permResult
+	}
+	return nil
+}
+
+func TestPumpForwardsUpdatesAndEndsTurn(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeACPClient{}
+	done := make(chan turnResult, 1)
+	s := &acpSession{acpID: "sess_x", client: fc, activeTurn: done}
+	uiCh := make(chan UIEvent, 8)
+	go s.pump(t.Context(), uiCh)
+
+	uiCh <- UIAssistantMessage{Content: "hello"}
+	uiCh <- UIToolStarted{Name: "shell__exec"}
+	uiCh <- UITaskIdle{}
+
+	select {
+	case tr := <-done:
+		require.NoError(t, tr.err)
+		assert.Equal(t, acp.StopEndTurn, tr.reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn did not finish")
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	require.Len(t, fc.notifications, 2)
+	for _, n := range fc.notifications {
+		assert.Equal(t, "session/update", n.method)
+	}
+}
+
+// gatedClient is an acp.Client whose Notify blocks until gate is closed,
+// simulating an editor that is slow to read stdout. It counts completed
+// notifications so a test can assert none were lost.
+type gatedClient struct {
+	gate chan struct{}
+	mu   sync.Mutex
+	n    int
+}
+
+func (c *gatedClient) Notify(_ context.Context, _ string, _ any) error {
+	<-c.gate
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *gatedClient) Call(context.Context, string, any, any) error { return nil }
+
+func (c *gatedClient) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+// TestPumpKeepsDrainingWhileEditorIsSlow is the regression guard for the
+// decoupling between draining UIEvents and writing to the editor. A slow editor
+// (Notify blocked) must not stall the pump: it keeps accepting events into an
+// unbounded queue, so Session.sendUI never fills uiCh and never drops a
+// turn-boundary event. The turn still resolves only after the editor drains its
+// updates, and no notification is lost.
+func TestPumpKeepsDrainingWhileEditorIsSlow(t *testing.T) {
+	t.Parallel()
+
+	fc := &gatedClient{gate: make(chan struct{})}
+	done := make(chan turnResult, 1)
+	s := &acpSession{acpID: "sess_x", client: fc, activeTurn: done}
+
+	// Unbuffered: a successful send proves the pump actually received the event
+	// rather than it sitting in a channel buffer.
+	uiCh := make(chan UIEvent)
+	go s.pump(t.Context(), uiCh)
+
+	const n = 100
+	for i := range n {
+		select {
+		case uiCh <- UIAssistantMessage{Content: "x"}:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("pump stopped draining at event %d while the editor was slow", i)
+		}
+	}
+	uiCh <- UITaskIdle{}
+
+	// The turn can't end before its updates reach the (still-blocked) editor.
+	select {
+	case <-done:
+		t.Fatal("turn resolved before the editor drained its updates")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(fc.gate) // editor catches up
+	select {
+	case tr := <-done:
+		require.NoError(t, tr.err)
+		assert.Equal(t, acp.StopEndTurn, tr.reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn did not finish after the editor caught up")
+	}
+	assert.Equal(t, n, fc.count(), "every notification should be delivered, none dropped")
+}
+
+func TestPumpBoundaryReasons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		event UIEvent
+		check func(t *testing.T, tr turnResult)
+	}{
+		{"cancelled", UICancelled{}, func(t *testing.T, tr turnResult) {
+			require.NoError(t, tr.err)
+			assert.Equal(t, acp.StopCancelled, tr.reason)
+		}},
+		{"error", UIError{Message: "boom"}, func(t *testing.T, tr turnResult) {
+			require.Error(t, tr.err)
+			assert.Contains(t, tr.err.Error(), "boom")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			done := make(chan turnResult, 1)
+			s := &acpSession{acpID: "sess_x", client: &fakeACPClient{}, activeTurn: done}
+			uiCh := make(chan UIEvent, 1)
+			go s.pump(t.Context(), uiCh)
+			uiCh <- tt.event
+			select {
+			case tr := <-done:
+				tt.check(t, tr)
+			case <-time.After(2 * time.Second):
+				t.Fatal("turn did not finish")
+			}
+		})
+	}
+}
+
+// TestPumpTeardownResolvesActiveTurn is the regression guard for a dying event
+// loop: when Session.Run exits without ever emitting a turn-boundary event
+// (e.g. the stream failed), the pump's teardown must still resolve the waiting
+// Prompt — with the loop's error — instead of leaving it blocked forever.
+func TestPumpTeardownResolvesActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeACPClient{}
+	done := make(chan turnResult, 1)
+	s := &acpSession{acpID: "sess_x", client: fc, activeTurn: done}
+	ctx, cancel := context.WithCancel(t.Context())
+	uiCh := make(chan UIEvent)
+	go s.pump(ctx, uiCh)
+
+	// Simulate the Run goroutine: record why the loop died, then cancel the
+	// session context, exactly in that order.
+	s.mu.Lock()
+	s.ended, s.runErr = true, errors.New("event stream lost")
+	s.mu.Unlock()
+	cancel()
+
+	select {
+	case tr := <-done:
+		require.Error(t, tr.err)
+		assert.ErrorContains(t, tr.err, "event stream lost")
+	case <-time.After(2 * time.Second):
+		t.Fatal("session teardown did not resolve the waiting turn")
+	}
+}
+
+// TestRunTurnFirstPromptCreatesTaskAndCompletes drives a whole first turn
+// through the real start path against a fake backend: the task is created with
+// the session's configured modes, the event loop connects to the scripted
+// stream, the assistant's message reaches the editor as a session/update, and
+// the final message resolves the turn with end_turn.
+func TestRunTurnFirstPromptCreatesTaskAndCompletes(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{stream: make(chan client.NeoStreamEvent, 8)}
+	fc := &fakeACPClient{}
+	s := &acpSession{
+		acpID:          "sess_x",
+		api:            fp,
+		orgName:        "acme",
+		projectName:    "proj",
+		stackRefName:   "dev",
+		client:         fc,
+		handlers:       map[string]ToolHandler{},
+		permissionMode: client.NeoPermissionModeReadOnly,
+		planMode:       true,
+	}
+	// Queue the turn-ending final assistant message so the event loop finds it
+	// as soon as it connects.
+	fp.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		Content: "done",
+		IsFinal: true,
+	})}
+
+	res, err := s.runTurn(t.Context(), t.Context(), "build it")
+	require.NoError(t, err)
+	assert.Equal(t, acp.StopEndTurn, res.StopReason)
+
+	fp.mu.Lock()
+	require.Len(t, fp.created, 1)
+	created := fp.created[0]
+	fp.mu.Unlock()
+	assert.Equal(t, "build it", created.content)
+	assert.Equal(t, "dev", created.stackName)
+	assert.Equal(t, "proj", created.projectName)
+	assert.Equal(t, "cli", created.opts.ToolExecutionMode)
+	assert.Equal(t, client.NeoApprovalModeManual, created.opts.ApprovalMode,
+		"approval stays manual so gated calls surface as editor permission requests")
+	assert.Equal(t, client.NeoPermissionModeReadOnly, created.opts.PermissionMode)
+	assert.True(t, created.opts.PlanMode)
+
+	s.mu.Lock()
+	assert.True(t, s.started)
+	assert.Equal(t, "task_1", s.taskID)
+	s.mu.Unlock()
+
+	// The assistant's message was written to the editor before the turn
+	// resolved (the pump orders updates ahead of the turn result).
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	require.NotEmpty(t, fc.notifications)
+	assert.Equal(t, "session/update", fc.notifications[0].method)
+}
+
+// TestStartDefaultsModes verifies the hardcoded baseline reaches task creation
+// when the editor never changed a config option: full-access permissions, plan
+// mode off.
+func TestStartDefaultsModes(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{}
+	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}}
+
+	require.NoError(t, s.start(t.Context(), "hello"))
+
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	require.Len(t, fp.created, 1)
+	assert.Equal(t, client.NeoPermissionModeDefault, fp.created[0].opts.PermissionMode)
+	assert.False(t, fp.created[0].opts.PlanMode)
+}
+
+// TestRunTurnCreateErrorReleasesTurn: a failed task creation must propagate the
+// error, leave the session unstarted, and release the turn slot so the editor
+// can retry the prompt.
+func TestRunTurnCreateErrorReleasesTurn(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{createErr: errors.New("task quota exceeded")}
+	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}}
+
+	_, err := s.runTurn(t.Context(), t.Context(), "hello")
+	require.ErrorContains(t, err, "task quota exceeded")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	assert.False(t, s.started, "a failed creation must not mark the session started")
+	assert.Nil(t, s.activeTurn, "a failed start must release the turn slot for a retry")
+}
+
+// TestRunTurnPostErrorReleasesTurn: on a later prompt, a failed user_message
+// post must propagate the error and release the turn slot so the editor can
+// retry — the documented cleanup in runTurn's start-error path.
+func TestRunTurnPostErrorReleasesTurn(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{postErr: errors.New("backend rejected the message")}
+	s := &acpSession{
+		acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{},
+		started: true, taskID: "task_9",
+	}
+
+	_, err := s.runTurn(t.Context(), t.Context(), "again")
+	require.ErrorContains(t, err, "backend rejected the message")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	assert.Nil(t, s.activeTurn, "a failed post must release the turn slot for a retry")
+}
+
+// TestRunTurnConcurrentPromptsExactlyOneWins races two prompts on a started
+// session: exactly one must register the turn (and complete once the pump
+// resolves it), the other must be rejected without posting to the backend.
+func TestRunTurnConcurrentPromptsExactlyOneWins(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{}
+	s := &acpSession{
+		acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{},
+		started: true, taskID: "task_9",
+	}
+
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := s.runTurn(t.Context(), t.Context(), "hi")
+			errs <- err
+		}()
+	}
+
+	// The loser fails fast; the winner blocks until the turn is resolved, so the
+	// first error to arrive must be the rejection.
+	select {
+	case err := <-errs:
+		require.ErrorContains(t, err, "already in progress")
+	case <-time.After(2 * time.Second):
+		t.Fatal("neither prompt returned; expected one to be rejected immediately")
+	}
+
+	// Resolve the winner's turn the way the pump would, once its post landed.
+	require.Eventually(t, func() bool {
+		fp.mu.Lock()
+		defer fp.mu.Unlock()
+		return len(fp.posted) == 1
+	}, 2*time.Second, 5*time.Millisecond, "the winning prompt should post exactly one user_message")
+	s.finishTurn(turnResult{reason: acp.StopEndTurn})
+
+	select {
+	case err := <-errs:
+		require.NoError(t, err, "the winning prompt should complete once the turn resolves")
+	case <-time.After(2 * time.Second):
+		t.Fatal("winning prompt did not resolve after finishTurn")
+	}
+}
+
+// TestStartEntityDroppedWarningReachesEditor: when the backend rejects the
+// attached stack and task creation falls back to no stack context, the editor
+// must be told — as a message-stream warning ahead of any stream events.
+func TestStartEntityDroppedWarningReachesEditor(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{rejectStack: true}
+	fc := &fakeACPClient{}
+	s := &acpSession{
+		acpID: "sess_x", api: fp, orgName: "acme", projectName: "proj", stackRefName: "dev",
+		client: fc, handlers: map[string]ToolHandler{},
+	}
+
+	require.NoError(t, s.start(t.Context(), "hello"))
+
+	// The task was still created, just without the stack attached.
+	fp.mu.Lock()
+	require.Len(t, fp.created, 1)
+	assert.Empty(t, fp.created[0].stackName)
+	fp.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		fc.mu.Lock()
+		defer fc.mu.Unlock()
+		for _, n := range fc.notifications {
+			sn, ok := n.params.(acp.SessionNotification)
+			if !ok {
+				continue
+			}
+			if chunk, ok := sn.Update.(acp.AgentMessageChunk); ok &&
+				strings.Contains(chunk.Content.Text, "could not attach stack acme/proj/dev") {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "the stack-dropped warning should reach the editor")
+}
+
+// TestRunTurnLaterPromptPostsUserMessage: once the task exists, a prompt posts a
+// user_message instead of creating a task, and resolves when the turn ends.
+func TestRunTurnLaterPromptPostsUserMessage(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{}
+	s := &acpSession{
+		acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{},
+		started: true, taskID: "task_9",
+	}
+
+	turnDone := make(chan struct{})
+	var res acp.PromptResult
+	var err error
+	go func() {
+		defer close(turnDone)
+		res, err = s.runTurn(t.Context(), t.Context(), "again")
+	}()
+
+	// Wait for the post, then resolve the turn the way the pump would.
+	require.Eventually(t, func() bool {
+		fp.mu.Lock()
+		defer fp.mu.Unlock()
+		return len(fp.posted) == 1
+	}, 2*time.Second, 5*time.Millisecond, "second prompt should post a user_message")
+	s.finishTurn(turnResult{reason: acp.StopEndTurn})
+	<-turnDone
+
+	require.NoError(t, err)
+	assert.Equal(t, acp.StopEndTurn, res.StopReason)
+
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	assert.Empty(t, fp.created, "no second task is created")
+	msg, ok := fp.posted[0].(apitype.AgentUserEventUserMessage)
+	require.True(t, ok)
+	assert.Equal(t, "user_message", msg.Type)
+	assert.Equal(t, "again", msg.Content)
+}
+
+func TestRequestPermissionRelaysDecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		outcome      acp.PermissionOutcome
+		callErr      error
+		wantApproved bool
+	}{
+		{"allow", acp.PermissionOutcome{Outcome: "selected", OptionID: "allow"}, nil, true},
+		{"reject", acp.PermissionOutcome{Outcome: "selected", OptionID: "reject"}, nil, false},
+		{"cancelled", acp.PermissionOutcome{Outcome: "cancelled"}, nil, false},
+		{"call error", acp.PermissionOutcome{}, errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fc := &fakeACPClient{permResult: acp.RequestPermissionResult{Outcome: tt.outcome}, callErr: tt.callErr}
+			fp := &fakeTaskAPI{}
+			s := &acpSession{acpID: "sess_x", client: fc, api: fp, orgName: "acme", taskID: "task_1"}
+
+			s.requestPermission(t.Context(), UIApprovalRequest{ApprovalID: "appr_1", Message: "run it?"})
+
+			fc.mu.Lock()
+			assert.Equal(t, "session/request_permission", fc.callMethod)
+			fc.mu.Unlock()
+
+			fp.mu.Lock()
+			defer fp.mu.Unlock()
+			require.Len(t, fp.posted, 1)
+			conf, ok := fp.posted[0].(apitype.AgentUserEventUserConfirmation)
+			require.True(t, ok)
+			assert.Equal(t, "appr_1", conf.ApprovalID)
+			assert.Equal(t, tt.wantApproved, conf.Approved)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/neo/acp_session_test.go
+++ b/pkg/cmd/pulumi/neo/acp_session_test.go
@@ -347,6 +347,25 @@ func TestRunTurnPostErrorReleasesTurn(t *testing.T) {
 	assert.Nil(t, s.activeTurn, "a failed post must release the turn slot for a retry")
 }
 
+// TestRunTurnSurvivesEventLoopPanic: a panic anywhere on the session event
+// loop goroutine (here: while connecting the event stream, but tool handlers
+// run there too) is recovered into runErr instead of crashing the process —
+// the waiting turn resolves with the panic error and later prompts fail fast
+// with the same cause.
+func TestRunTurnSurvivesEventLoopPanic(t *testing.T) {
+	t.Parallel()
+
+	fp := &fakeTaskAPI{streamPanic: true}
+	s := &acpSession{acpID: "sess_x", api: fp, orgName: "acme", client: &fakeACPClient{}}
+
+	_, err := s.runTurn(t.Context(), t.Context(), "hello")
+	require.ErrorContains(t, err, "panic in Neo session event loop")
+	require.ErrorContains(t, err, "stream exploded")
+
+	_, err = s.runTurn(t.Context(), t.Context(), "again")
+	require.ErrorContains(t, err, "panic in Neo session event loop")
+}
+
 // TestRunTurnConcurrentPromptsExactlyOneWins races two prompts on a started
 // session: exactly one must register the turn (and complete once the pump
 // resolves it), the other must be rejected without posting to the backend.

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -351,6 +351,39 @@ type neoRuntime struct {
 	pu       *tools.Pulumi
 }
 
+// readNeoProject reads the project enclosing dir (the process working directory
+// when empty), tolerating absence — `pulumi neo` can run outside a project.
+func readNeoProject(ws pkgWorkspace.Context, dir string) (*workspace.Project, error) {
+	project, _, err := ws.ReadProject(dir)
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, err
+	}
+	return project, nil
+}
+
+// neoUpgradeRequiredError carries the user-facing minimum-version message from
+// resolveNeoCloudBackend. It is a distinct type so the interactive path can
+// present the message bare (via FprintBailf) while other paths propagate it as
+// an ordinary error.
+type neoUpgradeRequiredError struct{ msg string }
+
+func (e neoUpgradeRequiredError) Error() string { return e.msg }
+
+// resolveNeoCloudBackend narrows be to the Pulumi Cloud backend and enforces
+// Neo's minimum CLI version, returning neoUpgradeRequiredError when an upgrade
+// is needed. Every Neo entrypoint gates through it so the backend requirement
+// and version policy live in one place.
+func resolveNeoCloudBackend(ctx context.Context, be backend.Backend) (httpstate.Backend, error) {
+	cloudBe, ok := be.(httpstate.Backend)
+	if !ok {
+		return nil, errors.New("`pulumi neo` requires the Pulumi Cloud backend")
+	}
+	if msg := neoUpgradeMessage(cloudBe.Capabilities(ctx), version.Version); msg != "" {
+		return nil, neoUpgradeRequiredError{msg: msg}
+	}
+	return cloudBe, nil
+}
+
 func prepareNeoRuntime(ctx context.Context, stderr io.Writer, cwdFlag string) (*neoRuntime, error) {
 	if cwdFlag == "" {
 		var err error
@@ -363,8 +396,8 @@ func prepareNeoRuntime(ctx context.Context, stderr io.Writer, cwdFlag string) (*
 	ws := pkgWorkspace.Instance
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	project, _, err := ws.ReadProject("")
-	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+	project, err := readNeoProject(ws, "")
+	if err != nil {
 		return nil, err
 	}
 
@@ -372,15 +405,16 @@ func prepareNeoRuntime(ctx context.Context, stderr io.Writer, cwdFlag string) (*
 	if err != nil {
 		return nil, err
 	}
-	cloudBe, ok := be.(httpstate.Backend)
-	if !ok {
-		return nil, errors.New("`pulumi neo` requires the Pulumi Cloud backend")
+	cloudBe, err := resolveNeoCloudBackend(ctx, be)
+	var upgradeErr neoUpgradeRequiredError
+	if errors.As(err, &upgradeErr) {
+		// Print the upgrade message bare (no "error:" prefix) and bail.
+		return nil, result.FprintBailf(stderr, "%s", upgradeErr.msg)
+	}
+	if err != nil {
+		return nil, err
 	}
 	pc := cloudBe.Client()
-
-	if msg := neoUpgradeMessage(cloudBe.Capabilities(ctx), version.Version); msg != "" {
-		return nil, result.FprintBailf(stderr, "%s", msg)
-	}
 
 	lt, err := buildLocalToolHandlers(cwdFlag, ws)
 	if err != nil {
@@ -411,7 +445,8 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 	}
 	opts.cwdFlag = rt.cwd
 
-	target, err := resolveTaskTarget(ctx, rt.ws, rt.cloudBe, rt.project, opts.stackName, opts.orgFlag, "")
+	target, err := resolveTaskTarget(ctx, rt.ws, rt.cloudBe, rt.project,
+		taskTargetOpts{stackName: opts.stackName, orgFlag: opts.orgFlag})
 	if err != nil {
 		return err
 	}
@@ -1105,10 +1140,20 @@ func (t taskTarget) stackName() string {
 	return t.ref.Name().String()
 }
 
-// resolveTaskTarget figures out the org, project, and stack to attach to the new Neo task. The
-// stack flag is optional — if it's empty we try the currently selected stack and fall back to a
-// project-only attachment if there isn't one. dir roots the current-stack lookup; when empty the
-// process working directory is used.
+// taskTargetOpts are the optional inputs to resolveTaskTarget.
+type taskTargetOpts struct {
+	// stackName is the --stack flag; when empty the currently selected stack is
+	// tried, falling back to a project-only attachment if there isn't one.
+	stackName string
+	// orgFlag is the --org flag; when set it wins over any stack-derived owner.
+	orgFlag string
+	// dir roots the current-stack lookup; empty means the process working
+	// directory.
+	dir string
+}
+
+// resolveTaskTarget figures out the org, project, and stack to attach to the
+// new Neo task.
 //
 // Org resolution: --org wins if provided; otherwise we use the owner carried
 // by the stack reference (so a workspace-selected `otherorg/proj/dev` keeps
@@ -1120,7 +1165,7 @@ func resolveTaskTarget(
 	ws pkgWorkspace.Context,
 	be httpstate.Backend,
 	project *workspace.Project,
-	stackName, orgFlag, dir string,
+	opts taskTargetOpts,
 ) (taskTarget, error) {
 	var t taskTarget
 	if project != nil {
@@ -1128,8 +1173,8 @@ func resolveTaskTarget(
 	}
 
 	var stackOwner string
-	if stackName != "" {
-		ref, err := be.ParseStackReference(stackName)
+	if opts.stackName != "" {
+		ref, err := be.ParseStackReference(opts.stackName)
 		if err != nil {
 			return taskTarget{}, err
 		}
@@ -1140,7 +1185,7 @@ func resolveTaskTarget(
 			}
 		}
 	} else {
-		s, err := state.CurrentStackAt(ctx, ws, be, dir)
+		s, err := state.CurrentStackAt(ctx, ws, be, opts.dir)
 		if err == nil && s != nil {
 			t.ref = s.Ref()
 			if owned, ok := s.Ref().(stackRefWithOrg); ok {
@@ -1152,8 +1197,8 @@ func resolveTaskTarget(
 	}
 
 	switch {
-	case orgFlag != "":
-		t.org = orgFlag
+	case opts.orgFlag != "":
+		t.org = opts.orgFlag
 	case stackOwner != "":
 		t.org = stackOwner
 	default:

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -282,6 +282,9 @@ func NewNeoCmd() *cobra.Command {
 		"Working directory for local tool execution (defaults to the current directory)")
 	cmd.AddCommand(resumeCmd)
 
+	// `pulumi neo acp` runs Neo as an Agent Client Protocol agent over stdio.
+	cmd.AddCommand(newNeoACPCmd())
+
 	return cmd
 }
 
@@ -408,7 +411,7 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 	}
 	opts.cwdFlag = rt.cwd
 
-	target, err := resolveTaskTarget(ctx, rt.ws, rt.cloudBe, rt.project, opts.stackName, opts.orgFlag)
+	target, err := resolveTaskTarget(ctx, rt.ws, rt.cloudBe, rt.project, opts.stackName, opts.orgFlag, "")
 	if err != nil {
 		return err
 	}
@@ -1104,7 +1107,8 @@ func (t taskTarget) stackName() string {
 
 // resolveTaskTarget figures out the org, project, and stack to attach to the new Neo task. The
 // stack flag is optional — if it's empty we try the currently selected stack and fall back to a
-// project-only attachment if there isn't one.
+// project-only attachment if there isn't one. dir roots the current-stack lookup; when empty the
+// process working directory is used.
 //
 // Org resolution: --org wins if provided; otherwise we use the owner carried
 // by the stack reference (so a workspace-selected `otherorg/proj/dev` keeps
@@ -1116,7 +1120,7 @@ func resolveTaskTarget(
 	ws pkgWorkspace.Context,
 	be httpstate.Backend,
 	project *workspace.Project,
-	stackName, orgFlag string,
+	stackName, orgFlag, dir string,
 ) (taskTarget, error) {
 	var t taskTarget
 	if project != nil {
@@ -1136,7 +1140,7 @@ func resolveTaskTarget(
 			}
 		}
 	} else {
-		s, err := state.CurrentStack(ctx, ws, be)
+		s, err := state.CurrentStackAt(ctx, ws, be, dir)
 		if err == nil && s != nil {
 			t.ref = s.Ref()
 			if owned, ok := s.Ref().(stackRefWithOrg); ok {

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -165,7 +165,7 @@ func TestResolveTaskTarget_UsesStackFlag(t *testing.T) {
 	ws := &pkgWorkspace.MockContext{}
 	project := &workspace.Project{Name: tokens.PackageName("my-proj")}
 
-	target, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "default-org", target.org)
 	assert.Equal(t, "my-proj", target.project)
@@ -185,7 +185,7 @@ func TestResolveTaskTarget_OrgFlagOverridesDefault(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit")
+	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit", "")
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", target.org)
 }
@@ -198,7 +198,7 @@ func TestResolveTaskTarget_FallsBackToBackendDefaultOrg(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "backend-default", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "backend-default", target.org)
 }
@@ -214,7 +214,7 @@ func TestResolveTaskTarget_ErrorsWhenOrgUnresolvable(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pass --org")
 }
@@ -229,7 +229,7 @@ func TestResolveTaskTarget_DefaultOrgLookupErrorIsWrapped(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "determining default organization")
 	assert.Contains(t, err.Error(), "boom")
@@ -245,7 +245,7 @@ func TestResolveTaskTarget_InvalidStackReferenceErrors(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid stack")
 }
@@ -257,7 +257,7 @@ func TestResolveTaskTarget_OmitsProjectNameWhenProjectNil(t *testing.T) {
 	// `pulumi neo` can be run outside a project — resolveTaskTarget must tolerate
 	// a nil project and return an empty projectName rather than panicking.
 	be := newFakeBackend()
-	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit", "")
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", target.org)
 	assert.Empty(t, target.project)
@@ -298,7 +298,7 @@ func TestResolveTaskTarget_StackFlagOwnerWinsOverDefaultOrg(t *testing.T) {
 		return "", nil
 	}
 
-	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "otherorg", target.org)
 	assert.Equal(t, "dev", target.stackName())
@@ -337,7 +337,7 @@ func TestResolveTaskTarget_WorkspaceStackOwnerWinsOverDefaultOrg(t *testing.T) {
 		},
 	}
 
-	target, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "")
+	target, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "otherorg", target.org)
 	assert.Equal(t, "dev", target.stackName())
@@ -354,7 +354,7 @@ func TestResolveTaskTarget_OrgFlagOverridesStackOwner(t *testing.T) {
 	be := newFakeBackend()
 	be.ParseStackReferenceF = parseQualifiedStackRefF
 
-	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit", "")
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", target.org)
 	assert.Equal(t, "dev", target.stackName())

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -165,7 +165,7 @@ func TestResolveTaskTarget_UsesStackFlag(t *testing.T) {
 	ws := &pkgWorkspace.MockContext{}
 	project := &workspace.Project{Name: tokens.PackageName("my-proj")}
 
-	target, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, project, taskTargetOpts{stackName: "prod"})
 	require.NoError(t, err)
 	assert.Equal(t, "default-org", target.org)
 	assert.Equal(t, "my-proj", target.project)
@@ -185,7 +185,7 @@ func TestResolveTaskTarget_OrgFlagOverridesDefault(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, nil, taskTargetOpts{orgFlag: "explicit"})
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", target.org)
 }
@@ -198,7 +198,7 @@ func TestResolveTaskTarget_FallsBackToBackendDefaultOrg(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "backend-default", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, nil, taskTargetOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, "backend-default", target.org)
 }
@@ -214,7 +214,7 @@ func TestResolveTaskTarget_ErrorsWhenOrgUnresolvable(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, taskTargetOpts{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pass --org")
 }
@@ -229,7 +229,7 @@ func TestResolveTaskTarget_DefaultOrgLookupErrorIsWrapped(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, taskTargetOpts{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "determining default organization")
 	assert.Contains(t, err.Error(), "boom")
@@ -245,7 +245,7 @@ func TestResolveTaskTarget_InvalidStackReferenceErrors(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, taskTargetOpts{stackName: "bad/stack/name/here"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid stack")
 }
@@ -257,7 +257,7 @@ func TestResolveTaskTarget_OmitsProjectNameWhenProjectNil(t *testing.T) {
 	// `pulumi neo` can be run outside a project — resolveTaskTarget must tolerate
 	// a nil project and return an empty projectName rather than panicking.
 	be := newFakeBackend()
-	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit", "")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, taskTargetOpts{orgFlag: "explicit"})
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", target.org)
 	assert.Empty(t, target.project)
@@ -298,7 +298,7 @@ func TestResolveTaskTarget_StackFlagOwnerWinsOverDefaultOrg(t *testing.T) {
 		return "", nil
 	}
 
-	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "", "")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, taskTargetOpts{stackName: "otherorg/proj/dev"})
 	require.NoError(t, err)
 	assert.Equal(t, "otherorg", target.org)
 	assert.Equal(t, "dev", target.stackName())
@@ -337,7 +337,7 @@ func TestResolveTaskTarget_WorkspaceStackOwnerWinsOverDefaultOrg(t *testing.T) {
 		},
 	}
 
-	target, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "", "")
+	target, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, taskTargetOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, "otherorg", target.org)
 	assert.Equal(t, "dev", target.stackName())
@@ -354,7 +354,8 @@ func TestResolveTaskTarget_OrgFlagOverridesStackOwner(t *testing.T) {
 	be := newFakeBackend()
 	be.ParseStackReferenceF = parseQualifiedStackRefF
 
-	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit", "")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil,
+		taskTargetOpts{stackName: "otherorg/proj/dev", orgFlag: "explicit"})
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", target.org)
 	assert.Equal(t, "dev", target.stackName())


### PR DESCRIPTION
Run Neo as an [ACP](https://agentclientprotocol.com) agent over stdio so ACP-capable editors (e.g. Zed) can drive it natively:

- `acp_adapter.go`: the command, the initialize/authenticate handshake (terminal-based `pulumi login` auth), and session construction scoped to the editor-supplied working directory.
- `acp_session.go`: per-session state, lazy task creation on the first prompt, and the event pump bridging Neo's stream to `session/update` notifications.
- `acp_config.go`: Neo read-only and plan mode exposed as ACP session config options.

File reads/writes route through the editor (unsaved buffers, native diffs) and shell commands run in the editor's terminal when supported, via the hooks introduced earlier in the stack. Part 5/5 of the ACP stack; replaces #23669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)