### PR TITLE
redact secrets in regular logs

### DIFF
--- a/changelog/pending/cli-improvement-20260714-172531.yaml
+++ b/changelog/pending/cli-improvement-20260714-172531.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Redact secrets in property values in logs. Add a --logsecrets flag to continue logging secrets
+time: 2026-07-14T17:25:31.43918684+02:00

--- a/changelog/pending/cli-improvement-20260714-172531.yaml
+++ b/changelog/pending/cli-improvement-20260714-172531.yaml
@@ -1,4 +1,4 @@
 component: cli
 kind: improvement
-body: Redact secrets in property values in logs. Add a --logsecrets flag to continue logging secrets
+body: Redact secrets in property values in logs
 time: 2026-07-14T17:25:31.43918684+02:00

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -322,14 +322,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			}
 
 			logging.InitLogging(logToStderr, verbose, logFlow)
-			if logSecrets {
-				logging.LogSecrets = true
-				if logFlow {
-					if err := os.Setenv("PULUMI_LOG_SECRETS", "true"); err != nil {
-						return err
-					}
-				}
-			}
+			logging.LogSecrets = logSecrets
 
 			// Start automatic logging. At this point we don't have a stack
 			// or secrets manager, so logs will be gzip-compressed (not

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -208,6 +208,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	var cwd string
 	var logFlow bool
 	var logToStderr bool
+	var logSecrets bool
 	var tracingFlag string
 	var tracingHeaderFlag string
 	var otelTracesFlag string
@@ -321,6 +322,14 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			}
 
 			logging.InitLogging(logToStderr, verbose, logFlow)
+			if logSecrets {
+				logging.LogSecrets = true
+				if logFlow {
+					if err := os.Setenv("PULUMI_LOG_SECRETS", "true"); err != nil {
+						return err
+					}
+				}
+			}
 
 			// Start automatic logging. At this point we don't have a stack
 			// or secrets manager, so logs will be gzip-compressed (not
@@ -459,6 +468,8 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		"Flow log settings to child processes (like plugins)")
 	cmd.PersistentFlags().BoolVar(&logToStderr, "logtostderr", false,
 		"Log to stderr instead of to files")
+	cmd.PersistentFlags().BoolVar(&logSecrets, "logsecrets", false,
+		"Include secret values in plaintext log output instead of redacting them")
 	cmd.PersistentFlags().BoolVar(&cmdutil.DisableInteractive, "non-interactive", false,
 		"Disable interactive mode for all commands")
 	cmd.PersistentFlags().StringVar(&tracingFlag, "tracing", "",

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -208,7 +208,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	var cwd string
 	var logFlow bool
 	var logToStderr bool
-	var logSecrets bool
 	var tracingFlag string
 	var tracingHeaderFlag string
 	var otelTracesFlag string
@@ -322,7 +321,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			}
 
 			logging.InitLogging(logToStderr, verbose, logFlow)
-			logging.LogSecrets = logSecrets
 
 			// Start automatic logging. At this point we don't have a stack
 			// or secrets manager, so logs will be gzip-compressed (not
@@ -461,8 +459,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		"Flow log settings to child processes (like plugins)")
 	cmd.PersistentFlags().BoolVar(&logToStderr, "logtostderr", false,
 		"Log to stderr instead of to files")
-	cmd.PersistentFlags().BoolVar(&logSecrets, "logsecrets", false,
-		"Include secret values in plaintext log output instead of redacting them")
 	cmd.PersistentFlags().BoolVar(&cmdutil.DisableInteractive, "non-interactive", false,
 		"Disable interactive mode for all commands")
 	cmd.PersistentFlags().StringVar(&tracingFlag, "tracing", "",

--- a/sdk/go/common/resource/logging_redact.go
+++ b/sdk/go/common/resource/logging_redact.go
@@ -1,0 +1,61 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"log/slog"
+)
+
+// RedactedLogValue replaces secret values with "[secret]" for plaintext log output. The encrypted
+// log sink and OTLP export receive the original values.
+func (v PropertyValue) RedactedLogValue() slog.Value {
+	return slog.AnyValue(redactSecretValues(v))
+}
+
+// RedactedLogValue replaces secret values with "[secret]" for plaintext log output. The encrypted
+// log sink and OTLP export receive the original values.
+func (m PropertyMap) RedactedLogValue() slog.Value {
+	return slog.AnyValue(redactSecretValues(NewProperty(m)).ObjectValue())
+}
+
+func redactSecretValues(v PropertyValue) PropertyValue {
+	switch {
+	case v.IsSecret():
+		return NewProperty("[secret]")
+	case v.IsOutput():
+		o := v.OutputValue()
+		if o.Secret {
+			return NewProperty("[secret]")
+		}
+		o.Element = redactSecretValues(o.Element)
+		return NewProperty(o)
+	case v.IsObject():
+		obj := v.ObjectValue()
+		redacted := make(PropertyMap, len(obj))
+		for k, e := range obj {
+			redacted[k] = redactSecretValues(e)
+		}
+		return NewProperty(redacted)
+	case v.IsArray():
+		arr := v.ArrayValue()
+		redacted := make([]PropertyValue, len(arr))
+		for i, e := range arr {
+			redacted[i] = redactSecretValues(e)
+		}
+		return NewProperty(redacted)
+	default:
+		return v
+	}
+}

--- a/sdk/go/common/resource/logging_redact_test.go
+++ b/sdk/go/common/resource/logging_redact_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// logRedactAttr mirrors what the logging package's primary output does with an attribute:
+// values implementing RedactedLogValue are replaced by their redacted form.
+func logRedactAttr(a slog.Attr) slog.Attr {
+	if a.Value.Kind() != slog.KindAny {
+		return a
+	}
+	if v, ok := a.Value.Any().(interface{ RedactedLogValue() slog.Value }); ok {
+		a.Value = v.RedactedLogValue()
+	}
+	return a
+}
+
+func TestRedactSecretAttr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("secret property value", func(t *testing.T) {
+		t.Parallel()
+		a := logRedactAttr(slog.Any("value", MakeSecret(NewProperty("hunter2"))))
+		pv, ok := a.Value.Any().(PropertyValue)
+		require.True(t, ok)
+		assert.Equal(t, NewProperty("[secret]"), pv)
+	})
+
+	t.Run("nested secrets in a property map", func(t *testing.T) {
+		t.Parallel()
+		m := PropertyMap{
+			"plain": NewProperty("visible"),
+			"token": MakeSecret(NewProperty("hunter2")),
+			"nested": NewProperty(PropertyMap{
+				"password": MakeSecret(NewProperty("hunter2")),
+			}),
+			"list": NewProperty([]PropertyValue{MakeSecret(NewProperty("hunter2"))}),
+		}
+		a := logRedactAttr(slog.Any("props", m))
+		redacted, ok := a.Value.Any().(PropertyMap)
+		require.True(t, ok)
+		assert.Equal(t, NewProperty("visible"), redacted["plain"])
+		assert.Equal(t, NewProperty("[secret]"), redacted["token"])
+		assert.Equal(t, NewProperty("[secret]"), redacted["nested"].ObjectValue()["password"])
+		assert.Equal(t, NewProperty("[secret]"), redacted["list"].ArrayValue()[0])
+		assert.Equal(t, MakeSecret(NewProperty("hunter2")), m["token"])
+	})
+
+	t.Run("secret output value", func(t *testing.T) {
+		t.Parallel()
+		a := logRedactAttr(slog.Any("value", NewProperty(Output{
+			Element: NewProperty("hunter2"),
+			Known:   true,
+			Secret:  true,
+		})))
+		pv, ok := a.Value.Any().(PropertyValue)
+		require.True(t, ok)
+		assert.Equal(t, NewProperty("[secret]"), pv)
+	})
+
+	t.Run("secret property.Value", func(t *testing.T) {
+		t.Parallel()
+		a := logRedactAttr(slog.Any("value", property.New("hunter2").WithSecret(true)))
+		pv, ok := a.Value.Any().(property.Value)
+		require.True(t, ok)
+		assert.Equal(t, property.New("[secret]"), pv)
+	})
+
+	t.Run("non-property attributes pass through", func(t *testing.T) {
+		t.Parallel()
+		a := logRedactAttr(slog.String("plain", "hunter2"))
+		assert.Equal(t, "hunter2", a.Value.String())
+	})
+}
+
+// TestSecretsRedactedFromPlaintextLogs verifies redaction end-to-end: a secret property logged
+// through slog never reaches the stderr log output.
+//
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestSecretsRedactedFromPlaintextLogs(t *testing.T) {
+	prevLog, prevV, prevFlow := logging.LogToStderr, logging.Verbose, logging.LogFlow
+	t.Cleanup(func() {
+		logging.LogToStderr, logging.Verbose, logging.LogFlow = prevLog, prevV, prevFlow
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	logging.InitLogging(true, 1, false)
+	os.Stderr = oldStderr
+
+	slog.Info("created resource", "props", PropertyMap{
+		"name":     NewProperty("web"),
+		"password": MakeSecret(NewProperty("hunter2")),
+	})
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "[secret]")
+	assert.Contains(t, string(out), "web")
+	assert.NotContains(t, string(out), "hunter2")
+}

--- a/sdk/go/common/util/logging/export.go
+++ b/sdk/go/common/util/logging/export.go
@@ -115,6 +115,16 @@ func (pv PropertyValue) LogValue() slog.Value {
 	return slog.StringValue(pv.String())
 }
 
+// RedactedLogValue replaces secret values with "[secret]" for plaintext log output. The encrypted
+// log sink and OTLP export receive the original values.
+func (pv PropertyValue) RedactedLogValue() slog.Value {
+	b, err := json.Marshal(redactSecretsInJSON(pv.Value.AsInterface()))
+	if err != nil {
+		return slog.StringValue("<error marshaling property value>")
+	}
+	return slog.StringValue(string(b))
+}
+
 type propertyValueExportHandler struct {
 	inner slog.Handler
 }

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -39,6 +39,7 @@ import (
 	// We need to re-use glogs flags otherwise we'd get conflicts if another dependency pulled in glog later.
 	_ "github.com/golang/glog"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
@@ -50,6 +51,7 @@ var (
 	LogToStderr = false // true if logging is being redirected to stderr.
 	Verbose     = 0     // >0 if verbose logging is enabled at a particular level.
 	LogFlow     = false // true to flow logging settings to child processes.
+	LogSecrets  = false // true to skip redacting secret values in plaintext log output.
 )
 
 var (
@@ -82,6 +84,54 @@ func rebuildLogger() {
 		exporter: exportHandler,
 	}}
 	slog.SetDefault(slog.New(h))
+}
+
+// logRedactable is implemented by attribute values (such as the property types) that know how to
+// replace their secret contents for plaintext log output. Only the primary (stderr or log file)
+// output redacts; the sink and export handlers receive unredacted records.
+type logRedactable interface {
+	RedactedLogValue() slog.Value
+}
+
+func redactAttr(a slog.Attr) slog.Attr {
+	if LogSecrets || a.Value.Kind() != slog.KindAny {
+		return a
+	}
+	switch v := a.Value.Any().(type) {
+	case logRedactable:
+		a.Value = v.RedactedLogValue()
+	case map[string]any:
+		a.Value = slog.AnyValue(redactSecretsInJSON(v))
+	case []any:
+		a.Value = slog.AnyValue(redactSecretsInJSON(v))
+	}
+	return a
+}
+
+// redactSecretsInJSON walks an already-serialized JSON value and replaces any object carrying the
+// Pulumi secret signature with "[secret]". Unlike the in-place walk `pulumi logs share` uses on
+// records it owns, this copies: the original value is shared with the unredacted sink and export
+// log outputs.
+func redactSecretsInJSON(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		if s, ok := val[sig.Key].(string); ok && s == sig.Secret {
+			return "[secret]"
+		}
+		redacted := make(map[string]any, len(val))
+		for k, child := range val {
+			redacted[k] = redactSecretsInJSON(child)
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(val))
+		for i, child := range val {
+			redacted[i] = redactSecretsInJSON(child)
+		}
+		return redacted
+	default:
+		return val
+	}
 }
 
 // SetExportHandler installs an slog.Handler for OTLP log export.
@@ -228,6 +278,9 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	} else if f := flag.CommandLine.Lookup("v"); f != nil {
 		fmt.Sscan(f.Value.String(), &Verbose) //nolint:errcheck
 	}
+	if os.Getenv("PULUMI_LOG_SECRETS") == "true" {
+		LogSecrets = true
+	}
 
 	initExportHandler(filepath.Base(os.Args[0]))
 
@@ -367,6 +420,7 @@ func (f formattingHandler) Handle(ctx context.Context, r slog.Record) error {
 	var fmtArgs []any
 	var other []slog.Attr
 	r.Attrs(func(a slog.Attr) bool {
+		a = redactAttr(a)
 		if strings.HasPrefix(a.Key, "pulumi.log.arg") {
 			fmtArgs = append(fmtArgs, a.Value.Any())
 		} else {
@@ -386,7 +440,11 @@ func (f formattingHandler) Handle(ctx context.Context, r slog.Record) error {
 }
 
 func (f formattingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return formattingHandler{inner: f.inner.WithAttrs(attrs)}
+	redacted := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		redacted[i] = redactAttr(a)
+	}
+	return formattingHandler{inner: f.inner.WithAttrs(redacted)}
 }
 
 func (f formattingHandler) WithGroup(name string) slog.Handler {

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -51,7 +51,6 @@ var (
 	LogToStderr = false // true if logging is being redirected to stderr.
 	Verbose     = 0     // >0 if verbose logging is enabled at a particular level.
 	LogFlow     = false // true to flow logging settings to child processes.
-	LogSecrets  = false // true to skip redacting secret values in plaintext log output.
 )
 
 var (
@@ -94,9 +93,6 @@ type logRedactable interface {
 }
 
 func redactAttr(a slog.Attr) slog.Attr {
-	if LogSecrets {
-		return a
-	}
 	if k := a.Value.Kind(); k != slog.KindAny && k != slog.KindLogValuer {
 		return a
 	}

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -94,7 +94,10 @@ type logRedactable interface {
 }
 
 func redactAttr(a slog.Attr) slog.Attr {
-	if LogSecrets || a.Value.Kind() != slog.KindAny {
+	if LogSecrets {
+		return a
+	}
+	if k := a.Value.Kind(); k != slog.KindAny && k != slog.KindLogValuer {
 		return a
 	}
 	switch v := a.Value.Any().(type) {
@@ -278,10 +281,6 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	} else if f := flag.CommandLine.Lookup("v"); f != nil {
 		fmt.Sscan(f.Value.String(), &Verbose) //nolint:errcheck
 	}
-	if os.Getenv("PULUMI_LOG_SECRETS") == "true" {
-		LogSecrets = true
-	}
-
 	initExportHandler(filepath.Base(os.Args[0]))
 
 	handlerMu.Lock()

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 )
 
 func TestInitLogging(t *testing.T) {
@@ -320,4 +322,156 @@ func TestLogToStderrFiltersHigherVerbosity(t *testing.T) {
 	assert.NotContains(t, string(out), "direct v5 hidden")
 	assert.Contains(t, string(out), "unleveled info shows")
 	assert.True(t, sink.saw("v5 hidden"))
+}
+
+// TestRedactingHandlerAppliesOnlyToPrimary verifies attribute values implementing
+// RedactedLogValue are redacted before the primary output, while the sink receives unredacted
+// attributes.
+//
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestRedactingHandlerAppliesOnlyToPrimary(t *testing.T) {
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	t.Cleanup(func() {
+		SetSinkHandler(nil)
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	InitLogging(true, 1, false)
+	os.Stderr = oldStderr
+
+	sink := &recordingAttrHandler{}
+	SetSinkHandler(sink)
+
+	slog.Info("logging in", "password", redactableSecret("hunter2"))
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "[secret]")
+	assert.NotContains(t, string(out), "hunter2")
+	assert.True(t, sink.sawAttr("password", "hunter2"))
+}
+
+type redactableSecret string
+
+func (s redactableSecret) RedactedLogValue() slog.Value { return slog.StringValue("[secret]") }
+
+type recordingAttrHandler struct {
+	mu    sync.Mutex
+	attrs []slog.Attr
+}
+
+func (h *recordingAttrHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingAttrHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r.Attrs(func(a slog.Attr) bool {
+		h.attrs = append(h.attrs, a)
+		return true
+	})
+	return nil
+}
+
+func (h *recordingAttrHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingAttrHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingAttrHandler) sawAttr(key, value string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, a := range h.attrs {
+		if a.Key == key && a.Value.String() == value {
+			return true
+		}
+	}
+	return false
+}
+
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestLogSecretsDisablesRedaction(t *testing.T) {
+	prevLog, prevV, prevFlow, prevSecrets := LogToStderr, Verbose, LogFlow, LogSecrets
+	t.Cleanup(func() {
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow, LogSecrets = prevLog, prevV, prevFlow, prevSecrets
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	InitLogging(true, 1, false)
+	os.Stderr = oldStderr
+
+	LogSecrets = true
+	slog.Info("logging in", "password", redactableSecret("hunter2"))
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "hunter2")
+	assert.NotContains(t, string(out), "[secret]")
+}
+
+func TestInitLoggingReadsLogSecretsEnv(t *testing.T) { //nolint:paralleltest // mutates global logging state
+	t.Setenv("PULUMI_LOG_SECRETS", "true")
+	prevLog, prevV, prevFlow, prevSecrets := LogToStderr, Verbose, LogFlow, LogSecrets
+	t.Cleanup(func() {
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow, LogSecrets = prevLog, prevV, prevFlow, prevSecrets
+	})
+
+	LogSecrets = false
+	InitLogging(false, 0, false)
+	assert.True(t, LogSecrets)
+}
+
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestSerializedSecretsRedactedBySignature(t *testing.T) {
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	t.Cleanup(func() {
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	InitLogging(true, 1, false)
+	os.Stderr = oldStderr
+
+	slog.Info("registering", "props", map[string]any{
+		"name": "web",
+		"password": map[string]any{
+			sig.Key:     sig.Secret,
+			"plaintext": "hunter2",
+		},
+	})
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "[secret]")
+	assert.Contains(t, string(out), "web")
+	assert.NotContains(t, string(out), "hunter2")
 }

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -398,35 +398,6 @@ func (h *recordingAttrHandler) sawAttr(key, value string) bool {
 }
 
 //nolint:paralleltest // mutates global logging state and os.Stderr
-func TestLogSecretsDisablesRedaction(t *testing.T) {
-	prevLog, prevV, prevFlow, prevSecrets := LogToStderr, Verbose, LogFlow, LogSecrets
-	t.Cleanup(func() {
-		handlerMu.Lock()
-		primary = discardHandler{}
-		rebuildLogger()
-		handlerMu.Unlock()
-		LogToStderr, Verbose, LogFlow, LogSecrets = prevLog, prevV, prevFlow, prevSecrets
-	})
-
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	oldStderr := os.Stderr
-	os.Stderr = w
-	InitLogging(true, 1, false)
-	os.Stderr = oldStderr
-
-	LogSecrets = true
-	slog.Info("logging in", "password", redactableSecret("hunter2"))
-
-	require.NoError(t, w.Close())
-	out, err := io.ReadAll(r)
-	require.NoError(t, err)
-
-	assert.Contains(t, string(out), "hunter2")
-	assert.NotContains(t, string(out), "[secret]")
-}
-
-//nolint:paralleltest // mutates global logging state and os.Stderr
 func TestPropertyValueAttrsRedacted(t *testing.T) {
 	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
 	t.Cleanup(func() {

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 )
@@ -425,20 +426,41 @@ func TestLogSecretsDisablesRedaction(t *testing.T) {
 	assert.NotContains(t, string(out), "[secret]")
 }
 
-func TestInitLoggingReadsLogSecretsEnv(t *testing.T) { //nolint:paralleltest // mutates global logging state
-	t.Setenv("PULUMI_LOG_SECRETS", "true")
-	prevLog, prevV, prevFlow, prevSecrets := LogToStderr, Verbose, LogFlow, LogSecrets
+//nolint:paralleltest // mutates global logging state and os.Stderr
+func TestPropertyValueAttrsRedacted(t *testing.T) {
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
 	t.Cleanup(func() {
 		handlerMu.Lock()
 		primary = discardHandler{}
 		rebuildLogger()
 		handlerMu.Unlock()
-		LogToStderr, Verbose, LogFlow, LogSecrets = prevLog, prevV, prevFlow, prevSecrets
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
 	})
 
-	LogSecrets = false
-	InitLogging(false, 0, false)
-	assert.True(t, LogSecrets)
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStderr := os.Stderr
+	os.Stderr = w
+	InitLogging(true, 1, false)
+	os.Stderr = oldStderr
+
+	sv, err := structpb.NewValue(map[string]any{
+		"name": "web",
+		"password": map[string]any{
+			sig.Key:     sig.Secret,
+			"plaintext": "hunter2",
+		},
+	})
+	require.NoError(t, err)
+	slog.Info("checking inputs", "inputs", PropertyValue{Key: "inputs", Value: sv})
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "[secret]")
+	assert.Contains(t, string(out), "web")
+	assert.NotContains(t, string(out), "hunter2")
 }
 
 //nolint:paralleltest // mutates global logging state and os.Stderr

--- a/sdk/go/property/logging_redact.go
+++ b/sdk/go/property/logging_redact.go
@@ -1,0 +1,58 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"log/slog"
+)
+
+// RedactedLogValue replaces secret values with "[secret]" for plaintext log output. The encrypted
+// log sink and OTLP export receive the original values.
+func (v Value) RedactedLogValue() slog.Value {
+	return slog.AnyValue(redactSecretValues(v))
+}
+
+// RedactedLogValue replaces secret values with "[secret]" for plaintext log output. The encrypted
+// log sink and OTLP export receive the original values.
+func (m Map) RedactedLogValue() slog.Value {
+	return slog.AnyValue(redactMapSecrets(m))
+}
+
+func redactSecretValues(v Value) Value {
+	switch {
+	case v.Secret():
+		return New("[secret]")
+	case v.IsMap():
+		return New(redactMapSecrets(v.AsMap()))
+	case v.IsArray():
+		arr := v.AsArray().AsSlice()
+		redacted := make([]Value, len(arr))
+		for i, e := range arr {
+			redacted[i] = redactSecretValues(e)
+		}
+		return New(NewArray(redacted))
+	default:
+		return v
+	}
+}
+
+func redactMapSecrets(m Map) Map {
+	orig := m.AsMap()
+	redacted := make(map[string]Value, len(orig))
+	for k, e := range orig {
+		redacted[k] = redactSecretValues(e)
+	}
+	return NewMap(redacted)
+}


### PR DESCRIPTION
Now that we're logging through slog, it becomes a bit easier to redact secrets in property values from logs.  While we can't guarantee that there's never any secrets in the logs, we can make a best effort to redact secrets, and do so here.

Also add a `--logsecrets` flag, that omits that behaviour, and allows secrets through as before.
