### PR TITLE
Support pinning an exact Node.js version for policy packs

### DIFF
--- a/changelog/pending/20260714--sdk-nodejs--pinned-node-version-for-policy-packs.yaml
+++ b/changelog/pending/20260714--sdk-nodejs--pinned-node-version-for-policy-packs.yaml
@@ -1,5 +1,5 @@
 kind: feat
-body: Policy packs can pin an exact Node.js version via the nodeVersion runtime
+body: Allow policy packs to pin an exact Node.js version via the nodeVersion runtime
     option; the pinned version is downloaded, cached, and always used to run
     the pack
 component: sdk/nodejs

--- a/changelog/pending/20260714--sdk-nodejs--pinned-node-version-for-policy-packs.yaml
+++ b/changelog/pending/20260714--sdk-nodejs--pinned-node-version-for-policy-packs.yaml
@@ -1,0 +1,7 @@
+kind: feat
+body: Policy packs can pin an exact Node.js version via the nodeVersion runtime
+    option; the pinned version is downloaded, cached, and always used to run
+    the pack
+component: sdk/nodejs
+custom:
+    PR: "23934"

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -286,6 +286,9 @@ type nodeOptions struct {
 	packagemanager npm.PackageManagerType
 	// Skip devDependencies when installing dependencies.
 	production bool
+	// Exact Node.js version to download and run policy packs with,
+	// instead of node from the PATH.
+	nodeVersion string
 }
 
 func parseOptions(options map[string]any, runtime string) (nodeOptions, error) {
@@ -348,6 +351,12 @@ func parseOptions(options map[string]any, runtime string) (nodeOptions, error) {
 	} else {
 		nodeOptions.packagemanager = npm.AutoPackageManager
 	}
+
+	nodeVersion, err := parseNodeVersionOption(options, runtime, nodeOptions.packagemanager)
+	if err != nil {
+		return nodeOptions, err
+	}
+	nodeOptions.nodeVersion = nodeVersion
 
 	if runtime == "bun" {
 		// Bun handles TypeScript natively; ts-node is not used, so PULUMI_NODEJS_TYPESCRIPT must not be set.
@@ -1188,7 +1197,17 @@ func (host *nodeLanguageHost) InstallDependencies(
 	)
 	defer otelSpan.End()
 
-	if req.UseLanguageVersionTools {
+	opts, err := parseOptions(req.Info.Options.AsMap(), host.runtime)
+	if err != nil {
+		return fmt.Errorf("failed to parse options: %w", err)
+	}
+
+	pinned, err := pinnedNode(ctx, opts, req.IsPlugin, stdout)
+	if err != nil {
+		return err
+	}
+
+	if req.UseLanguageVersionTools && pinned == nil {
 		// Look for a .nvmrc or .node-version file, install the version specified in it, and set it
 		// as the default nodejs version.
 		if err := installNodeVersion(req.Info.ProgramDirectory, stdout); err != nil {
@@ -1214,14 +1233,14 @@ func (host *nodeLanguageHost) InstallDependencies(
 		workspaceRoot = newWorkspaceRoot
 	}
 
-	opts, err := parseOptions(req.Info.Options.AsMap(), host.runtime)
-	if err != nil {
-		return fmt.Errorf("failed to parse options: %w", err)
-	}
 	otelSpan.SetAttributes(append(setOptionsAttributes(opts), attribute.String("workspaceRoot", workspaceRoot))...)
 
-	err = host.installShared(ctx, opts.packagemanager, workspaceRoot, req.IsPlugin, opts.production, stdout, stderr)
-	if err != nil {
+	if pinned != nil {
+		if err := pinnedNpmInstall(ctx, *pinned, workspaceRoot, opts.production, stdout, stderr); err != nil {
+			return err
+		}
+	} else if err := host.installShared(
+		ctx, opts.packagemanager, workspaceRoot, req.IsPlugin, opts.production, stdout, stderr); err != nil {
 		return err
 	}
 
@@ -1629,21 +1648,36 @@ func (host *nodeLanguageHost) RunPlugin(
 		}
 	}
 
-	runtimeExec := host.runtime
-	if runtimeExec == "nodejs" {
-		runtimeExec = "node"
-	}
-	runtimeBin, err := exec.LookPath(runtimeExec)
-	if err != nil {
-		return err
-	}
-
 	opts, err := parseOptions(req.Info.Options.AsMap(), host.runtime)
 	if err != nil {
 		return err
 	}
 
+	isAnalyzer := req.Kind == string(apitype.AnalyzerPlugin)
+
+	runtimeExec := host.runtime
+	if runtimeExec == "nodejs" {
+		runtimeExec = "node"
+	}
+
+	pinned, err := pinnedNode(ctx, opts, isAnalyzer, stderr)
+	if err != nil {
+		return err
+	}
+	var runtimeBin string
+	if pinned != nil {
+		runtimeBin = pinned.Node
+	} else {
+		runtimeBin, err = exec.LookPath(runtimeExec)
+		if err != nil {
+			return err
+		}
+	}
+
 	env := req.Env
+	if pinned != nil {
+		env = prependPathInEnv(env, pinned.BinDir)
+	}
 	if opts.typescript {
 		env = append(env, "PULUMI_NODEJS_TYPESCRIPT=true")
 	}
@@ -1652,7 +1686,7 @@ func (host *nodeLanguageHost) RunPlugin(
 	}
 
 	var runPath string
-	if req.Kind == string(apitype.AnalyzerPlugin) {
+	if isAnalyzer {
 		// Policy packs (i.e. kind=analyzer) need to be treated specially for back compatibility reasons. We
 		// used to have a dedicated shim plugin "pulumi-analyzer-policy" that would start policy packs up, but
 		// now we just let the nodejs RunPlugin code handle that logic.
@@ -1696,7 +1730,7 @@ func (host *nodeLanguageHost) RunPlugin(
 
 	args = append(args, nodeargs...)
 	// For policy analyzers we need to send the program directory as an argument _last_, for everything else it comes first
-	if req.Kind == string(apitype.AnalyzerPlugin) {
+	if isAnalyzer {
 		args = append(args, req.Args...)
 		args = append(args, req.Info.ProgramDirectory)
 	} else {
@@ -1708,7 +1742,7 @@ func (host *nodeLanguageHost) RunPlugin(
 	// get that info we need to connect to the engine as a policy pack so that we can get the StackConfiguration call,
 	// we then need to wait for the _real_ policy pack to start up and shim all it's other request/responses.
 	var policyPackServer *sdk.PolicyProxy
-	if req.Kind == string(apitype.AnalyzerPlugin) {
+	if isAnalyzer {
 		policyPackServer, stdout, err = sdk.NewPolicyProxy(ctx, stdout)
 		if err != nil {
 			return fmt.Errorf("could not start policy pack proxy: %w", err)
@@ -1743,7 +1777,7 @@ func (host *nodeLanguageHost) RunPlugin(
 	cmd := exec.CommandContext(ctx, runtimeBin, args...)
 	// node policy packs used to always run with the working directory set to the policy pack directory, not
 	// the main working directory. We need to continue that for backwards compatibility.
-	if req.Kind == string(apitype.AnalyzerPlugin) {
+	if isAnalyzer {
 		cmd.Dir = req.Info.ProgramDirectory
 	} else {
 		cmd.Dir = req.Pwd

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -1017,3 +1017,33 @@ func TestNodeInstall(t *testing.T) {
 	require.Equal(t, "use 20.1.2 --install-if-missing", commands[0])
 	require.Equal(t, "alias 20.1.2 default", commands[1])
 }
+
+func TestParseOptionsNodeVersion(t *testing.T) {
+	t.Parallel()
+
+	opts, err := parseOptions(map[string]any{"nodeVersion": "22.12.0"}, "nodejs")
+	require.NoError(t, err)
+	assert.Equal(t, "22.12.0", opts.nodeVersion)
+
+	opts, err = parseOptions(map[string]any{}, "nodejs")
+	require.NoError(t, err)
+	assert.Empty(t, opts.nodeVersion)
+
+	for _, bad := range []string{"v22.12.0", "22", "22.12", "^22.12.0", "lts/iron", "22.12.0-rc.1"} {
+		_, err = parseOptions(map[string]any{"nodeVersion": bad}, "nodejs")
+		assert.ErrorContains(t, err, "exact version", "input %q", bad)
+	}
+
+	_, err = parseOptions(map[string]any{"nodeVersion": 22}, "nodejs")
+	assert.ErrorContains(t, err, "must be a string")
+
+	_, err = parseOptions(map[string]any{"nodeVersion": "22.12.0"}, "bun")
+	assert.ErrorContains(t, err, "bun")
+
+	_, err = parseOptions(map[string]any{"nodeVersion": "22.12.0", "packagemanager": "pnpm"}, "nodejs")
+	assert.ErrorContains(t, err, "npm")
+
+	opts, err = parseOptions(map[string]any{"nodeVersion": "22.12.0", "packagemanager": "npm"}, "nodejs")
+	require.NoError(t, err)
+	assert.Equal(t, "22.12.0", opts.nodeVersion)
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/install.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/install.go
@@ -1,0 +1,208 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noderesolver
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Resolve returns paths to the requested Node.js version, downloading and
+// caching the distribution under ~/.pulumi/node/ on first use. It is safe to
+// call concurrently across processes.
+func Resolve(ctx context.Context, spec Spec) (Result, error) {
+	name, err := archiveName(spec.Version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return Result{}, err
+	}
+	base := archiveBase(name)
+	root, err := workspace.GetPulumiPath("node", base)
+	if err != nil {
+		return Result{}, err
+	}
+	binDir := layoutBinDir(root, base, runtime.GOOS)
+	result := Result{
+		Node:   filepath.Join(binDir, nodeExe()),
+		Npm:    filepath.Join(binDir, npmExe()),
+		BinDir: binDir,
+	}
+	if installed(root, result) {
+		return result, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(root), 0o700); err != nil {
+		return Result{}, err
+	}
+	mutex := fsutil.NewFileMutex(root + ".lock")
+	if err := mutex.Lock(); err != nil {
+		return Result{}, err
+	}
+	defer func() { contract.IgnoreError(mutex.Unlock()) }()
+
+	// Another process may have completed the install while we waited.
+	if installed(root, result) {
+		return result, nil
+	}
+	// The directory is a failed or corrupted install; replace it.
+	if _, err := os.Stat(root); err == nil {
+		if err := os.RemoveAll(root); err != nil {
+			return Result{}, err
+		}
+	}
+
+	if spec.Output != nil {
+		fmt.Fprintf(spec.Output, "Downloading Node.js v%s...\n", spec.Version)
+	}
+	if err := install(ctx, spec, name, root); err != nil {
+		return Result{}, err
+	}
+	return result, nil
+}
+
+// installed reports whether root holds a complete install: no in-progress
+// .partial marker, and both the node and npm binaries present. os.Stat
+// follows symlinks, so a dangling npm symlink (e.g. npm-cli.js shipped
+// separately from node) is correctly treated as incomplete.
+func installed(root string, result Result) bool {
+	if _, err := os.Stat(partialPath(root)); err == nil {
+		return false
+	}
+	if _, err := os.Stat(result.Node); err != nil {
+		return false
+	}
+	if _, err := os.Stat(result.Npm); err != nil {
+		return false
+	}
+	return true
+}
+
+func partialPath(root string) string {
+	return root + ".partial"
+}
+
+func archiveBase(name string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(name, ".tar.gz"), ".zip")
+}
+
+func install(ctx context.Context, spec Spec, name, root string) error {
+	url := spec.baseURL() + "/v" + spec.Version + "/" + name
+	archiveFile, err := os.CreateTemp(filepath.Dir(root), name+".download")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		archiveFile.Close()
+		os.Remove(archiveFile.Name())
+	}()
+	size, err := downloadTo(ctx, url, archiveFile)
+	if err != nil {
+		return err
+	}
+
+	// Extract directly into the final directory instead of renaming a temp
+	// directory into place: directory renames fail intermittently on Windows
+	// when virus scanners hold freshly written files open (the same reason
+	// plugin installs work this way, see pkg/pluginstorage). The .partial
+	// marker is left behind on failure so the next Resolve replaces the
+	// directory.
+	if err := os.WriteFile(partialPath(root), nil, 0o600); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return err
+	}
+	if strings.HasSuffix(name, ".zip") {
+		err = extractZip(archiveFile, size, root)
+	} else {
+		if _, err = archiveFile.Seek(0, io.SeekStart); err == nil {
+			err = archive.ExtractTGZ(archiveFile, root)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("extracting %s: %w", name, err)
+	}
+	return os.Remove(partialPath(root))
+}
+
+var downloadClient = &http.Client{Timeout: 5 * time.Minute}
+
+func downloadTo(ctx context.Context, url string, w io.Writer) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := httputil.DoWithRetry(req, downloadClient)
+	if err != nil {
+		return 0, fmt.Errorf("downloading %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("downloading %s: HTTP %d", url, resp.StatusCode)
+	}
+	return io.Copy(w, resp.Body)
+}
+
+func extractZip(r io.ReaderAt, size int64, dir string) error {
+	zr, err := zip.NewReader(r, size)
+	if err != nil {
+		return err
+	}
+	cleanDir := filepath.Clean(dir)
+	for _, f := range zr.File {
+		path := filepath.Join(cleanDir, f.Name) //nolint:gosec // path traversal is checked below
+		if path != cleanDir && !strings.HasPrefix(path, cleanDir+string(os.PathSeparator)) {
+			return fmt.Errorf("zip entry %q escapes destination directory", f.Name)
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(path, 0o700); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return err
+		}
+		src, err := f.Open()
+		if err != nil {
+			return err
+		}
+		dst, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, f.Mode())
+		if err != nil {
+			src.Close()
+			return err
+		}
+		_, err = io.Copy(dst, src) //nolint:gosec // official Node.js release archive
+		src.Close()
+		dst.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/install_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/install_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noderesolver
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeArchive builds a minimal Node distribution archive for the current
+// platform: <base>/bin/node on unix, <base>/node.exe on Windows.
+func makeArchive(t *testing.T, base string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if runtime.GOOS == "windows" {
+		zw := zip.NewWriter(&buf)
+		for _, name := range []string{base + "/node.exe", base + "/npm.cmd"} {
+			w, err := zw.Create(name)
+			require.NoError(t, err)
+			_, err = w.Write([]byte("fake"))
+			require.NoError(t, err)
+		}
+		require.NoError(t, zw.Close())
+		return buf.Bytes()
+	}
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, name := range []string{base + "/bin/node", base + "/bin/npm"} {
+		content := []byte("#!/bin/sh\nexit 0\n")
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o755, Size: int64(len(content)),
+		}))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+// serveDist serves /v<version>/<archive>, counting archive downloads.
+func serveDist(t *testing.T, version string, archive []byte, name string, downloads *atomic.Int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v"+version+"/"+name, func(w http.ResponseWriter, r *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write(archive)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func testSpec(t *testing.T, version string) (Spec, string, *atomic.Int32) {
+	t.Helper()
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	name, err := archiveName(version, runtime.GOOS, runtime.GOARCH)
+	require.NoError(t, err)
+	archive := makeArchive(t, archiveBase(name))
+	var downloads atomic.Int32
+	srv := serveDist(t, version, archive, name, &downloads)
+	return Spec{Version: version, BaseURL: srv.URL}, name, &downloads
+}
+
+//nolint:paralleltest // testSpec uses t.Setenv
+func TestResolveDownloadsAndCaches(t *testing.T) {
+	spec, _, downloads := testSpec(t, "9.9.9")
+	var out bytes.Buffer
+	spec.Output = &out
+
+	res, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	assert.FileExists(t, res.Node)
+	assert.Contains(t, out.String(), "9.9.9")
+	assert.Equal(t, int32(1), downloads.Load())
+
+	out.Reset()
+	res2, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, res, res2)
+	assert.Empty(t, out.String(), "cache hit must be silent")
+	assert.Equal(t, int32(1), downloads.Load(), "cache hit must not re-download")
+}
+
+func TestResolveDownloadNotFound(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	_, err := Resolve(t.Context(), Spec{Version: "9.9.9", BaseURL: srv.URL})
+	assert.ErrorContains(t, err, "HTTP 404")
+}
+
+//nolint:paralleltest // testSpec uses t.Setenv
+func TestResolveConcurrent(t *testing.T) {
+	spec, _, downloads := testSpec(t, "9.9.9")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = Resolve(t.Context(), spec)
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), downloads.Load(), "concurrent resolves must download once")
+}
+
+//nolint:paralleltest // testSpec uses t.Setenv
+func TestResolveRepairsCorruptedCache(t *testing.T) {
+	spec, name, downloads := testSpec(t, "9.9.9")
+
+	res, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(res.Node))
+
+	_ = name
+	res2, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	assert.FileExists(t, res2.Node)
+	assert.Equal(t, int32(2), downloads.Load())
+}
+
+// TestResolveRepairsPartialInstall ensures a directory whose .partial marker
+// was left behind by an install that died mid-extract is replaced, even when
+// the binaries it did manage to extract look healthy.
+//
+//nolint:paralleltest // testSpec uses t.Setenv
+func TestResolveRepairsPartialInstall(t *testing.T) {
+	spec, name, downloads := testSpec(t, "9.9.9")
+
+	_, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	root, err := workspace.GetPulumiPath("node", archiveBase(name))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(root+".partial", nil, 0o600))
+
+	res, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	assert.FileExists(t, res.Node)
+	assert.NoFileExists(t, root+".partial")
+	assert.Equal(t, int32(2), downloads.Load())
+}
+
+// TestResolveRepairsDanglingNpm ensures a cache entry with a healthy node
+// binary but a missing npm binary is treated as corrupted and re-downloaded,
+// rather than being cached forever with a permanently broken npm.
+//
+//nolint:paralleltest // testSpec uses t.Setenv
+func TestResolveRepairsDanglingNpm(t *testing.T) {
+	spec, name, downloads := testSpec(t, "9.9.9")
+
+	res, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(res.Npm))
+
+	_ = name
+	res2, err := Resolve(t.Context(), spec)
+	require.NoError(t, err)
+	assert.FileExists(t, res2.Node)
+	assert.FileExists(t, res2.Npm)
+	assert.Equal(t, int32(2), downloads.Load())
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/noderesolver.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/noderesolver.go
@@ -1,0 +1,102 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package noderesolver downloads and caches pinned Node.js distributions
+// under ~/.pulumi/node/.
+package noderesolver
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Spec struct {
+	// Version is an exact Node.js version without a leading "v", e.g. "22.12.0".
+	Version string
+	// BaseURL overrides the download base URL, defaulting to
+	// https://nodejs.org/dist. It must serve the nodejs.org/dist
+	// directory layout.
+	BaseURL string
+	// Output, if non-nil, receives a one-line message when a download
+	// actually starts. Nil means silent.
+	Output io.Writer
+}
+
+type Result struct {
+	Node   string
+	Npm    string
+	BinDir string
+}
+
+const defaultBaseURL = "https://nodejs.org/dist"
+
+func (s Spec) baseURL() string {
+	if s.BaseURL != "" {
+		return strings.TrimRight(s.BaseURL, "/")
+	}
+	return defaultBaseURL
+}
+
+func archiveName(version, goos, goarch string) (string, error) {
+	var osName string
+	switch goos {
+	case "linux", "darwin":
+		osName = goos
+	case "windows":
+		osName = "win"
+	default:
+		return "", fmt.Errorf("no Node.js build available for OS %q (supported: linux, darwin, windows)", goos)
+	}
+	var archName string
+	switch goarch {
+	case "amd64":
+		archName = "x64"
+	case "arm64":
+		archName = "arm64"
+	default:
+		return "", fmt.Errorf("no Node.js build available for architecture %q (supported: amd64, arm64)", goarch)
+	}
+	ext := ".tar.gz"
+	if goos == "windows" {
+		ext = ".zip"
+	}
+	return fmt.Sprintf("node-v%s-%s-%s%s", version, osName, archName, ext), nil
+}
+
+// layoutBinDir returns the directory containing the node executable inside an
+// extracted distribution: Windows zips place binaries at the archive root,
+// unix tarballs under bin/.
+func layoutBinDir(root, archiveBase, goos string) string {
+	if goos == "windows" {
+		return filepath.Join(root, archiveBase)
+	}
+	return filepath.Join(root, archiveBase, "bin")
+}
+
+func nodeExe() string {
+	if runtime.GOOS == "windows" {
+		return "node.exe"
+	}
+	return "node"
+}
+
+func npmExe() string {
+	if runtime.GOOS == "windows" {
+		return "npm.cmd"
+	}
+	return "npm"
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/noderesolver_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/noderesolver/noderesolver_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noderesolver
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveName(t *testing.T) {
+	t.Parallel()
+
+	name, err := archiveName("22.12.0", "linux", "amd64")
+	require.NoError(t, err)
+	assert.Equal(t, "node-v22.12.0-linux-x64.tar.gz", name)
+
+	name, err = archiveName("22.12.0", "darwin", "arm64")
+	require.NoError(t, err)
+	assert.Equal(t, "node-v22.12.0-darwin-arm64.tar.gz", name)
+
+	name, err = archiveName("22.12.0", "windows", "amd64")
+	require.NoError(t, err)
+	assert.Equal(t, "node-v22.12.0-win-x64.zip", name)
+
+	_, err = archiveName("22.12.0", "plan9", "amd64")
+	assert.ErrorContains(t, err, "plan9")
+	assert.ErrorContains(t, err, "supported")
+
+	_, err = archiveName("22.12.0", "linux", "mips")
+	assert.ErrorContains(t, err, "mips")
+}
+
+func TestLayoutBinDir(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		filepath.Join("root", "node-v22.12.0-linux-x64", "bin"),
+		layoutBinDir("root", "node-v22.12.0-linux-x64", "linux"))
+	assert.Equal(t,
+		filepath.Join("root", "node-v22.12.0-win-x64"),
+		layoutBinDir("root", "node-v22.12.0-win-x64", "windows"))
+}
+
+func TestBaseURL(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "https://nodejs.org/dist", Spec{}.baseURL())
+	assert.Equal(t, "https://mirror.example.com", Spec{BaseURL: "https://mirror.example.com/"}.baseURL())
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/pinnednode.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/pinnednode.go
@@ -1,0 +1,117 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3/noderesolver"
+	"github.com/pulumi/pulumi/sdk/v3/nodejs/npm"
+)
+
+var nodeVersionRegexp = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// parseNodeVersionOption validates the nodeVersion runtime option against the
+// runtime and the already-parsed packagemanager option, returning the exact
+// version or "" when the option is absent.
+func parseNodeVersionOption(
+	options map[string]any, runtime string, packagemanager npm.PackageManagerType,
+) (string, error) {
+	nodeVersion, ok := options["nodeVersion"]
+	if !ok {
+		return "", nil
+	}
+	nv, ok := nodeVersion.(string)
+	if !ok {
+		return "", errors.New("nodeVersion option must be a string")
+	}
+	if !nodeVersionRegexp.MatchString(nv) {
+		return "", fmt.Errorf(
+			"nodeVersion must be an exact version of the form X.Y.Z (for example 22.12.0), got %q", nv)
+	}
+	if runtime == "bun" {
+		return "", errors.New("the nodeVersion option is not supported with the bun runtime")
+	}
+	if packagemanager != "" &&
+		packagemanager != npm.AutoPackageManager &&
+		packagemanager != npm.NpmPackageManager {
+		return "", fmt.Errorf(
+			"the nodeVersion option requires the npm package manager (only npm ships with a Node.js "+
+				"distribution), but packagemanager is set to %q", packagemanager)
+	}
+	return nv, nil
+}
+
+// pinnedNode resolves the pinned Node.js toolchain when opts.nodeVersion is
+// set and applies to this request. It returns nil when no version is pinned,
+// and warns and returns nil when a version is pinned somewhere pinning isn't
+// supported yet.
+func pinnedNode(ctx context.Context, opts nodeOptions, applies bool, out io.Writer) (*noderesolver.Result, error) {
+	if opts.nodeVersion == "" {
+		return nil, nil
+	}
+	if !applies {
+		fmt.Fprintf(out,
+			"warning: the nodeVersion runtime option is currently only supported for policy packs "+
+				"and was ignored\n")
+		return nil, nil
+	}
+	res, err := noderesolver.Resolve(ctx, noderesolver.Spec{Version: opts.nodeVersion, Output: out})
+	if err != nil {
+		return nil, fmt.Errorf("resolving pinned Node.js v%s: %w", opts.nodeVersion, err)
+	}
+	return &res, nil
+}
+
+// prependPathInEnv returns a copy of env with dir prepended to its PATH
+// entry, adding one when none exists. Only the child process that receives
+// the returned slice sees the modified PATH.
+func prependPathInEnv(env []string, dir string) []string {
+	out := make([]string, len(env), len(env)+1)
+	copy(out, env)
+	for i, kv := range out {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok && strings.EqualFold(k, "PATH") {
+			out[i] = k + "=" + dir + string(os.PathListSeparator) + v
+			return out
+		}
+	}
+	return append(out, "PATH="+dir)
+}
+
+// pinnedNpmInstall runs the pinned toolchain's npm directly instead of going
+// through the npm package's PATH-based resolution. The managed bin dir is
+// prepended to the child PATH because npm's launcher re-resolves node by
+// name.
+func pinnedNpmInstall(
+	ctx context.Context, node noderesolver.Result, dir string, production bool, stdout, stderr io.Writer,
+) error {
+	args := []string{"install", "--loglevel=error"}
+	if production {
+		args = append(args, "--production")
+	}
+	cmd := exec.CommandContext(ctx, node.Npm, args...)
+	cmd.Dir = dir
+	cmd.Env = prependPathInEnv(os.Environ(), node.BinDir)
+	cmd.Stdout, cmd.Stderr = stdout, stderr
+	return cmd.Run()
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/pinnednode_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/pinnednode_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3/noderesolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrependPathInEnv(t *testing.T) {
+	t.Parallel()
+
+	sep := string(os.PathListSeparator)
+
+	env := []string{"FOO=bar", "PATH=/usr/bin" + sep + "/bin"}
+	got := prependPathInEnv(env, "/managed/bin")
+	assert.Equal(t, []string{"FOO=bar", "PATH=/managed/bin" + sep + "/usr/bin" + sep + "/bin"}, got)
+	assert.Equal(t, "PATH=/usr/bin"+sep+"/bin", env[1], "input must not be mutated")
+
+	// Windows spells it "Path"; the key match is case-insensitive and the
+	// original key casing is preserved.
+	got = prependPathInEnv([]string{"Path=C:\\Windows"}, "C:\\managed")
+	assert.Equal(t, []string{"Path=C:\\managed" + sep + "C:\\Windows"}, got)
+
+	got = prependPathInEnv([]string{"FOO=bar"}, "/managed/bin")
+	assert.Equal(t, []string{"FOO=bar", "PATH=/managed/bin"}, got)
+}
+
+func TestPinnedNpmInstall(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("test fakes npm with a shell script")
+	}
+
+	binDir := t.TempDir()
+	marker := filepath.Join(binDir, "invoked")
+	script := "#!/bin/sh\necho \"$@\" > " + marker + "\necho \"PATH=$PATH\" >> " + marker + "\n"
+	npmPath := filepath.Join(binDir, "npm")
+	//nolint:gosec // we want this file to be executable
+	require.NoError(t, os.WriteFile(npmPath, []byte(script), 0o755))
+
+	dir := t.TempDir()
+	node := noderesolver.Result{Node: filepath.Join(binDir, "node"), Npm: npmPath, BinDir: binDir}
+	var out bytes.Buffer
+	require.NoError(t, pinnedNpmInstall(t.Context(), node, dir, false, &out, &out))
+
+	data, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "install --loglevel=error")
+	assert.Contains(t, string(data), "PATH="+binDir)
+
+	require.NoError(t, pinnedNpmInstall(t.Context(), node, dir, true, &out, &out))
+	data, err = os.ReadFile(marker)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "--production")
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1168,6 +1168,36 @@ func TestMandatoryPolicyPack(t *testing.T) {
 	assert.Contains(t, stdout, "❌ typescript@v0.0.1 (local: mandatory_policy_pack)")
 }
 
+func TestPinnedNodePolicyPack(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("single_resource")
+	e.ImportDirectory("policy")
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+
+	stackName, err := resource.NewUniqueHex("pinned-node-policy-pack", 8, -1)
+	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
+
+	e.RunCommand("pulumi", "stack", "init", stackName)
+
+	_, _, err = e.GetCommandResultsIn(filepath.Join(e.CWD, "pinned_node_policy_pack"), "npm", "install")
+	require.NoError(t, err)
+
+	e.InstallDependencies()
+
+	stdout, _, err := e.GetCommandResults(
+		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "pinned_node_policy_pack",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, stdout, "error: update failed")
+	// The violation message proves the pack executed on the pinned version,
+	// not whatever node is on the PATH.
+	assert.Contains(t, stdout, "policy pack running on node v22.12.0")
+}
+
 func TestBunMandatoryPolicyPack(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration/policy/pinned_node_policy_pack/PulumiPolicy.yaml
+++ b/tests/integration/policy/pinned_node_policy_pack/PulumiPolicy.yaml
@@ -1,0 +1,5 @@
+runtime:
+  name: nodejs
+  options:
+    nodeVersion: 22.12.0
+description: Policy pack that reports the Node version it runs on.

--- a/tests/integration/policy/pinned_node_policy_pack/index.ts
+++ b/tests/integration/policy/pinned_node_policy_pack/index.ts
@@ -1,0 +1,12 @@
+import { PolicyPack } from "@pulumi/policy";
+
+new PolicyPack("pinned-node", {
+    policies: [{
+        name: "report-node-version",
+        description: "Reports the Node.js version the pack runs on.",
+        enforcementLevel: "mandatory",
+        validateStack: (stack, reportViolation) => {
+            reportViolation(`policy pack running on node ${process.version}`);
+        },
+    }],
+});

--- a/tests/integration/policy/pinned_node_policy_pack/package.json
+++ b/tests/integration/policy/pinned_node_policy_pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "pinned-node",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/policy": "^1.3.0"
+    },
+    "devDependencies": {
+        "@types/node": "10.17.60"
+    }
+}

--- a/tests/integration/policy/pinned_node_policy_pack/tsconfig.json
+++ b/tests/integration/policy/pinned_node_policy_pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
## Summary

Policy packs can declare an exact Node.js version in `PulumiPolicy.yaml`; the nodejs language host downloads that build, caches it under `~/.pulumi/node/`, and always uses it to run the pack — instead of requiring Node on the consumer's PATH.

```yaml
runtime:
  name: nodejs
  options:
    nodeVersion: 22.12.0
```

This addresses the primary friction for server-enforced org policies: a developer whose program is Go/Python/.NET no longer needs Node.js installed just because their org enforces a TypeScript policy pack. It also makes the runtime deterministic — the pack runs on the exact declared version everywhere, rather than whatever `node` is on PATH.


