### PR TITLE
OPA/Rego policy packs: SDK support (ConfigureStack, per-policy Type, policy-new hint)

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2021,6 +2021,7 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 			Tags:             policy.Tags,
 			RemediationSteps: policy.RemediationSteps,
 			URL:              policy.URL,
+			Type:             convertPolicyType(policy.Type),
 		}
 	}
 
@@ -2122,6 +2123,20 @@ func convertPolicyComplianceFramework(f *plugin.AnalyzerPolicyComplianceFramewor
 		Version:       f.Version,
 		Reference:     f.Reference,
 		Specification: f.Specification,
+	}
+}
+
+// convertPolicyType converts a policy's type from the analyzer to the apitype.
+func convertPolicyType(t plugin.AnalyzerPolicyType) apitype.PolicyType {
+	switch t {
+	case plugin.AnalyzerPolicyTypeResource:
+		return apitype.PolicyTypeResource
+	case plugin.AnalyzerPolicyTypeStack:
+		return apitype.PolicyTypeStack
+	case plugin.AnalyzerPolicyTypeUnknown:
+		fallthrough
+	default:
+		return apitype.PolicyTypeUnspecified
 	}
 }
 

--- a/pkg/backend/httpstate/client/client_policytype_test.go
+++ b/pkg/backend/httpstate/client/client_policytype_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestConvertPolicyType(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, apitype.PolicyTypeResource, convertPolicyType(plugin.AnalyzerPolicyTypeResource))
+	assert.Equal(t, apitype.PolicyTypeStack, convertPolicyType(plugin.AnalyzerPolicyTypeStack))
+	assert.Equal(t, apitype.PolicyTypeUnspecified, convertPolicyType(plugin.AnalyzerPolicyTypeUnknown))
+}

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	surveycore "github.com/AlecAivazis/survey/v2/core"
@@ -243,12 +242,11 @@ func printPolicyPackNextSteps(
 
 	usageCommandPreambles := []string{
 		"run the Policy Pack against a Pulumi program, in the directory of the Pulumi program run",
+		"publish the Policy Pack, run",
 	}
-	usageCommands := []string{"pulumi up --policy-pack " + root}
-
-	if strings.EqualFold(proj.Runtime.Name(), "nodejs") || strings.EqualFold(proj.Runtime.Name(), "python") {
-		usageCommandPreambles = append(usageCommandPreambles, "publish the Policy Pack, run")
-		usageCommands = append(usageCommands, "pulumi policy publish [org-name]")
+	usageCommands := []string{
+		"pulumi up --policy-pack " + root,
+		"pulumi policy publish [org-name]",
 	}
 
 	contract.Assertf(len(usageCommandPreambles) == len(usageCommands),

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -249,25 +249,13 @@ func printPolicyPackNextSteps(
 		"pulumi policy publish [org-name]",
 	}
 
-	contract.Assertf(len(usageCommandPreambles) == len(usageCommands),
-		"Number of command preambles (%d) must match number of commands (%d)",
-		len(usageCommandPreambles), len(usageCommands))
-
-	if len(usageCommands) == 1 {
-		usageMsg := fmt.Sprintf("Once you're done editing your Policy Pack, to %s `%s`", usageCommandPreambles[0],
-			usageCommands[0])
-		usageMsg = colors.Highlight(usageMsg, usageCommands[0], colors.BrightBlue+colors.Bold)
-		fmt.Fprintln(w, opts.Color.Colorize(usageMsg))
-		fmt.Fprintln(w)
-	} else {
-		fmt.Fprintln(w, "Once you're done editing your Policy Pack:")
-		fmt.Fprintln(w)
-		for i, cmd := range usageCommands {
-			cmdColors := colors.BrightBlue + colors.Bold + cmd + colors.Reset
-			fmt.Fprintf(w, "   * To %s `%s`\n", usageCommandPreambles[i], opts.Color.Colorize(cmdColors))
-		}
-		fmt.Fprintln(w)
+	fmt.Fprintln(w, "Once you're done editing your Policy Pack:")
+	fmt.Fprintln(w)
+	for i, cmd := range usageCommands {
+		cmdColors := colors.BrightBlue + colors.Bold + cmd + colors.Reset
+		fmt.Fprintf(w, "   * To %s `%s`\n", usageCommandPreambles[i], opts.Color.Colorize(cmdColors))
 	}
+	fmt.Fprintln(w)
 }
 
 // choosePolicyPackTemplate will prompt the user to choose amongst the available templates.

--- a/pkg/cmd/pulumi/policy/policy_new_test.go
+++ b/pkg/cmd/pulumi/policy/policy_new_test.go
@@ -15,12 +15,28 @@
 package policy
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPolicyPackNextStepsShowsPublishForOpa(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	proj := &workspace.PolicyPackProject{
+		Runtime: workspace.NewProjectRuntimeInfo("opa", nil),
+	}
+	printPolicyPackNextSteps(&buf, proj, ".", false /*generateOnly*/, display.Options{Color: colors.Never})
+
+	assert.Contains(t, buf.String(), "pulumi policy publish")
+}
 
 //nolint:paralleltest // changes directory for process
 func TestCreatingPolicyPackWithPromptedName(t *testing.T) {

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -133,7 +133,20 @@ type Policy struct {
 
 	// A URL to more information about the policy.
 	URL string `json:"url,omitempty"`
+
+	// Type indicates whether the policy validates a resource or the stack.
+	Type PolicyType `json:"type,omitempty"`
 }
+
+// PolicyType indicates whether a policy validates a single resource or the
+// whole stack.
+type PolicyType string
+
+const (
+	PolicyTypeUnspecified PolicyType = ""
+	PolicyTypeResource    PolicyType = "resource"
+	PolicyTypeStack       PolicyType = "stack"
+)
 
 // PolicyConfigSchema defines the JSON schema of a particular Policy's
 // configuration.

--- a/sdk/go/common/resource/plugin/analyzer.go
+++ b/sdk/go/common/resource/plugin/analyzer.go
@@ -64,6 +64,25 @@ type Analyzer interface {
 	Cancel(ctx context.Context) error
 }
 
+// AnalyzerStackConfigureArgs carries the per-stack configuration the engine
+// sends to an analyzer before analysis begins.
+type AnalyzerStackConfigureArgs struct {
+	Stack            string
+	Project          string
+	Organization     string
+	DryRun           bool
+	Tags             map[string]string
+	Config           map[string]string
+	ConfigSecretKeys []string
+}
+
+// StackConfigurableAnalyzer is optionally implemented by analyzers that want to
+// receive per-stack configuration. Analyzers that do not implement it keep the
+// default no-op ConfigureStack behavior.
+type StackConfigurableAnalyzer interface {
+	ConfigureStack(ctx context.Context, args AnalyzerStackConfigureArgs) error
+}
+
 // AnalyzerResource mirrors a resource that is passed to `Analyze`.
 type AnalyzerResource struct {
 	URN        resource.URN

--- a/sdk/go/common/resource/plugin/analyzer_server.go
+++ b/sdk/go/common/resource/plugin/analyzer_server.go
@@ -268,8 +268,21 @@ func (a *analyzerServer) Handshake(
 }
 
 func (a *analyzerServer) ConfigureStack(
-	context.Context, *pulumirpc.AnalyzerStackConfigureRequest,
+	ctx context.Context, req *pulumirpc.AnalyzerStackConfigureRequest,
 ) (*pulumirpc.AnalyzerStackConfigureResponse, error) {
+	if sc, ok := a.analyzer.(StackConfigurableAnalyzer); ok {
+		if err := sc.ConfigureStack(ctx, AnalyzerStackConfigureArgs{
+			Stack:            req.GetStack(),
+			Project:          req.GetProject(),
+			Organization:     req.GetOrganization(),
+			DryRun:           req.GetDryRun(),
+			Tags:             req.GetTags(),
+			Config:           req.GetConfig(),
+			ConfigSecretKeys: req.GetConfigSecretKeys(),
+		}); err != nil {
+			return nil, err
+		}
+	}
 	return &pulumirpc.AnalyzerStackConfigureResponse{}, nil
 }
 

--- a/sdk/go/common/resource/plugin/analyzer_server_test.go
+++ b/sdk/go/common/resource/plugin/analyzer_server_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// fakeAnalyzer implements Analyzer with no-op methods and does NOT implement
+// StackConfigurableAnalyzer.
+type fakeAnalyzer struct{}
+
+func (f *fakeAnalyzer) Close() error       { return nil }
+func (f *fakeAnalyzer) Name() tokens.QName { return "fake" }
+func (f *fakeAnalyzer) Analyze(context.Context, AnalyzerResource) (AnalyzeResponse, error) {
+	return AnalyzeResponse{}, nil
+}
+
+func (f *fakeAnalyzer) AnalyzeStack(context.Context, []AnalyzerStackResource) (AnalyzeResponse, error) {
+	return AnalyzeResponse{}, nil
+}
+
+func (f *fakeAnalyzer) Remediate(context.Context, AnalyzerResource) (RemediateResponse, error) {
+	return RemediateResponse{}, nil
+}
+
+func (f *fakeAnalyzer) GetAnalyzerInfo(context.Context) (AnalyzerInfo, error) {
+	return AnalyzerInfo{}, nil
+}
+
+func (f *fakeAnalyzer) GetPluginInfo(context.Context) (PluginInfo, error) {
+	return PluginInfo{}, nil
+}
+
+func (f *fakeAnalyzer) Configure(context.Context, map[string]AnalyzerPolicyConfig) error {
+	return nil
+}
+func (f *fakeAnalyzer) Cancel(context.Context) error { return nil }
+
+// fakeStackConfigurableAnalyzer additionally implements StackConfigurableAnalyzer.
+type fakeStackConfigurableAnalyzer struct {
+	fakeAnalyzer
+	gotArgs *AnalyzerStackConfigureArgs
+}
+
+func (f *fakeStackConfigurableAnalyzer) ConfigureStack(
+	_ context.Context, args AnalyzerStackConfigureArgs,
+) error {
+	f.gotArgs = &args
+	return nil
+}
+
+func TestConfigureStackForwardsToStackConfigurableAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeStackConfigurableAnalyzer{}
+	srv := NewAnalyzerServer(fake)
+
+	req := &pulumirpc.AnalyzerStackConfigureRequest{
+		Stack:            "dev",
+		Project:          "proj",
+		Organization:     "org",
+		DryRun:           true,
+		Tags:             map[string]string{"k": "v"},
+		Config:           map[string]string{"proj:key": "val"},
+		ConfigSecretKeys: []string{"proj:secret"},
+	}
+
+	_, err := srv.ConfigureStack(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, fake.gotArgs)
+	assert.Equal(t, "dev", fake.gotArgs.Stack)
+	assert.Equal(t, "proj", fake.gotArgs.Project)
+	assert.Equal(t, "org", fake.gotArgs.Organization)
+	assert.True(t, fake.gotArgs.DryRun)
+	assert.Equal(t, map[string]string{"k": "v"}, fake.gotArgs.Tags)
+	assert.Equal(t, map[string]string{"proj:key": "val"}, fake.gotArgs.Config)
+	assert.Equal(t, []string{"proj:secret"}, fake.gotArgs.ConfigSecretKeys)
+}
+
+func TestConfigureStackNoOpForPlainAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	srv := NewAnalyzerServer(&fakeAnalyzer{})
+	_, err := srv.ConfigureStack(
+		t.Context(),
+		&pulumirpc.AnalyzerStackConfigureRequest{Stack: "dev"},
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What

SDK-side changes to support authoring Pulumi policy packs in OPA/Rego (`runtime: opa`, evaluated by the `pulumi-analyzer-policy-opa` analyzer plugin). All three changes are additive and backward-compatible.

- **`ConfigureStack` forwarding.** Adds an optional `StackConfigurableAnalyzer` interface and `AnalyzerStackConfigureArgs` to `sdk/go/common/resource/plugin`. `NewAnalyzerServer.ConfigureStack` now forwards the stack configuration the engine already sends (stack, project, organization, dry-run, tags, config, config-secret-keys) to analyzers that opt in. Analyzers that don't implement the interface keep the existing no-op behavior — nothing breaks.
- **Per-policy `Type` on publish.** Adds `apitype.PolicyType` (`""`/`"resource"`/`"stack"`) and a `Type` field on `apitype.Policy`, and maps `AnalyzerPolicyInfo.Type` into the publish payload so the resource-vs-stack distinction is preserved end to end. The field is `omitempty`; analyzers that don't set it publish an absent value (treated as unspecified/legacy).
- **`pulumi policy new` publish hint.** The "publish the Policy Pack" next-step is now shown for all runtimes, not just `nodejs`/`python` (publish itself was never runtime-gated). Also drops a now-unreachable single-command branch this exposed.

## Why

These are the `pulumi/pulumi` prerequisites for OPA/Rego policy packs. The `ConfigureStack` forwarding lets a Rego evaluator see stack config/tags; the `Type` field lets consumers distinguish resource vs stack policies; the hint change removes a runtime-specific gap in `policy new`.

## Backward compatibility

- New optional interface (type assertion) — existing analyzer plugins are unaffected.
- New `apitype` field is additive and `omitempty`.
- No existing exported signature changed.

## Testing

- New unit tests: `ConfigureStack` forwarding (opt-in + no-op paths); `convertPolicyType` mapping; `policy new` publish-hint output.
- `go test` passes for all touched packages: `sdk/go/common/apitype`, `sdk/go/common/resource/plugin`, `pkg/backend/httpstate/client`, `pkg/cmd/pulumi/policy`.

## Notes for reviewers

- Draft. Still to do before ready: **add a changelog entry**.
- The analyzer plugin package exists in two copies (`sdk/...` consumed by external plugin authors, `pkg/...` used by the engine). The `ConfigureStack` change intentionally lands in the **sdk** copy only.
- Follow-up work (separate): the OPA analyzer plugin consuming `StackConfigurableAnalyzer`, publishing that plugin to the registry, and server-side support for the new `Type` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
