### PR TITLE
Only run SDK codegen toolchain checks in Linux CI

### DIFF
--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -459,6 +459,15 @@ func NoSDKCodegenChecks() bool {
 	return genSDKOnly
 }
 
+// runToolchainChecks reports whether the post-generation checks (compile, unit test) should run.
+// The checks invoke real language toolchains — e.g. `go build` over each generated SDK and its
+// full dependency graph — which is expensive, and their results do not depend on the host
+// platform, so CI only pays for them on Linux. All platforms still validate the generated files
+// against the goldens.
+func runToolchainChecks() bool {
+	return os.Getenv("CI") == "" || runtime.GOOS == "linux"
+}
+
 func init() {
 	noChecks := false
 	if env, ok := os.LookupEnv("PULUMI_TEST_SDK_NO_CHECKS"); ok {
@@ -632,6 +641,10 @@ func TestSDKCodegen(t *testing.T, opts *SDKCodegenOptions) { // revive:disable-l
 			//nolint:paralleltest // test functions are ordered
 			for _, check := range checkOrder {
 				t.Run(check, func(t *testing.T) {
+					if !runToolchainChecks() {
+						t.Skip("Skipping toolchain checks: their results are platform-independent, " +
+							"so they only run on Linux in CI.")
+					}
 					if tt.ShouldSkipTest(opts.Language, check) {
 						t.Skip()
 					}


### PR DESCRIPTION
## Impact

Removes ~35 minutes from the macOS `pkg 7/7` unit-test job — currently one of the two walltime bottlenecks in the merge queue. `TestSDKCodegen`'s toolchain checks (e.g. `go/compile` = `go mod tidy` + `go build -v all` per schema case, ~49 cases in parallel) recompile the full Pulumi SDK dependency graph per case and thrash the 3-core macOS runners; `TestGeneratePackage/kubernetes20/go/compile` alone logs 25m39s there.

## What changed

Post-generation toolchain checks (compile, unit test) now run only in Linux CI (`CI` set and `GOOS == linux`). Their results are platform-independent, and `TestSDKCodegen` was already skipped entirely on Windows on the same grounds. Golden-file validation (the actual codegen-output check) still runs everywhere.

## Coverage

No loss: the same checks continue to run in the ubuntu unit-test jobs (current and minimum Go versions).

---
Authored by Claude (AI), directed by @iwahbe.