### PR TITLE
Rename rawStringBytesDisplay to byteStringDisplay

### DIFF
--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -34,9 +34,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
-// rawStringBytesDisplay renders a string containing bytes that are not valid UTF-8 as b"<base64>",
+// byteStringDisplay renders a string containing bytes that are not valid UTF-8 as b"<base64>",
 // since such strings cannot be represented in JSON or terminal output directly.
-func rawStringBytesDisplay(s string) string {
+func byteStringDisplay(s string) string {
 	return `b"` + base64.StdEncoding.EncodeToString([]byte(s)) + `"`
 }
 
@@ -46,7 +46,7 @@ func rawStringBytesDisplay(s string) string {
 func massagePropertyValue(v resource.PropertyValue, showSecrets bool) resource.PropertyValue {
 	switch {
 	case v.IsString() && !utf8.ValidString(v.StringValue()):
-		return resource.NewProperty(rawStringBytesDisplay(v.StringValue()))
+		return resource.NewProperty(byteStringDisplay(v.StringValue()))
 	case v.IsArray():
 		new := make([]resource.PropertyValue, len(v.ArrayValue()))
 		for i, e := range v.ArrayValue() {

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -980,7 +980,7 @@ func (p *propertyPrinter) printPrimitivePropertyValue(v resource.PropertyValue) 
 		}
 	} else if v.IsString() {
 		if !utf8.ValidString(v.StringValue()) {
-			p.writeVerbatim(rawStringBytesDisplay(v.StringValue()))
+			p.writeVerbatim(byteStringDisplay(v.StringValue()))
 			return
 		}
 		if vv, kind, ok := p.decodeValue(v.StringValue()); ok {

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -164,7 +164,7 @@ func Test_PrintObject(t *testing.T) {
 			true,
 		},
 		{
-			"raw_string_bytes",
+			"byte_string",
 			resource.NewPropertyMapFromMap(map[string]any{
 				"bytes": resource.NewProperty("\x00hello \x80\xfe\xff world\xf0\x28"),
 			}),


### PR DESCRIPTION
Follow-up to the byte string display support in #23870. The signature
these values carry is named ByteString, so name the display helper to
match. No behavior change.