### PR TITLE
Move Operation to pkg

### DIFF
--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack/snapshot"
@@ -634,7 +635,7 @@ func NewSnapshotJournaler(
 			Manifest:          baseSnap.Manifest,
 			SecretsManager:    baseSnap.SecretsManager,
 			Resources:         make([]*resource.State, 0),
-			PendingOperations: make([]resource.Operation, 0),
+			PendingOperations: make([]pkgresource.Operation, 0),
 			Metadata:          baseSnap.Metadata,
 			Snippets:          baseSnap.Snippets,
 		}
@@ -783,7 +784,7 @@ func NewJournaler(
 			Manifest:          baseSnap.Manifest,
 			SecretsManager:    baseSnap.SecretsManager,
 			Resources:         make([]*resource.State, 0),
-			PendingOperations: make([]resource.Operation, 0),
+			PendingOperations: make([]pkgresource.Operation, 0),
 			Metadata:          baseSnap.Metadata,
 		}
 		// Copy the resources from the base snapshot to the new snapshot.

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack/snapshot"
@@ -72,13 +73,13 @@ type SnapshotPersister interface {
 // This is subtle and a little confusing. The reason for this is that the engine directly mutates resource objects
 // that it creates and expects those mutations to be persisted directly to the snapshot.
 type SnapshotManager struct {
-	persister      SnapshotPersister    // The persister responsible for invalidating and persisting the snapshot
-	baseSnapshot   *deploy.Snapshot     // The base snapshot for this plan
-	secretsManager secrets.Manager      // The default secrets manager to use
-	resources      []*resource.State    // The list of resources operated upon by this plan
-	operations     []resource.Operation // The set of operations known to be outstanding in this plan
-	snippets       []resource.Snippet   // The snippet list to persist with the next snapshot
-	hasSnippets    bool                 // Whether snippets has been set by the engine
+	persister      SnapshotPersister       // The persister responsible for invalidating and persisting the snapshot
+	baseSnapshot   *deploy.Snapshot        // The base snapshot for this plan
+	secretsManager secrets.Manager         // The default secrets manager to use
+	resources      []*resource.State       // The list of resources operated upon by this plan
+	operations     []pkgresource.Operation // The set of operations known to be outstanding in this plan
+	snippets       []resource.Snippet      // The snippet list to persist with the next snapshot
+	hasSnippets    bool                    // Whether snippets has been set by the engine
 
 	// The set of resources that have been operated upon already by this plan. These resources could also have
 	// been added to `resources` by other operations but need to be filtered out before writing the snapshot.
@@ -425,7 +426,7 @@ func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {
 func (sm *SnapshotManager) doCreate(step deploy.Step) (engine.SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doCreate(%s)", step.URN())
 	err := sm.mutate(func() bool {
-		sm.markOperationPending(step.New(), resource.OperationTypeCreating)
+		sm.markOperationPending(step.New(), pkgresource.OperationTypeCreating)
 		return true
 	})
 	if err != nil {
@@ -469,7 +470,7 @@ func (csm *createSnapshotMutation) End(step deploy.Step, successful bool) error 
 func (sm *SnapshotManager) doUpdate(step deploy.Step) (engine.SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doUpdate(%s)", step.URN())
 	err := sm.mutate(func() bool {
-		sm.markOperationPending(step.New(), resource.OperationTypeUpdating)
+		sm.markOperationPending(step.New(), pkgresource.OperationTypeUpdating)
 		return true
 	})
 	if err != nil {
@@ -499,7 +500,7 @@ func (usm *updateSnapshotMutation) End(step deploy.Step, successful bool) error 
 func (sm *SnapshotManager) doDelete(step deploy.Step) (engine.SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doDelete(%s)", step.URN())
 	err := sm.mutate(func() bool {
-		sm.markOperationPending(step.Old(), resource.OperationTypeDeleting)
+		sm.markOperationPending(step.Old(), pkgresource.OperationTypeDeleting)
 		return true
 	})
 	if err != nil {
@@ -546,7 +547,7 @@ func (rsm *replaceSnapshotMutation) End(step deploy.Step, successful bool) error
 func (sm *SnapshotManager) doRead(step deploy.Step) (engine.SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doRead(%s)", step.URN())
 	err := sm.mutate(func() bool {
-		sm.markOperationPending(step.New(), resource.OperationTypeReading)
+		sm.markOperationPending(step.New(), pkgresource.OperationTypeReading)
 		return true
 	})
 	if err != nil {
@@ -627,7 +628,7 @@ func (rsm *removePendingReplaceSnapshotMutation) End(step deploy.Step, successfu
 func (sm *SnapshotManager) doImport(step deploy.Step) (engine.SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doImport(%s)", step.URN())
 	err := sm.mutate(func() bool {
-		sm.markOperationPending(step.New(), resource.OperationTypeImporting)
+		sm.markOperationPending(step.New(), pkgresource.OperationTypeImporting)
 		return true
 	})
 	if err != nil {
@@ -673,9 +674,9 @@ func (sm *SnapshotManager) markNew(state *resource.State) {
 }
 
 // markOperationPending marks a resource as undergoing an operation that will now be considered pending.
-func (sm *SnapshotManager) markOperationPending(state *resource.State, op resource.OperationType) {
+func (sm *SnapshotManager) markOperationPending(state *resource.State, op pkgresource.OperationType) {
 	contract.Requiref(state != nil, "state", "must not be nil")
-	sm.operations = append(sm.operations, resource.NewOperation(state, op))
+	sm.operations = append(sm.operations, pkgresource.NewOperation(state, op))
 	logging.V(9).Infof("SnapshotManager.markPendingOperation(%s, %s)", state.URN, string(op))
 }
 
@@ -744,7 +745,7 @@ func (sm *SnapshotManager) Snap() *deploy.Snapshot {
 	}
 
 	// Record any pending operations, if there are any outstanding that have not completed yet.
-	var operations []resource.Operation
+	var operations []pkgresource.Operation
 	for _, op := range sm.operations {
 		if !sm.completeOps[op.Resource] {
 			operations = append(operations, op)
@@ -756,7 +757,7 @@ func (sm *SnapshotManager) Snap() *deploy.Snapshot {
 	// because these must require user intervention to be cleared or resolved.
 	if base := sm.baseSnapshot; base != nil {
 		for _, pendingOperation := range base.PendingOperations {
-			if pendingOperation.Type == resource.OperationTypeCreating {
+			if pendingOperation.Type == pkgresource.OperationTypeCreating {
 				operations = append(operations, pendingOperation)
 			}
 		}

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -36,6 +36,7 @@ import (
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -311,7 +312,7 @@ func NewRefreshCmd() *cobra.Command {
 			// We remove remaining pending creates
 			if clearPendingCreates && hasPendingCreates(snap) {
 				// Remove all pending creates.
-				removePendingCreates := func(op resource.Operation) (*resource.Operation, error) {
+				removePendingCreates := func(op pkgresource.Operation) (*pkgresource.Operation, error) {
 					return nil, nil
 				}
 				err := filterMapPendingCreates(ctx, s, opts.Display, yes, removePendingCreates)
@@ -523,7 +524,7 @@ func NewRefreshCmd() *cobra.Command {
 	return cmd
 }
 
-type editPendingOp = func(op resource.Operation) (*resource.Operation, error)
+type editPendingOp = func(op pkgresource.Operation) (*pkgresource.Operation, error)
 
 // filterMapPendingCreates applies f to each pending create. If f returns nil, then the op
 // is deleted. Otherwise is replaced by the returned op.
@@ -531,12 +532,12 @@ func filterMapPendingCreates(
 	ctx context.Context, s backend.Stack, opts display.Options, yes bool, f editPendingOp,
 ) error {
 	return state.TotalStateEdit(ctx, s, yes, opts, func(opts display.Options, snap *deploy.Snapshot) error {
-		var pending []resource.Operation
+		var pending []pkgresource.Operation
 		for _, op := range snap.PendingOperations {
 			if op.Resource == nil {
 				return errors.New("found operation without resource")
 			}
-			if op.Type != resource.OperationTypeCreating {
+			if op.Type != pkgresource.OperationTypeCreating {
 				pending = append(pending, op)
 				continue
 			}
@@ -567,10 +568,10 @@ func pendingCreatesToImports(ctx context.Context, s backend.Stack, yes bool, opt
 	for i := 0; i < len(importToCreates); i += 2 {
 		alteredOps[importToCreates[i]] = importToCreates[i+1]
 	}
-	err := filterMapPendingCreates(ctx, s, opts, yes, func(op resource.Operation) (*resource.Operation, error) {
+	err := filterMapPendingCreates(ctx, s, opts, yes, func(op pkgresource.Operation) (*pkgresource.Operation, error) {
 		if id, ok := alteredOps[string(op.Resource.URN)]; ok {
 			op.Resource.ID = resource.ID(id)
-			op.Type = resource.OperationTypeImporting
+			op.Type = pkgresource.OperationTypeImporting
 			delete(alteredOps, string(op.Resource.URN))
 			return &op, nil
 		}
@@ -588,14 +589,14 @@ func hasPendingCreates(snap *deploy.Snapshot) bool {
 		return false
 	}
 	for _, op := range snap.PendingOperations {
-		if op.Type == resource.OperationTypeCreating {
+		if op.Type == pkgresource.OperationTypeCreating {
 			return true
 		}
 	}
 	return false
 }
 
-func interactiveFixPendingCreate(op resource.Operation) (*resource.Operation, error) {
+func interactiveFixPendingCreate(op pkgresource.Operation) (*pkgresource.Operation, error) {
 	for {
 		option := ""
 		options := []string{
@@ -623,7 +624,7 @@ func interactiveFixPendingCreate(op resource.Operation) (*resource.Operation, er
 			}, &id, nil)
 			if err == nil {
 				op.Resource.ID = resource.ID(id)
-				op.Type = resource.OperationTypeImporting
+				op.Type = pkgresource.OperationTypeImporting
 				return &op, nil
 			}
 		default:

--- a/pkg/engine/journal_snapshot.go
+++ b/pkg/engine/journal_snapshot.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -158,7 +159,7 @@ type JournalEntry struct {
 	// The resource state associated with this journal entry.
 	State *resource.State
 	// The operation associated with this journal entry, if any.
-	Operation *resource.Operation
+	Operation *pkgresource.Operation
 	// If true, this journal entry can be elided and does not need to be written immediately.
 	ElideWrite bool
 	// If true, this journal entry is part of a refresh operation.
@@ -343,7 +344,7 @@ func (sm *JournalSnapshotManager) Write(base *deploy.Snapshot) error {
 		Manifest:          base.Manifest,
 		SecretsManager:    base.SecretsManager,
 		Resources:         make([]*resource.State, 0, len(base.Resources)),
-		PendingOperations: make([]resource.Operation, 0, len(base.PendingOperations)),
+		PendingOperations: make([]pkgresource.Operation, 0, len(base.PendingOperations)),
 		Metadata:          base.Metadata,
 		Extensions:        base.Extensions,
 		Snippets:          slices.Clone(base.Snippets),
@@ -585,7 +586,7 @@ func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {
 
 func (sm *JournalSnapshotManager) doCreate(step deploy.Step, operationID int64) (SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doCreate(%s)", step.URN())
-	op := resource.NewOperation(step.New(), resource.OperationTypeCreating)
+	op := pkgresource.NewOperation(step.New(), pkgresource.OperationTypeCreating)
 
 	journalEntry := sm.newJournalEntry(JournalEntryBegin, operationID)
 	journalEntry.Operation = &op
@@ -628,7 +629,7 @@ func (csm *createSnapshotMutation) End(step deploy.Step, successful bool) error 
 
 func (sm *JournalSnapshotManager) doUpdate(step deploy.Step, operationID int64) (SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doUpdate(%s)", step.URN())
-	op := resource.NewOperation(step.New(), resource.OperationTypeUpdating)
+	op := pkgresource.NewOperation(step.New(), pkgresource.OperationTypeUpdating)
 	journalEntry := sm.newJournalEntry(JournalEntryBegin, operationID)
 	journalEntry.Operation = &op
 	err := sm.addJournalEntry(journalEntry)
@@ -662,7 +663,7 @@ func (usm *updateSnapshotMutation) End(step deploy.Step, successful bool) error 
 
 func (sm *JournalSnapshotManager) doDelete(step deploy.Step, operationID int64) (SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doDelete(%s)", step.URN())
-	op := resource.NewOperation(step.Old(), resource.OperationTypeDeleting)
+	op := pkgresource.NewOperation(step.Old(), pkgresource.OperationTypeDeleting)
 	journalEntry := sm.newJournalEntry(JournalEntryBegin, operationID)
 	journalEntry.Operation = &op
 
@@ -722,7 +723,7 @@ func (rsm *replaceSnapshotMutation) End(step deploy.Step, successful bool) error
 
 func (sm *JournalSnapshotManager) doRead(step deploy.Step, operationID int64) (SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doRead(%s)", step.URN())
-	op := resource.NewOperation(step.New(), resource.OperationTypeReading)
+	op := pkgresource.NewOperation(step.New(), pkgresource.OperationTypeReading)
 	journalEntry := sm.newJournalEntry(JournalEntryBegin, operationID)
 	journalEntry.Operation = &op
 	err := sm.addJournalEntry(journalEntry)
@@ -834,7 +835,7 @@ func (rsm *removePendingReplaceSnapshotMutation) End(step deploy.Step, successfu
 
 func (sm *JournalSnapshotManager) doImport(step deploy.Step, operationID int64) (SnapshotMutation, error) {
 	logging.V(9).Infof("SnapshotManager.doImport(%s)", step.URN())
-	op := resource.NewOperation(step.New(), resource.OperationTypeImporting)
+	op := pkgresource.NewOperation(step.New(), pkgresource.OperationTypeImporting)
 	journalEntry := sm.newJournalEntry(JournalEntryBegin, operationID)
 	journalEntry.Operation = &op
 	err := sm.addJournalEntry(journalEntry)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
@@ -673,9 +674,9 @@ func TestPreviewWithPendingOperations(t *testing.T) {
 	}
 
 	old := &deploy.Snapshot{
-		PendingOperations: []resource.Operation{{
+		PendingOperations: []pkgresource.Operation{{
 			Resource: newResource(urnA, "0", false),
-			Type:     resource.OperationTypeUpdating,
+			Type:     pkgresource.OperationTypeUpdating,
 		}},
 		Resources: []*resource.State{
 			newResource(urnA, "0", false),
@@ -727,9 +728,9 @@ func TestRefreshWithPendingOperations(t *testing.T) {
 	}
 
 	old := &deploy.Snapshot{
-		PendingOperations: []resource.Operation{{
+		PendingOperations: []pkgresource.Operation{{
 			Resource: newResource(urnA, "0", false),
-			Type:     resource.OperationTypeUpdating,
+			Type:     pkgresource.OperationTypeUpdating,
 		}},
 		Resources: []*resource.State{
 			newResource(urnA, "0", false),
@@ -799,14 +800,14 @@ func TestRefreshPreservesPendingCreateOperations(t *testing.T) {
 	resA := newResource(urnA, "0", false)
 	resB := newResource(urnB, "0", false)
 	old := &deploy.Snapshot{
-		PendingOperations: []resource.Operation{
+		PendingOperations: []pkgresource.Operation{
 			{
 				Resource: resA,
-				Type:     resource.OperationTypeUpdating,
+				Type:     pkgresource.OperationTypeUpdating,
 			},
 			{
 				Resource: resB,
-				Type:     resource.OperationTypeCreating,
+				Type:     pkgresource.OperationTypeCreating,
 			},
 		},
 		Resources: []*resource.State{
@@ -837,12 +838,12 @@ func TestRefreshPreservesPendingCreateOperations(t *testing.T) {
 	require.NoError(t, err)
 	// Assert that pending CREATE operation was preserved
 	require.Len(t, new.PendingOperations, 1)
-	assert.Equal(t, resource.OperationTypeCreating, new.PendingOperations[0].Type)
+	assert.Equal(t, pkgresource.OperationTypeCreating, new.PendingOperations[0].Type)
 	assert.Equal(t, urnB, new.PendingOperations[0].Resource.URN)
 }
 
-func findPendingOperationsByType(opType resource.OperationType, snapshot *deploy.Snapshot) []resource.Operation {
-	var operations []resource.Operation
+func findPendingOperationsByType(opType pkgresource.OperationType, snapshot *deploy.Snapshot) []pkgresource.Operation {
+	var operations []pkgresource.Operation
 	for _, operation := range snapshot.PendingOperations {
 		if operation.Type == opType {
 			operations = append(operations, operation)
@@ -875,14 +876,14 @@ func TestUpdateShowsWarningWithPendingOperations(t *testing.T) {
 	}
 
 	old := &deploy.Snapshot{
-		PendingOperations: []resource.Operation{
+		PendingOperations: []pkgresource.Operation{
 			{
 				Resource: newResource(urnA, "0", false),
-				Type:     resource.OperationTypeUpdating,
+				Type:     pkgresource.OperationTypeUpdating,
 			},
 			{
 				Resource: newResource(urnB, "1", false),
-				Type:     resource.OperationTypeCreating,
+				Type:     pkgresource.OperationTypeCreating,
 			},
 		},
 		Resources: []*resource.State{
@@ -929,12 +930,12 @@ func TestUpdateShowsWarningWithPendingOperations(t *testing.T) {
 	new, _ := op.Run(project, target, options, false, nil, validate)
 	require.NotNil(t, new)
 
-	assert.Equal(t, resource.OperationTypeCreating, new.PendingOperations[0].Type)
+	assert.Equal(t, pkgresource.OperationTypeCreating, new.PendingOperations[0].Type)
 
 	// Assert that CREATE pending operations are retained
 	// TODO: should revisit whether non-CREATE pending operations should also be retained
 	require.Len(t, new.PendingOperations, 1)
-	createOperations := findPendingOperationsByType(resource.OperationTypeCreating, new)
+	createOperations := findPendingOperationsByType(pkgresource.OperationTypeCreating, new)
 	require.Len(t, createOperations, 1)
 	assert.Equal(t, urnB, createOperations[0].Resource.URN)
 }

--- a/pkg/engine/test_journal.go
+++ b/pkg/engine/test_journal.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"errors"
 
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -50,7 +51,7 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 	// Build up a list of current resources by replaying the journal.
 	resources, dones := []*resource.State{}, make(map[*resource.State]bool)
 	isRefresh := false
-	ops, doneOps := []resource.Operation{}, make(map[*resource.State]bool)
+	ops, doneOps := []pkgresource.Operation{}, make(map[*resource.State]bool)
 	// Collect extension blobs from ExtensionParameterizeStep entries seen during this plan.
 	liveExtensions := map[apitype.ExtensionRef]apitype.Extension{}
 	for _, e := range entries {
@@ -74,15 +75,15 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		case TestJournalEntryBegin:
 			switch e.Step.Op() {
 			case deploy.OpCreate, deploy.OpCreateReplacement:
-				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeCreating))
+				ops = append(ops, pkgresource.NewOperation(e.Step.New(), pkgresource.OperationTypeCreating))
 			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
-				ops = append(ops, resource.NewOperation(e.Step.Old(), resource.OperationTypeDeleting))
+				ops = append(ops, pkgresource.NewOperation(e.Step.Old(), pkgresource.OperationTypeDeleting))
 			case deploy.OpRead, deploy.OpReadReplacement:
-				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeReading))
+				ops = append(ops, pkgresource.NewOperation(e.Step.New(), pkgresource.OperationTypeReading))
 			case deploy.OpUpdate:
-				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeUpdating))
+				ops = append(ops, pkgresource.NewOperation(e.Step.New(), pkgresource.OperationTypeUpdating))
 			case deploy.OpImport, deploy.OpImportReplacement:
-				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeImporting))
+				ops = append(ops, pkgresource.NewOperation(e.Step.New(), pkgresource.OperationTypeImporting))
 			}
 		case TestJournalEntryFailure, TestJournalEntrySuccess:
 			switch e.Step.Op() {
@@ -170,7 +171,7 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 	}
 
 	// Append any pending operations.
-	var operations []resource.Operation
+	var operations []pkgresource.Operation
 	for _, op := range ops {
 		if !doneOps[op.Resource] {
 			operations = append(operations, op)
@@ -182,7 +183,7 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		// and propagate them to the new snapshot: we don't want to clear pending CREATE operations
 		// because these must require user intervention to be cleared or resolved.
 		for _, pendingOperation := range base.PendingOperations {
-			if pendingOperation.Type == resource.OperationTypeCreating {
+			if pendingOperation.Type == pkgresource.OperationTypeCreating {
 				operations = append(operations, pendingOperation)
 			}
 		}

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -40,7 +41,7 @@ func newResource(name string) *resource.State {
 	}
 }
 
-func newSnapshot(resources []*resource.State, ops []resource.Operation) *Snapshot {
+func newSnapshot(resources []*resource.State, ops []pkgresource.Operation) *Snapshot {
 	return NewSnapshot(Manifest{
 		Time:    time.Now(),
 		Version: version.Version,
@@ -55,9 +56,9 @@ func TestPendingOperationsDeployment(t *testing.T) {
 	resourceB := newResource("b")
 	snap := newSnapshot([]*resource.State{
 		resourceA,
-	}, []resource.Operation{
+	}, []pkgresource.Operation{
 		{
-			Type:     resource.OperationTypeCreating,
+			Type:     pkgresource.OperationTypeCreating,
 			Resource: resourceB,
 		},
 	})

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/go-test/deep"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack/snapshot"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -35,12 +36,12 @@ import (
 // IDs, names, and properties; their dependencies; and more.  A snapshot is a diffable entity and can be used to create
 // or apply an infrastructure deployment plan in order to make reality match the snapshot state.
 type Snapshot struct {
-	Manifest          Manifest             // a deployment manifest of versions, checksums, and so on.
-	SecretsManager    secrets.Manager      // the manager to use use when serializing this snapshot.
-	Resources         []*resource.State    // fetches all resources and their associated states.
-	PendingOperations []resource.Operation // all currently pending resource operations.
-	Metadata          SnapshotMetadata     // metadata associated with the snapshot.
-	Snippets          []resource.Snippet   // any PCL snippets associated with the snapshot.
+	Manifest          Manifest                // a deployment manifest of versions, checksums, and so on.
+	SecretsManager    secrets.Manager         // the manager to use use when serializing this snapshot.
+	Resources         []*resource.State       // fetches all resources and their associated states.
+	PendingOperations []pkgresource.Operation // all currently pending resource operations.
+	Metadata          SnapshotMetadata        // metadata associated with the snapshot.
+	Snippets          []resource.Snippet      // any PCL snippets associated with the snapshot.
 	// Extension-parameterization blobs keyed by content hash.
 	Extensions map[apitype.ExtensionRef]apitype.Extension
 }
@@ -65,7 +66,7 @@ type SnapshotIntegrityErrorMetadata struct {
 // NewSnapshot creates a snapshot from the given arguments.  The resources must be in topologically sorted order.
 // This property is not checked; for verification, please refer to the VerifyIntegrity function below.
 func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
-	resources []*resource.State, ops []resource.Operation,
+	resources []*resource.State, ops []pkgresource.Operation,
 	metadata SnapshotMetadata, snippets []resource.Snippet,
 	extensions map[apitype.ExtensionRef]apitype.Extension,
 ) *Snapshot {
@@ -340,7 +341,7 @@ func (snap *Snapshot) AssertEqual(expected *Snapshot) error {
 			len(snap.PendingOperations), snapPendingOps.String(), len(expected.PendingOperations), expectedPendingOps.String())
 	}
 
-	pendingOpsMap := make(map[resource.URN][]resource.Operation)
+	pendingOpsMap := make(map[resource.URN][]pkgresource.Operation)
 
 	for _, mop := range expected.PendingOperations {
 		pendingOpsMap[mop.Resource.URN] = append(pendingOpsMap[mop.Resource.URN], mop)

--- a/pkg/resource/operation.go
+++ b/pkg/resource/operation.go
@@ -1,4 +1,4 @@
-// Copyright 2016, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 package resource
+
+import sdkresource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 // OperationType is the type of operations issued by the engine.
 type OperationType string
@@ -33,12 +35,12 @@ const (
 // Operation represents an operation that the engine has initiated but has not yet completed. It is
 // essentially just a tuple of a resource and a string identifying the operation.
 type Operation struct {
-	Resource *State
+	Resource *sdkresource.State
 	Type     OperationType
 }
 
 // NewOperation constructs a new Operation from a state and an operation name.
-func NewOperation(state *State, op OperationType) Operation {
+func NewOperation(state *sdkresource.State, op OperationType) Operation {
 	return Operation{state, op}
 }
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -29,6 +29,7 @@ import (
 	fxs "github.com/pgavlin/fx/v2/slices"
 	"go.opentelemetry.io/otel"
 
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack/migrate"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -533,7 +534,7 @@ func DeserializeDeploymentV3(
 
 	type deserializedData struct {
 		resources []*resource.State
-		ops       []resource.Operation
+		ops       []pkgresource.Operation
 	}
 
 	data, err := BatchDecrypt(
@@ -550,7 +551,7 @@ func DeserializeDeploymentV3(
 				resources = append(resources, desres)
 			}
 
-			ops := slice.Prealloc[resource.Operation](len(deployment.PendingOperations))
+			ops := slice.Prealloc[pkgresource.Operation](len(deployment.PendingOperations))
 			for _, op := range deployment.PendingOperations {
 				desop, err := DeserializeOperation(op, dec)
 				if err != nil {
@@ -692,7 +693,7 @@ func SerializeResource(
 
 // SerializeOperation serializes a resource in a pending state.
 func SerializeOperation(
-	ctx context.Context, op resource.Operation, enc config.Encrypter, showSecrets bool,
+	ctx context.Context, op pkgresource.Operation, enc config.Encrypter, showSecrets bool,
 ) (apitype.OperationV2, error) {
 	res, err := SerializeResource(ctx, op.Resource, enc, showSecrets)
 	if err != nil {
@@ -920,12 +921,12 @@ func DeserializeResource(res apitype.ResourceV3, dec config.Decrypter) (*resourc
 
 // DeserializeOperation hydrates a pending resource/operation pair.
 func DeserializeOperation(op apitype.OperationV2, dec config.Decrypter,
-) (resource.Operation, error) {
+) (pkgresource.Operation, error) {
 	res, err := DeserializeResource(op.Resource, dec)
 	if err != nil {
-		return resource.Operation{}, err
+		return pkgresource.Operation{}, err
 	}
-	return resource.NewOperation(res, resource.OperationType(op.Type)), nil
+	return pkgresource.NewOperation(res, pkgresource.OperationType(op.Type)), nil
 }
 
 // DeserializeProperties deserializes an entire map of deploy properties into a resource property map.

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -284,9 +285,9 @@ func TestStackCommands(t *testing.T) {
 		// Let's say that the the CLI crashed during the deletion of the last resource and we've now got
 		// invalid resources in the snapshot.
 		res := snap.Resources[len(snap.Resources)-1]
-		snap.PendingOperations = append(snap.PendingOperations, resource.Operation{
+		snap.PendingOperations = append(snap.PendingOperations, pkgresource.Operation{
 			Resource: res,
-			Type:     resource.OperationTypeDeleting,
+			Type:     pkgresource.OperationTypeDeleting,
 		})
 		v3deployment, err := stack.SerializeDeployment(t.Context(), snap, false /* showSecrets */)
 		require.NoError(t, err)


### PR DESCRIPTION
Continuing to shrink the size of sdk/go/common. This moves the `Operation` struct from `sdk/go/common/resource` to `pkg/resource`. This was only referred to from other pkg code, so seems safe to move out of the sdk module.