### PR TITLE
Allow expressions for bool flags

### DIFF
--- a/changelog/pending/cli-do-feat-20260716-175321.yaml
+++ b/changelog/pending/cli-do-feat-20260716-175321.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: feat
+body: Allow expressions for boolean inputs
+time: 2026-07-16T17:53:21.38219+01:00

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2579,7 +2579,7 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 		"--azure:opt-two", "val2",
 		"--in1", "p1",
 		"--input:in-two", "p2",
-		"--input:dry-run", "true",
+		"--input:dry-run",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -2717,7 +2717,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 		"--azure:opt-two", "val2",
 		"--in1", "p1",
 		"--input:in-two", "p2",
-		"--input:dry-run", "true",
+		"--input:dry-run",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -2911,7 +2911,7 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 		"--input", "yaml",
 		"--input:number", "0o45",
 		"--input:expr", "{\"fn::secret\": 45}",
-		"--input:flag", "no",
+		"--input:flag=no",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2579,7 +2579,7 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 		"--azure:opt-two", "val2",
 		"--in1", "p1",
 		"--input:in-two", "p2",
-		"--input:dry-run",
+		"--input:dry-run", "true",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -2717,7 +2717,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 		"--azure:opt-two", "val2",
 		"--in1", "p1",
 		"--input:in-two", "p2",
-		"--input:dry-run",
+		"--input:dry-run", "true",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -2851,6 +2851,7 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 				assert.Equal(t, map[string]string{
 					"number": "0o45",
 					"expr":   "{\"fn::secret\": 45}",
+					"flag":   "no",
 				}, req.Attributes)
 
 				return &plugin.ConvertSnippetResponse{
@@ -2858,6 +2859,7 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 					Attributes: map[string]string{
 						"number": "37", // 0o45 is octal in yaml, pcl doesn't have octal
 						"expr":   "secret(45)",
+						"flag":   "false", // no is false in yaml
 					},
 				}, nil
 			},
@@ -2873,6 +2875,7 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 						Properties: map[string]schema.PropertySpec{
 							"number": {TypeSpec: schema.TypeSpec{Type: "number"}},
 							"expr":   {TypeSpec: schema.TypeSpec{Type: "number"}},
+							"flag":   {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 						},
 						Required: []string{"number", "expr"},
 					},
@@ -2889,6 +2892,8 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, 37.0, req.Args["number"].NumberValue())
+					assert.Equal(t, 45.0, req.Args["expr"].SecretValue().Element.NumberValue())
+					assert.Equal(t, false, req.Args["flag"].BoolValue())
 					return plugin.InvokeResponse{
 						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
 					}, nil
@@ -2906,6 +2911,7 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 		"--input", "yaml",
 		"--input:number", "0o45",
 		"--input:expr", "{\"fn::secret\": 45}",
+		"--input:flag", "no",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -315,7 +315,7 @@ func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
 		"--input-file", inputFile,
 		"--int-value", "42",
 		"--already-kebab-case", "kebab",
-		"--snake-case",
+		"--snake-case", "true",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -315,7 +315,7 @@ func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
 		"--input-file", inputFile,
 		"--int-value", "42",
 		"--already-kebab-case", "kebab",
-		"--snake-case", "true",
+		"--snake-case",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -552,12 +552,12 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		switch typ {
 		case schema.BoolType:
 			flagFunc = func(name, extraHelp string) {
-				flags.Bool(name, false, comment+extraHelp)
-				// N.B. This is hardcoded in the engine to the literal string "true" for the literal true. This works
-				// for PCL, and happens to also work for YAML, but if we add any new converters that _don't_ use the
-				// string "true" for their boolean true literal (for example Python uses "True"), then we'll need to add
-				// something here to support that. Probably pre-fetching the true literal text from the converter plugin
-				// to create the NoOptDefVal to match.
+				// N.B. This is hardcoded in the engine to the literal string "true/false" for the literal true/false.
+				// This works for PCL, and happens to also work for YAML, but if we add any new converters that _don't_
+				// use the string "true" for their boolean true literal (for example Python uses "True"), then we'll
+				// need to add something here to support that. Probably pre-fetching the literal text from the
+				// converter plugin to create the flag values to match.
+				flags.String(name, "false", comment+extraHelp)
 				flags.Lookup(name).NoOptDefVal = "true"
 			}
 		case schema.StringType, schema.IntType, schema.NumberType:

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -550,11 +550,7 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		comment := flagUsage(input.Comment)
 
 		switch typ {
-		case schema.BoolType:
-			flagFunc = func(name, extraHelp string) {
-				flags.Bool(name, false, comment+extraHelp)
-			}
-		case schema.StringType, schema.IntType, schema.NumberType:
+		case schema.BoolType, schema.StringType, schema.IntType, schema.NumberType:
 			flagFunc = func(name, extraHelp string) {
 				flags.String(name, "", comment+extraHelp)
 			}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -550,7 +550,17 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		comment := flagUsage(input.Comment)
 
 		switch typ {
-		case schema.BoolType, schema.StringType, schema.IntType, schema.NumberType:
+		case schema.BoolType:
+			flagFunc = func(name, extraHelp string) {
+				flags.Bool(name, false, comment+extraHelp)
+				// N.B. This is hardcoded in the engine to the literal string "true" for the literal true. This works
+				// for PCL, and happens to also work for YAML, but if we add any new converters that _don't_ use the
+				// string "true" for their boolean true literal (for example Python uses "True"), then we'll need to add
+				// something here to support that. Probably pre-fetching the true literal text from the converter plugin
+				// to create the NoOptDefVal to match.
+				flags.Lookup(name).NoOptDefVal = "true"
+			}
+		case schema.StringType, schema.IntType, schema.NumberType:
 			flagFunc = func(name, extraHelp string) {
 				flags.String(name, "", comment+extraHelp)
 			}


### PR DESCRIPTION
Follow on from https://github.com/pulumi/pulumi/pull/23954. Make bool flags also just be strings, so we can pass expressions for them.