### PR TITLE
Count transpositions as one edit when suggesting commands

### DIFF
--- a/changelog/pending/cli-suggest-commands-transpositions.yaml
+++ b/changelog/pending/cli-suggest-commands-transpositions.yaml
@@ -1,0 +1,5 @@
+kind: improvement
+body: Treat adjacent character swaps as a single typo when suggesting commands
+component: cli
+custom:
+    PR: "23899"

--- a/pkg/cmd/pulumi/rattler/rattler.go
+++ b/pkg/cmd/pulumi/rattler/rattler.go
@@ -366,6 +366,12 @@ func closeEnough(a, b string) bool {
 // the minimum number of single-rune insertions, deletions, substitutions, and
 // adjacent transpositions, compared case-insensitively. Unlike plain
 // Levenshtein, a swapped pair like "lsit" for "list" costs 1, not 2.
+//
+// Dynamic programming over prefix pairs: each cell takes the cheapest way an
+// edit sequence could end — delete a's last rune, insert b's, match or
+// substitute the last runes, or, when the prefixes end in the same two runes
+// swapped, transpose them. The transposition case reads two rows up, hence
+// the full matrix rather than the usual two rows.
 func editDistance(a, b string) int {
 	ra, rb := []rune(strings.ToLower(a)), []rune(strings.ToLower(b))
 

--- a/pkg/cmd/pulumi/rattler/rattler.go
+++ b/pkg/cmd/pulumi/rattler/rattler.go
@@ -368,25 +368,34 @@ func closeEnough(a, b string) bool {
 // Levenshtein, a swapped pair like "lsit" for "list" costs 1, not 2.
 func editDistance(a, b string) int {
 	ra, rb := []rune(strings.ToLower(a)), []rune(strings.ToLower(b))
-	d := make([][]int, len(ra)+1)
-	for i := range d {
-		d[i] = make([]int, len(rb)+1)
-		d[i][0] = i
+
+	// dist[i][j] is the edit distance between the first i runes of a and the
+	// first j runes of b, so dist[i][0] = i (delete everything) and
+	// dist[0][j] = j (insert everything).
+	dist := make([][]int, len(ra)+1)
+	for i := range dist {
+		dist[i] = make([]int, len(rb)+1)
+		dist[i][0] = i
 	}
 	for j := 1; j <= len(rb); j++ {
-		d[0][j] = j
+		dist[0][j] = j
 	}
+
 	for i := 1; i <= len(ra); i++ {
 		for j := 1; j <= len(rb); j++ {
-			cost := 1
-			if ra[i-1] == rb[j-1] {
-				cost = 0
+			deletion := dist[i-1][j] + 1
+			insertion := dist[i][j-1] + 1
+			substitution := dist[i-1][j-1]
+			if ra[i-1] != rb[j-1] {
+				substitution++
 			}
-			d[i][j] = min(d[i-1][j]+1, d[i][j-1]+1, d[i-1][j-1]+cost)
+			dist[i][j] = min(deletion, insertion, substitution)
+			// The last two runes of each prefix appear swapped: one
+			// transposition on top of whatever preceded them.
 			if i > 1 && j > 1 && ra[i-1] == rb[j-2] && ra[i-2] == rb[j-1] {
-				d[i][j] = min(d[i][j], d[i-2][j-2]+1)
+				dist[i][j] = min(dist[i][j], dist[i-2][j-2]+1)
 			}
 		}
 	}
-	return d[len(ra)][len(rb)]
+	return dist[len(ra)][len(rb)]
 }

--- a/pkg/cmd/pulumi/rattler/rattler.go
+++ b/pkg/cmd/pulumi/rattler/rattler.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/texttheater/golang-levenshtein/levenshtein"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -360,5 +359,34 @@ func closeEnough(a, b string) bool {
 	if max(len(a), len(b)) < 6 {
 		threshold = 1
 	}
-	return levenshtein.DistanceForStrings([]rune(a), []rune(b), levenshtein.DefaultOptionsWithSub) <= threshold
+	return editDistance(a, b) <= threshold
+}
+
+// editDistance returns the optimal-string-alignment distance between a and b:
+// the minimum number of single-rune insertions, deletions, substitutions, and
+// adjacent transpositions, compared case-insensitively. Unlike plain
+// Levenshtein, a swapped pair like "lsit" for "list" costs 1, not 2.
+func editDistance(a, b string) int {
+	ra, rb := []rune(strings.ToLower(a)), []rune(strings.ToLower(b))
+	d := make([][]int, len(ra)+1)
+	for i := range d {
+		d[i] = make([]int, len(rb)+1)
+		d[i][0] = i
+	}
+	for j := 1; j <= len(rb); j++ {
+		d[0][j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			d[i][j] = min(d[i-1][j]+1, d[i][j-1]+1, d[i-1][j-1]+cost)
+			if i > 1 && j > 1 && ra[i-1] == rb[j-2] && ra[i-2] == rb[j-1] {
+				d[i][j] = min(d[i][j], d[i-2][j-2]+1)
+			}
+		}
+	}
+	return d[len(ra)][len(rb)]
 }

--- a/pkg/cmd/pulumi/rattler/rattler.go
+++ b/pkg/cmd/pulumi/rattler/rattler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/editdistance"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
@@ -353,55 +354,13 @@ func normalize(token string) []string {
 	return parts
 }
 
-// closeEnough scales the allowed edit distance with the longer string.
+// closeEnough scales the allowed edit distance with the longer string. Both
+// words are expected to be lowercased already (see normalize), as the
+// distance is case-sensitive.
 func closeEnough(a, b string) bool {
 	threshold := 2
 	if max(len(a), len(b)) < 6 {
 		threshold = 1
 	}
-	return editDistance(a, b) <= threshold
-}
-
-// editDistance returns the optimal-string-alignment distance between a and b:
-// the minimum number of single-rune insertions, deletions, substitutions, and
-// adjacent transpositions, compared case-insensitively. Unlike plain
-// Levenshtein, a swapped pair like "lsit" for "list" costs 1, not 2.
-//
-// Dynamic programming over prefix pairs: each cell takes the cheapest way an
-// edit sequence could end — delete a's last rune, insert b's, match or
-// substitute the last runes, or, when the prefixes end in the same two runes
-// swapped, transpose them. The transposition case reads two rows up, hence
-// the full matrix rather than the usual two rows.
-func editDistance(a, b string) int {
-	ra, rb := []rune(strings.ToLower(a)), []rune(strings.ToLower(b))
-
-	// dist[i][j] is the edit distance between the first i runes of a and the
-	// first j runes of b, so dist[i][0] = i (delete everything) and
-	// dist[0][j] = j (insert everything).
-	dist := make([][]int, len(ra)+1)
-	for i := range dist {
-		dist[i] = make([]int, len(rb)+1)
-		dist[i][0] = i
-	}
-	for j := 1; j <= len(rb); j++ {
-		dist[0][j] = j
-	}
-
-	for i := 1; i <= len(ra); i++ {
-		for j := 1; j <= len(rb); j++ {
-			deletion := dist[i-1][j] + 1
-			insertion := dist[i][j-1] + 1
-			substitution := dist[i-1][j-1]
-			if ra[i-1] != rb[j-1] {
-				substitution++
-			}
-			dist[i][j] = min(deletion, insertion, substitution)
-			// The last two runes of each prefix appear swapped: one
-			// transposition on top of whatever preceded them.
-			if i > 1 && j > 1 && ra[i-1] == rb[j-2] && ra[i-2] == rb[j-1] {
-				dist[i][j] = min(dist[i][j], dist[i-2][j-2]+1)
-			}
-		}
-	}
-	return dist[len(ra)][len(rb)]
+	return editdistance.OSA(a, b) <= threshold
 }

--- a/pkg/cmd/pulumi/rattler/rattler_test.go
+++ b/pkg/cmd/pulumi/rattler/rattler_test.go
@@ -123,6 +123,13 @@ func TestSuggestCommands(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
+	t.Run("transposition typo", func(t *testing.T) {
+		t.Parallel()
+		got := suggestCommands(find("org", "member"), []string{"lsit"})
+		require.NotEmpty(t, got)
+		assert.Equal(t, "pulumi org member list", got[0])
+	})
+
 	t.Run("hidden commands are not suggested", func(t *testing.T) {
 		t.Parallel()
 		got := suggestCommands(newSuggestionsTestTree(), []string{"secret-cmd"})
@@ -243,6 +250,30 @@ func TestHasSyntheticRun(t *testing.T) {
 	assert.False(t, HasSyntheticRun(find("import")), "runnable leaf")
 	assert.False(t, HasSyntheticRun(find("stack", "export")), "nested runnable leaf")
 	assert.False(t, HasSyntheticRun(nil), "nil command")
+}
+
+func TestEditDistance(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"list", "list", 0},
+		{"lsit", "list", 1},   // adjacent transposition
+		{"stakc", "stack", 1}, // adjacent transposition
+		{"lisst", "list", 1},  // insertion
+		{"lit", "list", 1},    // deletion
+		{"lost", "list", 1},   // substitution
+		{"LIST", "list", 0},   // case-insensitive
+		{"", "list", 4},
+		{"abcd", "dbca", 2}, // non-adjacent swap still costs 2
+		{"up", "rm", 2},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, editDistance(c.a, c.b), "editDistance(%q, %q)", c.a, c.b)
+		assert.Equal(t, c.want, editDistance(c.b, c.a), "editDistance(%q, %q)", c.b, c.a)
+	}
 }
 
 func TestNormalize(t *testing.T) {

--- a/pkg/cmd/pulumi/rattler/rattler_test.go
+++ b/pkg/cmd/pulumi/rattler/rattler_test.go
@@ -260,6 +260,7 @@ func TestEditDistance(t *testing.T) {
 		want int
 	}{
 		{"list", "list", 0},
+		{"ab", "ba", 1},       // the minimal adjacent transposition
 		{"lsit", "list", 1},   // adjacent transposition
 		{"stakc", "stack", 1}, // adjacent transposition
 		{"lisst", "list", 1},  // insertion
@@ -267,12 +268,48 @@ func TestEditDistance(t *testing.T) {
 		{"lost", "list", 1},   // substitution
 		{"LIST", "list", 0},   // case-insensitive
 		{"", "list", 4},
-		{"abcd", "dbca", 2}, // non-adjacent swap still costs 2
+		{"abcd", "dbca", 2}, // non-adjacent swap: two substitutions, no discount
+		{"abc", "cab", 2},   // rotation is not a transposition
 		{"up", "rm", 2},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.want, editDistance(c.a, c.b), "editDistance(%q, %q)", c.a, c.b)
 		assert.Equal(t, c.want, editDistance(c.b, c.a), "editDistance(%q, %q)", c.b, c.a)
+	}
+}
+
+// closeEnough is where edit distance turns into a yes/no on suggesting a
+// command, so these cases double as a catalog of which typos we catch:
+// one edit for words under six runes, two for longer ones, with adjacent
+// swaps counting as a single edit.
+func TestCloseEnough(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		// Adjacent transpositions are one edit, so they fit even the
+		// short-word threshold.
+		{"lsit", "list", true},
+		{"stakc", "stack", true},
+		{"confgi", "config", true},
+		{"detsroy", "destroy", true},
+		// Single-rune slips.
+		{"previw", "preview", true},
+		{"lost", "list", true},
+		// Two edits are tolerated only in words of six runes or more...
+		{"import", "export", true}, // ranking still prefers exact matches
+		{"abcdef", "fbcdea", true}, // ...which admits non-adjacent swaps,
+		{"abcd", "dbca", false},    // but not in shorter words.
+		{"stack", "state", false},
+		{"up", "rm", false},
+		{"new", "ls", false},
+		{"xyzzyq", "list", false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, closeEnough(c.a, c.b), "closeEnough(%q, %q)", c.a, c.b)
+		assert.Equal(t, c.want, closeEnough(c.b, c.a), "closeEnough(%q, %q)", c.b, c.a)
 	}
 }
 

--- a/pkg/cmd/pulumi/rattler/rattler_test.go
+++ b/pkg/cmd/pulumi/rattler/rattler_test.go
@@ -125,7 +125,7 @@ func TestSuggestCommands(t *testing.T) {
 
 	t.Run("transposition typo", func(t *testing.T) {
 		t.Parallel()
-		got := suggestCommands(find("org", "member"), []string{"lsit"})
+		got := suggestCommands(find(t, newSuggestionsTestTree(), "org", "member"), []string{"lsit"})
 		require.NotEmpty(t, got)
 		assert.Equal(t, "pulumi org member list", got[0])
 	})
@@ -250,32 +250,6 @@ func TestHasSyntheticRun(t *testing.T) {
 	assert.False(t, HasSyntheticRun(find("import")), "runnable leaf")
 	assert.False(t, HasSyntheticRun(find("stack", "export")), "nested runnable leaf")
 	assert.False(t, HasSyntheticRun(nil), "nil command")
-}
-
-func TestEditDistance(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		a, b string
-		want int
-	}{
-		{"list", "list", 0},
-		{"ab", "ba", 1},       // the minimal adjacent transposition
-		{"lsit", "list", 1},   // adjacent transposition
-		{"stakc", "stack", 1}, // adjacent transposition
-		{"lisst", "list", 1},  // insertion
-		{"lit", "list", 1},    // deletion
-		{"lost", "list", 1},   // substitution
-		{"LIST", "list", 0},   // case-insensitive
-		{"", "list", 4},
-		{"abcd", "dbca", 2}, // non-adjacent swap: two substitutions, no discount
-		{"abc", "cab", 2},   // rotation is not a transposition
-		{"up", "rm", 2},
-	}
-	for _, c := range cases {
-		assert.Equal(t, c.want, editDistance(c.a, c.b), "editDistance(%q, %q)", c.a, c.b)
-		assert.Equal(t, c.want, editDistance(c.b, c.a), "editDistance(%q, %q)", c.b, c.a)
-	}
 }
 
 // closeEnough is where edit distance turns into a yes/no on suggesting a

--- a/pkg/util/editdistance/editdistance.go
+++ b/pkg/util/editdistance/editdistance.go
@@ -26,8 +26,7 @@ package editdistance
 // minimum number of single-rune insertions, deletions, substitutions, and
 // adjacent transpositions needed to turn one into the other.
 //
-// The comparison is case-sensitive; callers wanting case-insensitive matching
-// should normalize case before calling.
+// The comparison is case-sensitive.
 func OSA(a, b string) int {
 	ra, rb := []rune(a), []rune(b)
 

--- a/pkg/util/editdistance/editdistance.go
+++ b/pkg/util/editdistance/editdistance.go
@@ -1,0 +1,69 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package editdistance measures how far apart two strings are in terms of
+// single-character edits, for use in "did you mean" style suggestions.
+//
+// Plain Levenshtein distance counts an adjacent swap such as "lsit" for "list"
+// as two edits, which makes the most common typo shape look as far away as
+// two unrelated mistakes. The optimal string alignment distance implemented
+// here counts that swap as one edit, so tight thresholds that keep false
+// positives out of suggestions still catch transposition typos.
+package editdistance
+
+// OSA returns the optimal-string-alignment distance between a and b: the
+// minimum number of single-rune insertions, deletions, substitutions, and
+// adjacent transpositions needed to turn one into the other.
+//
+// The comparison is case-sensitive; callers wanting case-insensitive matching
+// should normalize case before calling.
+func OSA(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+
+	// Dynamic programming over prefix pairs: each cell takes the cheapest way an
+	// edit sequence could end — delete a's last rune, insert b's, match or
+	// substitute the last runes, or, when the prefixes end in the same two runes
+	// swapped, transpose them. The transposition case reads two rows up, hence
+	// the full matrix rather than the usual two rows.
+	//
+	// dist[i][j] is the edit distance between the first i runes of a and the
+	// first j runes of b, so dist[i][0] = i (delete everything) and
+	// dist[0][j] = j (insert everything).
+	dist := make([][]int, len(ra)+1)
+	for i := range dist {
+		dist[i] = make([]int, len(rb)+1)
+		dist[i][0] = i
+	}
+	for j := 1; j <= len(rb); j++ {
+		dist[0][j] = j
+	}
+
+	for i := 1; i <= len(ra); i++ {
+		for j := 1; j <= len(rb); j++ {
+			deletion := dist[i-1][j] + 1
+			insertion := dist[i][j-1] + 1
+			substitution := dist[i-1][j-1]
+			if ra[i-1] != rb[j-1] {
+				substitution++
+			}
+			dist[i][j] = min(deletion, insertion, substitution)
+			// The last two runes of each prefix appear swapped: one
+			// transposition on top of whatever preceded them.
+			if i > 1 && j > 1 && ra[i-1] == rb[j-2] && ra[i-2] == rb[j-1] {
+				dist[i][j] = min(dist[i][j], dist[i-2][j-2]+1)
+			}
+		}
+	}
+	return dist[len(ra)][len(rb)]
+}

--- a/pkg/util/editdistance/editdistance_test.go
+++ b/pkg/util/editdistance/editdistance_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package editdistance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOSA(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"list", "list", 0},
+		{"ab", "ba", 1},       // the minimal adjacent transposition
+		{"lsit", "list", 1},   // adjacent transposition
+		{"stakc", "stack", 1}, // adjacent transposition
+		{"lisst", "list", 1},  // insertion
+		{"lit", "list", 1},    // deletion
+		{"lost", "list", 1},   // substitution
+		{"LIST", "list", 4},   // case-sensitive
+		{"", "list", 4},
+		{"abcd", "dbca", 2}, // non-adjacent swap: two substitutions, no discount
+		{"abc", "cab", 2},   // rotation is not a transposition
+		{"up", "rm", 2},
+		{"héllo", "hello", 1}, // runes, not bytes
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, OSA(c.a, c.b), "OSA(%q, %q)", c.a, c.b)
+		assert.Equal(t, c.want, OSA(c.b, c.a), "OSA(%q, %q)", c.b, c.a)
+	}
+}


### PR DESCRIPTION
`pulumi org member lsit` got no "Did you mean this?" suggestion: plain
Levenshtein counts the adjacent swap in `lsit` -> `list` as two edits,
over the threshold of 1 for short words. Replace the levenshtein
library call with a hand-rolled optimal-string-alignment distance so
adjacent transpositions - the most common typo shape - cost one edit,
keeping the tight short-word threshold that prevents false positives.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
