### PR TITLE
Fix `pulumi api` probing the wrong backend's credentials

### DIFF
--- a/changelog/pending/20260713--cli--fix-pulumi-api-backend-url-probe.yaml
+++ b/changelog/pending/20260713--cli--fix-pulumi-api-backend-url-probe.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Make `pulumi api` validate credentials against the backend it actually uses, honouring PULUMI_BACKEND_URL outside a project directory
+time: 2026-07-13T00:00:00+00:00
+custom:
+  PR: "23917"

--- a/pkg/cmd/pulumi/cloud/resolve.go
+++ b/pkg/cmd/pulumi/cloud/resolve.go
@@ -71,16 +71,7 @@ func ResolveContext(ctx context.Context) (*ResolvedContext, error) {
 		return nil, fmt.Errorf("reading project: %w", err)
 	}
 
-	// Resolve the URL ourselves before probing credentials so we honour
-	// a project-declared backend (Pulumi.yaml's `backend.url`) without
-	// triggering CurrentBackend's interactive login path.
-	var projectURL string
-	if project != nil {
-		if u, perr := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project); perr == nil {
-			projectURL = u
-		}
-	}
-	cloudURL := httpstate.ValueOrDefaultURL(ws, projectURL)
+	cloudURL := resolveCloudURL(ws, project)
 
 	// Probe credentials non-interactively. (account == nil, err == nil) is
 	// the legitimate not-logged-in case — fall through to anonymous below.
@@ -129,6 +120,23 @@ func ResolveContext(ctx context.Context) (*ResolvedContext, error) {
 		StackName: stackName,
 		LoggedIn:  true,
 	}, nil
+}
+
+// resolveCloudURL returns the cloud URL a `pulumi api` credential probe should
+// target: the same URL CurrentBackend resolves, so we validate the token for
+// the backend we actually build. GetCurrentCloudURL honours PULUMI_BACKEND_URL,
+// a project-declared backend (Pulumi.yaml's `backend.url`), and stored
+// credentials; ValueOrDefaultURL supplies the default cloud URL when none is
+// set. Resolving it here lets us probe credentials without triggering
+// CurrentBackend's interactive login path.
+func resolveCloudURL(ws pkgWorkspace.Context, project *workspace.Project) string {
+	// GetCurrentCloudURL only errors when stored credentials can't be read;
+	// treat that as "no URL" so ValueOrDefaultURL falls back to the default.
+	backendURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
+	if err != nil {
+		backendURL = ""
+	}
+	return httpstate.ValueOrDefaultURL(ws, backendURL)
 }
 
 // currentStackSelection returns the (org, project, stack) of the user's

--- a/pkg/cmd/pulumi/cloud/resolve_test.go
+++ b/pkg/cmd/pulumi/cloud/resolve_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// The credential probe must target the same cloud URL CurrentBackend will
+// build, so it validates the token for the backend we actually use. The
+// regression this guards: PULUMI_BACKEND_URL is honoured by the backend build
+// (via GetCurrentCloudURL) but was ignored by the probe outside a project
+// directory, so the probe validated a different backend's token.
+func TestResolveCloudURL(t *testing.T) {
+	// Sets PULUMI_BACKEND_URL via t.Setenv, so cannot run in parallel.
+
+	const backendURL = "https://backend.example.com"
+	const credsURL = "https://app.example.com"
+	const projectBackendURL = "https://project.example.com"
+
+	storedCreds := func() (workspace.Credentials, error) {
+		return workspace.Credentials{Current: credsURL}, nil
+	}
+	projectWithBackend := &workspace.Project{
+		Backend: &workspace.ProjectBackend{URL: projectBackendURL},
+	}
+
+	tests := []struct {
+		name        string
+		backendEnv  string // PULUMI_BACKEND_URL value; "" means unset
+		project     *workspace.Project
+		expectedURL string
+	}{
+		{
+			// The bug: outside a project directory the probe ignored
+			// PULUMI_BACKEND_URL and fell back to stored credentials.
+			name:        "PULUMI_BACKEND_URL honoured without a project",
+			backendEnv:  backendURL,
+			project:     nil,
+			expectedURL: backendURL,
+		},
+		{
+			name:        "PULUMI_BACKEND_URL honoured with a project",
+			backendEnv:  backendURL,
+			project:     projectWithBackend,
+			expectedURL: backendURL,
+		},
+		{
+			name:        "stored credentials without a project",
+			project:     nil,
+			expectedURL: credsURL,
+		},
+		{
+			name:        "project backend without PULUMI_BACKEND_URL",
+			project:     projectWithBackend,
+			expectedURL: projectBackendURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set unconditionally (empty for the unset cases) so a
+			// PULUMI_BACKEND_URL in the developer's environment can't leak in.
+			t.Setenv(env.BackendURL.Var().Name(), tt.backendEnv)
+
+			ws := &pkgWorkspace.MockContext{GetStoredCredentialsF: storedCreds}
+			got := resolveCloudURL(ws, tt.project)
+			assert.Equal(t, tt.expectedURL, got)
+
+			// The probe must resolve the same URL CurrentBackend resolves.
+			build, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), tt.project)
+			require.NoError(t, err)
+			assert.Equal(t, build, got,
+				"probe URL must match the URL CurrentBackend resolves")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`pulumi api` validated credentials against a different backend than the one it used. The credential probe resolves its URL with `ValueOrDefaultURL`, which ignores `PULUMI_BACKEND_URL`; the backend it then builds resolves via `GetCurrentCloudURL`, which honours it. The probe only consulted `GetCurrentCloudURL` inside a project directory — so **outside a project directory with `PULUMI_BACKEND_URL` set**, the probe checked the default/current backend's token while the command targeted the `PULUMI_BACKEND_URL` backend. The probe could pass (or report not-logged-in) against the wrong backend.

## Fix

Resolve the probe URL through the same `GetCurrentCloudURL` path the backend build uses, keeping `ValueOrDefaultURL` as the default fallback. The probe now targets the same URL `CurrentBackend` resolves, so it validates the token for the backend actually built.

No behavior change when `PULUMI_BACKEND_URL` is unset, or inside a project directory — those paths already resolved through `GetCurrentCloudURL`.

## Notable choices

- A DIY current backend (`file://`, `s3://`) now passes through to the probe (matching the build) rather than being skipped. `pulumi api` requires the Cloud backend regardless, so this only sharpens the resulting error.

## Out of scope

- `CurrentBackend` resolves through `GetCurrentCloudURLWithAgentFallback`; this fix uses plain `GetCurrentCloudURL`. Closing that narrower agent-credential mismatch is a separate change with its own risk.

## Test plan

- [x] New `TestResolveCloudURL` (TDD, red→green): four cases — `PULUMI_BACKEND_URL` honoured without a project (the regression), plus three no-op guards (inside a project, stored-credentials-only, project-backend-only). Each asserts the probe resolves the same URL `GetCurrentCloudURL` (the build path) returns.
- [x] `go test ./pkg/cmd/pulumi/cloud/...` green; `go build ./...` and `go vet` clean.
