### PR TITLE
fix compatibility for property diffs

### DIFF
--- a/sdk/go/common/resource/property_compatibility_test.go
+++ b/sdk/go/common/resource/property_compatibility_test.go
@@ -122,3 +122,40 @@ func TestDiffCompatibility(t *testing.T) {
 			resource.ToResourcePropertyMap(a).Diff(resource.ToResourcePropertyMap(b)))
 	})
 }
+
+func TestDiffCompatibilityWrappedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a, b property.Map
+	}{
+		{
+			"secret arrays",
+			property.NewMap(map[string]property.Value{
+				"k": property.New([]property.Value{property.New(1.0)}).WithSecret(true),
+			}),
+			property.NewMap(map[string]property.Value{
+				"k": property.New([]property.Value{property.New(2.0)}).WithSecret(true),
+			}),
+		},
+		{
+			"secret maps with null values",
+			property.NewMap(map[string]property.Value{
+				"k": property.New(map[string]property.Value{"n": property.New(property.Null)}).WithSecret(true),
+			}),
+			property.NewMap(map[string]property.Value{
+				"k": property.New(property.Map{}).WithSecret(true),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t,
+				resource.ToResourceObjectDiff(tt.a.Diff(tt.b)),
+				resource.ToResourcePropertyMap(tt.a).Diff(resource.ToResourcePropertyMap(tt.b)))
+		})
+	}
+}

--- a/sdk/go/property/diff.go
+++ b/sdk/go/property/diff.go
@@ -265,6 +265,8 @@ func (v Value) diff(other Value, opts diffOptions, path Path) *ValueDiff {
 		return &ValueDiff{Old: v, New: other}
 	}
 
+	opaque := v.Secret() || len(v.Dependencies()) > 0
+
 	if v.IsArray() && other.IsArray() {
 		old := v.AsArray()
 		new := other.AsArray()
@@ -293,6 +295,9 @@ func (v Value) diff(other Value, opts diffOptions, path Path) *ValueDiff {
 		if len(adds) == 0 && len(deletes) == 0 && len(updates) == 0 {
 			return nil
 		}
+		if opaque {
+			return &ValueDiff{Old: v, New: other}
+		}
 		return &ValueDiff{
 			Old: v,
 			New: other,
@@ -308,6 +313,9 @@ func (v Value) diff(other Value, opts diffOptions, path Path) *ValueDiff {
 		old := v.AsMap()
 		new := other.AsMap()
 		if diff := old.diff(new, opts, path); diff != nil {
+			if opaque {
+				return &ValueDiff{Old: v, New: other}
+			}
 			return &ValueDiff{
 				Old:    v,
 				New:    other,


### PR DESCRIPTION
We have a test ensuring property.Value and resource.PropertyValue diffs are the same.  This test is flaky, because in property.Value diffs, when a secret value differs in an array, we still get a detailed diff, while in resource.PropertyValue, we get an opaque diff.

Fix the compatibility test by making sure the diffs are always the same for arrays/maps with secret values.

I'm not 100% sure this is the right fix here, so I'd appreciate a closer look by someone more familiar.

Fixes https://github.com/pulumi/pulumi/issues/23941