### PR TITLE
logging: avoid showing current log file for `pulumi logs` commands

### DIFF
--- a/changelog/pending/cli-fix-20260710-151741.yaml
+++ b/changelog/pending/cli-fix-20260710-151741.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Avoid `pulumi logs <command>` showing the log for the currently running command
+time: 2026-07-10T15:17:41.868061515+02:00

--- a/pkg/cmd/pulumi/logs/list.go
+++ b/pkg/cmd/pulumi/logs/list.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	backendlogging "github.com/pulumi/pulumi/pkg/v3/logging"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -114,9 +115,15 @@ func listLogs(logsDir string) ([]logEntry, error) {
 		return nil, fmt.Errorf("reading log directory %s: %w", logsDir, err)
 	}
 
+	ownLog := backendlogging.CurrentLogFilePath()
+
 	entries := slice.Prealloc[logEntry](len(dirEntries))
 	for _, e := range dirEntries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		path := filepath.Join(logsDir, e.Name())
+		if path == ownLog {
 			continue
 		}
 		ts, ok := parseLogTimestamp(e.Name())
@@ -127,7 +134,6 @@ func listLogs(logsDir string) ([]logEntry, error) {
 		if err != nil {
 			continue
 		}
-		path := filepath.Join(logsDir, e.Name())
 		stack, updateID, cliLevel := parseLogName(e.Name())
 		entries = append(entries, logEntry{
 			path:      path,

--- a/pkg/cmd/pulumi/logs/list_test.go
+++ b/pkg/cmd/pulumi/logs/list_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine/encryptedlog"
+	backendlogging "github.com/pulumi/pulumi/pkg/v3/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestParseLogName(t *testing.T) {
@@ -130,6 +132,25 @@ func TestListLogs(t *testing.T) {
 	require.Equal(t, "", entries[2].stack)
 	require.True(t, entries[2].cliLevel)
 	require.Equal(t, "9999", entries[2].updateID)
+}
+
+func TestListLogsExcludesOwnLog(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	l, err := backendlogging.StartLogging(t.Context(), nil)
+	require.NoError(t, err)
+	defer l.Close()
+
+	logsDir, err := workspace.GetPulumiPath("logs")
+	require.NoError(t, err)
+
+	otherPath := filepath.Join(logsDir, "dev-20260401T120000.log")
+	require.NoError(t, os.WriteFile(otherPath, []byte("x"), 0o600))
+
+	entries, err := listLogs(logsDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, otherPath, entries[0].path)
 }
 
 func TestListLogsMissingDir(t *testing.T) {

--- a/pkg/logging/encrypted.go
+++ b/pkg/logging/encrypted.go
@@ -56,6 +56,10 @@ func RenameCurrentLogger(stackName, updateID string) error {
 	return currentLogger.rename(stackName, updateID)
 }
 
+func CurrentLogFilePath() string {
+	return currentLogger.FilePath()
+}
+
 // Logger captures output to a log file on disk, optionally encrypted.
 type Logger struct {
 	mu        sync.Mutex


### PR DESCRIPTION
Currently when a user runs `pulumi logs decrypt` for example, the
command also shows the (still incomplete) log for the command itself
as an option to decrypt.  This doesn't make a lot of sense, and is
certainly not what the user wanted.

Exclude the currently open log file from the options for logs to show.