### PR TITLE
Add a --version flag to the pulumi command

### DIFF
--- a/changelog/pending/cli-improvement-version-flag.yaml
+++ b/changelog/pending/cli-improvement-version-flag.yaml
@@ -1,0 +1,4 @@
+kind: improvement
+body: Add a `--version` flag to the `pulumi` command that prints the version, same
+  as `pulumi version`
+component: cli

--- a/changelog/pending/cli-improvement-version-flag.yaml
+++ b/changelog/pending/cli-improvement-version-flag.yaml
@@ -2,3 +2,5 @@ kind: improvement
 body: Add a `--version` flag to the `pulumi` command that prints the version, same
   as `pulumi version`
 component: cli
+custom:
+    PR: "23898"

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -260,6 +260,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	cmd = &cobra.Command{
 		Use:           "pulumi",
 		Short:         "Pulumi command line",
+		Version:       version.Version,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Long: "Pulumi - Modern Infrastructure as Code\n" +
@@ -443,6 +444,9 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			}
 		},
 	}
+
+	// Make `pulumi --version` print the same output as `pulumi version`.
+	cmd.SetVersionTemplate("{{.Version}}\n")
 
 	cmd.PersistentFlags().StringVarP(&cwd, "cwd", "C", "",
 		"Run pulumi as if it had been started in another directory")

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -445,7 +445,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		},
 	}
 
-	// Make `pulumi --version` print the same output as `pulumi version`.
 	cmd.SetVersionTemplate("{{.Version}}\n")
 
 	cmd.PersistentFlags().StringVarP(&cwd, "cwd", "C", "",

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -1093,30 +1093,6 @@ func TestGroupCommandsBareInvocationExitsNonZero(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Usage:", "help text should still be printed")
 }
 
-// `pulumi --version` must print the same output as `pulumi version`.
-//
-//nolint:paralleltest // changes globals (version.Version)
-func TestVersionFlag(t *testing.T) {
-	realVersion := version.Version
-	t.Cleanup(func() {
-		version.Version = realVersion
-	})
-	version.Version = "v3.0.0-test"
-
-	pulumiCmd, cleanup := NewPulumiCmd()
-	defer cleanup()
-
-	var stdout, stderr bytes.Buffer
-	pulumiCmd.SetOut(&stdout)
-	pulumiCmd.SetErr(&stderr)
-	pulumiCmd.SetArgs([]string{"--version"})
-
-	err := pulumiCmd.Execute()
-	require.NoError(t, err)
-	assert.Equal(t, "v3.0.0-test\n", stdout.String())
-	assert.Empty(t, stderr.String())
-}
-
 // Requesting help explicitly must keep exiting 0.
 //
 //nolint:paralleltest // NewPulumiCmd registers env vars in a process-wide registry

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -1093,6 +1093,30 @@ func TestGroupCommandsBareInvocationExitsNonZero(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Usage:", "help text should still be printed")
 }
 
+// `pulumi --version` must print the same output as `pulumi version`.
+//
+//nolint:paralleltest // changes globals (version.Version)
+func TestVersionFlag(t *testing.T) {
+	realVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = realVersion
+	})
+	version.Version = "v3.0.0-test"
+
+	pulumiCmd, cleanup := NewPulumiCmd()
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	pulumiCmd.SetOut(&stdout)
+	pulumiCmd.SetErr(&stderr)
+	pulumiCmd.SetArgs([]string{"--version"})
+
+	err := pulumiCmd.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "v3.0.0-test\n", stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
 // Requesting help explicitly must keep exiting 0.
 //
 //nolint:paralleltest // NewPulumiCmd registers env vars in a process-wide registry

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1366,3 +1366,17 @@ func TestPulumiNewEmptyOperations(t *testing.T) {
 	e.RunCommand("pulumi", "stack", "init", "testing")
 	e.RunCommand("pulumi", "config", "set", "key", "value")
 }
+
+// Test that `pulumi --version` prints the same output as `pulumi version`.
+func TestVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	versionCmdStdout, _ := e.RunCommand("pulumi", "version")
+	versionFlagStdout, _ := e.RunCommand("pulumi", "--version")
+
+	assert.NotEmpty(t, strings.TrimSpace(versionCmdStdout))
+	assert.Equal(t, versionCmdStdout, versionFlagStdout)
+}


### PR DESCRIPTION
`pulumi --version` previously failed with "unknown flag"; the version was only available via the `pulumi version` subcommand. This wires up cobra's built-in version handling by setting the root command's `Version` field, with a version template so `pulumi --version` prints exactly the same output as `pulumi version` (just the version string).

Notes:

- The persistent `--verbose`/`-v` shorthand is unaffected: cobra only claims `-v` for `--version` when the shorthand is free, so `--version` gets no shorthand.
- Cobra handles `--version` before `PersistentPreRunE`, so `pulumi --version` skips the async update check that `pulumi version` triggers, which seems desirable for a plain version query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)