### PR TITLE
Move template helpers from sdk workspace to pkg templates

### DIFF
--- a/changelog/pending/sdk-chore-20260716-091126.yaml
+++ b/changelog/pending/sdk-chore-20260716-091126.yaml
@@ -1,0 +1,4 @@
+component: sdk
+kind: chore
+body: Move template helpers from workspace to pkg/cmd/pulumi/templates
+time: 2026-07-16T09:11:26.115633+01:00

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -318,7 +318,7 @@ func NewUpCmd() *cobra.Command {
 		// Retrieve the template repo.
 		templateSource := cmdTemplates.New(ctx,
 			templateNameOrURL, cmdTemplates.ScopeAll,
-			workspace.TemplateKindPulumiProject, env.Global())
+			cmdTemplates.TemplateKindPulumiProject, env.Global())
 		defer contract.IgnoreClose(templateSource)
 
 		// List the templates from the repo.
@@ -327,7 +327,7 @@ func NewUpCmd() *cobra.Command {
 			return err
 		}
 
-		var template workspace.Template
+		var template cmdTemplates.ProjectTemplate
 		if len(templates) == 0 {
 			return errors.New("no template found")
 		} else if len(templates) == 1 {
@@ -403,7 +403,7 @@ func NewUpCmd() *cobra.Command {
 		}
 
 		// Copy the template files from the repo to the temporary "virtual workspace" directory.
-		if err = workspace.CopyTemplateFiles(template.Dir, temp, true, name, description); err != nil {
+		if err = cmdTemplates.CopyTemplateFiles(template.Dir, temp, true, name, description); err != nil {
 			return err
 		}
 

--- a/pkg/cmd/pulumi/packagecmd/package_new.go
+++ b/pkg/cmd/pulumi/packagecmd/package_new.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -175,8 +176,8 @@ func runNewPackage(ctx context.Context, out io.Writer, args newPackageArgs) erro
 		}
 	}
 
-	repo, err := workspace.RetrieveTemplates(
-		ctx, args.templateNameOrURL, args.offline, workspace.TemplateKindPackage)
+	repo, err := cmdTemplates.RetrieveTemplates(
+		ctx, args.templateNameOrURL, args.offline, cmdTemplates.TemplateKindPackage)
 	if err != nil {
 		return err
 	}
@@ -189,7 +190,7 @@ func runNewPackage(ctx context.Context, out io.Writer, args newPackageArgs) erro
 		return err
 	}
 
-	var template workspace.PackageTemplate
+	var template cmdTemplates.PackageTemplate
 	switch {
 	case len(templates) == 0:
 		return errors.New("no templates")
@@ -209,7 +210,7 @@ func runNewPackage(ctx context.Context, out io.Writer, args newPackageArgs) erro
 	}
 
 	if !args.force {
-		if err := workspace.CopyTemplateFilesDryRun(template.Dir, cwd, args.name); err != nil {
+		if err := cmdTemplates.CopyTemplateFilesDryRun(template.Dir, cwd, args.name); err != nil {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 			}
@@ -248,7 +249,7 @@ func runNewPackage(ctx context.Context, out io.Writer, args newPackageArgs) erro
 		}
 	}
 
-	if err := workspace.CopyTemplateFiles(template.Dir, cwd, args.force, args.name, args.description); err != nil {
+	if err := cmdTemplates.CopyTemplateFiles(template.Dir, cwd, args.force, args.name, args.description); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 		}
@@ -315,11 +316,11 @@ func runNewPackage(ctx context.Context, out io.Writer, args newPackageArgs) erro
 }
 
 func choosePackageTemplate(
-	templates []workspace.PackageTemplate, opts display.Options,
-) (workspace.PackageTemplate, error) {
+	templates []cmdTemplates.PackageTemplate, opts display.Options,
+) (cmdTemplates.PackageTemplate, error) {
 	const chooseTemplateErr = "no template selected; please use `pulumi package new` to choose one"
 	if !opts.IsInteractive {
-		return workspace.PackageTemplate{}, errors.New(chooseTemplateErr)
+		return cmdTemplates.PackageTemplate{}, errors.New(chooseTemplateErr)
 	}
 
 	surveycore.DisableColor = true
@@ -334,14 +335,14 @@ func choosePackageTemplate(
 		Options:  options,
 		PageSize: cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: len(options)}),
 	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
-		return workspace.PackageTemplate{}, errors.New(chooseTemplateErr)
+		return cmdTemplates.PackageTemplate{}, errors.New(chooseTemplateErr)
 	}
 	return optionToTemplateMap[option], nil
 }
 
 func packageTemplatesToOptions(
-	templates []workspace.PackageTemplate,
-) ([]string, map[string]workspace.PackageTemplate) {
+	templates []cmdTemplates.PackageTemplate,
+) ([]string, map[string]cmdTemplates.PackageTemplate) {
 	maxNameLength := 0
 	for _, t := range templates {
 		if len(t.Name) > maxNameLength {
@@ -350,7 +351,7 @@ func packageTemplatesToOptions(
 	}
 
 	var options, brokenOptions []string
-	nameToTemplateMap := make(map[string]workspace.PackageTemplate)
+	nameToTemplateMap := make(map[string]cmdTemplates.PackageTemplate)
 	for _, t := range templates {
 		if t.Errored() {
 			t.Description = newcmd.BrokenTemplateDescription

--- a/pkg/cmd/pulumi/packagecmd/package_new_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_new_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -240,7 +241,7 @@ func TestPackageNew_InvalidName(t *testing.T) {
 func TestPackageTemplatesToOptions(t *testing.T) {
 	t.Parallel()
 
-	templates := []workspace.PackageTemplate{
+	templates := []cmdTemplates.PackageTemplate{
 		{Name: "zeta", Description: "last alphabetically"},
 		{Name: "alpha", Description: "first alphabetically"},
 		{Name: "broken", Error: assert.AnError},
@@ -262,7 +263,7 @@ func TestLoadPackageTemplate(t *testing.T) {
 		t.Parallel()
 		path, err := filepath.Abs(filepath.Join("testdata", "template-component-nodejs"))
 		require.NoError(t, err)
-		template, err := workspace.LoadPackageTemplate(path)
+		template, err := cmdTemplates.LoadPackageTemplate(path)
 		require.NoError(t, err)
 		assert.Equal(t, "template-component-nodejs", template.Name)
 		assert.Equal(t, "A Node.js component package starter", template.Description)
@@ -272,7 +273,7 @@ func TestLoadPackageTemplate(t *testing.T) {
 		t.Parallel()
 		path, err := filepath.Abs(filepath.Join("testdata", "template-broken"))
 		require.NoError(t, err)
-		_, err = workspace.LoadPackageTemplate(path)
+		_, err = cmdTemplates.LoadPackageTemplate(path)
 		require.Error(t, err)
 	})
 }

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -82,16 +83,20 @@ func newPolicyNewCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(
 		&args.dir, "dir", "",
-		"The location to place the generated Policy Pack; if not specified, the current directory is used")
+		"The location to place the generated Policy Pack; if not specified, the current directory is used",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.force, "force", "f", false,
-		"Forces content to be generated even if it would change existing files")
+		"Forces content to be generated even if it would change existing files",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.generateOnly, "generate-only", "g", false,
-		"Generate the Policy Pack only; do not install dependencies")
+		"Generate the Policy Pack only; do not install dependencies",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.offline, "offline", "o", false,
-		"Use locally cached templates without making any network requests")
+		"Use locally cached templates without making any network requests",
+	)
 
 	return cmd
 }
@@ -129,7 +134,9 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	}
 
 	// Retrieve the templates-policy repo.
-	repo, err := workspace.RetrieveTemplates(ctx, args.templateNameOrURL, args.offline, workspace.TemplateKindPolicyPack)
+	repo, err := cmdTemplates.RetrieveTemplates(
+		ctx, args.templateNameOrURL, args.offline, cmdTemplates.TemplateKindPolicyPack,
+	)
 	if err != nil {
 		return err
 	}
@@ -143,7 +150,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 		return err
 	}
 
-	var template workspace.PolicyPackTemplate
+	var template cmdTemplates.PolicyPackTemplate
 	if len(templates) == 0 {
 		return errors.New("no templates")
 	} else if len(templates) == 1 {
@@ -163,7 +170,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 
 	// Do a dry run, if we're not forcing files to be overwritten.
 	if !args.force {
-		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd, ""); err != nil {
+		if err = cmdTemplates.CopyTemplateFilesDryRun(template.Dir, cwd, ""); err != nil {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 			}
@@ -172,7 +179,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	}
 
 	// Actually copy the files.
-	if err = workspace.CopyTemplateFiles(template.Dir, cwd, args.force, "", ""); err != nil {
+	if err = cmdTemplates.CopyTemplateFiles(template.Dir, cwd, args.force, "", ""); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 		}
@@ -207,7 +214,8 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 
 	fmt.Fprintln(args.stdout,
 		opts.Color.Colorize(
-			colors.BrightGreen+colors.Bold+"Your new Policy Pack is ready to go!"+colors.Reset)+
+			colors.BrightGreen+colors.Bold+"Your new Policy Pack is ready to go!"+colors.Reset,
+		)+
 			" "+cmdutil.EmojiOr("✨", ""))
 	fmt.Fprintln(args.stdout)
 
@@ -274,12 +282,12 @@ func printPolicyPackNextSteps(
 }
 
 // choosePolicyPackTemplate will prompt the user to choose amongst the available templates.
-func choosePolicyPackTemplate(templates []workspace.PolicyPackTemplate,
+func choosePolicyPackTemplate(templates []cmdTemplates.PolicyPackTemplate,
 	opts display.Options,
-) (workspace.PolicyPackTemplate, error) {
+) (cmdTemplates.PolicyPackTemplate, error) {
 	const chooseTemplateErr = "no template selected; please use `pulumi policy new` to choose one"
 	if !opts.IsInteractive {
-		return workspace.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
+		return cmdTemplates.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
 	}
 
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
@@ -295,7 +303,7 @@ func choosePolicyPackTemplate(templates []workspace.PolicyPackTemplate,
 		Options:  options,
 		PageSize: cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: len(options)}),
 	}, &option, ui.SurveyIcons(opts.Color)); err != nil {
-		return workspace.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
+		return cmdTemplates.PolicyPackTemplate{}, errors.New(chooseTemplateErr)
 	}
 	return optionToTemplateMap[option], nil
 }
@@ -303,8 +311,8 @@ func choosePolicyPackTemplate(templates []workspace.PolicyPackTemplate,
 // policyTemplatesToOptionArrayAndMap returns an array of option strings and a map of option strings to policy
 // templates. Each option string is made up of the template name and description with some padding in between.
 func policyTemplatesToOptionArrayAndMap(
-	templates []workspace.PolicyPackTemplate,
-) ([]string, map[string]workspace.PolicyPackTemplate) {
+	templates []cmdTemplates.PolicyPackTemplate,
+) ([]string, map[string]cmdTemplates.PolicyPackTemplate) {
 	// Find the longest name length. Used to add padding between the name and description.
 	maxNameLength := 0
 	for _, template := range templates {
@@ -316,7 +324,7 @@ func policyTemplatesToOptionArrayAndMap(
 	// Build the array and map.
 	var options []string
 	var brokenOptions []string
-	nameToTemplateMap := make(map[string]workspace.PolicyPackTemplate)
+	nameToTemplateMap := make(map[string]cmdTemplates.PolicyPackTemplate)
 	for _, template := range templates {
 		// If template is broken, indicate it in the project description.
 		if template.Errored() {

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -46,7 +47,7 @@ func HandleConfig(
 	project *workspace.Project,
 	s backend.Stack,
 	templateNameOrURL string,
-	template workspace.Template,
+	template cmdTemplates.ProjectTemplate,
 	configArray []string,
 	yes bool,
 	path bool,

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -195,7 +195,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		scope = cmdTemplates.ScopeLocal
 	}
 	templateSource := cmdTemplates.New(ctx,
-		args.templateNameOrURL, scope, workspace.TemplateKindPulumiProject, env.Global())
+		args.templateNameOrURL, scope, cmdTemplates.TemplateKindPulumiProject, env.Global())
 	defer contract.IgnoreClose(templateSource)
 
 	// List the templates from the repo.
@@ -217,7 +217,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		}
 	}
 
-	var template workspace.Template
+	var template cmdTemplates.ProjectTemplate
 	if cmdTemplate == nil {
 		// Template might be nil if we're running in non-interactive mode and didn't pass a template to choose. In
 		// that case we'll write a minimal Pulumi.yaml.
@@ -231,7 +231,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			return fmt.Errorf("writing minimal Pulumi.yaml: %w", err)
 		}
 
-		template = workspace.Template{
+		template = cmdTemplates.ProjectTemplate{
 			Dir:         temp,
 			ProjectName: "${PROJECT}",
 		}
@@ -248,7 +248,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Do a dry run, if we're not forcing files to be overwritten.
 	if !args.force {
-		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd, args.name); err != nil {
+		if err = cmdTemplates.CopyTemplateFilesDryRun(template.Dir, cwd, args.name); err != nil {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 			}
@@ -337,7 +337,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	}
 
 	// Actually copy the files.
-	if err = workspace.CopyTemplateFiles(template.Dir, cwd, args.force, args.name, args.description); err != nil {
+	if err = cmdTemplates.CopyTemplateFiles(template.Dir, cwd, args.force, args.name, args.description); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 		}
@@ -547,7 +547,7 @@ func NewNewCmd() *cobra.Command {
 			scope = cmdTemplates.ScopeLocal
 		}
 		// Attempt to retrieve available templates.
-		s := cmdTemplates.New(ctx, "", scope, workspace.TemplateKindPulumiProject, env.Global())
+		s := cmdTemplates.New(ctx, "", scope, cmdTemplates.TemplateKindPulumiProject, env.Global())
 		t, err := s.Templates()
 		return t, s, err
 	}

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -272,29 +272,29 @@ func (r registryTemplate) Description() string {
 
 func (r registryTemplate) Error() error { return nil }
 
-func (r registryTemplate) Download(ctx context.Context) (workspace.Template, error) {
+func (r registryTemplate) Download(ctx context.Context) (ProjectTemplate, error) {
 	templateBytes, err := r.registry.DownloadTemplate(ctx, r.t.DownloadURL)
 	if err != nil {
-		return workspace.Template{}, fmt.Errorf("failed to download from %q: %w", r.t.DownloadURL, err)
+		return ProjectTemplate{}, fmt.Errorf("failed to download from %q: %w", r.t.DownloadURL, err)
 	}
 	defer contract.IgnoreClose(templateBytes)
 	templateDir, err := os.MkdirTemp("", "pulumi-template-")
 	if err != nil {
-		return workspace.Template{}, fmt.Errorf("failed to make temporary directory: %w", err)
+		return ProjectTemplate{}, fmt.Errorf("failed to make temporary directory: %w", err)
 	}
 	// Having created a template directory, we now add it to the list of directories to close.
 	r.source.addCloser(func() error { return os.RemoveAll(templateDir) })
 	tarReader, err := createTarReader(templateBytes)
 	if err != nil {
-		return workspace.Template{}, fmt.Errorf("failed to create tar reader: %w", err)
+		return ProjectTemplate{}, fmt.Errorf("failed to create tar reader: %w", err)
 	}
 	defer tarReader.Close()
 
 	if err := writeTar(ctx, tar.NewReader(tarReader), templateDir); err != nil {
-		return workspace.Template{}, err
+		return ProjectTemplate{}, err
 	}
 
-	template, err := workspace.LoadTemplate(templateDir)
+	template, err := LoadTemplate(templateDir)
 	return template, err
 }
 
@@ -446,27 +446,27 @@ func (t orgTemplate) Name() string        { return t.t.Name }
 func (t orgTemplate) DisplayName() string { return t.t.Name }
 func (t orgTemplate) Description() string { return t.t.Description }
 func (t orgTemplate) Error() error        { return nil }
-func (t orgTemplate) Download(ctx context.Context) (workspace.Template, error) {
+func (t orgTemplate) Download(ctx context.Context) (ProjectTemplate, error) {
 	templateDir, err := os.MkdirTemp("", "pulumi-template-")
 	if err != nil {
-		return workspace.Template{}, err
+		return ProjectTemplate{}, err
 	}
 	// Having created a template directory, we now add it to the list of directories to close.
 	t.source.addCloser(func() error { return os.RemoveAll(templateDir) })
 
 	tarReader, err := t.backend.DownloadTemplate(ctx, t.org, t.t.TemplateURL)
 	if err != nil {
-		return workspace.Template{}, err
+		return ProjectTemplate{}, err
 	}
 	if err := errors.Join(
 		writeTar(ctx, tarReader.Tar(), templateDir),
 		tarReader.Close(),
 	); err != nil {
-		return workspace.Template{}, err
+		return ProjectTemplate{}, err
 	}
 	slog.InfoContext(ctx, "downloaded template", "template", t.t.Name, "dir", templateDir)
 
-	return workspace.LoadTemplate(templateDir)
+	return LoadTemplate(templateDir)
 }
 
 const maxDecompressedSize = 100 << 20 // 100MB

--- a/pkg/cmd/pulumi/templates/project_templates.go
+++ b/pkg/cmd/pulumi/templates/project_templates.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workspace
+package templates
 
 import (
 	"context"
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,7 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 const (
@@ -64,22 +65,22 @@ func getTemplateGitRepository(templateKind TemplateKind) string {
 	switch templateKind {
 	case TemplateKindPolicyPack:
 		if repo := env.PolicyTemplateGitRepository.Value(); repo != "" {
-			logging.V(5).Infof("Using custom policy template repository from %s: %s",
-				env.PolicyTemplateGitRepository.Var().Name(), repo)
+			slog.Debug("Using custom policy template repository",
+				"env", env.PolicyTemplateGitRepository.Var().Name(), "repo", repo)
 			return repo
 		}
 		return pulumiPolicyTemplateGitRepository
 	case TemplateKindPackage:
 		if repo := env.PackageTemplateGitRepository.Value(); repo != "" {
-			logging.V(5).Infof("Using custom package template repository from %s: %s",
-				env.PackageTemplateGitRepository.Var().Name(), repo)
+			slog.Debug("Using custom package template repository",
+				"env", env.PackageTemplateGitRepository.Var().Name(), "repo", repo)
 			return repo
 		}
 		return pulumiPackageTemplateGitRepository
 	case TemplateKindPulumiProject:
 		if repo := env.TemplateGitRepository.Value(); repo != "" {
-			logging.V(5).Infof("Using custom template repository from %s: %s",
-				env.TemplateGitRepository.Var().Name(), repo)
+			slog.Debug("Using custom template repository",
+				"env", env.TemplateGitRepository.Var().Name(), "repo", repo)
 			return repo
 		}
 		return pulumiTemplateGitRepository
@@ -94,22 +95,22 @@ func getTemplateBranch(templateKind TemplateKind) string {
 	switch templateKind {
 	case TemplateKindPolicyPack:
 		if branch := env.PolicyTemplateBranch.Value(); branch != "" {
-			logging.V(5).Infof("Using custom policy template branch from %s: %s",
-				env.PolicyTemplateBranch.Var().Name(), branch)
+			slog.Debug("Using custom policy template branch",
+				"env", env.PolicyTemplateBranch.Var().Name(), "branch", branch)
 			return branch
 		}
 		return pulumiPolicyTemplateBranch
 	case TemplateKindPackage:
 		if branch := env.PackageTemplateBranch.Value(); branch != "" {
-			logging.V(5).Infof("Using custom package template branch from %s: %s",
-				env.PackageTemplateBranch.Var().Name(), branch)
+			slog.Debug("Using custom package template branch",
+				"env", env.PackageTemplateBranch.Var().Name(), "branch", branch)
 			return branch
 		}
 		return pulumiPackageTemplateBranch
 	case TemplateKindPulumiProject:
 		if branch := env.TemplateBranch.Value(); branch != "" {
-			logging.V(5).Infof("Using custom template branch from %s: %s",
-				env.TemplateBranch.Var().Name(), branch)
+			slog.Debug("Using custom template branch",
+				"env", env.TemplateBranch.Var().Name(), "branch", branch)
 			return branch
 		}
 		return pulumiTemplateBranch
@@ -149,115 +150,31 @@ func (repo TemplateRepository) Delete() error {
 }
 
 // Templates lists the templates in the repository.
-func (repo TemplateRepository) Templates() ([]Template, error) {
-	path := repo.SubDirectory
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-
-	// If it's a file, look in its directory.
-	if !info.IsDir() {
-		path = filepath.Dir(path)
-	}
-
-	// See if there's a Pulumi.yaml in the directory.
-	template, err := LoadTemplate(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return nil, err
-	} else if err == nil {
-		return []Template{template}, nil
-	}
-
-	// Otherwise, read all subdirectories to find the ones
-	// that contain a Pulumi.yaml.
-	infos, err := os.ReadDir(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var result []Template
-	for _, info := range infos {
-		if info.IsDir() {
-			name := info.Name()
-
-			// Ignore the .git directory.
-			if name == GitDir {
-				continue
-			}
-
-			template, err := LoadTemplate(filepath.Join(path, name))
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				logging.V(2).Infof(
-					"Failed to load template %s: %s",
-					name, err,
-				)
-				result = append(result, Template{Name: name, Error: err})
-			} else if err == nil {
-				result = append(result, template)
-			}
-		}
-	}
-	return result, nil
+func (repo TemplateRepository) Templates() ([]ProjectTemplate, error) {
+	return listTemplates(repo, LoadTemplate, func(name string, err error) ProjectTemplate {
+		return ProjectTemplate{Name: name, Error: err}
+	})
 }
 
 // PolicyTemplates lists the policy templates in the repository.
 func (repo TemplateRepository) PolicyTemplates() ([]PolicyPackTemplate, error) {
-	path := repo.SubDirectory
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-
-	// If it's a file, look in its directory.
-	if !info.IsDir() {
-		path = filepath.Dir(path)
-	}
-
-	// See if there's a PulumiPolicy.yaml in the directory.
-	template, err := LoadPolicyPackTemplate(path)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return nil, err
-	} else if err == nil {
-		return []PolicyPackTemplate{template}, nil
-	}
-
-	// Otherwise, read all subdirectories to find the ones
-	// that contain a PulumiPolicy.yaml.
-	infos, err := os.ReadDir(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var result []PolicyPackTemplate
-	for _, info := range infos {
-		if info.IsDir() {
-			name := info.Name()
-
-			// Ignore the .git directory.
-			if name == GitDir {
-				continue
-			}
-
-			template, err := LoadPolicyPackTemplate(filepath.Join(path, name))
-			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				logging.V(2).Infof(
-					"Failed to load template %s: %s",
-					name, err,
-				)
-				result = append(result, PolicyPackTemplate{Name: name, Error: err})
-			} else if err == nil {
-				result = append(result, template)
-			}
-		}
-	}
-	return result, nil
+	return listTemplates(repo, LoadPolicyPackTemplate, func(name string, err error) PolicyPackTemplate {
+		return PolicyPackTemplate{Name: name, Error: err}
+	})
 }
 
 // PackageTemplates lists the package templates in the repository.
 func (repo TemplateRepository) PackageTemplates() ([]PackageTemplate, error) {
+	return listTemplates(repo, LoadPackageTemplate, func(name string, err error) PackageTemplate {
+		return PackageTemplate{Name: name, Error: err}
+	})
+}
+
+func listTemplates[T any](
+	repo TemplateRepository,
+	load func(string) (T, error),
+	broken func(string, error) T,
+) ([]T, error) {
 	path := repo.SubDirectory
 
 	info, err := os.Stat(path)
@@ -269,11 +186,11 @@ func (repo TemplateRepository) PackageTemplates() ([]PackageTemplate, error) {
 		path = filepath.Dir(path)
 	}
 
-	template, err := LoadPackageTemplate(path)
+	template, err := load(path)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	} else if err == nil {
-		return []PackageTemplate{template}, nil
+		return []T{template}, nil
 	}
 
 	infos, err := os.ReadDir(path)
@@ -281,22 +198,19 @@ func (repo TemplateRepository) PackageTemplates() ([]PackageTemplate, error) {
 		return nil, err
 	}
 
-	var result []PackageTemplate
+	var result []T
 	for _, info := range infos {
 		if info.IsDir() {
 			name := info.Name()
 
-			if name == GitDir {
+			if name == workspace.GitDir {
 				continue
 			}
 
-			template, err := LoadPackageTemplate(filepath.Join(path, name))
+			template, err := load(filepath.Join(path, name))
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				logging.V(2).Infof(
-					"Failed to load template %s: %s",
-					name, err,
-				)
-				result = append(result, PackageTemplate{Name: name, Error: err})
+				slog.Debug("Failed to load template", "template", name, "error", err)
+				result = append(result, broken(name, err))
 			} else if err == nil {
 				result = append(result, template)
 			}
@@ -305,21 +219,21 @@ func (repo TemplateRepository) PackageTemplates() ([]PackageTemplate, error) {
 	return result, nil
 }
 
-// Template represents a project template.
-type Template struct {
-	Dir         string                                // The directory containing Pulumi.yaml.
-	Name        string                                // The name of the template.
-	Description string                                // Description of the template.
-	Quickstart  string                                // Optional text to be displayed after template creation.
-	Config      map[string]ProjectTemplateConfigValue // Optional template config.
-	Error       error                                 // Non-nil if the template is broken.
+// ProjectTemplate represents a project template.
+type ProjectTemplate struct {
+	Dir         string                                          // The directory containing Pulumi.yaml.
+	Name        string                                          // The name of the template.
+	Description string                                          // Description of the template.
+	Quickstart  string                                          // Optional text to be displayed after template creation.
+	Config      map[string]workspace.ProjectTemplateConfigValue // Optional template config.
+	Error       error                                           // Non-nil if the template is broken.
 
 	ProjectName        string // Name of the project.
 	ProjectDescription string // Optional description of the project.
 }
 
 // Errored returns if the template has an error
-func (t Template) Errored() bool {
+func (t ProjectTemplate) Errored() bool {
 	return t.Error != nil
 }
 
@@ -517,32 +431,23 @@ func findSpecificTemplate(repo TemplateRepository, name string) (TemplateReposit
 	return repo, nil
 }
 
-// RetrieveGitFolder downloads the repo to path and returns the full path on disk.
-//
-// Deprecated: Use [gitutil.RetrieveGitFolder] instead.
-//
-//go:fix inline
-func RetrieveGitFolder(ctx context.Context, rawurl string, path string) (string, error) {
-	return gitutil.RetrieveGitFolder(ctx, rawurl, path)
-}
-
 // LoadTemplate returns a template from a path.
-func LoadTemplate(path string) (Template, error) {
+func LoadTemplate(path string) (ProjectTemplate, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return Template{}, err
+		return ProjectTemplate{}, err
 	}
 	if !info.IsDir() {
-		return Template{}, fmt.Errorf("%s is not a directory", path)
+		return ProjectTemplate{}, fmt.Errorf("%s is not a directory", path)
 	}
 
 	// TODO handle other extensions like Pulumi.yml and Pulumi.json?
-	proj, err := LoadProject(filepath.Join(path, "Pulumi.yaml"))
+	proj, err := workspace.LoadProject(filepath.Join(path, "Pulumi.yaml"))
 	if err != nil {
-		return Template{}, err
+		return ProjectTemplate{}, err
 	}
 
-	template := Template{
+	template := ProjectTemplate{
 		Dir:  path,
 		Name: filepath.Base(path),
 
@@ -672,7 +577,7 @@ func LoadPolicyPackTemplate(path string) (PolicyPackTemplate, error) {
 		return PolicyPackTemplate{}, fmt.Errorf("%s is not a directory", path)
 	}
 
-	pack, err := LoadPolicyPack(filepath.Join(path, "PulumiPolicy.yaml"))
+	pack, err := workspace.LoadPolicyPack(filepath.Join(path, "PulumiPolicy.yaml"))
 	if err != nil {
 		return PolicyPackTemplate{}, err
 	}
@@ -697,7 +602,7 @@ func LoadPackageTemplate(path string) (PackageTemplate, error) {
 		return PackageTemplate{}, fmt.Errorf("%s is not a directory", path)
 	}
 
-	plugin, err := LoadPluginProject(filepath.Join(path, "PulumiPlugin.yaml"))
+	plugin, err := workspace.LoadPluginProject(filepath.Join(path, "PulumiPlugin.yaml"))
 	if err != nil {
 		return PackageTemplate{}, err
 	}
@@ -719,20 +624,20 @@ func GetTemplateDir(templateKind TemplateKind) (string, error) {
 	switch templateKind {
 	case TemplateKindPolicyPack:
 		override = env.PolicyTemplatePath.Value()
-		classicDir = TemplatePolicyDir
+		classicDir = workspace.TemplatePolicyDir
 	case TemplateKindPackage:
 		override = env.PackageTemplatePath.Value()
-		classicDir = TemplatePackageDir
+		classicDir = workspace.TemplatePackageDir
 	case TemplateKindPulumiProject:
 		override = env.TemplatePath.Value()
-		classicDir = TemplateDir
+		classicDir = workspace.TemplateDir
 	default:
 		contract.Failf("unhandled TemplateKind: %v", templateKind)
 	}
 	if override != "" {
 		return override, nil
 	}
-	return GetPulumiPath(classicDir)
+	return workspace.GetPulumiPath(classicDir)
 }
 
 // walkFiles is a helper that walks the directories/files in a source directory
@@ -755,7 +660,7 @@ func walkFiles(sourceDir string, destDir string, projectName string,
 
 		if entry.IsDir() {
 			// Ignore the .git directory.
-			if name == GitDir {
+			if name == workspace.GitDir {
 				continue
 			}
 

--- a/pkg/cmd/pulumi/templates/project_templates_test.go
+++ b/pkg/cmd/pulumi/templates/project_templates_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workspace
+package templates
 
 import (
 	"fmt"

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -15,7 +15,7 @@
 // Package templates adds an abstraction for project templates that may be local or
 // remote.
 //
-// All templates are convertible into [workspace.Template].
+// All templates are convertible into [ProjectTemplate].
 package templates
 
 import (
@@ -30,7 +30,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // Source provides access to a set of project templates, any set of which may be present on
@@ -126,8 +125,8 @@ type Template interface {
 	DisplayName() string
 	Description() string
 	Error() error
-	// Download the template and return an instantiable [workspace.Template] for this template.
-	Download(ctx context.Context) (workspace.Template, error)
+	// Download the template and return an instantiable [ProjectTemplate] for this template.
+	Download(ctx context.Context) (ProjectTemplate, error)
 }
 
 // SearchScope dictates where [New] will search for templates.
@@ -143,23 +142,23 @@ var (
 // Create a new [Template] [Source] associated with a given [SearchScope].
 func New(
 	ctx context.Context, templateNamePathOrURL string, scope SearchScope,
-	templateKind workspace.TemplateKind, e env.Env,
+	templateKind TemplateKind, e env.Env,
 ) *Source {
 	return newImpl(
 		ctx, templateNamePathOrURL, scope,
 		templateKind,
-		workspace.RetrieveTemplates,
+		RetrieveTemplates,
 		e,
 	)
 }
 
 // The impl for [New].
 //
-// having a separate impl function allows mocking out getWorkspaceTemplates.
+// having a separate impl function allows mocking out getProjectTemplates.
 func newImpl(
 	ctx context.Context, templateNamePathOrURL string, scope SearchScope,
-	templateKind workspace.TemplateKind,
-	getWorkspaceTemplates getWorkspaceTemplateFunc,
+	templateKind TemplateKind,
+	getProjectTemplates getProjectTemplateFunc,
 	e env.Env,
 ) *Source {
 	var source Source
@@ -169,12 +168,12 @@ func newImpl(
 	if scope == ScopeAll || scope == ScopeLocal {
 		source.wg.Add(1)
 		go func() {
-			source.getWorkspaceTemplates(ctx, templateNamePathOrURL, scope, templateKind, &source.wg, getWorkspaceTemplates)
+			source.getProjectTemplates(ctx, templateNamePathOrURL, scope, templateKind, getProjectTemplates)
 			source.wg.Done()
 		}()
 	}
 
-	if scope == ScopeAll && templateKind == workspace.TemplateKindPulumiProject && isTemplateName(templateNamePathOrURL) {
+	if scope == ScopeAll && templateKind == TemplateKindPulumiProject && isTemplateName(templateNamePathOrURL) {
 		source.wg.Add(1)
 		go func() {
 			source.getCloudTemplates(ctx, templateNamePathOrURL, &source.wg, e)
@@ -186,7 +185,7 @@ func newImpl(
 }
 
 func isTemplateName(templateNamePathOrURL string) bool {
-	return !workspace.IsGitRepoTemplateURL(templateNamePathOrURL) &&
+	return !IsGitRepoTemplateURL(templateNamePathOrURL) &&
 		!isTemplatePath(templateNamePathOrURL)
 }
 

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -62,8 +62,8 @@ func TestFilterOnName(t *testing.T) {
 		ctx := testContext(t)
 
 		source := newImpl(ctx, "name1",
-			ScopeAll, workspace.TemplateKindPulumiProject,
-			templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+			ScopeAll, TemplateKindPulumiProject,
+			templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 			env.NewEnv(mapStore),
 		)
 
@@ -225,13 +225,13 @@ func TestMultipleTemplateSources_OrgTemplates(t *testing.T) {
 runtime: dotnet
 description: An ASP.NET application running a simple container in a EKS Cluster
 `), 0o600))
-	repoTemplates := templateRepository(workspace.TemplateRepository{
+	repoTemplates := templateRepository(TemplateRepository{
 		Root:         repoTemplateDir,
 		SubDirectory: subdir,
 	}, nil)
 
 	source := newImpl(ctx, "",
-		ScopeAll, workspace.TemplateKindPulumiProject,
+		ScopeAll, TemplateKindPulumiProject,
 		repoTemplates, env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
 		}),
@@ -241,7 +241,7 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 	require.NoError(t, err)
 	assert.ElementsMatch(t,
 		[]Template{
-			workspaceTemplate{t: workspace.Template{
+			projectTemplate{t: ProjectTemplate{
 				Dir:                subdir,
 				Name:               "sub",
 				ProjectName:        "template3",
@@ -284,8 +284,8 @@ func TestSurfaceListTemplateErrors_OrgTemplates(t *testing.T) {
 	})
 
 	source := newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{"PULUMI_DISABLE_REGISTRY_RESOLVE": "true"}),
 	)
 
@@ -329,8 +329,8 @@ func TestSurfaceListTemplateErrors_RegistryTemplates(t *testing.T) {
 	})
 
 	source := newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 			"PULUMI_EXPERIMENTAL":             "true",
@@ -370,15 +370,15 @@ func TestSurfaceOnEmptyError_OrgTemplates(t *testing.T) {
 	})
 
 	source := newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
 		}),
 	)
 
 	_, err := source.Templates()
-	var expected workspace.TemplateNotFoundError
+	var expected TemplateNotFoundError
 	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.errorOnEmpty)
 }
 
@@ -415,8 +415,8 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 	})
 
 	source := newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 			"PULUMI_EXPERIMENTAL":             "true",
@@ -424,7 +424,7 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 	)
 
 	_, err := source.Templates()
-	var expected workspace.TemplateNotFoundError
+	var expected TemplateNotFoundError
 	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.errorOnEmpty)
 }
 
@@ -485,8 +485,8 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 	})
 
 	source := newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "true",
 		}),
@@ -584,8 +584,8 @@ func createMockRegistrySource(
 	})
 
 	return newImpl(ctx, "name1",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 			"PULUMI_EXPERIMENTAL":             "true",
@@ -705,8 +705,8 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 		},
 	})
 
-	source := newImpl(ctx, "", ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+	source := newImpl(ctx, "", ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 			"PULUMI_EXPERIMENTAL":             "true",
@@ -779,8 +779,8 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 		},
 	})
 
-	source := newImpl(ctx, "target", ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+	source := newImpl(ctx, "target", ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 			"PULUMI_EXPERIMENTAL":             "true",
@@ -798,10 +798,10 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 	assert.Equal(t, "This is from the registry", templates[1].Description())
 }
 
-func templateRepository(repo workspace.TemplateRepository, err error) getWorkspaceTemplateFunc {
+func templateRepository(repo TemplateRepository, err error) getProjectTemplateFunc {
 	return func(ctx context.Context, templateNamePathOrURL string, offline bool,
-		templateKind workspace.TemplateKind,
-	) (workspace.TemplateRepository, error) {
+		templateKind TemplateKind,
+	) (TemplateRepository, error) {
 		return repo, err
 	}
 }
@@ -986,8 +986,8 @@ func TestRegistryTemplateResolution(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			source := newImpl(ctx, tc.templateURL, ScopeAll, workspace.TemplateKindPulumiProject,
-				templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+			source := newImpl(ctx, tc.templateURL, ScopeAll, TemplateKindPulumiProject,
+				templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 				env.NewEnv(env.MapStore{
 					"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 					"PULUMI_EXPERIMENTAL":             "true",
@@ -1007,7 +1007,7 @@ func TestRegistryTemplateResolution(t *testing.T) {
 				if tc.expectSpecificError != "" {
 					assert.Contains(t, err.Error(), tc.expectSpecificError)
 				} else {
-					var templateNotFound workspace.TemplateNotFoundError
+					var templateNotFound TemplateNotFoundError
 					assert.ErrorAs(t, err, &templateNotFound)
 				}
 			}
@@ -1142,8 +1142,8 @@ func TestVersionedTemplateResolution(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			getTemplateCalls = nil
 
-			source := newImpl(ctx, tc.templateURL, ScopeAll, workspace.TemplateKindPulumiProject,
-				templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+			source := newImpl(ctx, tc.templateURL, ScopeAll, TemplateKindPulumiProject,
+				templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 				env.NewEnv(env.MapStore{
 					"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 					"PULUMI_EXPERIMENTAL":             "true",
@@ -1206,8 +1206,8 @@ func TestVCSBackedTemplateRejectsVersion(t *testing.T) {
 	})
 
 	source := newImpl(ctx, "github/pulumi/pulumi%2Ftemplates%2Ftypescript@1.0.0",
-		ScopeAll, workspace.TemplateKindPulumiProject,
-		templateRepository(workspace.TemplateRepository{}, workspace.TemplateNotFoundError{}),
+		ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
 		env.NewEnv(env.MapStore{
 			"PULUMI_DISABLE_REGISTRY_RESOLVE": "false",
 			"PULUMI_EXPERIMENTAL":             "true",

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -20,28 +20,26 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-type getWorkspaceTemplateFunc = func(ctx context.Context, templateNamePathOrURL string, offline bool,
-	templateKind workspace.TemplateKind,
-) (workspace.TemplateRepository, error)
+type getProjectTemplateFunc = func(ctx context.Context, templateNamePathOrURL string, offline bool,
+	templateKind TemplateKind,
+) (TemplateRepository, error)
 
-func (s *Source) getWorkspaceTemplates(
-	ctx context.Context, templateNamePathOrURL string, scope SearchScope, templateKind workspace.TemplateKind,
-	_ *sync.WaitGroup,
-	get getWorkspaceTemplateFunc,
+func (s *Source) getProjectTemplates(
+	ctx context.Context, templateNamePathOrURL string, scope SearchScope, templateKind TemplateKind,
+	get getProjectTemplateFunc,
 ) {
 	repo, err := get(ctx, templateNamePathOrURL, scope == ScopeLocal, templateKind)
 	if err != nil {
-		if notFound := (workspace.TemplateNotFoundError{}); errors.As(err, &notFound) {
+		if notFound := (TemplateNotFoundError{}); errors.As(err, &notFound) {
 			s.addErrorOnEmpty(notFound)
 			return
 		}
 		// Bail on all errors unless its a 401 from a Pulumi Cloud backend...
-		if !errors.Is(err, workspace.ErrPulumiCloudUnauthorized) {
+		if !errors.Is(err, ErrPulumiCloudUnauthorized) {
 			s.addError(err)
 			return
 		}
@@ -55,20 +53,20 @@ func (s *Source) getWorkspaceTemplates(
 		}
 	}
 	s.addCloser(repo.Delete)
-	workspaceTemplates, err := repo.Templates()
+	projectTemplates, err := repo.Templates()
 	if err != nil {
 		s.addError(fmt.Errorf("could not get template from workspace: %w", err))
 		return
 	}
 
-	s.addDownloadedTemplates(workspaceTemplates)
+	s.addDownloadedTemplates(projectTemplates)
 }
 
 // Retrieve a Private template from the given Pulumi Cloud URL **including an auth token for Pulumi Cloud**.
-func retrievePrivatePulumiCloudTemplate(templateURL string) (workspace.TemplateRepository, error) {
+func retrievePrivatePulumiCloudTemplate(templateURL string) (TemplateRepository, error) {
 	u, err := url.Parse(templateURL)
 	if err != nil {
-		return workspace.TemplateRepository{}, fmt.Errorf("parsing template URL: %w", err)
+		return TemplateRepository{}, fmt.Errorf("parsing template URL: %w", err)
 	}
 	// Docs convention is to store the cloud URL with the protocol.
 	// e.g. `pulumi login https://api.pulumi.com` or `pulumi login https://api.acme.org`
@@ -76,7 +74,7 @@ func retrievePrivatePulumiCloudTemplate(templateURL string) (workspace.TemplateR
 
 	account, _, err := workspace.GetAccountWithAgentFallback(templatePulumiCloudHost)
 	if err != nil {
-		return workspace.TemplateRepository{}, fmt.Errorf(
+		return TemplateRepository{}, fmt.Errorf(
 			"looking up pulumi cloud backend %s: %w",
 			templatePulumiCloudHost,
 			err,
@@ -84,15 +82,15 @@ func retrievePrivatePulumiCloudTemplate(templateURL string) (workspace.TemplateR
 	}
 
 	if account.AccessToken == "" {
-		return workspace.TemplateRepository{}, fmt.Errorf("no access token found for %s", templatePulumiCloudHost)
+		return TemplateRepository{}, fmt.Errorf("no access token found for %s", templatePulumiCloudHost)
 	}
 
-	templateRepository, err := workspace.RetrieveZIPTemplates(templateURL, func(req *http.Request) {
+	templateRepository, err := RetrieveZIPTemplates(templateURL, func(req *http.Request) {
 		req.Header.Set("Authorization", "token "+account.AccessToken)
 	})
 
-	if errors.Is(err, workspace.ErrPulumiCloudUnauthorized) {
-		return workspace.TemplateRepository{}, fmt.Errorf(
+	if errors.Is(err, ErrPulumiCloudUnauthorized) {
+		return TemplateRepository{}, fmt.Errorf(
 			"unauthorized to access template at %s. You may not have access to this template or token may have expired",
 			templatePulumiCloudHost,
 		)
@@ -102,20 +100,22 @@ func retrievePrivatePulumiCloudTemplate(templateURL string) (workspace.TemplateR
 	return templateRepository, err
 }
 
-func (s *Source) addDownloadedTemplates(src []workspace.Template) {
+func (s *Source) addDownloadedTemplates(src []ProjectTemplate) {
 	for _, t := range src {
-		s.addTemplate(workspaceTemplate{t})
+		s.addTemplate(projectTemplate{t})
 	}
 }
 
-var _ Template = workspaceTemplate{}
+var _ Template = projectTemplate{}
 
-type workspaceTemplate struct {
-	t workspace.Template
+type projectTemplate struct {
+	t ProjectTemplate
 }
 
-func (t workspaceTemplate) Name() string                                             { return t.t.Name }
-func (t workspaceTemplate) DisplayName() string                                      { return t.t.Name }
-func (t workspaceTemplate) Description() string                                      { return t.t.Description }
-func (t workspaceTemplate) Error() error                                             { return t.t.Error }
-func (t workspaceTemplate) Download(ctx context.Context) (workspace.Template, error) { return t.t, nil }
+func (t projectTemplate) Name() string        { return t.t.Name }
+func (t projectTemplate) DisplayName() string { return t.t.Name }
+func (t projectTemplate) Description() string { return t.t.Description }
+func (t projectTemplate) Error() error        { return t.t.Error }
+func (t projectTemplate) Download(ctx context.Context) (ProjectTemplate, error) {
+	return t.t, nil
+}

--- a/pkg/cmd/pulumi/templates/zip.go
+++ b/pkg/cmd/pulumi/templates/zip.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workspace
+package templates
 
 import (
 	"archive/zip"

--- a/pkg/cmd/pulumi/templates/zip_test.go
+++ b/pkg/cmd/pulumi/templates/zip_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workspace
+package templates
 
 import (
 	"archive/zip"

--- a/sdk/go/common/workspace/gitfolder_deprecated.go
+++ b/sdk/go/common/workspace/gitfolder_deprecated.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+)
+
+// RetrieveGitFolder downloads the repo to path and returns the full path on disk.
+//
+// Deprecated: Use [gitutil.RetrieveGitFolder] instead.
+//
+//go:fix inline
+func RetrieveGitFolder(ctx context.Context, rawurl string, path string) (string, error) {
+	return gitutil.RetrieveGitFolder(ctx, rawurl, path)
+}


### PR DESCRIPTION
The template loading/copying/retrieval code in sdk/go/common/workspace was only used by CLI code in pkg/, so consolidate it into the existing pkg/cmd/pulumi/templates package where it belongs. This shrinks the public sdk surface and removes an sdk -> git-repo-cloning dependency that non-CLI SDK users didn't need.

The moved project template struct would collide conceptually with the existing templates.Template chooser interface, so it is named templates.ProjectTemplate alongside PolicyPackTemplate and PackageTemplate. The moved repository listing logic now shares one helper, and moved logging uses slog to satisfy pkg lint rules.

RetrieveGitFolder stays in workspace as a deprecated shim (with //go:fix inline) because pulumi-kubernetes imports it.
