### PR TITLE
fix(cli): don't let agent auto-signup mask a rejected user login

### DIFF
--- a/changelog/pending/20260713--cli--fix-agent-signup-masks-rejected-user-token.yaml
+++ b/changelog/pending/20260713--cli--fix-agent-signup-masks-rejected-user-token.yaml
@@ -2,3 +2,5 @@ component: cli
 kind: fix
 body: Under an AI coding agent, a stored login whose token the service has rejected (e.g. revoked or server-expired) no longer triggers automatic signup of a new anonymous agent account; the CLI now reports that `pulumi login` is required instead of silently switching identities
 time: 2026-07-13T00:00:00+00:00
+custom:
+  PR: "23918"

--- a/changelog/pending/20260713--cli--fix-agent-signup-masks-rejected-user-token.yaml
+++ b/changelog/pending/20260713--cli--fix-agent-signup-masks-rejected-user-token.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Under an AI coding agent, a stored login whose token the service has rejected (e.g. revoked or server-expired) no longer triggers automatic signup of a new anonymous agent account; the CLI now reports that `pulumi login` is required instead of silently switching identities
+time: 2026-07-13T00:00:00+00:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -614,6 +614,9 @@ func (m defaultLoginManager) Current(
 	} else if err != nil {
 		logging.V(7).Infof("Could not read default credentials for %q: %v", cloudURL, err)
 	}
+	// Whether a stored user identity existed and the service rejected it. Gates the agent
+	// auto-signup below so a rejected user isn't silently replaced by an anonymous agent account.
+	userAccountRejected := false
 	if err == nil && existingAccount.HasCredential() &&
 		(accessToken == "" || existingAccount.AccessToken == accessToken) {
 		var valid bool
@@ -632,6 +635,14 @@ func (m defaultLoginManager) Current(
 
 			return &existingAccount, nil
 		}
+
+		// validateStoredAccount reports invalid either for a genuine server rejection or for a token
+		// that expired locally with no refresh token — the latter being the only non-rejection case.
+		// Treat everything but that case as a rejection of a real identity.
+		tokenInfo := existingAccount.TokenInformation
+		locallyExpiredNoRefresh := tokenInfo != nil && tokenInfo.ExpiresAt != nil &&
+			tokenInfo.ExpiresAt.Before(time.Now()) && existingAccount.RefreshToken == ""
+		userAccountRejected = !locallyExpiredNoRefresh
 	}
 
 	// We either have no token saved, or PULUMI_ACCESS_TOKEN
@@ -642,6 +653,15 @@ func (m defaultLoginManager) Current(
 		if agent != "" {
 			if err != nil && hasExplicitPulumiPathEnv() {
 				return nil, err
+			}
+			if userAccountRejected {
+				// The service rejected the stored user credentials. Don't sign up a new anonymous
+				// agent account in their place — that would silently swap the user's identity.
+				// Mirrors the agent-account guard in currentOrSignupAgentAccount.
+				logging.V(7).Infof("Stored user credentials for %q were rejected; not creating an agent account", cloudURL)
+				return nil, fmt.Errorf(
+					"stored credentials for %q can no longer authenticate; ask the user to run `pulumi login`: %w",
+					cloudURL, errors.Join(ErrUnauthorized, backenderr.LoginRequiredError{}))
 			}
 			logging.V(7).Infof("Detected agent mode (%s); checking shared agent credentials", agent)
 			return m.currentOrSignupAgentAccount(ctx, cloudURL, insecure, setCurrent, agent)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -614,8 +614,8 @@ func (m defaultLoginManager) Current(
 	} else if err != nil {
 		logging.V(7).Infof("Could not read default credentials for %q: %v", cloudURL, err)
 	}
-	// Whether a stored user identity existed and the service rejected it. Gates the agent
-	// auto-signup below so a rejected user isn't silently replaced by an anonymous agent account.
+	// Whether a stored user identity existed and the service rejected it; gates the agent-signup
+	// branch below.
 	userAccountRejected := false
 	if err == nil && existingAccount.HasCredential() &&
 		(accessToken == "" || existingAccount.AccessToken == accessToken) {

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -798,6 +798,62 @@ func TestCurrentRejectedAgentCredentialsWithUnexpiredTokenDoesNotSignup(t *testi
 	assert.Equal(t, 0, signupCalls)
 }
 
+// A stored user (default) account whose token the service rejects must not be silently replaced by a
+// new anonymous agent account. This mirrors the agent-account guard above: a rejected identity
+// surfaces a login-required error rather than triggering auto-signup.
+//
+//nolint:paralleltest // mutates env vars, default credentials, and shared temporary agent credentials
+func TestCurrentRejectedUserAccountDoesNotSignupAgent(t *testing.T) {
+	oldAgentCreds, err := workspace.GetAgentStoredCredentials()
+	require.NoError(t, err)
+	oldAgentClaim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, workspace.DeleteAgentCredentials())
+		require.NoError(t, workspace.StoreAgentCredentials(oldAgentCreds))
+		if oldAgentClaim.ClaimURL != "" {
+			require.NoError(t, workspace.StoreAgentClaim(oldAgentClaim))
+		}
+	})
+
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+	t.Setenv("CODEX_SANDBOX", "1") // agent mode
+
+	signupCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/user":
+			rw.WriteHeader(http.StatusUnauthorized)
+		case "/api/agents/signup":
+			signupCalls++
+			rw.WriteHeader(http.StatusInternalServerError)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	// A revoked personal access token: no expiry recorded, no refresh token. validateStoredAccount
+	// reports it invalid only because the service 401s /api/user — a genuine rejection, not a local
+	// expiry.
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken: "revoked-user-token",
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.ErrorIs(t, err, ErrUnauthorized)
+	require.ErrorIs(t, err, backenderr.LoginRequiredError{})
+	assert.ErrorContains(t, err, "pulumi login")
+	assert.Nil(t, account)
+	assert.Equal(t, 0, signupCalls, "a rejected user identity must not trigger agent auto-signup")
+
+	agentAccount, err := workspace.GetAgentAccount(server.URL)
+	require.NoError(t, err)
+	assert.Empty(t, agentAccount.AccessToken, "no agent account may be created to mask the rejected user")
+}
+
 //nolint:paralleltest // mutates shared temporary agent credentials
 func TestCurrentValidAgentCredentialsWithExpiredClaimDoesNotSignup(t *testing.T) {
 	oldAgentCreds, err := workspace.GetAgentStoredCredentials()


### PR DESCRIPTION
## Problem

When the CLI runs under an AI coding agent (`CLAUDECODE`, `CODEX_SANDBOX`, etc.) with no `PULUMI_ACCESS_TOKEN` set, `defaultLoginManager.Current` auto-creates an anonymous agent account when there's no usable login. But it treated a **stored user login that the service rejected** (a revoked or server-expired token → 401) exactly like *no login at all*: it fell through to agent signup and silently replaced the user's identity with a fresh anonymous agent account.

The agent path already guards the symmetric case — if the *agent* account's own token is server-rejected but locally valid, it refuses to re-signup and asks the user to run `pulumi login` (`currentOrSignupAgentAccount`). The user-login path had no such guard. That asymmetry was the bug.

## Fix

In `Current`, when a stored user account existed and the service rejected it, return a login-required error instead of falling through to agent signup — mirroring the existing agent-account guard. Under an agent, the user now sees:

> stored credentials for `<url>` can no longer authenticate; ask the user to run `pulumi login`

The one case deliberately *not* treated as a rejection: a token that expired locally with no refresh token. `validateStoredAccount` returns invalid from exactly two branches — the `expired && account.RefreshToken == ""` short-circuit (declared invalid locally, never sent to the server) and the `errors.Is(err, ErrUnauthorized)` branch (a genuine 401). They're mutually exclusive by construction, so `locallyExpiredNoRefresh` is the exact complement of "server rejected." Only the 401 is a rejection of a live identity; the local-expiry case is excluded, so a genuinely dead, unrefreshable token still lets a fresh agent proceed.

## Notable choices

- **The discriminator reads the returned account's own fields rather than widening `validateStoredAccount`.** `locallyExpiredNoRefresh` (`TokenInformation.ExpiresAt` in the past + empty `RefreshToken`) reconstructs the one non-rejection branch from the account itself. (Widening `validateStoredAccount` to report its invalid-reason directly is the cleaner shape; deferred to keep this narrow.)
- **Scoped to agent mode.** Non-agent invocations are unchanged: a rejected token still yields `nil, nil` ("not logged in"), which drives the normal login prompt. The new error only fires where the silent-signup problem exists.

## Test plan

- [x] `TestCurrentRejectedUserAccountDoesNotSignupAgent` (new) — a stored user token that 401s under agent mode must surface a login-required error and make **zero** signup calls. Verified red→green: against base it falls through to `/api/agents/signup`.
- [x] `go test ./pkg/backend/httpstate/` — full package green; no pre-existing test asserted the old fall-through behavior.
