### PR TITLE
Expose `pdag.DAG[T].{Predecessors,Successors}`

### DIFF
--- a/pkg/util/pdag/pdag.go
+++ b/pkg/util/pdag/pdag.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"iter"
 	"runtime/debug"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -252,6 +253,31 @@ func (g *DAG[T]) Drain(ctx context.Context) iter.Seq2[T, Done] {
 		for iterate(yield) {
 		}
 	}
+}
+
+// Return the set of nodes that n directly depends on.
+//
+// Predecessors is not safe to call while mutating the graph.
+func (g *DAG[T]) Predecessors(n Node) iter.Seq[Node] {
+	nInner := g.nodes[n.i]
+	predecessors := make([]Node, len(nInner.prerequisites))
+	for i, v := range nInner.prerequisites {
+		predecessors[i] = Node{v}
+	}
+	return slices.Values(predecessors)
+}
+
+// Return the set of nodes that have a direct dependency on n.
+//
+// Successors is not safe to call while mutating the graph.
+func (g *DAG[T]) Successors(n Node) iter.Seq[Node] {
+	successors := []Node{}
+	for i, candidate := range g.nodes {
+		if slices.Contains(candidate.prerequisites, n.i) {
+			successors = append(successors, Node{i})
+		}
+	}
+	return slices.Values(successors)
 }
 
 // Calling marks a process as done.

--- a/pkg/util/pdag/pdag_test.go
+++ b/pkg/util/pdag/pdag_test.go
@@ -786,14 +786,17 @@ func TestDAG_Predecessors(t *testing.T) {
 	a := newFinishedNode(dag, "a")
 	b := newFinishedNode(dag, "b")
 	c := newFinishedNode(dag, "c")
+	d := newFinishedNode(dag, "d")
 
 	require.NoError(t, dag.NewEdge(a, b))
 	require.NoError(t, dag.NewEdge(a, c))
 	require.NoError(t, dag.NewEdge(b, c))
+	require.NoError(t, dag.NewEdge(c, d))
 
 	assert.Empty(t, slices.Collect(dag.Predecessors(a)))
 	assert.Equal(t, []pdag.Node{a}, slices.Collect(dag.Predecessors(b)))
 	assert.ElementsMatch(t, []pdag.Node{a, b}, slices.Collect(dag.Predecessors(c)))
+	assert.Equal(t, []pdag.Node{c}, slices.Collect(dag.Predecessors(d)))
 }
 
 func TestDAG_Successors(t *testing.T) {
@@ -803,14 +806,17 @@ func TestDAG_Successors(t *testing.T) {
 	a := newFinishedNode(dag, "a")
 	b := newFinishedNode(dag, "b")
 	c := newFinishedNode(dag, "c")
+	d := newFinishedNode(dag, "d")
 
 	require.NoError(t, dag.NewEdge(a, b))
 	require.NoError(t, dag.NewEdge(a, c))
 	require.NoError(t, dag.NewEdge(b, c))
+	require.NoError(t, dag.NewEdge(c, d))
 
 	assert.ElementsMatch(t, []pdag.Node{b, c}, slices.Collect(dag.Successors(a)))
 	assert.Equal(t, []pdag.Node{c}, slices.Collect(dag.Successors(b)))
-	assert.Empty(t, slices.Collect(dag.Successors(c)))
+	assert.Equal(t, []pdag.Node{d}, slices.Collect(dag.Successors(c)))
+	assert.Empty(t, slices.Collect(dag.Successors(d)))
 }
 
 func TestWalk_DynamicNodeAddition(t *testing.T) {

--- a/pkg/util/pdag/pdag_test.go
+++ b/pkg/util/pdag/pdag_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -776,6 +777,40 @@ func TestNewEdge_ErrorReentrant(t *testing.T) {
 		err = dag.NewEdge(n1, n2)
 		require.NoError(t, err, "should allow edge from done to done")
 	})
+}
+
+func TestDAG_Predecessors(t *testing.T) {
+	t.Parallel()
+
+	dag := pdag.New[string]()
+	a := newFinishedNode(dag, "a")
+	b := newFinishedNode(dag, "b")
+	c := newFinishedNode(dag, "c")
+
+	require.NoError(t, dag.NewEdge(a, b))
+	require.NoError(t, dag.NewEdge(a, c))
+	require.NoError(t, dag.NewEdge(b, c))
+
+	assert.Empty(t, slices.Collect(dag.Predecessors(a)))
+	assert.Equal(t, []pdag.Node{a}, slices.Collect(dag.Predecessors(b)))
+	assert.ElementsMatch(t, []pdag.Node{a, b}, slices.Collect(dag.Predecessors(c)))
+}
+
+func TestDAG_Successors(t *testing.T) {
+	t.Parallel()
+
+	dag := pdag.New[string]()
+	a := newFinishedNode(dag, "a")
+	b := newFinishedNode(dag, "b")
+	c := newFinishedNode(dag, "c")
+
+	require.NoError(t, dag.NewEdge(a, b))
+	require.NoError(t, dag.NewEdge(a, c))
+	require.NoError(t, dag.NewEdge(b, c))
+
+	assert.ElementsMatch(t, []pdag.Node{b, c}, slices.Collect(dag.Successors(a)))
+	assert.Equal(t, []pdag.Node{c}, slices.Collect(dag.Successors(b)))
+	assert.Empty(t, slices.Collect(dag.Successors(c)))
 }
 
 func TestWalk_DynamicNodeAddition(t *testing.T) {


### PR DESCRIPTION
This information may be useful (and is in pulumi-labs/pulumi-hcl). It's simple to expose.