### PR TITLE
Remove template count from pulumi new --help

### DIFF
--- a/changelog/pending/cli-improvement-20260717-090000.yaml
+++ b/changelog/pending/cli-improvement-20260717-090000.yaml
@@ -1,0 +1,7 @@
+component: cli
+kind: improvement
+body: Remove the template count from `pulumi new --help`, which required a slow
+  template listing before help could display
+time: 2026-07-17T09:00:00.000000000-07:00
+custom:
+  PR: "23973"

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -638,26 +638,6 @@ func NewNewCmd() *cobra.Command {
 		Required:  0,
 	})
 
-	// Add additional help that includes a list of available templates.
-	defaultHelp := cmd.HelpFunc()
-	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		// Show default help.
-		defaultHelp(cmd, args)
-
-		templates, closer, err := getTemplates(cmd.Context())
-		contract.IgnoreClose(closer)
-		if err != nil {
-			slog.Warn("could not list templates", "err", err)
-			return
-		}
-
-		// If we have any templates, show them.
-		if len(templates) > 0 {
-			fmt.Fprintln(cmd.OutOrStdout())
-			fmt.Fprintf(cmd.OutOrStdout(), "There are %d available templates.\n", len(templates))
-		}
-	})
-
 	cmd.PersistentFlags().StringArrayVarP(
 		&args.configArray, "config", "c", []string{},
 		"Config to save")


### PR DESCRIPTION
## Summary

`pulumi new --help` overrode cobra's help function to fetch the full template list just to append "There are %d available templates." to the output. Listing templates takes more than five seconds, which made an otherwise instant `--help` invocation hang. The additional information isn't that helpful, and the wait makes `pulumi new --help` feel broken.

This deletes the help-function override so `pulumi new --help` renders immediately with cobra's default help.