### PR TITLE
Add `pulumi.run` for async Python program entrypoints

### DIFF
--- a/changelog/pending/sdk-python-async-entrypoint.yaml
+++ b/changelog/pending/sdk-python-async-entrypoint.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: feat
+body: Add `pulumi.run` for natively awaited Python program entrypoints that can return stack outputs
+time: 2026-07-15T16:12:38+02:00

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -121,6 +121,8 @@ from .stack_reference import (
     StackReferenceOutputDetails,
 )
 
+from .runtime.stack import run
+
 from .stash import (
     Stash,
 )
@@ -216,6 +218,8 @@ __all__ = [
     # stack_reference
     "StackReference",
     "StackReferenceOutputDetails",
+    # async program entrypoint
+    "run",
     # stash
     "Stash",
     # type_token

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -332,4 +332,4 @@ def set_mocks(
     # Ensure a new root stack resource has been initialized.
     if get_root_resource() is None:
         root_stack = Stack()
-        root_stack.finish()
+        root_stack._finish()

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -331,4 +331,5 @@ def set_mocks(
 
     # Ensure a new root stack resource has been initialized.
     if get_root_resource() is None:
-        Stack(lambda: None)
+        root_stack = Stack()
+        root_stack.finish()

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -17,10 +17,10 @@ Support for automatic stack components.
 """
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from inspect import isawaitable
-from typing import Any, Optional
-from collections.abc import Callable
-from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Any, Optional
+
 from google.protobuf import empty_pb2
 import grpc
 
@@ -33,6 +33,7 @@ from ..resource import (
     Resource,
     ResourceTransformation,
     ResourceTransform,
+    export,
 )
 from ..invoke import (
     InvokeTransform,
@@ -53,6 +54,50 @@ from .settings import (
     set_root_resource,
 )
 from .sync_await import _sync_await
+
+if TYPE_CHECKING:
+    from ..output import Inputs
+
+
+_AsyncProgram = Callable[[], Awaitable[Optional["Inputs"]]]
+
+
+def run(program: _AsyncProgram) -> None:
+    """Register an asynchronous entrypoint for the current Pulumi program.
+
+    The entrypoint is invoked and awaited after the program's top-level module
+    code has finished running. Each entry in a mapping returned by the entrypoint
+    is exported as if :func:`pulumi.export` had been called with its key and
+    value. This means returned entries merge with existing exports, overwriting
+    any existing export with the same name. The entrypoint may instead return
+    ``None`` and use :func:`pulumi.export` directly.
+
+    ``pulumi.run`` may only be called once per Pulumi program.
+
+    Example::
+
+        import pulumi
+
+        async def main() -> pulumi.Inputs:
+            value = await some_async_operation()
+            return {"value": value}
+
+        pulumi.run(main)
+
+    :param program: A zero-argument callable that returns an awaitable.
+    """
+    if not callable(program):
+        raise TypeError("pulumi.run expects a callable")
+
+    root = get_root_resource()
+    if not isinstance(root, Stack):
+        from ..errors import RunError
+
+        raise RunError(
+            "pulumi.run may only be called while a Pulumi program is running"
+        )
+
+    root._register_async_program(program)
 
 
 async def _wait_for_shutdown() -> None:
@@ -85,19 +130,23 @@ class ResourceRegistrationFailed(Exception):
     """
 
 
-async def run_pulumi_func(func: Callable[[], None]):
+async def run_pulumi_func(
+    func: Callable[[], Optional[Awaitable[None]]],
+) -> None:
     # Run the function and grab any exception it generates
-    ex = None
+    ex: Optional[BaseException] = None
     try:
-        func()
-    except Exception as e:  # noqa # We re-raise this below
+        result = func()
+        if isawaitable(result):
+            await result
+    except BaseException as e:  # noqa: BLE001 re-raised after runtime cleanup
         ex = e
 
     # Wait for RPCs to complete, then signal and wait for shutdown.
     try:
         await wait_for_rpcs()
         # If func succeeded, let the monitor decide when we should shutdown.
-        if not ex:
+        if ex is None:
             await _wait_for_shutdown()
     finally:
         # Finally, we must always shutdown the callbacks server when we're done.
@@ -105,7 +154,7 @@ async def run_pulumi_func(func: Callable[[], None]):
 
     # By now, all tasks have exited and we're good to go.
     log.debug("run_pulumi_func completed")
-    if ex:
+    if ex is not None:
         # Re-raise ex so the language runtime can report the error.
         raise ex
 
@@ -198,8 +247,24 @@ async def run_in_stack(func: Callable[[], Optional[Awaitable[None]]]):
     is meant for internal runtime use only and is used by the Python SDK entrypoint program.
     """
 
-    def run() -> None:
-        Stack(func)
+    async def run() -> None:
+        stack = Stack()
+        try:
+            result = func()
+            if isawaitable(result):
+                await result
+
+            program = stack._take_async_program()
+            if program is not None:
+                outputs = program()
+                if not isawaitable(outputs):
+                    raise TypeError(
+                        "The function passed to pulumi.run must return an awaitable"
+                    )
+
+                stack._add_program_outputs(await outputs)
+        finally:
+            stack.finish()
 
     await _load_monitor_feature_support()
     await run_pulumi_func(run)
@@ -212,7 +277,10 @@ class Stack(ComponentResource):
 
     outputs: dict[str, Any]
 
-    def __init__(self, func: Callable[[], Optional[Awaitable[None]]]) -> None:
+    def __init__(
+        self,
+        func: Optional[Callable[[], Optional[Awaitable[None]]]] = None,
+    ) -> None:
         # Ensure we don't already have a stack registered.
         if get_root_resource() is not None:
             raise Exception("Only one root Pulumi Stack may be active at once")
@@ -221,12 +289,22 @@ class Stack(ComponentResource):
         name = f"{get_project()}-{get_stack()}"
         super().__init__("pulumi:pulumi:Stack", name, None, None)
 
-        # Invoke the function while this stack is active and then register its outputs. func might return an awaitable
-        # so we need to await it, ideally we'd do this in a standard way but alas back compatibility means we do
-        # everything in stack constructors, so we have to use sync_await here.
-
         self.outputs = {}
+        self._async_program: Optional[_AsyncProgram] = None
+        self._async_program_registration_closed = False
+        self._outputs_registered = False
         set_root_resource(self)
+
+        # Stack historically invoked the program callback and finalized outputs
+        # in its constructor. Keep Stack(func) working for direct callers of this
+        # importable internal class. run_in_stack now creates Stack() and awaits
+        # user code itself.
+        if func is not None:
+            self._run_legacy_callback(func)
+
+    def _run_legacy_callback(
+        self, func: Callable[[], Optional[Awaitable[None]]]
+    ) -> None:
         try:
             awaitable = func()
             # This _should_ be an awaitable but old pulumi executors returned modules here, so we need to handle that
@@ -234,8 +312,36 @@ class Stack(ComponentResource):
             if isawaitable(awaitable):
                 _sync_await(awaitable)
         finally:
-            self.register_outputs(massage(self.outputs, []))
+            self.finish()
             # Intentionally leave this resource installed in case subsequent async work uses it.
+
+    def _register_async_program(self, program: _AsyncProgram) -> None:
+        from ..errors import RunError
+
+        if self._async_program is not None or self._async_program_registration_closed:
+            raise RunError("pulumi.run may only be called once")
+
+        self._async_program = program
+
+    def _take_async_program(self) -> Optional[_AsyncProgram]:
+        self._async_program_registration_closed = True
+        return self._async_program
+
+    def _add_program_outputs(self, outputs: Optional["Inputs"]) -> None:
+        if outputs is None:
+            return
+        for name, value in outputs.items():
+            export(name, value)
+
+    def finish(self) -> None:
+        """Register this stack's outputs exactly once."""
+        if self._outputs_registered:
+            return
+
+        self._async_program_registration_closed = True
+        outputs = massage(self.outputs, [])
+        self._outputs_registered = True
+        self.register_outputs(outputs)
 
     def output(self, name: str, value: Any):
         """

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -264,7 +264,7 @@ async def run_in_stack(func: Callable[[], Optional[Awaitable[None]]]):
 
                 stack._add_program_outputs(await outputs)
         finally:
-            stack.finish()
+            stack._finish()
 
     await _load_monitor_feature_support()
     await run_pulumi_func(run)
@@ -312,7 +312,7 @@ class Stack(ComponentResource):
             if isawaitable(awaitable):
                 _sync_await(awaitable)
         finally:
-            self.finish()
+            self._finish()
             # Intentionally leave this resource installed in case subsequent async work uses it.
 
     def _register_async_program(self, program: _AsyncProgram) -> None:
@@ -333,7 +333,7 @@ class Stack(ComponentResource):
         for name, value in outputs.items():
             export(name, value)
 
-    def finish(self) -> None:
+    def _finish(self) -> None:
         """Register this stack's outputs exactly once."""
         if self._outputs_registered:
             return

--- a/sdk/python/lib/test/runtime/test_stack.py
+++ b/sdk/python/lib/test/runtime/test_stack.py
@@ -302,7 +302,7 @@ async def test_stack_finish_registers_outputs_once(monkeypatch):
 
     root = get_root_resource()
     assert isinstance(root, stack.Stack)
-    root.finish()
+    root._finish()
     assert registrations == [{"message": "hello"}]
 
 

--- a/sdk/python/lib/test/runtime/test_stack.py
+++ b/sdk/python/lib/test/runtime/test_stack.py
@@ -12,12 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import sys
 import traceback
 
+import pulumi
 import pytest
 from pulumi.runtime import stack
-from pulumi.runtime.settings import _get_rpc_manager
+from pulumi.runtime import mocks, settings
+from pulumi.runtime.settings import _get_rpc_manager, get_root_resource
+
+
+class RuntimeMocks(pulumi.runtime.Mocks):
+    def call(self, args):
+        return {}
+
+    def new_resource(self, args):
+        return f"{args.name}-id", args.inputs
+
+
+def configure_mock_runtime():
+    settings.reset_options(project="project", stack="stack")
+    settings.SETTINGS.monitor = mocks.MockMonitor(RuntimeMocks())
+    settings.SETTINGS.engine = mocks.MockEngine(None)
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_settings():
+    configure_mock_runtime()
+    yield
+    settings.reset_options(project="project", stack="stack")
 
 
 async def _explode(n=10):
@@ -44,3 +68,258 @@ async def test_wait_for_rpcs():
         tb = ""
 
     assert "await _explode(n - 1)" in tb
+
+
+@pytest.mark.asyncio
+async def test_run_in_stack_preserves_synchronous_programs():
+    def program():
+        pulumi.export("message", "hello")
+
+    await stack.run_in_stack(program)
+
+    root = get_root_resource()
+    assert isinstance(root, stack.Stack)
+    assert root.outputs == {"message": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_run_in_stack_natively_awaits_inline_async_programs():
+    async def program():
+        await asyncio.sleep(0)
+        pulumi.export("message", "hello")
+
+    await stack.run_in_stack(program)
+
+    root = get_root_resource()
+    assert isinstance(root, stack.Stack)
+    assert root.outputs == {"message": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_run_returns_stack_outputs_and_creates_resources():
+    calls = 0
+
+    async def value():
+        await asyncio.sleep(0)
+        return "resolved"
+
+    async def program():
+        nonlocal calls
+        calls += 1
+
+        before = pulumi.ComponentResource("test:index:Component", "before")
+        await asyncio.sleep(0)
+        after = pulumi.ComponentResource("test:index:Component", "after")
+
+        return {
+            "plain": "value",
+            "output": pulumi.Output.from_input(value()),
+            "secret": pulumi.Output.secret("sensitive"),
+            "beforeUrn": before.urn,
+            "afterUrn": after.urn,
+        }
+
+    def load_program():
+        pulumi.run(program)
+
+    await stack.run_in_stack(load_program)
+
+    root = get_root_resource()
+    assert isinstance(root, stack.Stack)
+    assert calls == 1
+    assert root.outputs["plain"] == "value"
+    assert await root.outputs["output"].future() == "resolved"
+    assert await root.outputs["secret"].future() == "sensitive"
+    assert await root.outputs["secret"].is_secret()
+    assert await root.outputs["beforeUrn"].future() == (
+        "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:index:Component::before"
+    )
+    assert await root.outputs["afterUrn"].future() == (
+        "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:index:Component::after"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_none_with_explicit_exports():
+    async def program():
+        await asyncio.sleep(0)
+        pulumi.export("message", "hello")
+
+    def load_program():
+        pulumi.run(program)
+
+    await stack.run_in_stack(load_program)
+
+    root = get_root_resource()
+    assert isinstance(root, stack.Stack)
+    assert root.outputs == {"message": "hello"}
+
+
+def test_run_requires_active_stack():
+    async def program():
+        pass
+
+    with pytest.raises(
+        pulumi.RunError,
+        match="may only be called while a Pulumi program is running",
+    ):
+        pulumi.run(program)
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_multiple_calls():
+    calls = []
+
+    async def first():
+        calls.append("first")
+
+    async def second():
+        calls.append("second")
+
+    def load_program():
+        pulumi.run(first)
+        with pytest.raises(
+            pulumi.RunError,
+            match="may only be called once",
+        ):
+            pulumi.run(second)
+
+    await stack.run_in_stack(load_program)
+
+    assert calls == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_nested_calls():
+    calls = []
+
+    async def nested():
+        calls.append("nested")
+
+    async def program():
+        calls.append("program")
+        pulumi.run(nested)
+
+    def load_program():
+        pulumi.run(program)
+
+    with pytest.raises(
+        pulumi.RunError,
+        match="may only be called once",
+    ):
+        await stack.run_in_stack(load_program)
+
+    assert calls == ["program"]
+
+
+@pytest.mark.asyncio
+async def test_run_registration_does_not_leak_between_runs():
+    async def run_program(message):
+        async def program():
+            return {"message": message}
+
+        def load_program():
+            pulumi.run(program)
+
+        await stack.run_in_stack(load_program)
+        root = get_root_resource()
+        assert isinstance(root, stack.Stack)
+        return root.outputs
+
+    assert await run_program("first") == {"message": "first"}
+
+    configure_mock_runtime()
+
+    assert await run_program("second") == {"message": "second"}
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_non_awaitable_callback_result():
+    def program():
+        return {"message": "hello"}
+
+    def load_program():
+        pulumi.run(program)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="must return an awaitable"):
+        await stack.run_in_stack(load_program)
+
+
+@pytest.mark.asyncio
+async def test_run_merges_returned_outputs_via_export():
+    async def program():
+        return {
+            "message": "from return",
+            "returned": "returned value",
+        }
+
+    def load_program():
+        pulumi.export("existing", "existing value")
+        pulumi.export("message", "from export")
+        pulumi.run(program)
+
+    await stack.run_in_stack(load_program)
+
+    root = get_root_resource()
+    assert isinstance(root, stack.Stack)
+    assert root.outputs == {
+        "existing": "existing value",
+        "message": "from return",
+        "returned": "returned value",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_propagates_exception_after_await():
+    async def program():
+        await asyncio.sleep(0)
+        raise RuntimeError("entrypoint failed")
+
+    def load_program():
+        pulumi.run(program)
+
+    with pytest.raises(RuntimeError, match="entrypoint failed"):
+        await stack.run_in_stack(load_program)
+
+
+@pytest.mark.asyncio
+async def test_stack_finish_registers_outputs_once(monkeypatch):
+    registrations = []
+
+    monkeypatch.setattr(
+        stack.Stack,
+        "register_outputs",
+        lambda _self, outputs: registrations.append(outputs),
+    )
+
+    async def program():
+        return {"message": "hello"}
+
+    def load_program():
+        pulumi.run(program)
+
+    await stack.run_in_stack(load_program)
+
+    root = get_root_resource()
+    assert isinstance(root, stack.Stack)
+    root.finish()
+    assert registrations == [{"message": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_run_pulumi_func_shuts_down_callbacks_after_cancellation(monkeypatch):
+    cleaned_up = False
+
+    async def shutdown_callbacks():
+        nonlocal cleaned_up
+        cleaned_up = True
+
+    async def program():
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(stack, "_shutdown_callbacks", shutdown_callbacks)
+
+    with pytest.raises(asyncio.CancelledError):
+        await stack.run_pulumi_func(program)
+
+    assert cleaned_up

--- a/sdk/python/lib/test/test_stack_registers_outputs.py
+++ b/sdk/python/lib/test/test_stack_registers_outputs.py
@@ -93,3 +93,19 @@ async def test_stack_registers_outputs():
         assert stack.outputs["fruit"] == "banana"
     finally:
         settings.configure(old_settings)
+
+
+@pytest.mark.asyncio
+async def test_legacy_stack_awaits_program():
+    settings.reset_options()
+    old_settings = deepcopy(settings.SETTINGS)
+
+    async def program():
+        pulumi.export("fruit", "banana")
+
+    try:
+        Stack(program)
+        stack = get_root_resource()
+        assert stack.outputs == {"fruit": "banana"}
+    finally:
+        settings.configure(old_settings)


### PR DESCRIPTION
Python programs can register a zero-argument async entrypoint:

```python
# __main__.py

async def main() -> pulumi.Inputs:
    value_a = await some_async_operation()
    value_b = await some_other_async_operation()
    return {"value_a": value, "value_b": value_b} # This will register a stack outputs `value_a` and `value_b`

pulumi.run(main)
```

`pulumi.run` may be called only once per Pulumi program. The runtime invokes the callback after top-level module initialization and awaits it on the existing event loop.

If the callback returns a mapping, the runtime iterates over it and calls `pulumi.export(k, v)` for each entry. Returned outputs therefore merge with explicit exports using normal export behavior, including replacing an earlier export with the same name. The callback may instead return `None` and call `pulumi.export` directly.

Fixes https://github.com/pulumi/pulumi/issues/12172