### PR TITLE
Prefer mise-action rather than changie-action

### DIFF
--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -61,9 +61,11 @@ jobs:
           fi
 
           ./.github/scripts/set-output version "${PULUMI_VERSION}"
-      - uses: miniscruff/changie-action@v2
+      - uses: ./.github/actions/retry
         with:
-          version: v1.21.0
+          action: jdx/mise-action@v2
+          with: |
+            experimental: true
       - name: Backfill PR numbers in pending changelog entries
         run: |
           python3 scripts/changie-pr-lookup.py

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -191,9 +191,11 @@ jobs:
             check-latest: true
           attempt_limit: 3
           attempt_delay: 5000
-      - uses: miniscruff/changie-action@v2
+      - uses: ./.github/actions/retry
         with:
-          version: v1.21.0
+          action: jdx/mise-action@v2
+          with: |
+            experimental: true
       - run: make lint_changelog
 
   pulumi-json:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -45,9 +45,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: sdk/go.mod
-      - uses: miniscruff/changie-action@v2
+      - uses: ./.github/actions/retry
         with:
-          version: v1.21.0
+          action: jdx/mise-action@v2
+          with: |
+            experimental: true
       - name: Create PR
         env:
           PULUMI_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Noticed while doing the release that that changelog was still messed up. Tha was because the CI jobs were still using an old version of changie, even though local uses had been updated because we'd changed the version in mise.toml.

Simplest fix for consistency is to just use mise to ensure changie is installed rather than using `changie-action`.
