### PR TITLE
vendor charmbracelet/bubbles/textinput & atotto/clipboard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -239,6 +239,7 @@ linters:
       - node_modules
       - testdata$
       - third_party$
+      - third_party/
       - vendor$
 formatters:
   enable:
@@ -252,4 +253,5 @@ formatters:
       - node_modules
       - testdata$
       - third_party$
+      - third_party/
       - vendor$

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/git-pkgs/manifests v0.4.1
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4
 	github.com/golang/glog v1.2.5
@@ -76,13 +77,11 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20260211083412-859bfffeef82 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
@@ -135,7 +134,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kevinburke/ssh_config v1.6.0
-	github.com/mattn/go-runewidth v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.20
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -236,8 +236,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/sdk/go/common/util/cmdutil/console_input.go
+++ b/sdk/go/common/util/cmdutil/console_input.go
@@ -19,11 +19,11 @@ package cmdutil
 import (
 	"io"
 
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/internal/third_party/textinput"
 )
 
 func readConsoleFancy(stdout io.Writer, stdin io.Reader, prompt string, secret bool) (string, error) {

--- a/sdk/go/internal/third_party/clipboard/LICENSE
+++ b/sdk/go/internal/third_party/clipboard/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Ato Araki. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of @atotto. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sdk/go/internal/third_party/clipboard/clipboard.go
+++ b/sdk/go/internal/third_party/clipboard/clipboard.go
@@ -1,0 +1,31 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package clipboard read/write on clipboard
+//
+// Vendored unmodified from github.com/tgummerer/clipboard@d02d263e614e
+// (BSD-3-Clause, see LICENSE in this directory), a fork of
+// github.com/atotto/clipboard@v0.1.4 whose only change is loading user32.dll
+// lazily on Windows instead of in package init. atotto/clipboard's init-time
+// load crashes the whole process when user32.dll cannot be loaded (e.g. under
+// desktop heap exhaustion), and since it runs at init there is no error path.
+// The fork cannot be required directly because its go.mod still declares the
+// atotto module path, and a replace directive would not propagate to
+// downstream modules that build against this SDK. See
+// https://github.com/pulumi/pulumi/issues/19342.
+package clipboard
+
+// ReadAll read string from clipboard
+func ReadAll() (string, error) {
+	return readAll()
+}
+
+// WriteAll write string to clipboard
+func WriteAll(text string) error {
+	return writeAll(text)
+}
+
+// Unsupported might be set true during clipboard init, to help callers decide
+// whether or not to offer clipboard options.
+var Unsupported bool

--- a/sdk/go/internal/third_party/clipboard/clipboard_darwin.go
+++ b/sdk/go/internal/third_party/clipboard/clipboard_darwin.go
@@ -1,0 +1,52 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin
+
+package clipboard
+
+import (
+	"os/exec"
+)
+
+var (
+	pasteCmdArgs = "pbpaste"
+	copyCmdArgs  = "pbcopy"
+)
+
+func getPasteCommand() *exec.Cmd {
+	return exec.Command(pasteCmdArgs)
+}
+
+func getCopyCommand() *exec.Cmd {
+	return exec.Command(copyCmdArgs)
+}
+
+func readAll() (string, error) {
+	pasteCmd := getPasteCommand()
+	out, err := pasteCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func writeAll(text string) error {
+	copyCmd := getCopyCommand()
+	in, err := copyCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := copyCmd.Start(); err != nil {
+		return err
+	}
+	if _, err := in.Write([]byte(text)); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	return copyCmd.Wait()
+}

--- a/sdk/go/internal/third_party/clipboard/clipboard_plan9.go
+++ b/sdk/go/internal/third_party/clipboard/clipboard_plan9.go
@@ -1,0 +1,42 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9
+
+package clipboard
+
+import (
+	"os"
+	"io/ioutil"
+)
+
+func readAll() (string, error) {
+	f, err := os.Open("/dev/snarf")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	str, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	
+	return string(str), nil
+}
+
+func writeAll(text string) error {
+	f, err := os.OpenFile("/dev/snarf", os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	
+	_, err = f.Write([]byte(text))
+	if err != nil {
+		return err
+	}
+	
+	return nil
+}

--- a/sdk/go/internal/third_party/clipboard/clipboard_unix.go
+++ b/sdk/go/internal/third_party/clipboard/clipboard_unix.go
@@ -1,0 +1,149 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd linux netbsd openbsd solaris dragonfly
+
+package clipboard
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+const (
+	xsel               = "xsel"
+	xclip              = "xclip"
+	powershellExe      = "powershell.exe"
+	clipExe            = "clip.exe"
+	wlcopy             = "wl-copy"
+	wlpaste            = "wl-paste"
+	termuxClipboardGet = "termux-clipboard-get"
+	termuxClipboardSet = "termux-clipboard-set"
+)
+
+var (
+	Primary bool
+	trimDos bool
+
+	pasteCmdArgs []string
+	copyCmdArgs  []string
+
+	xselPasteArgs = []string{xsel, "--output", "--clipboard"}
+	xselCopyArgs  = []string{xsel, "--input", "--clipboard"}
+
+	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
+	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
+
+	powershellExePasteArgs = []string{powershellExe, "Get-Clipboard"}
+	clipExeCopyArgs        = []string{clipExe}
+
+	wlpasteArgs = []string{wlpaste, "--no-newline"}
+	wlcopyArgs  = []string{wlcopy}
+
+	termuxPasteArgs = []string{termuxClipboardGet}
+	termuxCopyArgs  = []string{termuxClipboardSet}
+
+	missingCommands = errors.New("No clipboard utilities available. Please install xsel, xclip, wl-clipboard or Termux:API add-on for termux-clipboard-get/set.")
+)
+
+func init() {
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		pasteCmdArgs = wlpasteArgs
+		copyCmdArgs = wlcopyArgs
+
+		if _, err := exec.LookPath(wlcopy); err == nil {
+			if _, err := exec.LookPath(wlpaste); err == nil {
+				return
+			}
+		}
+	}
+
+	pasteCmdArgs = xclipPasteArgs
+	copyCmdArgs = xclipCopyArgs
+
+	if _, err := exec.LookPath(xclip); err == nil {
+		return
+	}
+
+	pasteCmdArgs = xselPasteArgs
+	copyCmdArgs = xselCopyArgs
+
+	if _, err := exec.LookPath(xsel); err == nil {
+		return
+	}
+
+	pasteCmdArgs = termuxPasteArgs
+	copyCmdArgs = termuxCopyArgs
+
+	if _, err := exec.LookPath(termuxClipboardSet); err == nil {
+		if _, err := exec.LookPath(termuxClipboardGet); err == nil {
+			return
+		}
+	}
+
+	pasteCmdArgs = powershellExePasteArgs
+	copyCmdArgs = clipExeCopyArgs
+	trimDos = true
+
+	if _, err := exec.LookPath(clipExe); err == nil {
+		if _, err := exec.LookPath(powershellExe); err == nil {
+			return
+		}
+	}
+
+	Unsupported = true
+}
+
+func getPasteCommand() *exec.Cmd {
+	if Primary {
+		pasteCmdArgs = pasteCmdArgs[:1]
+	}
+	return exec.Command(pasteCmdArgs[0], pasteCmdArgs[1:]...)
+}
+
+func getCopyCommand() *exec.Cmd {
+	if Primary {
+		copyCmdArgs = copyCmdArgs[:1]
+	}
+	return exec.Command(copyCmdArgs[0], copyCmdArgs[1:]...)
+}
+
+func readAll() (string, error) {
+	if Unsupported {
+		return "", missingCommands
+	}
+	pasteCmd := getPasteCommand()
+	out, err := pasteCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	result := string(out)
+	if trimDos && len(result) > 1 {
+		result = result[:len(result)-2]
+	}
+	return result, nil
+}
+
+func writeAll(text string) error {
+	if Unsupported {
+		return missingCommands
+	}
+	copyCmd := getCopyCommand()
+	in, err := copyCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := copyCmd.Start(); err != nil {
+		return err
+	}
+	if _, err := in.Write([]byte(text)); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	return copyCmd.Wait()
+}

--- a/sdk/go/internal/third_party/clipboard/clipboard_windows.go
+++ b/sdk/go/internal/third_party/clipboard/clipboard_windows.go
@@ -1,0 +1,159 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package clipboard
+
+import (
+	"runtime"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	cfUnicodetext = 13
+	gmemMoveable  = 0x0002
+)
+
+var (
+	user32                     = windows.NewLazySystemDLL("user32.dll")
+	isClipboardFormatAvailable = user32.NewProc("IsClipboardFormatAvailable")
+	openClipboard              = user32.NewProc("OpenClipboard")
+	closeClipboard             = user32.NewProc("CloseClipboard")
+	emptyClipboard             = user32.NewProc("EmptyClipboard")
+	getClipboardData           = user32.NewProc("GetClipboardData")
+	setClipboardData           = user32.NewProc("SetClipboardData")
+
+	kernel32     = windows.NewLazySystemDLL("kernel32")
+	globalAlloc  = kernel32.NewProc("GlobalAlloc")
+	globalFree   = kernel32.NewProc("GlobalFree")
+	globalLock   = kernel32.NewProc("GlobalLock")
+	globalUnlock = kernel32.NewProc("GlobalUnlock")
+	lstrcpy      = kernel32.NewProc("lstrcpyW")
+)
+
+// waitOpenClipboard opens the clipboard, waiting for up to a second to do so.
+func waitOpenClipboard() error {
+	started := time.Now()
+	limit := started.Add(time.Second)
+	var r uintptr
+	var err error
+	for time.Now().Before(limit) {
+		r, _, err = openClipboard.Call(0)
+		if r != 0 {
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return err
+}
+
+func readAll() (string, error) {
+	// LockOSThread ensure that the whole method will keep executing on the same thread from begin to end (it actually locks the goroutine thread attribution).
+	// Otherwise if the goroutine switch thread during execution (which is a common practice), the OpenClipboard and CloseClipboard will happen on two different threads, and it will result in a clipboard deadlock.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if formatAvailable, _, err := isClipboardFormatAvailable.Call(cfUnicodetext); formatAvailable == 0 {
+		return "", err
+	}
+	err := waitOpenClipboard()
+	if err != nil {
+		return "", err
+	}
+
+	h, _, err := getClipboardData.Call(cfUnicodetext)
+	if h == 0 {
+		_, _, _ = closeClipboard.Call()
+		return "", err
+	}
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		_, _, _ = closeClipboard.Call()
+		return "", err
+	}
+
+	text := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(l))[:])
+
+	r, _, err := globalUnlock.Call(h)
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return "", err
+	}
+
+	closed, _, err := closeClipboard.Call()
+	if closed == 0 {
+		return "", err
+	}
+	return text, nil
+}
+
+func writeAll(text string) error {
+	// LockOSThread ensure that the whole method will keep executing on the same thread from begin to end (it actually locks the goroutine thread attribution).
+	// Otherwise if the goroutine switch thread during execution (which is a common practice), the OpenClipboard and CloseClipboard will happen on two different threads, and it will result in a clipboard deadlock.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	err := waitOpenClipboard()
+	if err != nil {
+		return err
+	}
+
+	r, _, err := emptyClipboard.Call(0)
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+
+	data := syscall.StringToUTF16(text)
+
+	// "If the hMem parameter identifies a memory object, the object must have
+	// been allocated using the function with the GMEM_MOVEABLE flag."
+	h, _, err := globalAlloc.Call(gmemMoveable, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
+	if h == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+	defer func() {
+		if h != 0 {
+			globalFree.Call(h)
+		}
+	}()
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+
+	r, _, err = lstrcpy.Call(l, uintptr(unsafe.Pointer(&data[0])))
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+
+	r, _, err = globalUnlock.Call(h)
+	if r == 0 {
+		if err.(syscall.Errno) != 0 {
+			_, _, _ = closeClipboard.Call()
+			return err
+		}
+	}
+
+	r, _, err = setClipboardData.Call(cfUnicodetext, h)
+	if r == 0 {
+		_, _, _ = closeClipboard.Call()
+		return err
+	}
+	h = 0 // suppress deferred cleanup
+	closed, _, err := closeClipboard.Call()
+	if closed == 0 {
+		return err
+	}
+	return nil
+}

--- a/sdk/go/internal/third_party/textinput/LICENSE
+++ b/sdk/go/internal/third_party/textinput/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2025 Charmbracelet, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/go/internal/third_party/textinput/textinput.go
+++ b/sdk/go/internal/third_party/textinput/textinput.go
@@ -1,0 +1,900 @@
+// Package textinput provides a text input component for Bubble Tea
+// applications.
+//
+// Vendored from github.com/charmbracelet/bubbles@v1.0.0/textinput (MIT, see
+// LICENSE in this directory) with a single modification: the
+// github.com/atotto/clipboard import is replaced with the vendored
+// [github.com/pulumi/pulumi/sdk/v3/go/internal/third_party/clipboard], which
+// does not load user32.dll at process init. atotto/clipboard's init-time DLL
+// load crashes any binary that links it (including all provider plugins built
+// against this SDK) on Windows systems where user32.dll cannot be loaded,
+// e.g. under desktop heap exhaustion. See
+// https://github.com/pulumi/pulumi/issues/19342.
+package textinput
+
+import (
+	"reflect"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/internal/third_party/clipboard"
+	"github.com/charmbracelet/bubbles/cursor"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/runeutil"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	rw "github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
+)
+
+// Internal messages for clipboard operations.
+type (
+	pasteMsg    string
+	pasteErrMsg struct{ error }
+)
+
+// EchoMode sets the input behavior of the text input field.
+type EchoMode int
+
+const (
+	// EchoNormal displays text as is. This is the default behavior.
+	EchoNormal EchoMode = iota
+
+	// EchoPassword displays the EchoCharacter mask instead of actual
+	// characters. This is commonly used for password fields.
+	EchoPassword
+
+	// EchoNone displays nothing as characters are entered. This is commonly
+	// seen for password fields on the command line.
+	EchoNone
+)
+
+// ValidateFunc is a function that returns an error if the input is invalid.
+type ValidateFunc func(string) error
+
+// KeyMap is the key bindings for different actions within the textinput.
+type KeyMap struct {
+	CharacterForward        key.Binding
+	CharacterBackward       key.Binding
+	WordForward             key.Binding
+	WordBackward            key.Binding
+	DeleteWordBackward      key.Binding
+	DeleteWordForward       key.Binding
+	DeleteAfterCursor       key.Binding
+	DeleteBeforeCursor      key.Binding
+	DeleteCharacterBackward key.Binding
+	DeleteCharacterForward  key.Binding
+	LineStart               key.Binding
+	LineEnd                 key.Binding
+	Paste                   key.Binding
+	AcceptSuggestion        key.Binding
+	NextSuggestion          key.Binding
+	PrevSuggestion          key.Binding
+}
+
+// DefaultKeyMap is the default set of key bindings for navigating and acting
+// upon the textinput.
+var DefaultKeyMap = KeyMap{
+	CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f")),
+	CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b")),
+	WordForward:             key.NewBinding(key.WithKeys("alt+right", "ctrl+right", "alt+f")),
+	WordBackward:            key.NewBinding(key.WithKeys("alt+left", "ctrl+left", "alt+b")),
+	DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w")),
+	DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d")),
+	DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k")),
+	DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u")),
+	DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h")),
+	DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d")),
+	LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a")),
+	LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e")),
+	Paste:                   key.NewBinding(key.WithKeys("ctrl+v")),
+	AcceptSuggestion:        key.NewBinding(key.WithKeys("tab")),
+	NextSuggestion:          key.NewBinding(key.WithKeys("down", "ctrl+n")),
+	PrevSuggestion:          key.NewBinding(key.WithKeys("up", "ctrl+p")),
+}
+
+// Model is the Bubble Tea model for this text input element.
+type Model struct {
+	Err error
+
+	// General settings.
+	Prompt        string
+	Placeholder   string
+	EchoMode      EchoMode
+	EchoCharacter rune
+	Cursor        cursor.Model
+
+	// Deprecated: use [cursor.BlinkSpeed] instead.
+	BlinkSpeed time.Duration
+
+	// Styles. These will be applied as inline styles.
+	//
+	// For an introduction to styling with Lip Gloss see:
+	// https://github.com/charmbracelet/lipgloss
+	PromptStyle      lipgloss.Style
+	TextStyle        lipgloss.Style
+	PlaceholderStyle lipgloss.Style
+	CompletionStyle  lipgloss.Style
+
+	// Deprecated: use Cursor.Style instead.
+	CursorStyle lipgloss.Style
+
+	// CharLimit is the maximum amount of characters this input element will
+	// accept. If 0 or less, there's no limit.
+	CharLimit int
+
+	// Width is the maximum number of characters that can be displayed at once.
+	// It essentially treats the text field like a horizontally scrolling
+	// viewport. If 0 or less this setting is ignored.
+	Width int
+
+	// KeyMap encodes the keybindings recognized by the widget.
+	KeyMap KeyMap
+
+	// Underlying text value.
+	value []rune
+
+	// focus indicates whether user input focus should be on this input
+	// component. When false, ignore keyboard input and hide the cursor.
+	focus bool
+
+	// Cursor position.
+	pos int
+
+	// Used to emulate a viewport when width is set and the content is
+	// overflowing.
+	offset      int
+	offsetRight int
+
+	// Validate is a function that checks whether or not the text within the
+	// input is valid. If it is not valid, the `Err` field will be set to the
+	// error returned by the function. If the function is not defined, all
+	// input is considered valid.
+	Validate ValidateFunc
+
+	// rune sanitizer for input.
+	rsan runeutil.Sanitizer
+
+	// Should the input suggest to complete
+	ShowSuggestions bool
+
+	// suggestions is a list of suggestions that may be used to complete the
+	// input.
+	suggestions            [][]rune
+	matchedSuggestions     [][]rune
+	currentSuggestionIndex int
+}
+
+// New creates a new model with default settings.
+func New() Model {
+	return Model{
+		Prompt:           "> ",
+		EchoCharacter:    '*',
+		CharLimit:        0,
+		PlaceholderStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		ShowSuggestions:  false,
+		CompletionStyle:  lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Cursor:           cursor.New(),
+		KeyMap:           DefaultKeyMap,
+
+		suggestions: [][]rune{},
+		value:       nil,
+		focus:       false,
+		pos:         0,
+	}
+}
+
+// NewModel creates a new model with default settings.
+//
+// Deprecated: Use [New] instead.
+var NewModel = New
+
+// SetValue sets the value of the text input.
+func (m *Model) SetValue(s string) {
+	// Clean up any special characters in the input provided by the
+	// caller. This avoids bugs due to e.g. tab characters and whatnot.
+	runes := m.san().Sanitize([]rune(s))
+	err := m.validate(runes)
+	m.setValueInternal(runes, err)
+}
+
+func (m *Model) setValueInternal(runes []rune, err error) {
+	m.Err = err
+
+	empty := len(m.value) == 0
+
+	if m.CharLimit > 0 && len(runes) > m.CharLimit {
+		m.value = runes[:m.CharLimit]
+	} else {
+		m.value = runes
+	}
+	if (m.pos == 0 && empty) || m.pos > len(m.value) {
+		m.SetCursor(len(m.value))
+	}
+	m.handleOverflow()
+}
+
+// Value returns the value of the text input.
+func (m Model) Value() string {
+	return string(m.value)
+}
+
+// Position returns the cursor position.
+func (m Model) Position() int {
+	return m.pos
+}
+
+// SetCursor moves the cursor to the given position. If the position is
+// out of bounds the cursor will be moved to the start or end accordingly.
+func (m *Model) SetCursor(pos int) {
+	m.pos = clamp(pos, 0, len(m.value))
+	m.handleOverflow()
+}
+
+// CursorStart moves the cursor to the start of the input field.
+func (m *Model) CursorStart() {
+	m.SetCursor(0)
+}
+
+// CursorEnd moves the cursor to the end of the input field.
+func (m *Model) CursorEnd() {
+	m.SetCursor(len(m.value))
+}
+
+// Focused returns the focus state on the model.
+func (m Model) Focused() bool {
+	return m.focus
+}
+
+// Focus sets the focus state on the model. When the model is in focus it can
+// receive keyboard input and the cursor will be shown.
+func (m *Model) Focus() tea.Cmd {
+	m.focus = true
+	return m.Cursor.Focus()
+}
+
+// Blur removes the focus state on the model.  When the model is blurred it can
+// not receive keyboard input and the cursor will be hidden.
+func (m *Model) Blur() {
+	m.focus = false
+	m.Cursor.Blur()
+}
+
+// Reset sets the input to its default state with no input.
+func (m *Model) Reset() {
+	m.value = nil
+	m.SetCursor(0)
+}
+
+// SetSuggestions sets the suggestions for the input.
+func (m *Model) SetSuggestions(suggestions []string) {
+	m.suggestions = make([][]rune, len(suggestions))
+	for i, s := range suggestions {
+		m.suggestions[i] = []rune(s)
+	}
+
+	m.updateSuggestions()
+}
+
+// rsan initializes or retrieves the rune sanitizer.
+func (m *Model) san() runeutil.Sanitizer {
+	if m.rsan == nil {
+		// Textinput has all its input on a single line so collapse
+		// newlines/tabs to single spaces.
+		m.rsan = runeutil.NewSanitizer(
+			runeutil.ReplaceTabs(" "), runeutil.ReplaceNewlines(" "))
+	}
+	return m.rsan
+}
+
+func (m *Model) insertRunesFromUserInput(v []rune) {
+	// Clean up any special characters in the input provided by the
+	// clipboard. This avoids bugs due to e.g. tab characters and
+	// whatnot.
+	paste := m.san().Sanitize(v)
+
+	var availSpace int
+	if m.CharLimit > 0 {
+		availSpace = m.CharLimit - len(m.value)
+
+		// If the char limit's been reached, cancel.
+		if availSpace <= 0 {
+			return
+		}
+
+		// If there's not enough space to paste the whole thing cut the pasted
+		// runes down so they'll fit.
+		if availSpace < len(paste) {
+			paste = paste[:availSpace]
+		}
+	}
+
+	// Stuff before and after the cursor
+	head := m.value[:m.pos]
+	tailSrc := m.value[m.pos:]
+	tail := make([]rune, len(tailSrc))
+	copy(tail, tailSrc)
+
+	// Insert pasted runes
+	for _, r := range paste {
+		head = append(head, r)
+		m.pos++
+		if m.CharLimit > 0 {
+			availSpace--
+			if availSpace <= 0 {
+				break
+			}
+		}
+	}
+
+	// Put it all back together
+	value := append(head, tail...)
+	inputErr := m.validate(value)
+	m.setValueInternal(value, inputErr)
+}
+
+// If a max width is defined, perform some logic to treat the visible area
+// as a horizontally scrolling viewport.
+func (m *Model) handleOverflow() {
+	if m.Width <= 0 || uniseg.StringWidth(string(m.value)) <= m.Width {
+		m.offset = 0
+		m.offsetRight = len(m.value)
+		return
+	}
+
+	// Correct right offset if we've deleted characters
+	m.offsetRight = min(m.offsetRight, len(m.value))
+
+	if m.pos < m.offset {
+		m.offset = m.pos
+
+		w := 0
+		i := 0
+		runes := m.value[m.offset:]
+
+		for i < len(runes) && w <= m.Width {
+			w += rw.RuneWidth(runes[i])
+			if w <= m.Width+1 {
+				i++
+			}
+		}
+
+		m.offsetRight = m.offset + i
+	} else if m.pos >= m.offsetRight {
+		m.offsetRight = m.pos
+
+		w := 0
+		runes := m.value[:m.offsetRight]
+		i := len(runes) - 1
+
+		for i > 0 && w < m.Width {
+			w += rw.RuneWidth(runes[i])
+			if w <= m.Width {
+				i--
+			}
+		}
+
+		m.offset = m.offsetRight - (len(runes) - 1 - i)
+	}
+}
+
+// deleteBeforeCursor deletes all text before the cursor.
+func (m *Model) deleteBeforeCursor() {
+	m.value = m.value[m.pos:]
+	m.Err = m.validate(m.value)
+	m.offset = 0
+	m.SetCursor(0)
+}
+
+// deleteAfterCursor deletes all text after the cursor. If input is masked
+// delete everything after the cursor so as not to reveal word breaks in the
+// masked input.
+func (m *Model) deleteAfterCursor() {
+	m.value = m.value[:m.pos]
+	m.Err = m.validate(m.value)
+	m.SetCursor(len(m.value))
+}
+
+// deleteWordBackward deletes the word left to the cursor.
+func (m *Model) deleteWordBackward() {
+	if m.pos == 0 || len(m.value) == 0 {
+		return
+	}
+
+	if m.EchoMode != EchoNormal {
+		m.deleteBeforeCursor()
+		return
+	}
+
+	// Linter note: it's critical that we acquire the initial cursor position
+	// here prior to altering it via SetCursor() below. As such, moving this
+	// call into the corresponding if clause does not apply here.
+	oldPos := m.pos
+
+	m.SetCursor(m.pos - 1)
+	for unicode.IsSpace(m.value[m.pos]) {
+		if m.pos <= 0 {
+			break
+		}
+		// ignore series of whitespace before cursor
+		m.SetCursor(m.pos - 1)
+	}
+
+	for m.pos > 0 {
+		if !unicode.IsSpace(m.value[m.pos]) {
+			m.SetCursor(m.pos - 1)
+		} else {
+			if m.pos > 0 {
+				// keep the previous space
+				m.SetCursor(m.pos + 1)
+			}
+			break
+		}
+	}
+
+	if oldPos > len(m.value) {
+		m.value = m.value[:m.pos]
+	} else {
+		m.value = append(m.value[:m.pos], m.value[oldPos:]...)
+	}
+	m.Err = m.validate(m.value)
+}
+
+// deleteWordForward deletes the word right to the cursor. If input is masked
+// delete everything after the cursor so as not to reveal word breaks in the
+// masked input.
+func (m *Model) deleteWordForward() {
+	if m.pos >= len(m.value) || len(m.value) == 0 {
+		return
+	}
+
+	if m.EchoMode != EchoNormal {
+		m.deleteAfterCursor()
+		return
+	}
+
+	oldPos := m.pos
+	m.SetCursor(m.pos + 1)
+	for unicode.IsSpace(m.value[m.pos]) {
+		// ignore series of whitespace after cursor
+		m.SetCursor(m.pos + 1)
+
+		if m.pos >= len(m.value) {
+			break
+		}
+	}
+
+	for m.pos < len(m.value) {
+		if !unicode.IsSpace(m.value[m.pos]) {
+			m.SetCursor(m.pos + 1)
+		} else {
+			break
+		}
+	}
+
+	if m.pos > len(m.value) {
+		m.value = m.value[:oldPos]
+	} else {
+		m.value = append(m.value[:oldPos], m.value[m.pos:]...)
+	}
+	m.Err = m.validate(m.value)
+
+	m.SetCursor(oldPos)
+}
+
+// wordBackward moves the cursor one word to the left. If input is masked, move
+// input to the start so as not to reveal word breaks in the masked input.
+func (m *Model) wordBackward() {
+	if m.pos == 0 || len(m.value) == 0 {
+		return
+	}
+
+	if m.EchoMode != EchoNormal {
+		m.CursorStart()
+		return
+	}
+
+	i := m.pos - 1
+	for i >= 0 {
+		if unicode.IsSpace(m.value[i]) {
+			m.SetCursor(m.pos - 1)
+			i--
+		} else {
+			break
+		}
+	}
+
+	for i >= 0 {
+		if !unicode.IsSpace(m.value[i]) {
+			m.SetCursor(m.pos - 1)
+			i--
+		} else {
+			break
+		}
+	}
+}
+
+// wordForward moves the cursor one word to the right. If the input is masked,
+// move input to the end so as not to reveal word breaks in the masked input.
+func (m *Model) wordForward() {
+	if m.pos >= len(m.value) || len(m.value) == 0 {
+		return
+	}
+
+	if m.EchoMode != EchoNormal {
+		m.CursorEnd()
+		return
+	}
+
+	i := m.pos
+	for i < len(m.value) {
+		if unicode.IsSpace(m.value[i]) {
+			m.SetCursor(m.pos + 1)
+			i++
+		} else {
+			break
+		}
+	}
+
+	for i < len(m.value) {
+		if !unicode.IsSpace(m.value[i]) {
+			m.SetCursor(m.pos + 1)
+			i++
+		} else {
+			break
+		}
+	}
+}
+
+func (m Model) echoTransform(v string) string {
+	switch m.EchoMode {
+	case EchoPassword:
+		return strings.Repeat(string(m.EchoCharacter), uniseg.StringWidth(v))
+	case EchoNone:
+		return ""
+	case EchoNormal:
+		return v
+	default:
+		return v
+	}
+}
+
+// Update is the Bubble Tea update loop.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.focus {
+		return m, nil
+	}
+
+	// Need to check for completion before, because key is configurable and might be double assigned
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if ok && key.Matches(keyMsg, m.KeyMap.AcceptSuggestion) {
+		if m.canAcceptSuggestion() {
+			m.value = append(m.value, m.matchedSuggestions[m.currentSuggestionIndex][len(m.value):]...)
+			m.CursorEnd()
+		}
+	}
+
+	// Let's remember where the position of the cursor currently is so that if
+	// the cursor position changes, we can reset the blink.
+	oldPos := m.pos
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.KeyMap.DeleteWordBackward):
+			m.deleteWordBackward()
+		case key.Matches(msg, m.KeyMap.DeleteCharacterBackward):
+			m.Err = nil
+			if len(m.value) > 0 {
+				m.value = append(m.value[:max(0, m.pos-1)], m.value[m.pos:]...)
+				m.Err = m.validate(m.value)
+				if m.pos > 0 {
+					m.SetCursor(m.pos - 1)
+				}
+			}
+		case key.Matches(msg, m.KeyMap.WordBackward):
+			m.wordBackward()
+		case key.Matches(msg, m.KeyMap.CharacterBackward):
+			if m.pos > 0 {
+				m.SetCursor(m.pos - 1)
+			}
+		case key.Matches(msg, m.KeyMap.WordForward):
+			m.wordForward()
+		case key.Matches(msg, m.KeyMap.CharacterForward):
+			if m.pos < len(m.value) {
+				m.SetCursor(m.pos + 1)
+			}
+		case key.Matches(msg, m.KeyMap.LineStart):
+			m.CursorStart()
+		case key.Matches(msg, m.KeyMap.DeleteCharacterForward):
+			if len(m.value) > 0 && m.pos < len(m.value) {
+				m.value = append(m.value[:m.pos], m.value[m.pos+1:]...)
+				m.Err = m.validate(m.value)
+			}
+		case key.Matches(msg, m.KeyMap.LineEnd):
+			m.CursorEnd()
+		case key.Matches(msg, m.KeyMap.DeleteAfterCursor):
+			m.deleteAfterCursor()
+		case key.Matches(msg, m.KeyMap.DeleteBeforeCursor):
+			m.deleteBeforeCursor()
+		case key.Matches(msg, m.KeyMap.Paste):
+			return m, Paste
+		case key.Matches(msg, m.KeyMap.DeleteWordForward):
+			m.deleteWordForward()
+		case key.Matches(msg, m.KeyMap.NextSuggestion):
+			m.nextSuggestion()
+		case key.Matches(msg, m.KeyMap.PrevSuggestion):
+			m.previousSuggestion()
+		default:
+			// Input one or more regular characters.
+			m.insertRunesFromUserInput(msg.Runes)
+		}
+
+		// Check again if can be completed
+		// because value might be something that does not match the completion prefix
+		m.updateSuggestions()
+
+	case pasteMsg:
+		m.insertRunesFromUserInput([]rune(msg))
+
+	case pasteErrMsg:
+		m.Err = msg
+	}
+
+	var cmds []tea.Cmd
+	var cmd tea.Cmd
+
+	m.Cursor, cmd = m.Cursor.Update(msg)
+	cmds = append(cmds, cmd)
+
+	if oldPos != m.pos && m.Cursor.Mode() == cursor.CursorBlink {
+		m.Cursor.Blink = false
+		cmds = append(cmds, m.Cursor.BlinkCmd())
+	}
+
+	m.handleOverflow()
+	return m, tea.Batch(cmds...)
+}
+
+// View renders the textinput in its current state.
+func (m Model) View() string {
+	// Placeholder text
+	if len(m.value) == 0 && m.Placeholder != "" {
+		return m.placeholderView()
+	}
+
+	styleText := m.TextStyle.Inline(true).Render
+
+	value := m.value[m.offset:m.offsetRight]
+	pos := max(0, m.pos-m.offset)
+	v := styleText(m.echoTransform(string(value[:pos])))
+
+	if pos < len(value) { //nolint:nestif
+		char := m.echoTransform(string(value[pos]))
+		m.Cursor.SetChar(char)
+		v += m.Cursor.View()                                   // cursor and text under it
+		v += styleText(m.echoTransform(string(value[pos+1:]))) // text after cursor
+		v += m.completionView(0)                               // suggested completion
+	} else {
+		if m.focus && m.canAcceptSuggestion() {
+			suggestion := m.matchedSuggestions[m.currentSuggestionIndex]
+			if len(value) < len(suggestion) {
+				m.Cursor.TextStyle = m.CompletionStyle
+				m.Cursor.SetChar(m.echoTransform(string(suggestion[pos])))
+				v += m.Cursor.View()
+				v += m.completionView(1)
+			} else {
+				m.Cursor.SetChar(" ")
+				v += m.Cursor.View()
+			}
+		} else {
+			m.Cursor.SetChar(" ")
+			v += m.Cursor.View()
+		}
+	}
+
+	// If a max width and background color were set fill the empty spaces with
+	// the background color.
+	valWidth := uniseg.StringWidth(string(value))
+	if m.Width > 0 && valWidth <= m.Width {
+		padding := max(0, m.Width-valWidth)
+		if valWidth+padding <= m.Width && pos < len(value) {
+			padding++
+		}
+		v += styleText(strings.Repeat(" ", padding))
+	}
+
+	return m.PromptStyle.Render(m.Prompt) + v
+}
+
+// placeholderView returns the prompt and placeholder view, if any.
+func (m Model) placeholderView() string {
+	var (
+		v     string
+		style = m.PlaceholderStyle.Inline(true).Render
+		p     = m.PromptStyle.Render(m.Prompt)
+	)
+
+	m.Cursor.TextStyle = m.PlaceholderStyle
+	first, rest, _, _ := uniseg.FirstGraphemeClusterInString(m.Placeholder, 0)
+	m.Cursor.SetChar(first)
+	v += m.Cursor.View()
+
+	// If the entire placeholder is already set and no padding is needed, finish
+	if m.Width < 1 && uniseg.StringWidth(rest) <= 1 {
+		return m.PromptStyle.Render(m.Prompt) + v
+	}
+
+	// If Width is set then size placeholder accordingly
+	if m.Width > 0 {
+		width := m.Width - lipgloss.Width(p) - lipgloss.Width(v)
+		placeholderRest := ansi.Truncate(rest, width, "…")
+		availWidth := max(0, width-lipgloss.Width(placeholderRest))
+		v += style(placeholderRest) + strings.Repeat(" ", availWidth)
+	} else {
+		// if there is no width, the placeholder can be any length
+		v += style(rest)
+	}
+
+	return p + v
+}
+
+// Blink is a command used to initialize cursor blinking.
+func Blink() tea.Msg {
+	return cursor.Blink()
+}
+
+// Paste is a command for pasting from the clipboard into the text input.
+func Paste() tea.Msg {
+	str, err := clipboard.ReadAll()
+	if err != nil {
+		return pasteErrMsg{err}
+	}
+	return pasteMsg(str)
+}
+
+func clamp(v, low, high int) int {
+	if high < low {
+		low, high = high, low
+	}
+	return min(high, max(low, v))
+}
+
+// Deprecated.
+
+// Deprecated: use [cursor.Mode].
+//
+//nolint:revive
+type CursorMode int
+
+//nolint:revive
+const (
+	// Deprecated: use [cursor.CursorBlink].
+	CursorBlink = CursorMode(cursor.CursorBlink)
+	// Deprecated: use [cursor.CursorStatic].
+	CursorStatic = CursorMode(cursor.CursorStatic)
+	// Deprecated: use [cursor.CursorHide].
+	CursorHide = CursorMode(cursor.CursorHide)
+)
+
+func (c CursorMode) String() string {
+	return cursor.Mode(c).String()
+}
+
+// Deprecated: use [cursor.Mode].
+//
+//nolint:revive
+func (m Model) CursorMode() CursorMode {
+	return CursorMode(m.Cursor.Mode())
+}
+
+// Deprecated: use cursor.SetMode().
+//
+//nolint:revive
+func (m *Model) SetCursorMode(mode CursorMode) tea.Cmd {
+	return m.Cursor.SetMode(cursor.Mode(mode))
+}
+
+func (m Model) completionView(offset int) string {
+	var (
+		value = m.value
+		style = m.PlaceholderStyle.Inline(true).Render
+	)
+
+	if m.canAcceptSuggestion() {
+		suggestion := m.matchedSuggestions[m.currentSuggestionIndex]
+		if len(value) < len(suggestion) {
+			return style(string(suggestion[len(value)+offset:]))
+		}
+	}
+	return ""
+}
+
+func (m *Model) getSuggestions(sugs [][]rune) []string {
+	suggestions := make([]string, len(sugs))
+	for i, s := range sugs {
+		suggestions[i] = string(s)
+	}
+	return suggestions
+}
+
+// AvailableSuggestions returns the list of available suggestions.
+func (m *Model) AvailableSuggestions() []string {
+	return m.getSuggestions(m.suggestions)
+}
+
+// MatchedSuggestions returns the list of matched suggestions.
+func (m *Model) MatchedSuggestions() []string {
+	return m.getSuggestions(m.matchedSuggestions)
+}
+
+// CurrentSuggestionIndex returns the currently selected suggestion index.
+func (m *Model) CurrentSuggestionIndex() int {
+	return m.currentSuggestionIndex
+}
+
+// CurrentSuggestion returns the currently selected suggestion.
+func (m *Model) CurrentSuggestion() string {
+	if m.currentSuggestionIndex >= len(m.matchedSuggestions) {
+		return ""
+	}
+
+	return string(m.matchedSuggestions[m.currentSuggestionIndex])
+}
+
+// canAcceptSuggestion returns whether there is an acceptable suggestion to
+// autocomplete the current value.
+func (m *Model) canAcceptSuggestion() bool {
+	return len(m.matchedSuggestions) > 0
+}
+
+// updateSuggestions refreshes the list of matching suggestions.
+func (m *Model) updateSuggestions() {
+	if !m.ShowSuggestions {
+		return
+	}
+
+	if len(m.value) <= 0 || len(m.suggestions) <= 0 {
+		m.matchedSuggestions = [][]rune{}
+		return
+	}
+
+	matches := [][]rune{}
+	for _, s := range m.suggestions {
+		suggestion := string(s)
+
+		if strings.HasPrefix(strings.ToLower(suggestion), strings.ToLower(string(m.value))) {
+			matches = append(matches, []rune(suggestion))
+		}
+	}
+	if !reflect.DeepEqual(matches, m.matchedSuggestions) {
+		m.currentSuggestionIndex = 0
+	}
+
+	m.matchedSuggestions = matches
+}
+
+// nextSuggestion selects the next suggestion.
+func (m *Model) nextSuggestion() {
+	m.currentSuggestionIndex = (m.currentSuggestionIndex + 1)
+	if m.currentSuggestionIndex >= len(m.matchedSuggestions) {
+		m.currentSuggestionIndex = 0
+	}
+}
+
+// previousSuggestion selects the previous suggestion.
+func (m *Model) previousSuggestion() {
+	m.currentSuggestionIndex = (m.currentSuggestionIndex - 1)
+	if m.currentSuggestionIndex < 0 {
+		m.currentSuggestionIndex = len(m.matchedSuggestions) - 1
+	}
+}
+
+func (m Model) validate(v []rune) error {
+	if m.Validate != nil {
+		return m.Validate(string(v))
+	}
+	return nil
+}

--- a/sdk/go/internal/third_party/textinput/textinput_test.go
+++ b/sdk/go/internal/third_party/textinput/textinput_test.go
@@ -1,0 +1,118 @@
+package textinput
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func Test_CurrentSuggestion(t *testing.T) {
+	textinput := New()
+	textinput.ShowSuggestions = true
+
+	suggestion := textinput.CurrentSuggestion()
+	expected := ""
+	if suggestion != expected {
+		t.Fatalf("Error: expected no current suggestion but was %s", suggestion)
+	}
+
+	textinput.SetSuggestions([]string{"test1", "test2", "test3"})
+	suggestion = textinput.CurrentSuggestion()
+	expected = ""
+	if suggestion != expected {
+		t.Fatalf("Error: expected no current suggestion but was %s", suggestion)
+	}
+
+	textinput.SetValue("test")
+	textinput.updateSuggestions()
+	textinput.nextSuggestion()
+	suggestion = textinput.CurrentSuggestion()
+	expected = "test2"
+	if suggestion != expected {
+		t.Fatalf("Error: expected first suggestion but was %s", suggestion)
+	}
+
+	textinput.Blur()
+	if strings.HasSuffix(textinput.View(), "test2") {
+		t.Fatalf("Error: suggestions should not be rendered when input isn't focused. expected \"> test\" but got \"%s\"", textinput.View())
+	}
+}
+
+func Test_SlicingOutsideCap(t *testing.T) {
+	textinput := New()
+	textinput.Placeholder = "作業ディレクトリを指定してください"
+	textinput.Width = 32
+	textinput.View()
+}
+
+func TestChinesePlaceholder(t *testing.T) {
+	textinput := New()
+	textinput.Placeholder = "输入消息..."
+	textinput.Width = 20
+
+	got := textinput.View()
+	expected := "> 输入消息...       "
+	if got != expected {
+		t.Fatalf("expected %q but got %q", expected, got)
+	}
+}
+
+func TestPlaceholderTruncate(t *testing.T) {
+	textinput := New()
+	textinput.Placeholder = "A very long placeholder, or maybe not so much"
+	textinput.Width = 10
+
+	got := textinput.View()
+	expected := "> A very …"
+	if got != expected {
+		t.Fatalf("expected %q but got %q", expected, got)
+	}
+}
+
+func ExampleValidateFunc() {
+	creditCardNumber := New()
+	creditCardNumber.Placeholder = "4505 **** **** 1234"
+	creditCardNumber.Focus()
+	creditCardNumber.CharLimit = 20
+	creditCardNumber.Width = 30
+	creditCardNumber.Prompt = ""
+	// This anonymous function is a valid function for ValidateFunc.
+	creditCardNumber.Validate = func(s string) error {
+		// Credit Card Number should a string less than 20 digits
+		// It should include 16 integers and 3 spaces
+		if len(s) > 16+3 {
+			return fmt.Errorf("CCN is too long")
+		}
+
+		if len(s) == 0 || len(s)%5 != 0 && (s[len(s)-1] < '0' || s[len(s)-1] > '9') {
+			return fmt.Errorf("CCN is invalid")
+		}
+
+		// The last digit should be a number unless it is a multiple of 4 in which
+		// case it should be a space
+		if len(s)%5 == 0 && s[len(s)-1] != ' ' {
+			return fmt.Errorf("CCN must separate groups with spaces")
+		}
+
+		// The remaining digits should be integers
+		c := strings.ReplaceAll(s, " ", "")
+		_, err := strconv.ParseInt(c, 10, 64)
+
+		return err
+	}
+}
+
+func keyPress(key rune) tea.Msg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}, Alt: false}
+}
+
+func sendString(m Model, str string) Model {
+	for _, k := range str {
+		m, _ = m.Update(keyPress(k))
+	}
+
+	return m
+}

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/sdk/go/pulumi-language-go/go.sum
+++ b/sdk/go/pulumi-language-go/go.sum
@@ -375,8 +375,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20260211083412-859bfffeef82 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
@@ -372,8 +372,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/sdk/pcl/go.mod
+++ b/sdk/pcl/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/sdk/pcl/go.sum
+++ b/sdk/pcl/go.sum
@@ -370,8 +370,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20260211083412-859bfffeef82 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.sum
+++ b/sdk/python/cmd/pulumi-language-python/go.sum
@@ -375,8 +375,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -94,7 +94,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.12 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.19 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.25 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -3927,7 +3927,6 @@ github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 h1:GCbb1ndr
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0/go.mod h1:IRPBaI8jXdrNfD0e4Zm7Fbcgaz5shKxOQv4axiL09xs=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
 github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/tests/integration/construct_component_provider_propagation/go/go.sum
+++ b/tests/integration/construct_component_provider_propagation/go/go.sum
@@ -191,8 +191,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/tests/integration/construct_component_resource_options/go/go.sum
+++ b/tests/integration/construct_component_resource_options/go/go.sum
@@ -191,8 +191,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/tests/integration/construct_nested_component/go/go.sum
+++ b/tests/integration/construct_nested_component/go/go.sum
@@ -192,8 +192,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/texttheater/golang-levenshtein v1.0.1 h1:+cRNoVrfiwufQPhoMzB6N0Yf/Mqajr6t1lOv8GyGE2U=
 github.com/texttheater/golang-levenshtein v1.0.1/go.mod h1:PYAKrbF5sAiq9wd+H82hs7gNaen0CplQ9uvm6+enD/8=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e h1:LeK2XS53TqtYZH7qGVycAthdNBbxaKr0s541PI5jidY=
-github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/tests/integration/run_plugin/go/go.mod
+++ b/tests/integration/run_plugin/go/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/charmbracelet/bubbles v1.0.0 // indirect

--- a/tests/integration/run_plugin/go/go.sum
+++ b/tests/integration/run_plugin/go/go.sum
@@ -14,8 +14,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
-github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=


### PR DESCRIPTION
atotto/clipboard suffers from unfortunate crashes on windows because of DLL loading. Unfortunately upstream doesn't seem to accept my PR https://github.com/atotto/clipboard/pull/74.

We are currently using replace statements for this, but those don't apply to downstream dependencies.  Instead of trying to fix all downstream dependencies manually, let's vendor
charmbracelet/bubbles/textinput, and make it use the fixed atotto/clipboard (also vendored).  This way downstream dependencies (for example pulumi-random, which currently causes flakes in CI, see https://github.com/pulumi/pulumi/issues/23958) will get the correct version automatically.

As a new version of the dependency gets released, it'll pull in the fix.
