### PR TITLE
Add parent and properties to ResourceImport in the converter protocol

### DIFF
--- a/changelog/pending/protobuf-improvement-20260714-160121.yaml
+++ b/changelog/pending/protobuf-improvement-20260714-160121.yaml
@@ -2,3 +2,5 @@ component: protobuf
 kind: improvement
 body: Add parent and properties fields to ResourceImport so state converters can express resource hierarchy and property filters
 time: 2026-07-14T16:01:21.472291+02:00
+custom:
+    PR: "23929"

--- a/changelog/pending/protobuf-improvement-20260714-160121.yaml
+++ b/changelog/pending/protobuf-improvement-20260714-160121.yaml
@@ -1,0 +1,4 @@
+component: protobuf
+kind: improvement
+body: Add parent and properties fields to ResourceImport so state converters can express resource hierarchy and property filters
+time: 2026-07-14T16:01:21.472291+02:00

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -104,6 +104,8 @@ func makeImportFileFromResourceList(resources []plugin.ResourceImport) (importFi
 			Component:         res.IsComponent,
 			Remote:            res.IsRemote,
 			LogicalName:       res.LogicalName,
+			Parent:            res.Parent,
+			Properties:        res.Properties,
 		}
 		if p := res.Parameterization; p != nil {
 			specs[i].Parameterization = &importParameterization{

--- a/pkg/resource/plugin/converter.go
+++ b/pkg/resource/plugin/converter.go
@@ -41,6 +41,14 @@ type ResourceImport struct {
 	// Extension is set when an extension parameterization should be applied to the resource's (base)
 	// provider. Mutually exclusive with Parameterization.
 	Extension *ResourceExtension
+
+	// Parent is the name of the resource's parent, if any. It must reference the name of another resource
+	// in the same response; resources without a parent are parented to the stack root.
+	Parent string
+
+	// Properties lists the input properties to include when generating code for the resource. Defaults to
+	// the resource's required properties.
+	Properties []string
 }
 
 // ResourceParameterization describes the base plugin that a resource's parameterized provider is built

--- a/pkg/resource/plugin/converter_plugin.go
+++ b/pkg/resource/plugin/converter_plugin.go
@@ -135,6 +135,8 @@ func (c *converter) ConvertState(ctx context.Context, req *ConvertStateRequest) 
 			LogicalName:       resource.LogicalName,
 			IsRemote:          resource.IsRemote,
 			IsComponent:       resource.IsComponent,
+			Parent:            resource.Parent,
+			Properties:        resource.Properties,
 		}
 		if p := resource.Parameterization; p != nil {
 			resources[i].Parameterization = &ResourceParameterization{

--- a/pkg/resource/plugin/converter_plugin_test.go
+++ b/pkg/resource/plugin/converter_plugin_test.go
@@ -64,6 +64,8 @@ func (c *testConverterClient) ConvertState(
 					Version: "4.5.6",
 					Value:   []byte("test:extValue"),
 				},
+				Parent:     "test:parent",
+				Properties: []string{"prop1", "prop2"},
 			},
 		},
 		Diagnostics: c.diagnostics,
@@ -154,6 +156,8 @@ func TestConverterPlugin_State(t *testing.T) {
 	assert.Equal(t, "test:extension", res.Extension.Name)
 	assert.Equal(t, "4.5.6", res.Extension.Version)
 	assert.Equal(t, []byte("test:extValue"), res.Extension.Value)
+	assert.Equal(t, "test:parent", res.Parent)
+	assert.Equal(t, []string{"prop1", "prop2"}, res.Properties)
 
 	diag := resp.Diagnostics[0]
 	assert.Equal(t, hcl.DiagError, diag.Severity)

--- a/pkg/resource/plugin/converter_server.go
+++ b/pkg/resource/plugin/converter_server.go
@@ -54,6 +54,8 @@ func (c *converterServer) ConvertState(ctx context.Context,
 			LogicalName:       resource.LogicalName,
 			IsRemote:          resource.IsRemote,
 			IsComponent:       resource.IsComponent,
+			Parent:            resource.Parent,
+			Properties:        resource.Properties,
 		}
 		if p := resource.Parameterization; p != nil {
 			resources[i].Parameterization = &pulumirpc.ResourceParameterization{

--- a/pkg/resource/plugin/converter_server_test.go
+++ b/pkg/resource/plugin/converter_server_test.go
@@ -72,6 +72,8 @@ func (c *testConverter) ConvertState(
 					Version: "4.5.6",
 					Value:   []byte("test:extValue"),
 				},
+				Parent:     "test:parent",
+				Properties: []string{"prop1", "prop2"},
 			},
 		},
 		Diagnostics: diags,
@@ -165,6 +167,8 @@ func TestConverterServer_State(t *testing.T) {
 	assert.Equal(t, "test:extension", res.Extension.Name)
 	assert.Equal(t, "4.5.6", res.Extension.Version)
 	assert.Equal(t, []byte("test:extValue"), res.Extension.Value)
+	assert.Equal(t, "test:parent", res.Parent)
+	assert.Equal(t, []string{"prop1", "prop2"}, res.Properties)
 
 	diag := resp.Diagnostics[0]
 	assert.Equal(t, codegenrpc.DiagnosticSeverity_DIAG_ERROR, diag.Severity)

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -73,6 +73,14 @@ message ResourceImport {
     // parameterization, the resource's own type is in the base provider's package; the extension is a blob
     // applied on top of that provider. Mutually exclusive with parameterization.
     ResourceExtension extension = 10;
+
+    // the name of the resource's parent, if any. Must reference the name of another resource in the same
+    // response; resources without a parent are parented to the stack root.
+    string parent = 11;
+
+    // the input properties to include when generating code for the resource. Defaults to the resource's
+    // required properties.
+    repeated string properties = 12;
 }
 
 // A ResourceParameterization describes the base plugin that a resource's parameterized provider is built

--- a/sdk/nodejs/proto/converter_pb.d.ts
+++ b/sdk/nodejs/proto/converter_pb.d.ts
@@ -60,6 +60,12 @@ export class ResourceImport extends jspb.Message {
     clearExtension$(): void;
     getExtension$(): ResourceExtension | undefined;
     setExtension$(value?: ResourceExtension): ResourceImport;
+    getParent(): string;
+    setParent(value: string): ResourceImport;
+    clearPropertiesList(): void;
+    getPropertiesList(): Array<string>;
+    setPropertiesList(value: Array<string>): ResourceImport;
+    addProperties(value: string, index?: number): string;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): ResourceImport.AsObject;
@@ -83,6 +89,8 @@ export namespace ResourceImport {
         isRemote: boolean,
         parameterization?: ResourceParameterization.AsObject,
         extension?: ResourceExtension.AsObject,
+        parent: string,
+        propertiesList: Array<string>,
     }
 }
 

--- a/sdk/nodejs/proto/converter_pb.js
+++ b/sdk/nodejs/proto/converter_pb.js
@@ -60,7 +60,7 @@ if (goog.DEBUG && !COMPILED) {
  * @constructor
  */
 proto.pulumirpc.ResourceImport = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.pulumirpc.ResourceImport.repeatedFields_, null);
 };
 goog.inherits(proto.pulumirpc.ResourceImport, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
@@ -404,6 +404,13 @@ proto.pulumirpc.ConvertStateRequest.prototype.clearArgsList = function() {
 
 
 
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.pulumirpc.ResourceImport.repeatedFields_ = [12];
+
 
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
@@ -444,7 +451,9 @@ logicalName: jspb.Message.getFieldWithDefault(msg, 6, ""),
 isComponent: jspb.Message.getBooleanFieldWithDefault(msg, 7, false),
 isRemote: jspb.Message.getBooleanFieldWithDefault(msg, 8, false),
 parameterization: (f = msg.getParameterization()) && proto.pulumirpc.ResourceParameterization.toObject(includeInstance, f),
-extension: (f = msg.getExtension$()) && proto.pulumirpc.ResourceExtension.toObject(includeInstance, f)
+extension: (f = msg.getExtension$()) && proto.pulumirpc.ResourceExtension.toObject(includeInstance, f),
+parent: jspb.Message.getFieldWithDefault(msg, 11, ""),
+propertiesList: (f = jspb.Message.getRepeatedField(msg, 12)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -522,6 +531,14 @@ proto.pulumirpc.ResourceImport.deserializeBinaryFromReader = function(msg, reade
       var value = new proto.pulumirpc.ResourceExtension;
       reader.readMessage(value,proto.pulumirpc.ResourceExtension.deserializeBinaryFromReader);
       msg.setExtension$(value);
+      break;
+    case 11:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setParent(value);
+      break;
+    case 12:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addProperties(value);
       break;
     default:
       reader.skipField();
@@ -622,6 +639,20 @@ proto.pulumirpc.ResourceImport.serializeBinaryToWriter = function(message, write
       10,
       f,
       proto.pulumirpc.ResourceExtension.serializeBinaryToWriter
+    );
+  }
+  f = message.getParent();
+  if (f.length > 0) {
+    writer.writeString(
+      11,
+      f
+    );
+  }
+  f = message.getPropertiesList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      12,
+      f
     );
   }
 };
@@ -842,6 +873,61 @@ proto.pulumirpc.ResourceImport.prototype.clearExtension$ = function() {
  */
 proto.pulumirpc.ResourceImport.prototype.hasExtension$ = function() {
   return jspb.Message.getField(this, 10) != null;
+};
+
+
+/**
+ * optional string parent = 11;
+ * @return {string}
+ */
+proto.pulumirpc.ResourceImport.prototype.getParent = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 11, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.pulumirpc.ResourceImport} returns this
+ */
+proto.pulumirpc.ResourceImport.prototype.setParent = function(value) {
+  return jspb.Message.setProto3StringField(this, 11, value);
+};
+
+
+/**
+ * repeated string properties = 12;
+ * @return {!Array<string>}
+ */
+proto.pulumirpc.ResourceImport.prototype.getPropertiesList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 12));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.pulumirpc.ResourceImport} returns this
+ */
+proto.pulumirpc.ResourceImport.prototype.setPropertiesList = function(value) {
+  return jspb.Message.setField(this, 12, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.pulumirpc.ResourceImport} returns this
+ */
+proto.pulumirpc.ResourceImport.prototype.addProperties = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 12, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.pulumirpc.ResourceImport} returns this
+ */
+proto.pulumirpc.ResourceImport.prototype.clearPropertiesList = function() {
+  return this.setPropertiesList([]);
 };
 
 

--- a/sdk/proto/go/converter.pb.go
+++ b/sdk/proto/go/converter.pb.go
@@ -116,7 +116,13 @@ type ResourceImport struct {
 	// the extension parameterization to apply to the resource's provider, if any. Unlike a replacement
 	// parameterization, the resource's own type is in the base provider's package; the extension is a blob
 	// applied on top of that provider. Mutually exclusive with parameterization.
-	Extension     *ResourceExtension `protobuf:"bytes,10,opt,name=extension,proto3" json:"extension,omitempty"`
+	Extension *ResourceExtension `protobuf:"bytes,10,opt,name=extension,proto3" json:"extension,omitempty"`
+	// the name of the resource's parent, if any. Must reference the name of another resource in the same
+	// response; resources without a parent are parented to the stack root.
+	Parent string `protobuf:"bytes,11,opt,name=parent,proto3" json:"parent,omitempty"`
+	// the input properties to include when generating code for the resource. Defaults to the resource's
+	// required properties.
+	Properties    []string `protobuf:"bytes,12,rep,name=properties,proto3" json:"properties,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -217,6 +223,20 @@ func (x *ResourceImport) GetParameterization() *ResourceParameterization {
 func (x *ResourceImport) GetExtension() *ResourceExtension {
 	if x != nil {
 		return x.Extension
+	}
+	return nil
+}
+
+func (x *ResourceImport) GetParent() string {
+	if x != nil {
+		return x.Parent
+	}
+	return ""
+}
+
+func (x *ResourceImport) GetProperties() []string {
+	if x != nil {
+		return x.Properties
 	}
 	return nil
 }
@@ -712,7 +732,7 @@ const file_pulumi_converter_proto_rawDesc = "" +
 	"\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\"N\n" +
 	"\x13ConvertStateRequest\x12#\n" +
 	"\rmapper_target\x18\x01 \x01(\tR\fmapperTarget\x12\x12\n" +
-	"\x04args\x18\x02 \x03(\tR\x04args\"\x80\x03\n" +
+	"\x04args\x18\x02 \x03(\tR\x04args\"\xb8\x03\n" +
 	"\x0eResourceImport\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x0e\n" +
@@ -724,7 +744,11 @@ const file_pulumi_converter_proto_rawDesc = "" +
 	"\tis_remote\x18\b \x01(\bR\bisRemote\x12O\n" +
 	"\x10parameterization\x18\t \x01(\v2#.pulumirpc.ResourceParameterizationR\x10parameterization\x12:\n" +
 	"\textension\x18\n" +
-	" \x01(\v2\x1c.pulumirpc.ResourceExtensionR\textension\"x\n" +
+	" \x01(\v2\x1c.pulumirpc.ResourceExtensionR\textension\x12\x16\n" +
+	"\x06parent\x18\v \x01(\tR\x06parent\x12\x1e\n" +
+	"\n" +
+	"properties\x18\f \x03(\tR\n" +
+	"properties\"x\n" +
 	"\x18ResourceParameterization\x12\x1f\n" +
 	"\vplugin_name\x18\x01 \x01(\tR\n" +
 	"pluginName\x12%\n" +

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
@@ -15,7 +15,7 @@ from .codegen import hcl_pb2 as pulumi_dot_codegen_dot_hcl__pb2
 from .codegen import loader_pb2 as pulumi_dot_codegen_dot_loader__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\":\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\x93\x02\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\x12=\n\x10parameterization\x18\t \x01(\x0b\x32#.pulumirpc.ResourceParameterization\x12/\n\textension\x18\n \x01(\x0b\x32\x1c.pulumirpc.ResourceExtension\"V\n\x18ResourceParameterization\x12\x13\n\x0bplugin_name\x18\x01 \x01(\t\x12\x16\n\x0eplugin_version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"A\n\x11ResourceExtension\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\x84\x02\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xe8\x01\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x12\x45\n\nattributes\x18\x04 \x03(\x0b\x32\x31.pulumirpc.ConvertSnippetResponse.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\":\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\xb7\x02\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\x12=\n\x10parameterization\x18\t \x01(\x0b\x32#.pulumirpc.ResourceParameterization\x12/\n\textension\x18\n \x01(\x0b\x32\x1c.pulumirpc.ResourceExtension\x12\x0e\n\x06parent\x18\x0b \x01(\t\x12\x12\n\nproperties\x18\x0c \x03(\t\"V\n\x18ResourceParameterization\x12\x13\n\x0bplugin_name\x18\x01 \x01(\t\x12\x16\n\x0eplugin_version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"A\n\x11ResourceExtension\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\x84\x02\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xe8\x01\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x12\x45\n\nattributes\x18\x04 \x03(\x0b\x32\x31.pulumirpc.ConvertSnippetResponse.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -30,25 +30,25 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_CONVERTSTATEREQUEST']._serialized_start=92
   _globals['_CONVERTSTATEREQUEST']._serialized_end=150
   _globals['_RESOURCEIMPORT']._serialized_start=153
-  _globals['_RESOURCEIMPORT']._serialized_end=428
-  _globals['_RESOURCEPARAMETERIZATION']._serialized_start=430
-  _globals['_RESOURCEPARAMETERIZATION']._serialized_end=516
-  _globals['_RESOURCEEXTENSION']._serialized_start=518
-  _globals['_RESOURCEEXTENSION']._serialized_end=583
-  _globals['_CONVERTSTATERESPONSE']._serialized_start=585
-  _globals['_CONVERTSTATERESPONSE']._serialized_end=705
-  _globals['_CONVERTPROGRAMREQUEST']._serialized_start=708
-  _globals['_CONVERTPROGRAMREQUEST']._serialized_end=880
-  _globals['_CONVERTPROGRAMRESPONSE']._serialized_start=882
-  _globals['_CONVERTPROGRAMRESPONSE']._serialized_end=958
-  _globals['_CONVERTSNIPPETREQUEST']._serialized_start=961
-  _globals['_CONVERTSNIPPETREQUEST']._serialized_end=1221
-  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_start=1172
-  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_end=1221
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=1224
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=1456
-  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_start=1172
-  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_end=1221
-  _globals['_CONVERTER']._serialized_start=1459
-  _globals['_CONVERTER']._serialized_end=1731
+  _globals['_RESOURCEIMPORT']._serialized_end=464
+  _globals['_RESOURCEPARAMETERIZATION']._serialized_start=466
+  _globals['_RESOURCEPARAMETERIZATION']._serialized_end=552
+  _globals['_RESOURCEEXTENSION']._serialized_start=554
+  _globals['_RESOURCEEXTENSION']._serialized_end=619
+  _globals['_CONVERTSTATERESPONSE']._serialized_start=621
+  _globals['_CONVERTSTATERESPONSE']._serialized_end=741
+  _globals['_CONVERTPROGRAMREQUEST']._serialized_start=744
+  _globals['_CONVERTPROGRAMREQUEST']._serialized_end=916
+  _globals['_CONVERTPROGRAMRESPONSE']._serialized_start=918
+  _globals['_CONVERTPROGRAMRESPONSE']._serialized_end=994
+  _globals['_CONVERTSNIPPETREQUEST']._serialized_start=997
+  _globals['_CONVERTSNIPPETREQUEST']._serialized_end=1257
+  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_start=1208
+  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_end=1257
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=1260
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=1492
+  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_start=1208
+  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_end=1257
+  _globals['_CONVERTER']._serialized_start=1495
+  _globals['_CONVERTER']._serialized_end=1767
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
@@ -67,6 +67,8 @@ class ResourceImport(google.protobuf.message.Message):
     IS_REMOTE_FIELD_NUMBER: builtins.int
     PARAMETERIZATION_FIELD_NUMBER: builtins.int
     EXTENSION_FIELD_NUMBER: builtins.int
+    PARENT_FIELD_NUMBER: builtins.int
+    PROPERTIES_FIELD_NUMBER: builtins.int
     type: builtins.str
     """the type token for the resource."""
     name: builtins.str
@@ -83,6 +85,10 @@ class ResourceImport(google.protobuf.message.Message):
     """true if this is a component resource."""
     is_remote: builtins.bool
     """true if this is a remote resource. Ignored if is_component is false."""
+    parent: builtins.str
+    """the name of the resource's parent, if any. Must reference the name of another resource in the same
+    response; resources without a parent are parented to the stack root.
+    """
     @property
     def parameterization(self) -> global___ResourceParameterization:
         """the replacement parameterization to use for the resource's provider, if any. Set when the resource
@@ -94,6 +100,12 @@ class ResourceImport(google.protobuf.message.Message):
         """the extension parameterization to apply to the resource's provider, if any. Unlike a replacement
         parameterization, the resource's own type is in the base provider's package; the extension is a blob
         applied on top of that provider. Mutually exclusive with parameterization.
+        """
+
+    @property
+    def properties(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
+        """the input properties to include when generating code for the resource. Defaults to the resource's
+        required properties.
         """
 
     def __init__(
@@ -109,9 +121,11 @@ class ResourceImport(google.protobuf.message.Message):
         is_remote: builtins.bool = ...,
         parameterization: global___ResourceParameterization | None = ...,
         extension: global___ResourceExtension | None = ...,
+        parent: builtins.str = ...,
+        properties: collections.abc.Iterable[builtins.str] | None = ...,
     ) -> None: ...
     def HasField(self, field_name: typing.Literal["extension", b"extension", "parameterization", b"parameterization"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing.Literal["extension", b"extension", "id", b"id", "is_component", b"is_component", "is_remote", b"is_remote", "logical_name", b"logical_name", "name", b"name", "parameterization", b"parameterization", "pluginDownloadURL", b"pluginDownloadURL", "type", b"type", "version", b"version"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["extension", b"extension", "id", b"id", "is_component", b"is_component", "is_remote", b"is_remote", "logical_name", b"logical_name", "name", b"name", "parameterization", b"parameterization", "parent", b"parent", "pluginDownloadURL", b"pluginDownloadURL", "properties", b"properties", "type", b"type", "version", b"version"]) -> None: ...
 
 global___ResourceImport = ResourceImport
 


### PR DESCRIPTION
The keys missing from the basic `ResourceImport` structure to populate `importSpec`.