### PR TITLE
Align pulumi commands with the CLI command guidelines

### DIFF
--- a/changelog/pending/cli-verb-aliases.yaml
+++ b/changelog/pending/cli-verb-aliases.yaml
@@ -1,0 +1,8 @@
+kind: improvement
+body: Align commands with the CLI naming guidelines, adding `ls`, `rm`, `delete`, `mv`,
+    `update`, `modify`, `create` and `setup` aliases to list/remove/move/edit/new
+    commands and making `state remove` and `package remove` the canonical names with
+    `delete` kept as an alias
+component: cli
+custom:
+    PR: "23903"

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -360,7 +360,7 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 
 	rmCmd := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Remove configuration value",
 		Long: "Remove configuration value.\n\n" +
 			"The `--path` flag can be used to remove a value inside a map or list:\n\n" +
@@ -439,7 +439,7 @@ func newConfigRemoveAllCmd(ws pkgWorkspace.Context, stack *string, configFile *s
 
 	rmAllCmd := &cobra.Command{
 		Use:     "remove-all",
-		Aliases: []string{"rm-all"},
+		Aliases: []string{"rm-all", "delete-all"},
 		Short:   "Remove multiple configuration values",
 		Long: "Remove multiple configuration values.\n\n" +
 			"The `--path` flag indicates that keys should be parsed within maps or lists:\n\n" +

--- a/pkg/cmd/pulumi/config/config_env_remove.go
+++ b/pkg/cmd/pulumi/config/config_env_remove.go
@@ -27,7 +27,7 @@ func newConfigEnvRemoveCmd(parent *configEnvCmd) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Remove environment from a stack",
 		Long:    "Removes an environment from a stack's import list.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pulumi/deployment/deployment_list.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list.go
@@ -81,8 +81,9 @@ func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List deployments for a stack",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List deployments for a stack",
 		Long: "[EXPERIMENTAL] List deployments for a stack.\n" +
 			"\n" +
 			"Returns deployments for the selected stack, showing each deployment's ID,\n" +

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -160,9 +160,10 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 	args.outputFormat = defaultDeploymentSettingsGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "edit",
-		Short: "[EXPERIMENTAL] Create or update deployment settings for a stack",
-		Long:  "[EXPERIMENTAL] Create or update deployment settings for a stack.",
+		Use:     "edit",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Create or update deployment settings for a stack",
+		Long:    "[EXPERIMENTAL] Create or update deployment settings for a stack.",
 		Example: "  # Switch the deployment source branch.\n" +
 			"  pulumi deployment settings edit --branch feature-x\n\n" +
 			"  # Configure a GitHub source.\n" +

--- a/pkg/cmd/pulumi/insights/insights_account_new.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new.go
@@ -91,8 +91,9 @@ func newInsightsAccountNewCmdWith(factory accountNewClientFactory) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "new",
-		Short: "[EXPERIMENTAL] Create a new Insights account",
+		Use:     "new",
+		Aliases: []string{"create", "setup"},
+		Short:   "[EXPERIMENTAL] Create a new Insights account",
 		Long: "[EXPERIMENTAL] Create a new Pulumi Insights account.\n\n" +
 			"An Insights account represents a cloud provider account (e.g. AWS,\n" +
 			"Azure, GCP, OCI, Kubernetes) configured for resource discovery.",

--- a/pkg/cmd/pulumi/logs/remove.go
+++ b/pkg/cmd/pulumi/logs/remove.go
@@ -43,7 +43,7 @@ func newRemoveCmd() *cobra.Command {
 
 	command := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Remove automatic log files",
 		Long: "Remove automatic log files.\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/org/org_audit_log_list.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_list.go
@@ -86,8 +86,9 @@ func newOrgAuditLogListCmdWith(factory orgAuditLogListClientFactory) *cobra.Comm
 	args.outputFormat = defaultOrgAuditLogListOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List audit log events for an organization",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List audit log events for an organization",
 		Long: "[EXPERIMENTAL] List audit log events for an organization.\n" +
 			"\n" +
 			"Returns audit log events for the organization. Results may be filtered\n" +

--- a/pkg/cmd/pulumi/org/org_member_edit.go
+++ b/pkg/cmd/pulumi/org/org_member_edit.go
@@ -82,8 +82,9 @@ func newOrgMemberEditCmdWith(factory orgMemberEditClientFactory) *cobra.Command 
 	args.outputFormat = defaultOrgMemberGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "edit <user-login>",
-		Short: "[EXPERIMENTAL] Modify a member's role within an organization",
+		Use:     "edit <user-login>",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Modify a member's role within an organization",
 		Long: "[EXPERIMENTAL] Modify a member's role within an organization.\n" +
 			"\n" +
 			"Updates the role assigned to an organization member. Pass --role to\n" +

--- a/pkg/cmd/pulumi/org/org_member_list.go
+++ b/pkg/cmd/pulumi/org/org_member_list.go
@@ -78,8 +78,9 @@ func newOrgMemberListCmdWith(factory orgMemberListClientFactory) *cobra.Command 
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List members of an organization",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List members of an organization",
 		Long: "[EXPERIMENTAL] List members of an organization.\n" +
 			"\n" +
 			"Returns the members of the organization, showing each member's user name,\n" +

--- a/pkg/cmd/pulumi/org/org_member_remove.go
+++ b/pkg/cmd/pulumi/org/org_member_remove.go
@@ -77,8 +77,9 @@ func newOrgMemberRemoveCmdWith(factory orgMemberRemoveClientFactory) *cobra.Comm
 	args.outputFormat = defaultOrgMemberRemoveOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "remove <user-login>",
-		Short: "[EXPERIMENTAL] Remove a member from an organization",
+		Use:     "remove <user-login>",
+		Aliases: []string{"rm", "delete"},
+		Short:   "[EXPERIMENTAL] Remove a member from an organization",
 		Long: "[EXPERIMENTAL] Remove a member from an organization.\n" +
 			"\n" +
 			"Removes a user from an organization. The removed user loses access to\n" +

--- a/pkg/cmd/pulumi/org/org_role_edit.go
+++ b/pkg/cmd/pulumi/org/org_role_edit.go
@@ -45,8 +45,9 @@ func newOrgRoleEditCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	output := defaultRoleSingleOutput()
 
 	cmd := &cobra.Command{
-		Use:   "edit <role-id>",
-		Short: "[EXPERIMENTAL] Update a custom role's name, description, or permissions",
+		Use:     "edit <role-id>",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Update a custom role's name, description, or permissions",
 		Long: "[EXPERIMENTAL] Update a custom role's name, description, or permissions.\n" +
 			"\n" +
 			"Each field follows ternary semantics: a flag that is not passed leaves the\n" +

--- a/pkg/cmd/pulumi/org/org_role_list.go
+++ b/pkg/cmd/pulumi/org/org_role_list.go
@@ -49,8 +49,9 @@ func newOrgRoleListCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List custom roles for an organization",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List custom roles for an organization",
 		Long: "[EXPERIMENTAL] List custom roles for an organization.\n" +
 			"\n" +
 			"Displays the ID, name, description, UX purpose, and version of each role.\n" +

--- a/pkg/cmd/pulumi/org/org_role_new.go
+++ b/pkg/cmd/pulumi/org/org_role_new.go
@@ -44,8 +44,9 @@ func newOrgRoleNewCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	output := defaultRoleSingleOutput()
 
 	cmd := &cobra.Command{
-		Use:   "new <name> <details-file>",
-		Short: "[EXPERIMENTAL] Create a new custom role for an organization",
+		Use:     "new <name> <details-file>",
+		Aliases: []string{"create", "setup"},
+		Short:   "[EXPERIMENTAL] Create a new custom role for an organization",
 		Long: "[EXPERIMENTAL] Create a new custom role for an organization.\n" +
 			"\n" +
 			"The role's permission tree is read from the JSON file at <details-file>.\n" +

--- a/pkg/cmd/pulumi/org/org_role_remove.go
+++ b/pkg/cmd/pulumi/org/org_role_remove.go
@@ -56,8 +56,9 @@ func newOrgRoleRemoveCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	output := defaultRoleRemoveOutput()
 
 	cmd := &cobra.Command{
-		Use:   "remove <role-id>",
-		Short: "[EXPERIMENTAL] Delete a custom role from an organization",
+		Use:     "remove <role-id>",
+		Aliases: []string{"rm", "delete"},
+		Short:   "[EXPERIMENTAL] Delete a custom role from an organization",
 		Long: "[EXPERIMENTAL] Delete a custom role from an organization.\n" +
 			"\n" +
 			"Removing a role revokes any permissions it had granted to members and\n" +

--- a/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
@@ -66,8 +66,9 @@ func newOrgWebhookDeliveryListCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List recent deliveries for an organization webhook",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List recent deliveries for an organization webhook",
 		Long: "[EXPERIMENTAL] List recent deliveries for an organization webhook.\n" +
 			"\n" +
 			"Returns the recent delivery history for a specific webhook. Each\n" +

--- a/pkg/cmd/pulumi/org/org_webhook_edit.go
+++ b/pkg/cmd/pulumi/org/org_webhook_edit.go
@@ -73,8 +73,9 @@ func newOrgWebhookEditCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "edit",
-		Short: "[EXPERIMENTAL] Update an organization webhook's configuration",
+		Use:     "edit",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Update an organization webhook's configuration",
 		Long: "[EXPERIMENTAL] Update an organization webhook's configuration.\n" +
 			"\n" +
 			"Modifies an existing webhook. Only the flags you pass are changed;\n" +

--- a/pkg/cmd/pulumi/org/org_webhook_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_list.go
@@ -83,8 +83,9 @@ func newOrgWebhookListCmdWith(
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List all webhooks configured for an organization",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List all webhooks configured for an organization",
 		Long: "[EXPERIMENTAL] List all webhooks configured for an organization.\n" +
 			"\n" +
 			"Returns all webhooks configured at the organization level. Each\n" +

--- a/pkg/cmd/pulumi/org/org_webhook_new.go
+++ b/pkg/cmd/pulumi/org/org_webhook_new.go
@@ -123,8 +123,9 @@ func newOrgWebhookNewCmdWith(
 	}
 
 	cmd := &cobra.Command{
-		Use:   "new",
-		Short: "[EXPERIMENTAL] Create a new organization webhook",
+		Use:     "new",
+		Aliases: []string{"create", "setup"},
+		Short:   "[EXPERIMENTAL] Create a new organization webhook",
 		Long: "[EXPERIMENTAL] Create a new organization webhook.\n" +
 			"\n" +
 			"Creates a webhook that delivers events for the specified organization\n" +

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -49,8 +49,9 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 	orcmd := &orgWebhookRemoveCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "remove",
-		Short: "[EXPERIMENTAL] Delete an organization webhook",
+		Use:     "remove",
+		Aliases: []string{"rm", "delete"},
+		Short:   "[EXPERIMENTAL] Delete an organization webhook",
 		Long: "[EXPERIMENTAL] Delete an organization webhook.\n" +
 			"\n" +
 			"Permanently removes the specified webhook from the organization.\n" +

--- a/pkg/cmd/pulumi/packagecmd/package_delete.go
+++ b/pkg/cmd/pulumi/packagecmd/package_delete.go
@@ -40,15 +40,16 @@ func newPackageDeleteCmd() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Delete a package version from the registry",
+		Use:     "remove",
+		Aliases: []string{"rm", "delete"},
+		Short:   "Delete a package version from the registry",
 		Long: `Delete a package version from the Pulumi Registry.
 
 The package version must be specified in the format:
   [[<source>/]<publisher>/]<name>[@<version>]
 
 Example:
-  pulumi package delete private/myorg/my-package@1.0.0
+  pulumi package remove private/myorg/my-package@1.0.0
 
 Warning: If this is the only version of the package, the entire package
 will be removed. This action cannot be undone.

--- a/pkg/cmd/pulumi/packagecmd/package_new.go
+++ b/pkg/cmd/pulumi/packagecmd/package_new.go
@@ -87,7 +87,8 @@ func newPackageNewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:        "new [template|url]",
-		SuggestFor: []string{"init", "create"},
+		Aliases:    []string{"create", "setup"},
+		SuggestFor: []string{"init"},
 		Short:      "[EXPERIMENTAL] Create a new Pulumi package",
 		Long: "[EXPERIMENTAL] Create a new Pulumi package from a template.\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/plugin/plugin_remove.go
+++ b/pkg/cmd/pulumi/plugin/plugin_remove.go
@@ -41,7 +41,7 @@ func newPluginRemoveCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Remove one or more plugins from the download cache",
 		Long: "Remove one or more plugins from the download cache.\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/policy/policy_compliance_list.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance_list.go
@@ -79,8 +79,9 @@ func newPolicyComplianceListCmdWith(factory complianceListClientFactory) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List compliance results grouped by entity",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List compliance results grouped by entity",
 		Long: "[EXPERIMENTAL] List compliance results grouped by entity.\n" +
 			"\n" +
 			"Returns compliance results for policy issues grouped by stack,\n" +

--- a/pkg/cmd/pulumi/policy/policy_group_edit.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit.go
@@ -90,8 +90,9 @@ func newPolicyGroupEditCmdWith(factory policyGroupEditClientFactory) *cobra.Comm
 	args.outputFormat = defaultPolicyGroupGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "edit <name>",
-		Short: "[EXPERIMENTAL] Update a Policy Group's configuration",
+		Use:     "edit <name>",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Update a Policy Group's configuration",
 		Long: "[EXPERIMENTAL] Update a Policy Group's configuration.\n" +
 			"\n" +
 			"Renames a Policy Group, adds or removes stacks, applies or detaches\n" +

--- a/pkg/cmd/pulumi/policy/policy_group_new.go
+++ b/pkg/cmd/pulumi/policy/policy_group_new.go
@@ -77,8 +77,9 @@ func newPolicyGroupNewCmdWith(factory policyGroupNewClientFactory) *cobra.Comman
 	args.outputFormat = defaultPolicyGroupGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "new <name>",
-		Short: "[EXPERIMENTAL] Create a new Policy Group",
+		Use:     "new <name>",
+		Aliases: []string{"create", "setup"},
+		Short:   "[EXPERIMENTAL] Create a new Policy Group",
 		Long: "[EXPERIMENTAL] Create a new Policy Group.\n" +
 			"\n" +
 			"Creates a new Policy Group in the given organization. Policy Groups\n" +

--- a/pkg/cmd/pulumi/policy/policy_group_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove.go
@@ -77,8 +77,9 @@ func newPolicyGroupRemoveCmdWith(factory policyGroupRemoveClientFactory) *cobra.
 	args.outputFormat = defaultPolicyGroupRemoveOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "remove <name>",
-		Short: "[EXPERIMENTAL] Delete a Policy Group",
+		Use:     "remove <name>",
+		Aliases: []string{"rm", "delete"},
+		Short:   "[EXPERIMENTAL] Delete a Policy Group",
 		Long: "[EXPERIMENTAL] Delete a Policy Group.\n" +
 			"\n" +
 			"Deletes a Policy Group from an organization. This cannot be undone.\n" +

--- a/pkg/cmd/pulumi/policy/policy_issue_list.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_list.go
@@ -84,8 +84,9 @@ func newPolicyIssueListCmdWith(factory policyIssueListClientFactory) *cobra.Comm
 	args.outputFormat = defaultPolicyIssueListOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List all policy issues for an organization",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List all policy issues for an organization",
 		Long: "[EXPERIMENTAL] List all policy issues for an organization.\n" +
 			"\n" +
 			"Returns a list of policy issues for the organization. Each issue\n" +

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -52,7 +52,8 @@ func newPolicyNewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:        "new",
-		SuggestFor: []string{"init", "create"},
+		Aliases:    []string{"create", "setup"},
+		SuggestFor: []string{"init"},
 		Short:      "Create a new Pulumi Policy Pack",
 		Long: "Create a new Pulumi Policy Pack from a template.\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/policy/policy_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_remove.go
@@ -33,7 +33,7 @@ func newPolicyRemoveCmd() *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Removes a Policy Pack from a Pulumi organization",
 		Long: "Removes a Policy Pack from a Pulumi organization. " +
 			"The Policy Pack must be disabled from all Policy Groups before it can be removed.",

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -554,7 +554,8 @@ func NewNewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:        "new [template|url]",
-		SuggestFor: []string{"init", "create"},
+		Aliases:    []string{"create", "setup"},
+		SuggestFor: []string{"init"},
 		Short:      "Create a new Pulumi project",
 		Long: "Create a new Pulumi project and stack from a template.\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/stack/stack_drift_list.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_list.go
@@ -79,8 +79,9 @@ func newStackDriftListCmdWith(factory driftListClientFactory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List drift detection runs for a stack",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List drift detection runs for a stack",
 		Long: "[EXPERIMENTAL] List drift detection runs for a stack.\n" +
 			"\n" +
 			"Returns drift detection runs for the specified stack. Each run\n" +

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -42,7 +42,7 @@ func newStackNewCmd() *cobra.Command {
 	var sicmd stackNewCmd
 	cmd := &cobra.Command{
 		Use:     "new",
-		Aliases: []string{"init"},
+		Aliases: []string{"init", "create", "setup"},
 		Short:   "Create an empty stack with the given name, ready for updates",
 		Long: "Create an empty stack with the given name, ready for updates\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/stack/stack_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_remove.go
@@ -45,7 +45,7 @@ func newStackRemoveCmd() *cobra.Command {
 	var removeBackups bool
 	cmd := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Remove a stack and its configuration",
 		Long: "Remove a stack and its configuration\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/stack/stack_schedule_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_edit.go
@@ -87,8 +87,9 @@ func newStackScheduleEditCmdWith(factory stackScheduleEditClientFactory) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:   "edit <schedule-id>",
-		Short: "[EXPERIMENTAL] Update the configuration of a scheduled deployment action",
+		Use:     "edit <schedule-id>",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Update the configuration of a scheduled deployment action",
 		Long: "[EXPERIMENTAL] Update the configuration of a scheduled deployment action.\n\n" +
 			"Only the fields you pass are changed; everything else is preserved. " +
 			"Each flag is only valid for a subset of kinds:\n" +

--- a/pkg/cmd/pulumi/stack/stack_schedule_list.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_list.go
@@ -57,9 +57,10 @@ func newStackScheduleListCmdWith(factory stackScheduleListClientFactory) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List all scheduled actions configured for a stack",
-		Long:  "[EXPERIMENTAL] List all scheduled actions configured for a stack.",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List all scheduled actions configured for a stack",
+		Long:    "[EXPERIMENTAL] List all scheduled actions configured for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultStackScheduleListClientFactory

--- a/pkg/cmd/pulumi/stack/stack_schedule_new.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_new.go
@@ -75,8 +75,9 @@ func newStackScheduleNewCmdWith(factory stackScheduleNewClientFactory) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:   "new",
-		Short: "[EXPERIMENTAL] Create a scheduled deployment action for a stack",
+		Use:     "new",
+		Aliases: []string{"create", "setup"},
+		Short:   "[EXPERIMENTAL] Create a scheduled deployment action for a stack",
 		Long: "[EXPERIMENTAL] Create a scheduled deployment action for a stack.\n\n" +
 			"The --kind flag selects the schedule type:\n" +
 			"  raw   — runs a Pulumi operation on a cron or one-time schedule.\n" +

--- a/pkg/cmd/pulumi/stack/stack_schedule_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_remove.go
@@ -50,8 +50,9 @@ func newStackScheduleRemoveCmdWith(factory stackScheduleRemoveClientFactory) *co
 	)
 
 	cmd := &cobra.Command{
-		Use:   "remove <schedule-id>",
-		Short: "[EXPERIMENTAL] Delete a scheduled deployment action",
+		Use:     "remove <schedule-id>",
+		Aliases: []string{"rm", "delete"},
+		Short:   "[EXPERIMENTAL] Delete a scheduled deployment action",
 		Long: "[EXPERIMENTAL] Delete a scheduled deployment action.\n\n" +
 			"You will be prompted to confirm by typing `remove` unless --yes is passed.",
 		Example: "  # Remove a schedule (prompts for confirmation)\n" +

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -179,7 +179,7 @@ func printStackTags(w io.Writer, tags map[apitype.StackTagName]string) {
 func newStackTagRemoveCmd(stack *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove",
-		Aliases: []string{"rm"},
+		Aliases: []string{"rm", "delete"},
 		Short:   "Remove a stack tag",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
@@ -77,8 +77,9 @@ func newStackWebhookDeliveryListCmdWith(
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List recent deliveries for a stack webhook",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List recent deliveries for a stack webhook",
 		Long: "[EXPERIMENTAL] List recent deliveries for a stack webhook.\n" +
 			"\n" +
 			"Returns the recent delivery history for a specific webhook. Each\n" +

--- a/pkg/cmd/pulumi/stack/stack_webhook_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_edit.go
@@ -68,8 +68,9 @@ func newStackWebhookEditCmdWith(factory stackWebhookEditClientFactory) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:   "edit",
-		Short: "[EXPERIMENTAL] Update a stack webhook's configuration",
+		Use:     "edit",
+		Aliases: []string{"update", "modify"},
+		Short:   "[EXPERIMENTAL] Update a stack webhook's configuration",
 		Long: "[EXPERIMENTAL] Update a stack webhook's configuration.\n" +
 			"\n" +
 			"Modifies an existing webhook. Only the flags you pass are changed;\n" +

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -58,8 +58,9 @@ func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "[EXPERIMENTAL] List all webhooks configured for a stack",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List all webhooks configured for a stack",
 		Long: "[EXPERIMENTAL] List all webhooks configured for a stack.\n" +
 			"\n" +
 			"Displays the ID, name, payload URL, format, event groups, events, and active\n" +

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -79,8 +79,9 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 	}
 
 	cmd := &cobra.Command{
-		Use:   "new",
-		Short: "[EXPERIMENTAL] Create a new stack webhook",
+		Use:     "new",
+		Aliases: []string{"create", "setup"},
+		Short:   "[EXPERIMENTAL] Create a new stack webhook",
 		Long: "[EXPERIMENTAL] Create a new stack webhook.\n" +
 			"\n" +
 			"Creates a webhook that delivers events for the specified stack to a\n" +

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove.go
@@ -54,8 +54,9 @@ func newStackWebhookRemoveCmdWith(factory stackWebhookRemoveClientFactory) *cobr
 	)
 
 	cmd := &cobra.Command{
-		Use:   "remove",
-		Short: "[EXPERIMENTAL] Delete a stack webhook",
+		Use:     "remove",
+		Aliases: []string{"rm", "delete"},
+		Short:   "[EXPERIMENTAL] Delete a stack webhook",
 		Long: "[EXPERIMENTAL] Delete a stack webhook.\n" +
 			"\n" +
 			"Permanently removes the specified webhook from the stack. This cannot\n" +

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -43,8 +43,9 @@ func newStateDeleteCommand(ws pkgWorkspace.Context, lm backend.LoginManager) *co
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Deletes one or more resources from a stack's state",
+		Use:     "remove",
+		Aliases: []string{"rm", "delete"},
+		Short:   "Deletes one or more resources from a stack's state",
 		Long: `Deletes one or more resources from a stack's state
 
 This command deletes resources from a stack's state, as long as it is safe to do so. Each resource is specified
@@ -57,7 +58,7 @@ Make sure that URNs are single-quoted to avoid having characters unexpectedly in
 
 To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 `,
-		Example: "pulumi state delete 'urn:pulumi:stage::demo::pkg:index:Type::res-a' " +
+		Example: "pulumi state remove 'urn:pulumi:stage::demo::pkg:index:Type::res-a' " +
 			"'urn:pulumi:stage::demo::pkg:index:Type::res-b'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/pkg/cmd/pulumi/state/state_edit.go
+++ b/pkg/cmd/pulumi/state/state_edit.go
@@ -47,7 +47,8 @@ func newStateEditCommand() *cobra.Command {
 		Colorizer: cmdutil.GetGlobalColorization(),
 	}
 	cmd := &cobra.Command{
-		Use: "edit",
+		Use:     "edit",
+		Aliases: []string{"update", "modify"},
 		// TODO(dixler) Add test for unicode round-tripping before unhiding.
 		// TODO(fraser) This needs tests _in general_ it is currently basically untested.
 		Hidden: !env.Experimental.Value(),

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -65,8 +65,9 @@ func newStateMoveCommand() *cobra.Command {
 		Colorizer: cmdutil.GetGlobalColorization(),
 	}
 	cmd := &cobra.Command{
-		Use:   "move",
-		Short: "Move resources from one stack to another",
+		Use:     "move",
+		Aliases: []string{"mv"},
+		Short:   "Move resources from one stack to another",
 		Long: `Move resources from one stack to another
 
 This command can be used to move resources from one stack to another. This can be useful when


### PR DESCRIPTION
## Summary

Extends #23901's alignment with the [CLI Command Guidelines](https://app.notion.com/p/CLI-Command-Guidelines-350fdbdf1cce80b89367c16b7b421e3d) to the whole `pulumi` command tree:

- `list` commands (`deployment`, `org`, `policy`, `stack` subcommands) gain an `ls` alias.
- `remove` commands gain `rm`/`delete` aliases (`org member/role/webhook`, `stack schedule/webhook`, `policy group`, and `delete` added where only `rm` existed).
- `state delete` and `package delete` become `state remove` and `package remove`, with `rm` and `delete` kept as aliases.
- `state move` gains `mv`; `edit` commands gain `update`/`modify`; `new` commands (including top-level `pulumi new`) gain `create`/`setup`.

All renames keep the old spelling as an alias, so nothing breaks.

## Test plan

Covered by the existing CLI tests; verified every new alias resolves to its canonical command in the built CLI.

## Changelog

- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)