### PR TITLE
Fix converter not being called for empty files

### DIFF
--- a/changelog/pending/cli-do-fix-20260715-223614.yaml
+++ b/changelog/pending/cli-do-fix-20260715-223614.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: fix
+body: Fix the converter plugin not being called if just attributes needed converting
+time: 2026-07-15T22:36:14.359311+01:00

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2723,3 +2723,94 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, configureCalled, "Configure should be called with the converted provider config")
 }
+
+func TestDoCmdFunctionInvokeWithYAMLInputFlagsNoInputFile(t *testing.T) {
+	t.Parallel()
+
+	converterCalled := false
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
+			return &workspace.Project{
+				Name:    tokens.PackageName("my-project"),
+				Runtime: workspace.NewProjectRuntimeInfo("yaml", nil),
+			}, t.TempDir(), nil
+		},
+	}
+	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
+	}
+	loadConverter := func(
+		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
+	) (plugin.Converter, error) {
+		assert.Equal(t, "yaml", name)
+		return &plugin.MockConverter{
+			ConvertSnippetF: func(ctx context.Context, req *plugin.ConvertSnippetRequest) (
+				*plugin.ConvertSnippetResponse, error,
+			) {
+				converterCalled = true
+				assert.Equal(t, "<no input file>", req.Filename)
+				assert.Empty(t, req.Source)
+				assert.NotEmpty(t, req.TargetLoader)
+				assert.Equal(t, "azure:index:myFunction", req.Token)
+				assert.Equal(t, map[string]string{"message": "instring"}, req.Attributes)
+				return &plugin.ConvertSnippetResponse{
+					Filename: "inputs.pp",
+					Attributes: map[string]string{
+						"message": "\"outstring\"",
+					},
+				}, nil
+			},
+		}, nil
+	}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"message": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						Required: []string{"message"},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					assert.Equal(t, "outstring", req.Args["message"].StringValue())
+					return plugin.InvokeResponse{
+						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+					}, nil
+				},
+			},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, yamlHost, loadConverter)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"azure:index:myFunction",
+		"--input", "yaml",
+		"--input:message", "instring",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.True(t, converterCalled, "ConvertSnippet should be called for YAML flags even without --input-file")
+	assert.JSONEq(t, `{"output1": "world"}`, stdout.String())
+}

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -988,7 +988,8 @@ func providerFlagStackContext(
 //
 //nolint:paralleltest // mutates cmdBackend.BackendInstance via providerFlagStackContext.
 func TestDoCmdResourceProviderFlagURNNotInSnapshot(t *testing.T) {
-	cmd, _, _ := providerFlagStackContext(t,
+	cmd, _, _ := providerFlagStackContext(
+		t,
 		&testProvider{spec: doResourceSpec(false)},
 		&deploy.Snapshot{}, // empty snapshot — no resources
 	)
@@ -1056,7 +1057,8 @@ func TestDoCmdResourceProviderFlagURNNotAProvider(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, _, _ := providerFlagStackContext(t,
+			cmd, _, _ := providerFlagStackContext(
+				t,
 				&testProvider{spec: doResourceSpec(false)},
 				&deploy.Snapshot{Resources: tc.resources},
 			)
@@ -1089,21 +1091,22 @@ func TestDoCmdResourceProviderFlagMergesStackInputs(t *testing.T) {
 		},
 	}
 	var gotInputs resource.PropertyMap
-	cmd, _, _ := providerFlagStackContext(t, &testProvider{
-		spec: spec,
-		MockProvider: plugin.MockProvider{
-			ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-				gotInputs = req.Inputs
-				return plugin.ConfigureResponse{}, nil
-			},
-			ReadF: func(_ context.Context, _ plugin.ReadRequest) (plugin.ReadResponse, error) {
-				return plugin.ReadResponse{ReadResult: plugin.ReadResult{
-					ID:      "res-1",
-					Outputs: resource.PropertyMap{"name": resource.NewProperty("hello")},
-				}}, nil
+	cmd, _, _ := providerFlagStackContext(
+		t, &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+					gotInputs = req.Inputs
+					return plugin.ConfigureResponse{}, nil
+				},
+				ReadF: func(_ context.Context, _ plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      "res-1",
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("hello")},
+					}}, nil
+				},
 			},
 		},
-	},
 		//nolint:requiredfield // Only the fields configureProvider's matcher reads matter here.
 		&deploy.Snapshot{Resources: []*resource.State{
 			(&resource.NewState{
@@ -1121,6 +1124,7 @@ func TestDoCmdResourceProviderFlagMergesStackInputs(t *testing.T) {
 	// `tenant` is not supplied here and should fall through from the snapshot's inputs.
 	cmd.SetArgs([]string{
 		"azure:index:myResource", "read", "res-1",
+		"--input", "pcl",
 		"--provider", string(providerURN),
 		"--azure:region", "us-west-2",
 	})

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -313,8 +313,9 @@ func evaluatePCL(
 
 // evaluateFile reads an input file in the given format and evaluates it. For non-PCL formats the source is routed
 // through the named converter plugin's ConvertSnippet RPC and the resulting PCL is fed into the same bind pipeline.
-// An empty path is treated as "no input provided" and always goes through the PCL path so the bind step's
-// missing-required check still fires.
+// An empty path with no input flags is treated as "no input provided"; converter-backed formats still run for
+// resource/function input flags so those flags are interpreted by the selected converter before the bind step's
+// missing-required check runs.
 func evaluateFile(
 	ctx context.Context,
 	path, fileType, inputFormat, token string,
@@ -325,21 +326,26 @@ func evaluateFile(
 	evalContext functionEvalContext,
 	inputFlags map[string]inputFlagValue,
 ) (resource.PropertyMap, error) {
+	contract.Requiref(inputFormat != "", "inputFormat", "inputFormat must be non-empty")
+	filename := path
+
 	var pcl []byte
-	var filename string
-	var literals map[string]string
-	if path == "" || inputFormat == "" || inputFormat == "pcl" {
+	if path == "" {
+		// Bind still runs against an empty file so the schema's required-input check fires.
+		filename = fmt.Sprintf("<no %s file>", fileType)
+	} else {
 		var err error
-		filename = path
-		if path == "" {
-			// Bind still runs against an empty file so the schema's required-input check fires.
-			filename = fmt.Sprintf("<no %s file>", fileType)
-		} else {
-			pcl, err = os.ReadFile(path)
-			if err != nil {
-				return nil, fmt.Errorf("open %s file: %w", fileType, err)
-			}
+		pcl, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("open %s file: %w", fileType, err)
 		}
+	}
+
+	var literals map[string]string
+	if len(pcl) == 0 && len(inputFlags) == 0 {
+		// No input provided; pcl and literals are empty
+	} else if inputFormat == "pcl" {
+		var err error
 		literals, err = inputFlagLiterals(inputFlags)
 		if err != nil {
 			return nil, err
@@ -351,13 +357,9 @@ func evaluateFile(
 		}
 		defer contract.IgnoreClose(converter)
 
-		source, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("read %s file: %w", fileType, err)
-		}
 		resp, err := converter.ConvertSnippet(ctx, &plugin.ConvertSnippetRequest{
-			Filename:     path,
-			Source:       source,
+			Filename:     filename,
+			Source:       pcl,
 			TargetLoader: loaderTarget,
 			Package:      packageDescriptor,
 			Token:        token,
@@ -376,6 +378,9 @@ func evaluateFile(
 		}
 		pcl = resp.Source
 		filename = resp.Filename
+		if filename == "" {
+			filename = fmt.Sprintf("<converted %s>", fileType)
+		}
 		literals = resp.Attributes
 	}
 


### PR DESCRIPTION
If we didn't have an input file we skipped calling into the converter even though we still had attributes. This adds a test that we run through the converter, and fixes the evaluateFile function to pass.