### PR TITLE
neo/tools: populate pulumiResult ConsoleURL/UpdateID/Version for in-process runs

### DIFF
--- a/changelog/pending/cli-neo-improvement-20260716-164913.yaml
+++ b/changelog/pending/cli-neo-improvement-20260716-164913.yaml
@@ -1,4 +1,6 @@
 component: cli/neo
 kind: improvement
 body: Populate the console URL and deployment ID for in-process `pulumi neo` pulumi_preview/pulumi_up tool results
+custom:
+  PR: 23966
 time: 2026-07-16T16:49:13.289828+02:00

--- a/changelog/pending/cli-neo-improvement-20260716-164913.yaml
+++ b/changelog/pending/cli-neo-improvement-20260716-164913.yaml
@@ -1,0 +1,4 @@
+component: cli/neo
+kind: improvement
+body: Populate the console URL and deployment ID for in-process `pulumi neo` pulumi_preview/pulumi_up tool results
+time: 2026-07-16T16:49:13.289828+02:00

--- a/changelog/pending/cli-neo-improvement-20260716-164913.yaml
+++ b/changelog/pending/cli-neo-improvement-20260716-164913.yaml
@@ -1,6 +1,6 @@
 component: cli/neo
 kind: improvement
-body: Populate the console URL and deployment ID for in-process `pulumi neo` pulumi_preview/pulumi_up tool results
+body: Populate the console URL and update identifiers for in-process `pulumi neo` pulumi_preview/pulumi_up tool results
 custom:
   PR: 23966
 time: 2026-07-16T16:49:13.289828+02:00

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -368,6 +368,15 @@ type UpdateOptions struct {
 	SkipPreview bool
 	// PreviewOnly, when true, causes only the preview step to be run, without running the Update.
 	PreviewOnly bool
+
+	// OnPermalink, when set, is invoked by backends that mint operation permalinks —
+	// currently only the Pulumi Cloud (httpstate) backend — immediately after the
+	// permalink is computed and before the engine action runs. url is the full console
+	// URL; updateID is the operation's UpdateID (a UUID string, stable across preview
+	// and update); version is the stack's update version counter, only meaningful when
+	// preview is false. preview reports whether this is a preview (dry-run) or an
+	// update. Other backends never call it; leaving it nil is always safe.
+	OnPermalink func(url string, updateID string, version int, preview bool)
 }
 
 // CancellationScope provides a scoped source of cancellation and termination requests.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -369,13 +369,9 @@ type UpdateOptions struct {
 	// PreviewOnly, when true, causes only the preview step to be run, without running the Update.
 	PreviewOnly bool
 
-	// OnPermalink, when set, is invoked by backends that mint operation permalinks —
-	// currently only the Pulumi Cloud (httpstate) backend — immediately after the
-	// permalink is computed and before the engine action runs. url is the full console
-	// URL; updateID is the operation's UpdateID (a UUID string, stable across preview
-	// and update); version is the stack's update version counter, only meaningful when
-	// preview is false. preview reports whether this is a preview (dry-run) or an
-	// update. Other backends never call it; leaving it nil is always safe.
+	// OnPermalink, when set, is invoked with the operation's permalink, UpdateID, and
+	// version once the permalink is known. Only backends that mint permalinks call it
+	// (currently the Pulumi Cloud backend); version is only meaningful when preview is false.
 	OnPermalink func(url string, updateID string, version int, preview bool)
 }
 

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -71,6 +71,15 @@ type Options struct {
 	NeoSummaryModel  string // the Neo summary model to use (default: "gpt-4o-mini").
 	NeoSummaryMaxLen int    // the maximum length of the Neo summary. (default 80 characters).
 
+	// OnPermalink, when set, is invoked once a cloud-backend operation's permalink to the
+	// Pulumi Console is known, immediately after it is computed and before the engine action
+	// runs. url is the full console URL; updateID is the operation's UpdateIdentifier.UpdateID
+	// (a UUID string, stable across preview and update); version is the stack's update version
+	// counter, only meaningful when preview is false. preview reports whether this is a preview
+	// (dry-run) or an update. Callers that don't run against a cloud backend (e.g. DIY backends)
+	// may never invoke this callback.
+	OnPermalink func(url string, updateID string, version int, preview bool)
+
 	// Low level options
 	term                terminal.Terminal
 	DeterministicOutput bool // true to disable timing-based rendering

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -71,15 +71,6 @@ type Options struct {
 	NeoSummaryModel  string // the Neo summary model to use (default: "gpt-4o-mini").
 	NeoSummaryMaxLen int    // the maximum length of the Neo summary. (default 80 characters).
 
-	// OnPermalink, when set, is invoked once a cloud-backend operation's permalink to the
-	// Pulumi Console is known, immediately after it is computed and before the engine action
-	// runs. url is the full console URL; updateID is the operation's UpdateIdentifier.UpdateID
-	// (a UUID string, stable across preview and update); version is the stack's update version
-	// counter, only meaningful when preview is false. preview reports whether this is a preview
-	// (dry-run) or an update. Callers that don't run against a cloud backend (e.g. DIY backends)
-	// may never invoke this callback.
-	OnPermalink func(url string, updateID string, version int, preview bool)
-
 	// Low level options
 	term                terminal.Terminal
 	DeterministicOutput bool // true to disable timing-based rendering

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1997,6 +1997,9 @@ func (b *cloudBackend) apply(
 	displayBackendMessages(updateMeta.messages)
 
 	permalink := b.getPermalink(update, updateMeta.version, opts.DryRun)
+	if op.Opts.Display.OnPermalink != nil {
+		op.Opts.Display.OnPermalink(permalink, update.UpdateID, updateMeta.version, opts.DryRun)
+	}
 	return b.runEngineAction(
 		ctx, kind, stack.Ref(), op, update, updateMeta.leaseToken,
 		permalink, events, opts.DryRun, updateMeta.journalVersion)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1997,8 +1997,8 @@ func (b *cloudBackend) apply(
 	displayBackendMessages(updateMeta.messages)
 
 	permalink := b.getPermalink(update, updateMeta.version, opts.DryRun)
-	if op.Opts.Display.OnPermalink != nil {
-		op.Opts.Display.OnPermalink(permalink, update.UpdateID, updateMeta.version, opts.DryRun)
+	if op.Opts.OnPermalink != nil {
+		op.Opts.OnPermalink(permalink, update.UpdateID, updateMeta.version, opts.DryRun)
 	}
 	return b.runEngineAction(
 		ctx, kind, stack.Ref(), op, update, updateMeta.leaseToken,

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -163,9 +163,7 @@ func (e envVal) Value() string {
 
 // pulumiResult matches pulumi-service's PulumiOperationResult so tool consumers on the
 // agent side don't care whether the call ran locally or in a Deployment.
-// DeploymentID is reserved for Deployments-API runs and stays empty on the
-// in-process path; UpdateID and Version identify the in-process operation
-// instead (see backend.UpdateOptions.OnPermalink).
+// DeploymentID is reserved for Deployments-API runs; empty for in-process runs.
 type pulumiResult struct {
 	DeploymentID  string `json:"deployment_id"`
 	ConsoleURL    string `json:"console_url"`
@@ -176,11 +174,9 @@ type pulumiResult struct {
 	StackName     string `json:"stack_name"`
 	UpdateSummary string `json:"update_summary,omitempty"`
 	EventsFile    string `json:"events_file,omitempty"`
-	// UpdateID is the operation's UpdateID (a UUID string), set for both
-	// previews and updates when running against the cloud backend.
+	// UpdateID identifies the operation; set when running against the cloud backend.
 	UpdateID string `json:"update_id,omitempty"`
-	// Version is the stack's update version counter, only meaningful for
-	// non-preview updates.
+	// Version is the stack's update version; only meaningful for non-preview updates.
 	Version int `json:"version,omitempty"`
 }
 
@@ -298,12 +294,8 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		return failedResult(a, "", fmt.Errorf("gathering metadata: %w", err))
 	}
 
-	// consoleURL, updateID, and version are populated by opts.OnPermalink once the
-	// cloud backend computes the operation's permalink, so they thread through to
-	// newPulumiResult below. OnPermalink runs synchronously on this goroutine (inside the
-	// PreviewStack/UpdateStack call below), not on the drain goroutine, so no
-	// synchronization is needed. All remain zero for non-cloud backends, which never
-	// call OnPermalink.
+	// Populated by opts.OnPermalink when the cloud backend computes the permalink.
+	// The callback runs synchronously on this goroutine, so no locking is needed.
 	var consoleURL, updateID string
 	var version int
 
@@ -673,10 +665,8 @@ func silenceStd() func() {
 // the LLM passes an FQSN — a phrasing the CLI itself encourages via some of
 // its own error messages.
 //
-// consoleURL, updateID, and version come from backend.UpdateOptions.OnPermalink
-// (see run); all are zero when running against a non-cloud backend, which never
-// calls it. DeploymentID is deliberately left empty — it is reserved for
-// Deployments-API runs, which don't go through this path.
+// consoleURL, updateID, and version come from OnPermalink and are zero for
+// non-cloud backends. DeploymentID stays empty (Deployments-API runs only).
 func newPulumiResult(
 	proj *workspace.Project, stackRef backend.StackReference,
 	eventsPath, consoleURL, updateID string, version int,

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -99,6 +99,10 @@ type PulumiSink struct {
 	// wrapped engine error string. counts is the typed ResourceChanges map
 	// from the engine.
 	OnEnd func(toolName, err string, counts display.ResourceChanges, elapsed string)
+	// OnPermalink reports the operation's identifiers when the cloud backend
+	// computes the permalink at operation start; it never fires for non-cloud
+	// backends. Mirrors backend.UpdateOptions.OnPermalink.
+	OnPermalink func(url string, updateID string, version int, preview bool)
 }
 
 // NewPulumi creates a Pulumi handler sandboxed under cwd. The workspace is captured
@@ -317,8 +321,11 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 			Stdout:           io.Discard,
 			Stderr:           io.Discard,
 		},
-		OnPermalink: func(url string, id string, v int, _ bool) {
+		OnPermalink: func(url string, id string, v int, preview bool) {
 			consoleURL, updateID, version = url, id, v
+			if p.Sink != nil && p.Sink.OnPermalink != nil {
+				p.Sink.OnPermalink(url, id, v, preview)
+			}
 		},
 	}
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -289,6 +290,14 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		return failedResult(a, "", fmt.Errorf("gathering metadata: %w", err))
 	}
 
+	// consoleURL and updateIdentifier are populated by opts.Display.OnPermalink once the
+	// cloud backend computes the operation's permalink, so they thread through to
+	// newPulumiResult below. OnPermalink runs synchronously on this goroutine (inside the
+	// PreviewStack/UpdateStack call below), not on the drain goroutine, so no
+	// synchronization is needed. Both remain empty for non-cloud backends, which never
+	// call OnPermalink.
+	var consoleURL, updateIdentifier string
+
 	opts := backend.UpdateOptions{
 		AutoApprove: true, // Upstream approval already gates pulumi_up before dispatch.
 		Engine: engine.UpdateOptions{
@@ -306,6 +315,14 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 			Type:             backendDisplay.DisplayProgress,
 			Stdout:           io.Discard,
 			Stderr:           io.Discard,
+			OnPermalink: func(url string, updateID string, version int, preview bool) {
+				consoleURL = url
+				if preview {
+					updateIdentifier = updateID
+				} else {
+					updateIdentifier = strconv.Itoa(version)
+				}
+			},
 		},
 	}
 
@@ -371,7 +388,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	close(eventsCh)
 	<-drainDone
 
-	res := newPulumiResult(proj, s.Ref(), eventsPath)
+	res := newPulumiResult(proj, s.Ref(), eventsPath, consoleURL, updateIdentifier)
 
 	switch {
 	case runErr != nil && errors.Is(ctx.Err(), context.Canceled):
@@ -651,11 +668,21 @@ func silenceStd() func() {
 // would cause the agent to construct entities with malformed names whenever
 // the LLM passes an FQSN — a phrasing the CLI itself encourages via some of
 // its own error messages.
-func newPulumiResult(proj *workspace.Project, stackRef backend.StackReference, eventsPath string) pulumiResult {
+//
+// consoleURL and deploymentID come from backendDisplay.Options.OnPermalink (see run);
+// they are empty when running against a non-cloud backend, which never calls it.
+// deploymentID is the preview's UpdateID (a UUID) for previews, or the update's decimal
+// version number for updates — matching how the Pulumi Console routes /previews/<id> vs
+// /updates/<version>.
+func newPulumiResult(
+	proj *workspace.Project, stackRef backend.StackReference, eventsPath, consoleURL, deploymentID string,
+) pulumiResult {
 	return pulumiResult{
-		ProjectName: proj.Name.String(),
-		StackName:   stackRef.Name().String(),
-		EventsFile:  eventsPath,
+		ProjectName:  proj.Name.String(),
+		StackName:    stackRef.Name().String(),
+		EventsFile:   eventsPath,
+		ConsoleURL:   consoleURL,
+		DeploymentID: deploymentID,
 	}
 }
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -164,6 +163,9 @@ func (e envVal) Value() string {
 
 // pulumiResult matches pulumi-service's PulumiOperationResult so tool consumers on the
 // agent side don't care whether the call ran locally or in a Deployment.
+// DeploymentID is reserved for Deployments-API runs and stays empty on the
+// in-process path; UpdateID and Version identify the in-process operation
+// instead (see backend.UpdateOptions.OnPermalink).
 type pulumiResult struct {
 	DeploymentID  string `json:"deployment_id"`
 	ConsoleURL    string `json:"console_url"`
@@ -174,6 +176,12 @@ type pulumiResult struct {
 	StackName     string `json:"stack_name"`
 	UpdateSummary string `json:"update_summary,omitempty"`
 	EventsFile    string `json:"events_file,omitempty"`
+	// UpdateID is the operation's UpdateID (a UUID string), set for both
+	// previews and updates when running against the cloud backend.
+	UpdateID string `json:"update_id,omitempty"`
+	// Version is the stack's update version counter, only meaningful for
+	// non-preview updates.
+	Version int `json:"version,omitempty"`
 }
 
 // Invoke dispatches a single pulumi method call.
@@ -290,13 +298,14 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		return failedResult(a, "", fmt.Errorf("gathering metadata: %w", err))
 	}
 
-	// consoleURL and updateIdentifier are populated by opts.OnPermalink once the
+	// consoleURL, updateID, and version are populated by opts.OnPermalink once the
 	// cloud backend computes the operation's permalink, so they thread through to
 	// newPulumiResult below. OnPermalink runs synchronously on this goroutine (inside the
 	// PreviewStack/UpdateStack call below), not on the drain goroutine, so no
-	// synchronization is needed. Both remain empty for non-cloud backends, which never
+	// synchronization is needed. All remain zero for non-cloud backends, which never
 	// call OnPermalink.
-	var consoleURL, updateIdentifier string
+	var consoleURL, updateID string
+	var version int
 
 	opts := backend.UpdateOptions{
 		AutoApprove: true, // Upstream approval already gates pulumi_up before dispatch.
@@ -316,13 +325,8 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 			Stdout:           io.Discard,
 			Stderr:           io.Discard,
 		},
-		OnPermalink: func(url string, updateID string, version int, preview bool) {
-			consoleURL = url
-			if preview {
-				updateIdentifier = updateID
-			} else {
-				updateIdentifier = strconv.Itoa(version)
-			}
+		OnPermalink: func(url string, id string, v int, _ bool) {
+			consoleURL, updateID, version = url, id, v
 		},
 	}
 
@@ -388,7 +392,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	close(eventsCh)
 	<-drainDone
 
-	res := newPulumiResult(proj, s.Ref(), eventsPath, consoleURL, updateIdentifier)
+	res := newPulumiResult(proj, s.Ref(), eventsPath, consoleURL, updateID, version)
 
 	switch {
 	case runErr != nil && errors.Is(ctx.Err(), context.Canceled):
@@ -669,20 +673,21 @@ func silenceStd() func() {
 // the LLM passes an FQSN — a phrasing the CLI itself encourages via some of
 // its own error messages.
 //
-// consoleURL and deploymentID come from backend.UpdateOptions.OnPermalink (see run);
-// they are empty when running against a non-cloud backend, which never calls it.
-// deploymentID is the preview's UpdateID (a UUID) for previews, or the update's decimal
-// version number for updates — matching how the Pulumi Console routes /previews/<id> vs
-// /updates/<version>.
+// consoleURL, updateID, and version come from backend.UpdateOptions.OnPermalink
+// (see run); all are zero when running against a non-cloud backend, which never
+// calls it. DeploymentID is deliberately left empty — it is reserved for
+// Deployments-API runs, which don't go through this path.
 func newPulumiResult(
-	proj *workspace.Project, stackRef backend.StackReference, eventsPath, consoleURL, deploymentID string,
+	proj *workspace.Project, stackRef backend.StackReference,
+	eventsPath, consoleURL, updateID string, version int,
 ) pulumiResult {
 	return pulumiResult{
-		ProjectName:  proj.Name.String(),
-		StackName:    stackRef.Name().String(),
-		EventsFile:   eventsPath,
-		ConsoleURL:   consoleURL,
-		DeploymentID: deploymentID,
+		ProjectName: proj.Name.String(),
+		StackName:   stackRef.Name().String(),
+		EventsFile:  eventsPath,
+		ConsoleURL:  consoleURL,
+		UpdateID:    updateID,
+		Version:     version,
 	}
 }
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -290,7 +290,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		return failedResult(a, "", fmt.Errorf("gathering metadata: %w", err))
 	}
 
-	// consoleURL and updateIdentifier are populated by opts.Display.OnPermalink once the
+	// consoleURL and updateIdentifier are populated by opts.OnPermalink once the
 	// cloud backend computes the operation's permalink, so they thread through to
 	// newPulumiResult below. OnPermalink runs synchronously on this goroutine (inside the
 	// PreviewStack/UpdateStack call below), not on the drain goroutine, so no
@@ -315,14 +315,14 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 			Type:             backendDisplay.DisplayProgress,
 			Stdout:           io.Discard,
 			Stderr:           io.Discard,
-			OnPermalink: func(url string, updateID string, version int, preview bool) {
-				consoleURL = url
-				if preview {
-					updateIdentifier = updateID
-				} else {
-					updateIdentifier = strconv.Itoa(version)
-				}
-			},
+		},
+		OnPermalink: func(url string, updateID string, version int, preview bool) {
+			consoleURL = url
+			if preview {
+				updateIdentifier = updateID
+			} else {
+				updateIdentifier = strconv.Itoa(version)
+			}
 		},
 	}
 
@@ -669,7 +669,7 @@ func silenceStd() func() {
 // the LLM passes an FQSN — a phrasing the CLI itself encourages via some of
 // its own error messages.
 //
-// consoleURL and deploymentID come from backendDisplay.Options.OnPermalink (see run);
+// consoleURL and deploymentID come from backend.UpdateOptions.OnPermalink (see run);
 // they are empty when running against a non-cloud backend, which never calls it.
 // deploymentID is the preview's UpdateID (a UUID) for previews, or the update's decimal
 // version number for updates — matching how the Pulumi Console routes /previews/<id> vs

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -493,6 +495,115 @@ func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 	}
 }
 
+// TestPulumi_Run_PopulatesConsoleURLAndDeploymentID proves run() wires
+// backendDisplay.Options.OnPermalink through to pulumiResult.ConsoleURL /
+// DeploymentID for both preview and up, using the same identifier convention
+// as the Pulumi Console: the preview's UpdateID (a UUID) for previews, and
+// the update's decimal version number for updates. The fake backend's
+// PreviewF/UpdateF invoke OnPermalink itself, mirroring what
+// cloudBackend.apply does in the real httpstate backend.
+//
+//nolint:paralleltest // mutates the global cmdBackend.DefaultLoginManager
+func TestPulumi_Run_PopulatesConsoleURLAndDeploymentID(t *testing.T) {
+	tests := []struct {
+		method       string
+		wantPreview  bool
+		wantDeployID string
+	}{
+		{method: "pulumi_preview", wantPreview: true, wantDeployID: "11111111-2222-3333-4444-555555555555"},
+		{method: "pulumi_up", wantPreview: false, wantDeployID: "42"},
+	}
+
+	for _, tc := range tests {
+		//nolint:paralleltest // mutates the global cmdBackend.DefaultLoginManager
+		t.Run(tc.method, func(t *testing.T) {
+			dir := newProjectDir(t)
+
+			const wantURL = "https://app.pulumi.com/o/proj/dev/updates/42"
+			fireOnPermalink := func(op backend.UpdateOperation) {
+				if op.Opts.Display.OnPermalink == nil {
+					return
+				}
+				if tc.wantPreview {
+					op.Opts.Display.OnPermalink(wantURL, tc.wantDeployID, 0, true)
+				} else {
+					op.Opts.Display.OnPermalink(wantURL, "11111111-2222-3333-4444-555555555555", 42, false)
+				}
+			}
+
+			stackRef := &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("dev"),
+				FullyQualifiedNameV: tokens.QName("organization/p/dev"),
+			}
+
+			var stk backend.Stack
+			be := &backend.MockBackend{
+				ParseStackReferenceF: func(name string) (backend.StackReference, error) {
+					return stackRef, nil
+				},
+				GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
+					return stk, nil
+				},
+				PreviewF: func(_ context.Context, _ backend.Stack, op backend.UpdateOperation,
+				) (*deploy.Plan, display.ResourceChanges, error) {
+					fireOnPermalink(op)
+					return nil, display.ResourceChanges{}, nil
+				},
+				UpdateF: func(_ context.Context, _ backend.Stack, op backend.UpdateOperation,
+				) (display.ResourceChanges, error) {
+					fireOnPermalink(op)
+					return display.ResourceChanges{}, nil
+				},
+			}
+			stk = &backend.MockStack{
+				RefF:     func() backend.StackReference { return stackRef },
+				BackendF: func() backend.Backend { return be },
+				DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {
+					return b64.NewBase64SecretsManager(), nil
+				},
+			}
+
+			prev := cmdBackend.DefaultLoginManager
+			cmdBackend.DefaultLoginManager = &cmdBackend.MockLoginManager{
+				CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool,
+				) (backend.Backend, error) {
+					return be, nil
+				},
+				LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+					url string, project *workspace.Project, setCurrent bool,
+					insecure bool, color colors.Colorization,
+				) (backend.Backend, error) {
+					return be, nil
+				},
+			}
+			t.Cleanup(func() { cmdBackend.DefaultLoginManager = prev })
+
+			ws := &pkgWorkspace.MockContext{
+				ReadProjectF: func(_ string) (*workspace.Project, string, error) {
+					return &workspace.Project{Name: "p"}, dir, nil
+				},
+			}
+			p := &Pulumi{Cwd: dir, Workspace: ws}
+
+			args, err := json.Marshal(map[string]any{
+				"project_name":     "p",
+				"stack_name":       "dev",
+				"local_pulumi_dir": dir,
+			})
+			require.NoError(t, err)
+
+			value, err := p.Invoke(t.Context(), tc.method, args)
+			require.NoError(t, err)
+			res, ok := value.(pulumiResult)
+			require.True(t, ok, "expected pulumiResult, got %T", value)
+			assert.Equal(t, "succeeded", res.Status)
+			assert.Equal(t, wantURL, res.ConsoleURL)
+			assert.Equal(t, tc.wantDeployID, res.DeploymentID)
+		})
+	}
+}
+
 // recorder collects invocations into the PulumiSink so tests can assert which
 // callbacks fired and with what arguments. It's a struct of slices rather than
 // counters so the test can inspect the exact event order.
@@ -867,11 +978,13 @@ func TestNewPulumiResultUsesParsedNames(t *testing.T) {
 	proj := &workspace.Project{Name: tokens.PackageName("real-proj")}
 	stackRef := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	res := newPulumiResult(proj, stackRef, "/tmp/events.ndjson")
+	res := newPulumiResult(proj, stackRef, "/tmp/events.ndjson", "https://app.pulumi.com/o/p/s/updates/3", "3")
 
 	assert.Equal(t, "real-proj", res.ProjectName)
 	assert.Equal(t, "dev", res.StackName)
 	assert.Equal(t, "/tmp/events.ndjson", res.EventsFile)
+	assert.Equal(t, "https://app.pulumi.com/o/p/s/updates/3", res.ConsoleURL)
+	assert.Equal(t, "3", res.DeploymentID)
 }
 
 func TestAutonamingStackContextFor_NonHTTPStateStack(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -495,23 +495,23 @@ func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 	}
 }
 
-// TestPulumi_Run_PopulatesConsoleURLAndDeploymentID proves run() wires
+// TestPulumi_Run_PopulatesConsoleURLAndUpdateIdentifiers proves run() wires
 // backend.UpdateOptions.OnPermalink through to pulumiResult.ConsoleURL /
-// DeploymentID for both preview and up, using the same identifier convention
-// as the Pulumi Console: the preview's UpdateID (a UUID) for previews, and
-// the update's decimal version number for updates. The fake backend's
-// PreviewF/UpdateF invoke OnPermalink itself, mirroring what
+// UpdateID / Version for both preview and up. DeploymentID must stay empty on
+// this in-process path — it is reserved for Deployments-API runs. The fake
+// backend's PreviewF/UpdateF invoke OnPermalink itself, mirroring what
 // cloudBackend.apply does in the real httpstate backend.
 //
 //nolint:paralleltest // mutates the global cmdBackend.DefaultLoginManager
-func TestPulumi_Run_PopulatesConsoleURLAndDeploymentID(t *testing.T) {
+func TestPulumi_Run_PopulatesConsoleURLAndUpdateIdentifiers(t *testing.T) {
+	const wantUpdateID = "11111111-2222-3333-4444-555555555555"
 	tests := []struct {
-		method       string
-		wantPreview  bool
-		wantDeployID string
+		method      string
+		wantPreview bool
+		wantVersion int
 	}{
-		{method: "pulumi_preview", wantPreview: true, wantDeployID: "11111111-2222-3333-4444-555555555555"},
-		{method: "pulumi_up", wantPreview: false, wantDeployID: "42"},
+		{method: "pulumi_preview", wantPreview: true, wantVersion: 0},
+		{method: "pulumi_up", wantPreview: false, wantVersion: 42},
 	}
 
 	for _, tc := range tests {
@@ -524,11 +524,7 @@ func TestPulumi_Run_PopulatesConsoleURLAndDeploymentID(t *testing.T) {
 				if op.Opts.OnPermalink == nil {
 					return
 				}
-				if tc.wantPreview {
-					op.Opts.OnPermalink(wantURL, tc.wantDeployID, 0, true)
-				} else {
-					op.Opts.OnPermalink(wantURL, "11111111-2222-3333-4444-555555555555", 42, false)
-				}
+				op.Opts.OnPermalink(wantURL, wantUpdateID, tc.wantVersion, tc.wantPreview)
 			}
 
 			stackRef := &backend.MockStackReference{
@@ -599,7 +595,10 @@ func TestPulumi_Run_PopulatesConsoleURLAndDeploymentID(t *testing.T) {
 			require.True(t, ok, "expected pulumiResult, got %T", value)
 			assert.Equal(t, "succeeded", res.Status)
 			assert.Equal(t, wantURL, res.ConsoleURL)
-			assert.Equal(t, tc.wantDeployID, res.DeploymentID)
+			assert.Equal(t, wantUpdateID, res.UpdateID)
+			assert.Equal(t, tc.wantVersion, res.Version)
+			assert.Empty(t, res.DeploymentID,
+				"DeploymentID is reserved for Deployments-API runs and must stay empty in-process")
 		})
 	}
 }
@@ -978,13 +977,16 @@ func TestNewPulumiResultUsesParsedNames(t *testing.T) {
 	proj := &workspace.Project{Name: tokens.PackageName("real-proj")}
 	stackRef := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	res := newPulumiResult(proj, stackRef, "/tmp/events.ndjson", "https://app.pulumi.com/o/p/s/updates/3", "3")
+	res := newPulumiResult(proj, stackRef, "/tmp/events.ndjson",
+		"https://app.pulumi.com/o/p/s/updates/3", "11111111-2222-3333-4444-555555555555", 3)
 
 	assert.Equal(t, "real-proj", res.ProjectName)
 	assert.Equal(t, "dev", res.StackName)
 	assert.Equal(t, "/tmp/events.ndjson", res.EventsFile)
 	assert.Equal(t, "https://app.pulumi.com/o/p/s/updates/3", res.ConsoleURL)
-	assert.Equal(t, "3", res.DeploymentID)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", res.UpdateID)
+	assert.Equal(t, 3, res.Version)
+	assert.Empty(t, res.DeploymentID, "DeploymentID is reserved for Deployments-API runs")
 }
 
 func TestAutonamingStackContextFor_NonHTTPStateStack(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -496,7 +496,7 @@ func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 }
 
 // TestPulumi_Run_PopulatesConsoleURLAndDeploymentID proves run() wires
-// backendDisplay.Options.OnPermalink through to pulumiResult.ConsoleURL /
+// backend.UpdateOptions.OnPermalink through to pulumiResult.ConsoleURL /
 // DeploymentID for both preview and up, using the same identifier convention
 // as the Pulumi Console: the preview's UpdateID (a UUID) for previews, and
 // the update's decimal version number for updates. The fake backend's
@@ -521,13 +521,13 @@ func TestPulumi_Run_PopulatesConsoleURLAndDeploymentID(t *testing.T) {
 
 			const wantURL = "https://app.pulumi.com/o/proj/dev/updates/42"
 			fireOnPermalink := func(op backend.UpdateOperation) {
-				if op.Opts.Display.OnPermalink == nil {
+				if op.Opts.OnPermalink == nil {
 					return
 				}
 				if tc.wantPreview {
-					op.Opts.Display.OnPermalink(wantURL, tc.wantDeployID, 0, true)
+					op.Opts.OnPermalink(wantURL, tc.wantDeployID, 0, true)
 				} else {
-					op.Opts.Display.OnPermalink(wantURL, "11111111-2222-3333-4444-555555555555", 42, false)
+					op.Opts.OnPermalink(wantURL, "11111111-2222-3333-4444-555555555555", 42, false)
 				}
 			}
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -580,7 +580,17 @@ func TestPulumi_Run_PopulatesConsoleURLAndUpdateIdentifiers(t *testing.T) {
 					return &workspace.Project{Name: "p"}, dir, nil
 				},
 			}
-			p := &Pulumi{Cwd: dir, Workspace: ws}
+			type permalinkCall struct {
+				url, updateID string
+				version       int
+				preview       bool
+			}
+			var sinkCalls []permalinkCall
+			p := &Pulumi{Cwd: dir, Workspace: ws, Sink: &PulumiSink{
+				OnPermalink: func(url, updateID string, version int, preview bool) {
+					sinkCalls = append(sinkCalls, permalinkCall{url, updateID, version, preview})
+				},
+			}}
 
 			args, err := json.Marshal(map[string]any{
 				"project_name":     "p",
@@ -599,6 +609,8 @@ func TestPulumi_Run_PopulatesConsoleURLAndUpdateIdentifiers(t *testing.T) {
 			assert.Equal(t, tc.wantVersion, res.Version)
 			assert.Empty(t, res.DeploymentID,
 				"DeploymentID is reserved for Deployments-API runs and must stay empty in-process")
+			assert.Equal(t, []permalinkCall{{wantURL, wantUpdateID, tc.wantVersion, tc.wantPreview}}, sinkCalls,
+				"Sink.OnPermalink must receive exactly the callback the backend fired")
 		})
 	}
 }


### PR DESCRIPTION
When `pulumi neo` runs `pulumi_preview` or `pulumi_up` in-process, the tool result comes back with an empty `console_url` and nothing that identifies the operation. The cloud backend does compute the permalink inside `apply()`, but only the display ever sees it.

## Changes

- New optional callback `backend.UpdateOptions.OnPermalink(url, updateID string, version int, preview bool)`. `cloudBackend.apply()` calls it once the update has started. Other backends never call it.
- `neo/tools` uses it to fill `console_url` and two new result fields, `update_id` and `version`. `deployment_id` stays empty because it is reserved for Deployments runs.
- `PulumiSink.OnPermalink` forwards the same call to anyone embedding the tools.

## Worth knowing before you review

- A `pulumi up` is two operations on the service: a preview, then the update. Each has its own ID and link, so the callback fires twice. `run()` keeps the last call. A successful up reports the update. An up that fails in its preview step reports that preview, which is where the error is.
- The callback carries both `updateID` and `version` because a consumer may need either. Every operation has an `updateID`, and it is the only handle a preview has (`/previews/<updateID>`, see `getPermalink`). An update's console page and its entry in `pulumi stack history` go by version (`/updates/8`), so linking to an update needs the number.
- `version` is 0 for previews. Starting a preview returns the stack's next version number (say 8), but a preview never enters the stack's history, and the next real update becomes version 8. Reporting 8 for a preview would point at an unrelated update, so `notifyPermalink` zeroes it.
- The callback gets the real console permalink. #24476 can replace the displayed link with an account claim URL, and that swap stays display-only.
- The callback runs synchronously in `apply()`, before the engine starts. That is why `run()` captures into plain locals without a lock.

## Testing

`TestNotifyPermalink` covers the helper. The `neo/tools` tests cover a preview, a successful up (two calls, the update wins), and an up whose preview step fails. `go test -race` passes on `backend`, `backend/httpstate` and `cmd/pulumi/neo/tools`, and lint is clean.
