### PR TITLE
do: introduce --timeout flag

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -502,6 +502,7 @@ type packageCommand struct {
 	providerFile      string
 	providerURN       string
 	format            string
+	timeout           string
 	spec              schema.PackageReference
 	providerDef       *schema.Resource
 	dryrun            bool

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
@@ -97,6 +98,17 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 	return cmd
 }
 
+func (pc *packageCommand) timeoutSeconds() (float64, error) {
+	if pc.timeout == "" {
+		return 0, nil
+	}
+	duration, err := time.ParseDuration(pc.timeout)
+	if err != nil {
+		return 0, fmt.Errorf("parse --timeout: %w", err)
+	}
+	return duration.Seconds(), nil
+}
+
 func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.Command {
 	var inputFile string
 	var yes bool
@@ -109,6 +121,10 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 				return errStatefulNotImplemented("create")
 			}
 			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			timeout, err := pc.timeoutSeconds()
+			if err != nil {
 				return err
 			}
 			ctx := cmd.Context()
@@ -137,6 +153,7 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 					Name:       urn.Name(),
 					Type:       urn.Type(),
 					Properties: checked,
+					Timeout:    timeout,
 					Preview:    pc.dryrun,
 				})
 				if err != nil {
@@ -178,16 +195,22 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
+	cmd.Flags().StringVar(&pc.timeout, "timeout", "",
+		"Timeout for the operation, specified as a duration (e.g. 30s, 5m, 1h)")
 	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
 }
 
 func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "read <id>",
 		Short: "Read a resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			timeout, err := pc.timeoutSeconds()
+			if err != nil {
+				return err
+			}
 			ctx := cmd.Context()
 			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
@@ -199,12 +222,13 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 				New: operationState(urn, id, nil, nil),
 			}, func() (*resource.State, error) {
 				response, err := pc.provider.Read(ctx, plugin.ReadRequest{
-					URN:    urn,
-					Name:   urn.Name(),
-					Type:   urn.Type(),
-					ID:     id,
-					Inputs: resource.PropertyMap{},
-					State:  resource.PropertyMap{},
+					URN:     urn,
+					Name:    urn.Name(),
+					Type:    urn.Type(),
+					ID:      id,
+					Inputs:  resource.PropertyMap{},
+					State:   resource.PropertyMap{},
+					Timeout: timeout,
 				})
 				if err != nil {
 					return nil, err
@@ -219,6 +243,9 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 			})
 		},
 	}
+	cmd.Flags().StringVar(&pc.timeout, "timeout", "",
+		"Timeout for the operation, specified as a duration (e.g. 30s, 5m, 1h)")
+	return cmd
 }
 
 func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.Command {
@@ -234,6 +261,10 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 				return errStatefulNotImplemented("patch")
 			}
 			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			timeout, err := pc.timeoutSeconds()
+			if err != nil {
 				return err
 			}
 			ctx := cmd.Context()
@@ -309,6 +340,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 					OldInputs:  oldInputs,
 					OldOutputs: read.Outputs,
 					NewInputs:  checked,
+					Timeout:    timeout,
 					Preview:    pc.dryrun,
 				})
 				if err != nil {
@@ -322,6 +354,8 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
+	cmd.Flags().StringVar(&pc.timeout, "timeout", "",
+		"Timeout for the operation, specified as a duration (e.g. 30s, 5m, 1h)")
 	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
 }
@@ -337,6 +371,10 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 				return errStatefulNotImplemented("delete")
 			}
 			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			timeout, err := pc.timeoutSeconds()
+			if err != nil {
 				return err
 			}
 			ctx := cmd.Context()
@@ -386,6 +424,7 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 					ID:      id,
 					Inputs:  response.Inputs,
 					Outputs: response.Outputs,
+					Timeout: timeout,
 				})
 				return nil, err
 			})
@@ -393,6 +432,8 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 	}
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
+	cmd.Flags().StringVar(&pc.timeout, "timeout", "",
+		"Timeout for the operation, specified as a duration (e.g. 30s, 5m, 1h)")
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -219,6 +219,7 @@ func TestDoCmdResourceCreate(t *testing.T) {
 			CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 				calls = append(calls, "create")
 				assert.Equal(t, "example", req.Properties["name"].StringValue())
+				assert.Equal(t, 90.0, req.Timeout)
 				return plugin.CreateResponse{
 					ID: "res-1",
 					Properties: resource.PropertyMap{
@@ -237,7 +238,7 @@ size = 2
 `)
 	cmd.SetArgs([]string{
 		"--stateless", "azure:index:myResource", "create", "--yes",
-		"--input", "pcl", "--input-file", inputFile, "--output", "json",
+		"--input", "pcl", "--input-file", inputFile, "--output", "json", "--timeout", "1m30s",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -335,6 +336,7 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 					assert.Equal(t, resource.ID("res-1"), req.ID)
+					assert.Equal(t, 90.0, req.Timeout)
 					return plugin.ReadResponse{
 						ReadResult: plugin.ReadResult{
 							ID: "res-1",
@@ -347,7 +349,7 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 				},
 			},
 		})
-		cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1", "--output", "json"})
+		cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1", "--output", "json", "--timeout", "1m30s"})
 		err := cmd.Execute()
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"id":"res-1","name":"read","size":3}`, stdout.String())
@@ -372,12 +374,13 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 					assert.Equal(t, resource.ID("res-1"), req.ID)
 					assert.Equal(t, resource.PropertyMap{"name": resource.NewProperty("in")}, req.Inputs)
 					assert.Equal(t, resource.PropertyMap{"name": resource.NewProperty("out")}, req.Outputs)
+					assert.Equal(t, 90.0, req.Timeout)
 					deleted = true
 					return plugin.DeleteResponse{}, nil
 				},
 			},
 		})
-		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes", "--timeout", "1m30s"})
 		err := cmd.Execute()
 		require.NoError(t, err)
 		assert.True(t, deleted)
@@ -428,6 +431,7 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 					assert.Equal(t, "new", req.NewInputs["name"].StringValue())
 					assert.Equal(t, 1.0, req.NewInputs["size"].NumberValue())
 					assert.Equal(t, true, req.NewInputs["enabled"].BoolValue())
+					assert.Equal(t, 90.0, req.Timeout)
 					return plugin.UpdateResponse{
 						Properties: resource.PropertyMap{
 							"name":    resource.NewProperty("new"),
@@ -445,7 +449,7 @@ enabled = true
 `)
 		cmd.SetArgs([]string{
 			"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
-			"--input", "pcl", "--input-file", inputFile, "--output", "json",
+			"--input", "pcl", "--input-file", inputFile, "--output", "json", "--timeout", "1m30s",
 		})
 		err := cmd.Execute()
 		require.NoError(t, err)
@@ -587,6 +591,15 @@ func TestDoCmdResourceList(t *testing.T) {
 		err := cmd.Execute()
 		require.ErrorContains(t, err, "--all and --count are mutually exclusive")
 	})
+}
+
+func TestDoCmdResourceTimeoutInvalidDuration(t *testing.T) {
+	t.Parallel()
+
+	cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
+	cmd.SetArgs([]string{"azure:index:myResource", "read", "res-1", "--timeout", "bogus"})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "parse --timeout")
 }
 
 // TestDoCmdResourceNonInteractiveRequiresYes asserts that destructive subcommands refuse to run when the user is


### PR DESCRIPTION
`do` operations can potentially take a long time, since they are
operations on a cloud provider. Add a `--timeout` flag, which
essentially works the same as the timeout resource option.