### PR TITLE
logging: stop giving plugins their own logfiles with --logflow

### DIFF
--- a/changelog/pending/cli-improvement-20260715-115414.yaml
+++ b/changelog/pending/cli-improvement-20260715-115414.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Make `-v<n> --logflow` no longer produce separate log files for plugins
+time: 2026-07-15T11:54:14.933795614+02:00

--- a/pkg/logging/otel_exporter.go
+++ b/pkg/logging/otel_exporter.go
@@ -48,19 +48,31 @@ func (e *SlogLogExporter) exportRecord(lr plog.LogRecord) {
 
 	attrs := make([]any, 0, lr.Attributes().Len()*2)
 	lr.Attributes().Range(func(key string, val pcommon.Value) bool {
-		if val.Type() == pcommon.ValueTypeBytes {
-			raw := val.Bytes().AsRaw()
-			sv, err := logging.DecodeStructValueFromLog(raw)
-			if err == nil {
-				attrs = append(attrs, key, logging.PropertyValue{Key: key, Value: sv})
-				return true
-			}
-		}
-		attrs = append(attrs, key, val.AsString())
+		attrs = append(attrs, key, logAttrValue(key, val))
 		return true
 	})
 
 	slog.Log(context.Background(), level, msg, attrs...)
+}
+
+// logAttrValue converts an OTLP attribute back into the value the plugin
+// originally logged, so that downstream handlers see the integer "v"
+// verbosity attribute and structured values instead of their string forms.
+func logAttrValue(key string, val pcommon.Value) any {
+	switch val.Type() {
+	case pcommon.ValueTypeBytes:
+		if sv, err := logging.DecodeStructValueFromLog(val.Bytes().AsRaw()); err == nil {
+			return logging.PropertyValue{Key: key, Value: sv}
+		}
+		return val.AsString()
+	case pcommon.ValueTypeInt, pcommon.ValueTypeDouble, pcommon.ValueTypeBool,
+		pcommon.ValueTypeMap, pcommon.ValueTypeSlice:
+		return val.AsRaw()
+	case pcommon.ValueTypeEmpty, pcommon.ValueTypeStr:
+		return val.AsString()
+	default:
+		return val.AsString()
+	}
 }
 
 func otlpSeverityToSlog(sev plog.SeverityNumber) slog.Level {

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -234,10 +234,10 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	handlerMu.Lock()
 
 	switch {
-	case LogToStderr && exportHandler != nil:
-		// Logs already flow to the engine over OTel, so ignore --logtostderr:
-		// writing JSON records to stderr would only leak them into the
-		// engine's display of our output.
+	case exportHandler != nil:
+		// Logs already flow to the engine over OTel, so skip local output:
+		// a log file would only duplicate them, and writing JSON records to
+		// stderr would leak them into the engine's display of our output.
 		primary = discardHandler{}
 	case LogToStderr:
 		primary = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -68,6 +68,33 @@ func TestInitLoggingIgnoresLogToStderrWithOTel(t *testing.T) {
 	assert.Equal(t, discardHandler{}, primary)
 }
 
+// TestInitLoggingSkipsLogFileWithOTel verifies that no local log file is
+// created when logs are exported over OTel: the engine receives the records
+// and writes them to its own log output.
+func TestInitLoggingSkipsLogFileWithOTel(t *testing.T) { //nolint:paralleltest // mutates global logging state
+	t.Setenv("PULUMI_LOG_OTLP_ENDPOINT", "127.0.0.1:1")
+
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	prevPath, prevFile := logFilePath, logFile
+	t.Cleanup(func() {
+		shutdownExportHandler()
+		handlerMu.Lock()
+		primary = discardHandler{}
+		logFilePath, logFile = prevPath, prevFile
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	InitLogging(false, 9, false)
+
+	handlerMu.RLock()
+	defer handlerMu.RUnlock()
+	require.NotNil(t, exportHandler)
+	assert.Equal(t, discardHandler{}, primary)
+	assert.Equal(t, prevPath, logFilePath)
+}
+
 func TestFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Currently when the user passes `--logflow` and `-v<n>`, but not `--logtostderr`, each plugin creates its own logfile in addidion to sending the logs to the CLI via otel.

This duplication is both unnecessary and makes it harder to build improvements in the logging system.

While there, also improve the way we send attributes, so they are returned in their correct type when possible, instead of always returning them as strings.
