### PR TITLE
Move RetrieveGitFolder to the gitutil package

### DIFF
--- a/changelog/pending/sdk-chore-20260715-213650.yaml
+++ b/changelog/pending/sdk-chore-20260715-213650.yaml
@@ -1,0 +1,4 @@
+component: sdk
+kind: chore
+body: Move RetrieveGitFolder to the gitutil package
+time: 2026-07-15T21:36:50.064272+01:00

--- a/sdk/go/common/util/gitutil/retrieve.go
+++ b/sdk/go/common/util/gitutil/retrieve.go
@@ -1,0 +1,89 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// RetrieveGitFolder downloads the repo to path and returns the full path on disk.
+func RetrieveGitFolder(ctx context.Context, rawurl string, path string) (string, error) {
+	url, urlPath, err := ParseGitRepoURL(rawurl)
+	if err != nil {
+		return "", err
+	}
+
+	ref, commit, subDirectory, err := GetGitReferenceNameOrHashAndSubDirectory(url, urlPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get git ref: %w", err)
+	}
+	logging.V(10).Infof(
+		"Attempting to fetch from %s at commit %s@%s for subdirectory '%s'",
+		url, ref, commit, subDirectory)
+
+	if ref != "" {
+		// Different reference attempts to cycle through
+		// We default to master then main in that order. We need to order them to avoid breaking
+		// already existing processes for repos that already have a master and main branch.
+		refAttempts := []plumbing.ReferenceName{plumbing.Master, plumbing.NewBranchReferenceName("main")}
+
+		if ref != plumbing.HEAD {
+			// If we have a non-default reference, we just use it
+			refAttempts = []plumbing.ReferenceName{ref}
+		}
+
+		var cloneErrs []error
+		for _, ref := range refAttempts {
+			// Attempt the clone. If it succeeds, break
+			err := GitCloneOrPull(ctx, url, ref, path, true /*shallow*/)
+			if err == nil {
+				break
+			}
+			logging.V(10).Infof("Failed to clone %s@%s: %v", url, ref, err)
+			cloneErrs = append(cloneErrs, fmt.Errorf("ref '%s': %w", ref, err))
+		}
+		if len(cloneErrs) == len(refAttempts) {
+			return "", fmt.Errorf("failed to clone %s: %w", rawurl, errors.Join(cloneErrs...))
+		}
+	} else {
+		if cloneErr := GitCloneAndCheckoutCommit(ctx, url, commit, path); cloneErr != nil {
+			logging.V(10).Infof("Failed to clone %s@%s: %v", url, commit, err)
+			return "", fmt.Errorf("failed to clone and checkout %s(%s): %w", url, commit, cloneErr)
+		}
+	}
+
+	// Verify the sub directory exists.
+	fullPath := filepath.Join(path, filepath.FromSlash(subDirectory))
+	logging.V(10).Infof("Cloned %s at commit %s@%s to %s", url, ref, commit, fullPath)
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		logging.V(10).Infof("Failed to stat %s after cloning %s: %v", fullPath, url, err)
+		return "", err
+	}
+	if !info.IsDir() {
+		logging.V(10).Infof("%s was not a directory after cloning %s: %v", fullPath, url, err)
+		return "", fmt.Errorf("%s is not a directory", fullPath)
+	}
+
+	return fullPath, nil
+}

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -442,7 +442,7 @@ func retrieveURLTemplates(
 	}
 
 	var fullPath string
-	if fullPath, err = RetrieveGitFolder(ctx, rawurl, temp); err != nil {
+	if fullPath, err = gitutil.RetrieveGitFolder(ctx, rawurl, temp); err != nil {
 		return TemplateRepository{}, fmt.Errorf("failed to retrieve git folder: %w", err)
 	}
 
@@ -518,65 +518,12 @@ func findSpecificTemplate(repo TemplateRepository, name string) (TemplateReposit
 }
 
 // RetrieveGitFolder downloads the repo to path and returns the full path on disk.
+//
+// Deprecated: Use [gitutil.RetrieveGitFolder] instead.
+//
+//go:fix inline
 func RetrieveGitFolder(ctx context.Context, rawurl string, path string) (string, error) {
-	url, urlPath, err := gitutil.ParseGitRepoURL(rawurl)
-	if err != nil {
-		return "", err
-	}
-
-	ref, commit, subDirectory, err := gitutil.GetGitReferenceNameOrHashAndSubDirectory(url, urlPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to get git ref: %w", err)
-	}
-	logging.V(10).Infof(
-		"Attempting to fetch from %s at commit %s@%s for subdirectory '%s'",
-		url, ref, commit, subDirectory)
-
-	if ref != "" {
-		// Different reference attempts to cycle through
-		// We default to master then main in that order. We need to order them to avoid breaking
-		// already existing processes for repos that already have a master and main branch.
-		refAttempts := []plumbing.ReferenceName{plumbing.Master, plumbing.NewBranchReferenceName("main")}
-
-		if ref != plumbing.HEAD {
-			// If we have a non-default reference, we just use it
-			refAttempts = []plumbing.ReferenceName{ref}
-		}
-
-		var cloneErrs []error
-		for _, ref := range refAttempts {
-			// Attempt the clone. If it succeeds, break
-			err := gitutil.GitCloneOrPull(ctx, url, ref, path, true /*shallow*/)
-			if err == nil {
-				break
-			}
-			logging.V(10).Infof("Failed to clone %s@%s: %v", url, ref, err)
-			cloneErrs = append(cloneErrs, fmt.Errorf("ref '%s': %w", ref, err))
-		}
-		if len(cloneErrs) == len(refAttempts) {
-			return "", fmt.Errorf("failed to clone %s: %w", rawurl, errors.Join(cloneErrs...))
-		}
-	} else {
-		if cloneErr := gitutil.GitCloneAndCheckoutCommit(ctx, url, commit, path); cloneErr != nil {
-			logging.V(10).Infof("Failed to clone %s@%s: %v", url, commit, err)
-			return "", fmt.Errorf("failed to clone and checkout %s(%s): %w", url, commit, cloneErr)
-		}
-	}
-
-	// Verify the sub directory exists.
-	fullPath := filepath.Join(path, filepath.FromSlash(subDirectory))
-	logging.V(10).Infof("Cloned %s at commit %s@%s to %s", url, ref, commit, fullPath)
-	info, err := os.Stat(fullPath)
-	if err != nil {
-		logging.V(10).Infof("Failed to stat %s after cloning %s: %v", fullPath, url, err)
-		return "", err
-	}
-	if !info.IsDir() {
-		logging.V(10).Infof("%s was not a directory after cloning %s: %v", fullPath, url, err)
-		return "", fmt.Errorf("%s is not a directory", fullPath)
-	}
-
-	return fullPath, nil
+	return gitutil.RetrieveGitFolder(ctx, rawurl, path)
 }
 
 // LoadTemplate returns a template from a path.


### PR DESCRIPTION
The workspace package's RetrieveGitFolder was only used internally, but is imported externally by pulumi-kubernetes. Move the implementation to gitutil where it fits alongside the other git helpers, and leave a deprecated `//go:fix inline` shim in workspace so callers migrate automatically.
