### PR TITLE
feat: respect ctrl+c & ctrl+a/ctrl+e for text nav in neo

### DIFF
--- a/changelog/pending/20260713--cli-neo--fix-line-editing-keys.yaml
+++ b/changelog/pending/20260713--cli-neo--fix-line-editing-keys.yaml
@@ -1,0 +1,4 @@
+component: cli/neo
+kind: feat
+body: Make Ctrl+C clear typed text and preserve Ctrl+A/Ctrl+E line navigation in `pulumi neo`
+time: 2026-07-13T00:00:00+00:00

--- a/changelog/pending/20260713--cli-neo--fix-line-editing-keys.yaml
+++ b/changelog/pending/20260713--cli-neo--fix-line-editing-keys.yaml
@@ -2,3 +2,5 @@ component: cli/neo
 kind: feat
 body: Make Ctrl+C clear typed text and preserve Ctrl+A/Ctrl+E line navigation in `pulumi neo`
 time: 2026-07-13T00:00:00+00:00
+custom:
+  PR: "23932"

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -412,6 +412,38 @@ func (m *Model) recallInput(s string) {
 	m.textInput.MoveToEnd()
 }
 
+func addKeyAliases(binding *key.Binding, aliases ...string) {
+	binding.SetKeys(append(binding.Keys(), aliases...)...)
+}
+
+func (m Model) draftEditingKey(msg tea.KeyPressMsg) bool {
+	if m.textInput.Value() == "" {
+		return false
+	}
+
+	km := m.textInput.KeyMap
+	return key.Matches(msg,
+		km.CharacterBackward,
+		km.CharacterForward,
+		km.DeleteAfterCursor,
+		km.DeleteBeforeCursor,
+		km.DeleteCharacterBackward,
+		km.DeleteCharacterForward,
+		km.DeleteWordBackward,
+		km.DeleteWordForward,
+		km.LineEnd,
+		km.LineStart,
+		km.InputBegin,
+		km.InputEnd,
+		km.WordBackward,
+		km.WordForward,
+		km.CapitalizeWordForward,
+		km.LowercaseWordForward,
+		km.UppercaseWordForward,
+		km.TransposeCharacterBackward,
+	)
+}
+
 // historyPrev steps to an older prompt. It returns true when it handled the
 // key (so the caller swallows it). The first step out of the live draft
 // stashes that draft in historyDraft so a later Down can restore it.
@@ -498,6 +530,9 @@ func NewModel(cfg ModelConfig) Model {
 		key.WithKeys("shift+enter", "alt+enter", "ctrl+j"),
 		key.WithHelp("shift+enter / alt+enter / ctrl+j", "newline"),
 	)
+	addKeyAliases(&ti.KeyMap.WordForward, "meta+f")
+	addKeyAliases(&ti.KeyMap.WordBackward, "meta+b")
+	addKeyAliases(&ti.KeyMap.DeleteWordBackward, "meta+backspace", "super+backspace")
 	ti.Focus()
 
 	sp := spinner.New(
@@ -668,6 +703,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// When the user is editing a draft, let textarea keep ownership of its
+		// line-editing keymap before app-level shortcuts see the same key.
+		if m.draftEditingKey(msg) {
+			var tiCmd tea.Cmd
+			m.textInput, tiCmd = m.textInput.Update(msg)
+			return m, tiCmd
+		}
+
 		// Ctrl+D mirrors Ctrl+C when the draft is empty: same arm/quit gate,
 		// same cancel-when-busy semantics. Two bindings is friendlier than
 		// picking one and forcing users to discover it.
@@ -712,15 +755,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.overlay.SetSize(m.width, m.height)
 			m.overlay.Refresh(m.toolHistory)
 			return m, nil
-		}
-
-		// When the user is editing a draft, keep the terminal editing keys
-		// bound by textarea: Ctrl+A moves to the start of the current line
-		// and Ctrl+E moves to the end.
-		if keyStr == "ctrl+a" && m.textInput.Value() != "" {
-			var tiCmd tea.Cmd
-			m.textInput, tiCmd = m.textInput.Update(msg)
-			return m, tiCmd
 		}
 
 		// Shift+Tab toggles plan mode. The toggle must run before the approval

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -660,9 +660,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		}
-		// Ctrl+D mirrors Ctrl+C: same arm/quit gate, same cancel-when-busy
-		// semantics. Two bindings is friendlier than picking one and forcing
-		// users to discover it.
+		// Ctrl+C clears an in-progress draft first, matching the normal line
+		// editing behavior users expect from agent CLIs. With an empty draft,
+		// it falls through to the quit/cancel gate below.
+		if keyStr == "ctrl+c" && m.textInput.Value() != "" {
+			m.textInput.Reset()
+			return m, nil
+		}
+
+		// Ctrl+D mirrors Ctrl+C when the draft is empty: same arm/quit gate,
+		// same cancel-when-busy semantics. Two bindings is friendlier than
+		// picking one and forcing users to discover it.
 		if keyStr == "ctrl+c" || keyStr == "ctrl+d" {
 			if m.ctrlCArmed {
 				return m, tea.Quit
@@ -704,6 +712,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.overlay.SetSize(m.width, m.height)
 			m.overlay.Refresh(m.toolHistory)
 			return m, nil
+		}
+
+		// When the user is editing a draft, keep the terminal editing keys
+		// bound by textarea: Ctrl+A moves to the start of the current line
+		// and Ctrl+E moves to the end.
+		if keyStr == "ctrl+a" && m.textInput.Value() != "" {
+			var tiCmd tea.Cmd
+			m.textInput, tiCmd = m.textInput.Update(msg)
+			return m, tiCmd
 		}
 
 		// Shift+Tab toggles plan mode. The toggle must run before the approval

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -415,6 +415,20 @@ func TestModel_Update_KeyCtrlC_TwoPressesQuit(t *testing.T) {
 	assert.True(t, ok, "second consecutive Ctrl+C must produce a tea.QuitMsg")
 }
 
+func TestModel_Update_KeyCtrlC_WithDraftClearsInput(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{})
+	m.textInput.SetValue("half typed")
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	um := updated.(Model)
+
+	assert.Empty(t, um.textInput.Value(), "Ctrl+C with a draft must clear the textarea")
+	assert.False(t, um.ctrlCArmed, "clearing a draft must not arm the exit prompt")
+	assert.Nil(t, cmd, "clearing a draft must not quit")
+}
+
 func TestModel_Update_KeyCtrlC_FirstPressCancelsWhenBusy(t *testing.T) {
 	t.Parallel()
 
@@ -470,6 +484,38 @@ func TestModel_Update_KeyCtrlC_OtherKeyDisarms(t *testing.T) {
 	}
 }
 
+func TestModel_Update_CtrlAWithDraftMovesCursorStart(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+	m.textInput.SetValue("hello")
+	m.textInput.MoveToEnd()
+	require.Equal(t, 5, m.textInput.Column(), "precondition: cursor starts at the end")
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl})
+	um := updated.(Model)
+
+	assert.Equal(t, 0, um.textInput.Column(), "Ctrl+A with a draft must move to line start")
+	assert.Equal(t, client.NeoApprovalModeManual, um.approvalMode,
+		"Ctrl+A with a draft must not toggle approval mode")
+}
+
+func TestModel_Update_CtrlEWithDraftMovesCursorEnd(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{})
+	m.textInput.SetValue("hello")
+	m.textInput.CursorStart()
+	require.Equal(t, 0, m.textInput.Column(), "precondition: cursor starts at the beginning")
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	um := updated.(Model)
+
+	assert.Equal(t, 5, um.textInput.Column(), "Ctrl+E must move to line end")
+}
+
 func TestModel_Update_KeyCtrlC_TimeoutDisarms(t *testing.T) {
 	t.Parallel()
 
@@ -504,6 +550,11 @@ func TestModel_Update_KeyCtrlC_StaleDisarmIgnored(t *testing.T) {
 	updated, _ = um.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
 	um = updated.(Model)
 	require.False(t, um.ctrlCArmed)
+
+	updated, _ = um.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	um = updated.(Model)
+	require.False(t, um.ctrlCArmed, "Ctrl+C with a draft must clear before re-arming")
+	require.Empty(t, um.textInput.Value())
 
 	updated, _ = um.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
 	um = updated.(Model)

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -516,6 +516,64 @@ func TestModel_Update_CtrlEWithDraftMovesCursorEnd(t *testing.T) {
 	assert.Equal(t, 5, um.textInput.Column(), "Ctrl+E must move to line end")
 }
 
+func TestModel_Update_DraftEditingKeysUseTextareaKeymap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ctrl+d deletes forward instead of arming quit", func(t *testing.T) {
+		t.Parallel()
+
+		m := NewModel(ModelConfig{})
+		m.textInput.SetValue("abc")
+		m.textInput.CursorStart()
+
+		updated, cmd := m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+		um := updated.(Model)
+
+		assert.Equal(t, "bc", um.textInput.Value())
+		assert.False(t, um.ctrlCArmed)
+		assert.Nil(t, cmd)
+	})
+
+	t.Run("meta+f moves forward one word", func(t *testing.T) {
+		t.Parallel()
+
+		m := NewModel(ModelConfig{})
+		m.textInput.SetValue("hello world")
+		m.textInput.CursorStart()
+
+		updated, _ := m.Update(tea.KeyPressMsg{Code: 'f', Mod: tea.ModMeta})
+		um := updated.(Model)
+
+		assert.Equal(t, 5, um.textInput.Column())
+	})
+
+	t.Run("meta+b moves backward one word", func(t *testing.T) {
+		t.Parallel()
+
+		m := NewModel(ModelConfig{})
+		m.textInput.SetValue("hello world")
+		m.textInput.MoveToEnd()
+
+		updated, _ := m.Update(tea.KeyPressMsg{Code: 'b', Mod: tea.ModMeta})
+		um := updated.(Model)
+
+		assert.Equal(t, 6, um.textInput.Column())
+	})
+
+	t.Run("cmd+backspace deletes backward one word", func(t *testing.T) {
+		t.Parallel()
+
+		m := NewModel(ModelConfig{})
+		m.textInput.SetValue("hello world")
+		m.textInput.MoveToEnd()
+
+		updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModSuper})
+		um := updated.(Model)
+
+		assert.Equal(t, "hello ", um.textInput.Value())
+	})
+}
+
 func TestModel_Update_KeyCtrlC_TimeoutDisarms(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

Improve `pulumi neo` line editing behavior so Ctrl+C clears an in-progress draft before arming the quit/cancel flow, while preserving Ctrl+A/Ctrl+E textarea navigation when editing text.

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [ ] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

Low. This only affects `pulumi neo` TUI keyboard handling for draft input and mode-toggle shortcuts. The main risk is changing expected Ctrl+C/Ctrl+A behavior in edge cases, covered by focused unit tests. No public SDK API, engine lifecycle, protocol, or protobuf changes.


<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
