### PR TITLE
Type check snippets before persisting them

### DIFF
--- a/changelog/pending/engine-fix-20260714-092027.yaml
+++ b/changelog/pending/engine-fix-20260714-092027.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Validate snippets before persisting them
+time: 2026-07-14T09:20:27.306103+01:00

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -264,6 +264,12 @@ func newDeployment(
 		contract.IgnoreClose(plugctx)
 		return nil, err
 	}
+	if len(opts.Snippets) > 0 && !opts.DryRun {
+		if err := persistValidatedSnippets(baseCtx, ctx.SnapshotManager, target.Snapshot.Snippets, plugctx); err != nil {
+			contract.IgnoreClose(plugctx)
+			return nil, err
+		}
+	}
 
 	deplOpts := &deploy.Options{
 		ParallelDiff:              opts.ParallelDiff,

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -1763,6 +1763,27 @@ func TestPclSnippetOptionValidation(t *testing.T) {
 			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "delete-missing")
 		require.ErrorContains(t, err, fmt.Sprintf("cannot delete snippet %q: no such snippet in snapshot", snippetID))
 	})
+
+	t.Run("invalid snippet is not persisted", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
+			snippetID: {
+				Name: "test-resource", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       ``,
+			},
+		}
+
+		snap, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "invalid")
+		require.ErrorContains(t, err, "bind snippet")
+		require.ErrorContains(t, err, "missing required attribute 'propA'")
+		require.NotNil(t, snap)
+		require.Empty(t, snap.Snippets)
+	})
 }
 
 // newPclSnippetTestPlan returns an empty-snapshot TestPlan wired to the standard pkgA snippet

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -572,12 +572,6 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	logging.V(7).Infof("*** Starting Update(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Update(preview=%v) complete ***", dryRun)
 
-	if len(opts.Snippets) > 0 && !dryRun && ctx.SnapshotManager != nil {
-		if err := ctx.SnapshotManager.SetSnippets(effectiveSnippets); err != nil {
-			return nil, nil, err
-		}
-	}
-
 	// We skip the target check here because the targeted resource may not exist yet.
 
 	return update(ctx, info, &deploymentOptions{
@@ -589,6 +583,27 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 		DryRun:        dryRun,
 		pluginManager: ctx.PluginManager,
 	})
+}
+
+func persistValidatedSnippets(
+	ctx context.Context,
+	manager SnapshotManager,
+	snippets []resource.Snippet,
+	plugctx *plugin.Context,
+) error {
+	if manager == nil {
+		return nil
+	}
+	loader := schema.NewPluginLoader(plugctx)
+	for _, snippet := range snippets {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := deploy.ValidateSnippet(snippet, loader); err != nil {
+			return err
+		}
+	}
+	return manager.SetSnippets(snippets)
 }
 
 func installPlugins(

--- a/pkg/resource/deploy/snippet_source.go
+++ b/pkg/resource/deploy/snippet_source.go
@@ -68,6 +68,77 @@ func NewSnippetSource(ctx context.Context,
 	return src.run
 }
 
+// ValidateSnippet parses and binds a PCL resource snippet against its package schema.
+func ValidateSnippet(s resource.Snippet, loader schema.ReferenceLoader) error {
+	_, _, err := bindSnippetProgram(&s, loader)
+	return err
+}
+
+func bindSnippetProgram(
+	snippet *resource.Snippet,
+	loader schema.ReferenceLoader,
+) (*pcl.Program, map[string]*schema.PackageDescriptor, error) {
+	// Build the schema.PackageDescriptor from the structurally-attached Snippet.Descriptor. The binder and
+	// interpreter both consult this to load the right (possibly parameterized) package schema.
+	var parameterization *schema.ParameterizationDescriptor
+	if snippet.Descriptor.Parameterization != nil {
+		parameterization = &schema.ParameterizationDescriptor{
+			Name:    snippet.Descriptor.Parameterization.Name,
+			Version: snippet.Descriptor.Parameterization.Version,
+			Value:   snippet.Descriptor.Parameterization.Value,
+		}
+	}
+	descriptor := &schema.PackageDescriptor{
+		Name:             snippet.Descriptor.Name,
+		Version:          snippet.Descriptor.Version,
+		DownloadURL:      snippet.Descriptor.DownloadURL,
+		Parameterization: parameterization,
+	}
+
+	// Determine the package name the binder will key the descriptor by. For unparameterized snippets this is
+	// the descriptor's Name; for parameterized snippets it's the parameterization's Name (the alias visible
+	// to PCL code). DecomposeToken on the snippet's Type gives us that key directly.
+	pkgName, _, _, diags := pcl.DecomposeToken(snippet.Type, hcl.Range{})
+	if diags.HasErrors() {
+		return nil, nil, fmt.Errorf("invalid snippet type %q: %s", snippet.Type, diags.Error())
+	}
+	packageDescriptors := map[string]*schema.PackageDescriptor{pkgName: descriptor}
+
+	// Parse the snippet as a resource body. Use the snippet's name in the filename so diagnostics
+	// distinguish between multiple snippets in the same update.
+	filename := fmt.Sprintf("<snippet:%s>", snippet.Name)
+	parser := hclsyntax.NewParser()
+	if err := parser.ParseFile(strings.NewReader(snippet.Code), filename); err != nil {
+		return nil, nil, fmt.Errorf("parse snippet: %w", err)
+	}
+	if parser.Diagnostics.HasErrors() {
+		return nil, nil, fmt.Errorf("parse snippet: %v", parser.Diagnostics)
+	}
+
+	// Pre-declare scope variables for References so the binder typechecks `producer.value` and friends
+	// without seeing a `resource` block for them. The runtime values are injected on the eval context
+	// further down once the registration observer has resolved each URN.
+	bindOpts := []pcl.BindOption{
+		pcl.PackageDescriptors(packageDescriptors),
+	}
+	if len(snippet.References) > 0 {
+		extras := make(map[string]*model.Variable, len(snippet.References))
+		for name := range snippet.References {
+			extras[name] = &model.Variable{Name: name, VariableType: model.DynamicType}
+		}
+		bindOpts = append(bindOpts, pcl.ExtraScopeVariables(extras))
+	}
+	program, diags, err := pcl.BindResourceProgram(
+		parser.Files[0], snippet.Name, snippet.Type, loader, bindOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("bind snippet: %w", err)
+	}
+	if diags.HasErrors() {
+		return nil, nil, fmt.Errorf("bind snippet: %v", diags)
+	}
+	return program, packageDescriptors, nil
+}
+
 func (s *snippet) run(resourceMonitorTarget string) *promise.Promise[struct{}] {
 	cts := &promise.CompletionSource[struct{}]{}
 
@@ -81,67 +152,9 @@ func (s *snippet) run(resourceMonitorTarget string) *promise.Promise[struct{}] {
 			fail(err)
 			return
 		}
-		// Build the schema.PackageDescriptor from the structurally-attached Snippet.Descriptor. The binder and
-		// interpreter both consult this to load the right (possibly parameterized) package schema.
-		var parameterization *schema.ParameterizationDescriptor
-		if s.snippet.Descriptor.Parameterization != nil {
-			parameterization = &schema.ParameterizationDescriptor{
-				Name:    s.snippet.Descriptor.Parameterization.Name,
-				Version: s.snippet.Descriptor.Parameterization.Version,
-				Value:   s.snippet.Descriptor.Parameterization.Value,
-			}
-		}
-		descriptor := &schema.PackageDescriptor{
-			Name:             s.snippet.Descriptor.Name,
-			Version:          s.snippet.Descriptor.Version,
-			DownloadURL:      s.snippet.Descriptor.DownloadURL,
-			Parameterization: parameterization,
-		}
-
-		// Determine the package name the binder will key the descriptor by. For unparameterized snippets this is
-		// the descriptor's Name; for parameterized snippets it's the parameterization's Name (the alias visible
-		// to PCL code). DecomposeToken on the snippet's Type gives us that key directly.
-		pkgName, _, _, diags := pcl.DecomposeToken(s.snippet.Type, hcl.Range{})
-		if diags.HasErrors() {
-			fail(fmt.Errorf("invalid snippet type %q: %s", s.snippet.Type, diags.Error()))
-			return
-		}
-		packageDescriptors := map[string]*schema.PackageDescriptor{pkgName: descriptor}
-
-		// Parse the snippet as a resource body. Use the snippet's name in the filename so diagnostics
-		// distinguish between multiple snippets in the same update.
-		filename := fmt.Sprintf("<snippet:%s>", s.snippet.Name)
-		parser := hclsyntax.NewParser()
-		if err := parser.ParseFile(strings.NewReader(s.snippet.Code), filename); err != nil {
-			fail(fmt.Errorf("parse snippet: %w", err))
-			return
-		}
-		if parser.Diagnostics.HasErrors() {
-			fail(fmt.Errorf("parse snippet: %v", parser.Diagnostics))
-			return
-		}
-
-		// Pre-declare scope variables for References so the binder typechecks `producer.value` and friends
-		// without seeing a `resource` block for them. The runtime values are injected on the eval context
-		// further down once the registration observer has resolved each URN.
-		bindOpts := []pcl.BindOption{
-			pcl.PackageDescriptors(packageDescriptors),
-		}
-		if len(s.snippet.References) > 0 {
-			extras := make(map[string]*model.Variable, len(s.snippet.References))
-			for name := range s.snippet.References {
-				extras[name] = &model.Variable{Name: name, VariableType: model.DynamicType}
-			}
-			bindOpts = append(bindOpts, pcl.ExtraScopeVariables(extras))
-		}
-		program, diags, err := pcl.BindResourceProgram(
-			parser.Files[0], s.snippet.Name, s.snippet.Type, s.loader, bindOpts...)
+		program, packageDescriptors, err := bindSnippetProgram(s.snippet, s.loader)
 		if err != nil {
-			fail(fmt.Errorf("bind snippet: %w", err))
-			return
-		}
-		if diags.HasErrors() {
-			fail(fmt.Errorf("bind snippet: %v", diags))
+			fail(err)
 			return
 		}
 

--- a/pkg/resource/deploy/snippet_source_wasm.go
+++ b/pkg/resource/deploy/snippet_source_wasm.go
@@ -37,6 +37,11 @@ func NewSnippetSource(
 	return unsupportedWasmSource("snippet sources are not supported in wasm builds")
 }
 
+// ValidateSnippet is unavailable in wasm builds.
+func ValidateSnippet(resource.Snippet, schema.ReferenceLoader) error {
+	return errors.New("snippet validation is not supported in wasm builds")
+}
+
 // NewMuxSource is unavailable in wasm display builds when secondary sources are present.
 func NewMuxSource(
 	_ context.Context,


### PR DESCRIPTION
Change snippet logic to validate and type check the snippet before persisting it to the snapshot system. This used to eagerly save the snippets when added so you could end up with invalid snippets in state.