### PR TITLE
logging: fix -v=<n> output

### DIFF
--- a/changelog/pending/20260713--cli--fix-v-log-level-filtering.yaml
+++ b/changelog/pending/20260713--cli--fix-v-log-level-filtering.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Respect the -v log level again so that without -v only warnings and errors are written to stderr
+time: 2026-07-13T00:00:00+00:00
+custom:
+  PR: "23910"

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -120,8 +120,10 @@ func verbosityLevel(verbose int) slog.Level {
 		return LevelTrace
 	case verbose >= 10:
 		return slog.LevelDebug
-	default:
+	case verbose >= 1:
 		return slog.LevelInfo
+	default:
+		return slog.LevelWarn
 	}
 }
 

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -75,7 +75,7 @@ func init() {
 // handlerMu held for writing. slog.SetDefault is safe for concurrent use
 // with readers, so no additional synchronisation is needed.
 func rebuildLogger() {
-	var p slog.Handler = formattingHandler{inner: primary}
+	var p slog.Handler = verbosityHandler{inner: formattingHandler{inner: primary}}
 	var h slog.Handler = filteringHandler{inner: &teeHandler{
 		primary:  p,
 		sink:     sinkHandler,
@@ -451,6 +451,42 @@ func FilterString(msg string) string {
 	}
 
 	return msg
+}
+
+// verbosityHandler drops records whose "v" attribute exceeds the requested -v level before they
+// reach the primary log output. Records carry their original pulumi verbosity in the "v"
+// attribute, while their slog levels are bucketed too coarsely (V(1)-V(9) all map to Info) for
+// level-based filtering alone. Only the primary output filters by verbosity; the sink and export
+// handlers receive every record.
+type verbosityHandler struct {
+	inner slog.Handler
+}
+
+func (h verbosityHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h verbosityHandler) Handle(ctx context.Context, r slog.Record) error {
+	drop := false
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "v" && a.Value.Kind() == slog.KindInt64 {
+			drop = a.Value.Int64() > int64(Verbose)
+			return false
+		}
+		return true
+	})
+	if drop {
+		return nil
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h verbosityHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return verbosityHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h verbosityHandler) WithGroup(name string) slog.Handler {
+	return verbosityHandler{inner: h.inner.WithGroup(name)}
 }
 
 type discardHandler struct{}

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -15,9 +15,14 @@
 package logging
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -143,4 +148,149 @@ func TestLoggingDoesNotConflictWithGlog(t *testing.T) {
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
+}
+
+// TestInitLoggingFiltersVerbosity verifies that the stderr handler filters records logged directly
+// through slog by the -v level: without -v only warnings and errors pass.
+//
+//nolint:paralleltest // mutates global logging state
+func TestInitLoggingFiltersVerbosity(t *testing.T) {
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	t.Cleanup(func() {
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	enabled := func(level slog.Level) bool {
+		handlerMu.RLock()
+		defer handlerMu.RUnlock()
+		return primary.Enabled(t.Context(), level)
+	}
+
+	InitLogging(true, 0, false)
+	assert.False(t, enabled(slog.LevelInfo))
+	assert.False(t, enabled(slog.LevelDebug))
+	assert.True(t, enabled(slog.LevelWarn))
+	assert.True(t, enabled(slog.LevelError))
+
+	InitLogging(true, 1, false)
+	assert.True(t, enabled(slog.LevelInfo))
+	assert.False(t, enabled(slog.LevelDebug))
+
+	InitLogging(true, 10, false)
+	assert.True(t, enabled(slog.LevelDebug))
+	assert.False(t, enabled(LevelTrace))
+
+	InitLogging(true, 11, false)
+	assert.True(t, enabled(LevelTrace))
+}
+
+// TestLogToStderrRespectsVerbosity verifies that with --logtostderr and no -v, neither V-guarded
+// nor direct slog info records reach stderr — even while a sink handler (as installed for
+// encrypted logs) keeps them flowing — and warnings still show.
+//
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestLogToStderrRespectsVerbosity(t *testing.T) {
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	t.Cleanup(func() {
+		SetSinkHandler(nil)
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	InitLogging(true, 0, false)
+	os.Stderr = oldStderr
+
+	sink := &recordingHandler{}
+	SetSinkHandler(sink)
+
+	V(9).Infof("guarded info %d", 42)
+	Infof("unguarded info")
+	slog.Info("direct info")
+	Warningf("warning shows")
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "guarded info")
+	assert.NotContains(t, string(out), "unguarded info")
+	assert.NotContains(t, string(out), "direct info")
+	assert.Contains(t, string(out), "warning shows")
+	assert.True(t, sink.saw("guarded info %d"))
+}
+
+type recordingHandler struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingHandler) saw(msg string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return slices.Contains(h.msgs, msg)
+}
+
+// TestLogToStderrFiltersHigherVerbosity reproduces `pulumi up --logtostderr -v=1` showing v=5
+// records: the primary handler must drop records whose "v" attribute exceeds the requested level,
+// for both the V() wrapper and direct slog calls that carry the attribute.
+//
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestLogToStderrFiltersHigherVerbosity(t *testing.T) {
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	t.Cleanup(func() {
+		SetSinkHandler(nil)
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	InitLogging(true, 1, false)
+	os.Stderr = oldStderr
+
+	sink := &recordingHandler{}
+	SetSinkHandler(sink)
+
+	V(1).Infof("v1 shows")
+	V(5).Infof("v5 hidden")
+	slog.Info("direct v5 hidden", "v", 5)
+	slog.Info("unleveled info shows")
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "v1 shows")
+	assert.NotContains(t, string(out), "v5 hidden")
+	assert.NotContains(t, string(out), "direct v5 hidden")
+	assert.Contains(t, string(out), "unleveled info shows")
+	assert.True(t, sink.saw("v5 hidden"))
 }


### PR DESCRIPTION
With the introduction of automatic logging, we introduce a bug, where the log levels with -v would not be respected correctly anymore.

Introduce a verbosityHandler, that does that filtering for us in a more granular manner than slog can (as people seeem to be relying on that).
