### PR TITLE
Fix dangling ReplaceWith references in the journal replayer

### DIFF
--- a/changelog/pending/backend-fix-journal-replacewith.yaml
+++ b/changelog/pending/backend-fix-journal-replacewith.yaml
@@ -1,0 +1,4 @@
+component: backend
+kind: fix
+body: Fix dangling ReplaceWith references in the journal replayer
+time: 2026-07-14T15:09:07.610190+02:00

--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -287,10 +287,14 @@ func rebuildDependencies(resources []apitype.ResourceV3) {
 				}
 			}
 		}
-		for i, r := range resources[i].ReplaceWith {
-			if !referenceable[r] {
-				resources[i].ReplaceWith = append(resources[i].ReplaceWith, "")
+		newReplaceWith := []resource.URN{}
+		for _, r := range resources[i].ReplaceWith {
+			if referenceable[r] {
+				newReplaceWith = append(newReplaceWith, r)
 			}
+		}
+		if len(resources[i].ReplaceWith) > 0 {
+			resources[i].ReplaceWith = newReplaceWith
 		}
 		if !referenceable[resources[i].DeletedWith] {
 			resources[i].DeletedWith = ""

--- a/pkg/backend/journal_test.go
+++ b/pkg/backend/journal_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,4 +73,55 @@ func TestJournalReplayerSeedsExtensionsFromBase(t *testing.T) {
 	require.Contains(t, deployment.Deployment.Extensions, ref,
 		"extensions from base must survive replay even with no extension journal entries")
 	assert.Equal(t, ext, deployment.Deployment.Extensions[ref])
+}
+
+// TestJournalReplayerRefreshPrunesReplaceWith tests that a targeted refresh which deletes a resource prunes
+// dangling ReplaceWith references to it from resources that were not themselves refreshed, while keeping
+// references that are still valid.
+func TestJournalReplayerRefreshPrunesReplaceWith(t *testing.T) {
+	t.Parallel()
+
+	res := func(name string) apitype.ResourceV3 {
+		return apitype.ResourceV3{
+			URN:    resource.URN("urn:pulumi:test::test::pkgA:m:typA::" + name),
+			Type:   "pkgA:m:typA",
+			Custom: true,
+			ID:     resource.ID("id-" + name),
+		}
+	}
+	a, b := res("a"), res("b")
+	unrelated, dependent := res("unrelated"), res("dependent")
+	dependent.ReplaceWith = []resource.URN{a.URN, b.URN}
+	base := &apitype.DeploymentV3{Resources: []apitype.ResourceV3{a, b, unrelated, dependent}}
+
+	replayer := NewJournalReplayer(base)
+
+	// Model a targeted refresh of only "b" (index 1 of the base snapshot), where the provider reports that
+	// "b" no longer exists. "dependent" is not refreshed, so replay must repair the ReplaceWith list from its
+	// old state in the base snapshot.
+	removeOld := int64(1)
+	require.NoError(t, replayer.Add(apitype.JournalEntry{
+		Kind:        apitype.JournalEntryKindRefreshSuccess,
+		OperationID: 1,
+		RemoveOld:   &removeOld,
+	}))
+
+	deployment, err := replayer.GenerateDeployment()
+	require.NoError(t, err)
+
+	byURN := make(map[resource.URN]apitype.ResourceV3, len(deployment.Deployment.Resources))
+	for _, r := range deployment.Deployment.Resources {
+		byURN[r.URN] = r
+	}
+	require.NotContains(t, byURN, b.URN)
+	require.Contains(t, byURN, dependent.URN)
+
+	// The reference to the deleted "b" is pruned and the reference to the surviving "a" is kept.
+	assert.Equal(t, []resource.URN{a.URN}, byURN[dependent.URN].ReplaceWith)
+	// The old implementation shadowed the current resource index and could append an empty URN to an unrelated
+	// resource instead of repairing the dependent resource.
+	assert.Empty(t, byURN[unrelated.URN].ReplaceWith)
+	for _, r := range deployment.Deployment.Resources {
+		assert.NotContains(t, r.ReplaceWith, resource.URN(""), "resource %s", r.URN)
+	}
 }

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -919,6 +919,7 @@ func (ex *deploymentExecutor) rebuildBaseState(resourceToStep map[*resource.Stat
 
 		newDeps := []resource.URN{}
 		newPropDeps := map[resource.PropertyKey][]resource.URN{}
+		newReplaceWith := []resource.URN{}
 
 		_, allDeps := new.GetAllDependencies()
 		for _, dep := range allDeps {
@@ -940,14 +941,14 @@ func (ex *deploymentExecutor) rebuildBaseState(resourceToStep map[*resource.Stat
 					new.DeletedWith = ""
 				}
 			case resource.ResourceReplaceWith:
-				if !referenceable[dep.URN] {
-					new.ReplaceWith = nil
+				if referenceable[dep.URN] {
+					newReplaceWith = append(newReplaceWith, dep.URN)
 				}
 			}
 		}
 
-		// Since we can only have shrunk the sets of dependencies and property
-		// dependencies, we'll only update them if they were non empty to begin
+		// Since we can only have shrunk the sets of dependencies, property dependencies,
+		// and replace-with dependencies, we'll only update them if they were non empty to begin
 		// with. This is to avoid e.g. replacing a nil input with an non-nil but
 		// empty output, which while equivalent in many cases is not the same and
 		// could result in subtly different behaviour in some parts of the engine.
@@ -956,6 +957,9 @@ func (ex *deploymentExecutor) rebuildBaseState(resourceToStep map[*resource.Stat
 		}
 		if len(new.PropertyDependencies) > 0 {
 			new.PropertyDependencies = newPropDeps
+		}
+		if len(new.ReplaceWith) > 0 {
+			new.ReplaceWith = newReplaceWith
 		}
 
 		// Add this resource to the resource list and mark it as referenceable.

--- a/pkg/resource/deploy/deployment_executor_test.go
+++ b/pkg/resource/deploy/deployment_executor_test.go
@@ -127,6 +127,23 @@ func TestRebuildBaseStateDeletedWith(t *testing.T) {
 	}, ex.deployment.olds)
 }
 
+func TestRebuildBaseStateReplaceWith(t *testing.T) {
+	t.Parallel()
+
+	steps, ex := makeStepsAndExecutor(
+		&resource.State{URN: "A"},
+		// "B" is missing.
+		&resource.State{URN: "C", ReplaceWith: []resource.URN{"A", "B"}},
+	)
+
+	ex.rebuildBaseState(steps)
+
+	assert.EqualValues(t, map[resource.URN]*resource.State{
+		"A": {URN: "A"},
+		"C": {URN: "C", ReplaceWith: []resource.URN{"A"}},
+	}, ex.deployment.olds)
+}
+
 func TestRebuildBaseStatePropertyDependencies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When a targeted journaled refresh removes a resource, prune dangling ReplaceWith references while preserving valid ones.
