### PR TITLE
fix(cli): scope current stack selection to the active backend

### DIFF
--- a/changelog/pending/cli-fix-local-backend-stale-stack.yaml
+++ b/changelog/pending/cli-fix-local-backend-stale-stack.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Scope current stack selection to the active backend so switching backends no longer surfaces stale stack errors
+time: 2026-07-20T00:00:00+00:00
+custom:
+  PR: "23974"

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -35,7 +35,7 @@ func CurrentStack(ctx context.Context, ws pkgWorkspace.Context, b backend.Backen
 func CurrentStackAt(
 	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, dir string,
 ) (backend.Stack, error) {
-	stackName, err := getCurrentStackName(ws, dir)
+	stackName, fromLegacy, err := getCurrentStackName(ws, dir, b.URL())
 	if err != nil {
 		return nil, err
 	} else if stackName == "" {
@@ -49,25 +49,33 @@ func CurrentStackAt(
 
 	ref, err := b.ParseStackReference(qualifiedStackName)
 	if err != nil {
+		// A legacy unscoped workspace selection may belong to a different backend
+		// (for example a cloud FQN after `pulumi login --local`). Treat that as
+		// unset for this backend. Explicit per-backend selections and PULUMI_STACK
+		// still surface parse errors.
+		if fromLegacy {
+			return nil, nil
+		}
 		return nil, err
 	}
 
 	return b.GetStack(ctx, ref)
 }
 
-func getCurrentStackName(ws pkgWorkspace.Context, dir string) (string, error) {
+func getCurrentStackName(ws pkgWorkspace.Context, dir, backendURL string) (name string, fromLegacy bool, err error) {
 	// PULUMI_STACK environment variable overrides any stack name in the workspace settings
 	if stackName, ok := os.LookupEnv("PULUMI_STACK"); ok {
-		return stackName, nil
+		return stackName, false, nil
 	}
 
 	// An empty dir resolves to the process working directory inside ws.New.
 	w, err := ws.New(dir)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return w.Settings().Stack, nil
+	name, fromLegacy = w.Settings().StackForBackend(backendURL)
+	return name, fromLegacy, nil
 }
 
 // Potentially qualifies a stack name with the username as the org, if orgs are supported by the backend.
@@ -91,8 +99,8 @@ func getStackNameWithLegacyOrgNameIfNeeded(b backend.Backend, stackName string) 
 	return stackName, nil
 }
 
-// SetCurrentStack changes the current stack to the given stack name.
-func SetCurrentStack(ws pkgWorkspace.Context, name string) error {
+// SetCurrentStack changes the current stack for the given backend URL.
+func SetCurrentStack(ws pkgWorkspace.Context, backendURL, name string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting current working directory: %w", err)
@@ -104,6 +112,6 @@ func SetCurrentStack(ws pkgWorkspace.Context, name string) error {
 		return err
 	}
 
-	w.Settings().Stack = name
+	w.Settings().SetStackForBackend(backendURL, name)
 	return w.Save()
 }

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -24,6 +24,18 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 )
 
+// BackendURLKey returns the stable URL used to scope workspace stack selection.
+// For Pulumi Cloud backends this is the API URL (e.g. https://api.pulumi.com), matching
+// GetCurrentCloudURL / credentials.Current. Backend.URL() is wrong here: for the cloud
+// backend it returns a console URL that may include the current user.
+func BackendURLKey(b backend.Backend) string {
+	type cloudURLer interface{ CloudURL() string }
+	if c, ok := b.(cloudURLer); ok {
+		return c.CloudURL()
+	}
+	return b.URL()
+}
+
 // CurrentStack reads the current stack and returns an instance connected to its backend provider.
 func CurrentStack(ctx context.Context, ws pkgWorkspace.Context, b backend.Backend) (backend.Stack, error) {
 	return CurrentStackAt(ctx, ws, b, "")
@@ -35,7 +47,7 @@ func CurrentStack(ctx context.Context, ws pkgWorkspace.Context, b backend.Backen
 func CurrentStackAt(
 	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, dir string,
 ) (backend.Stack, error) {
-	stackName, fromLegacy, err := getCurrentStackName(ws, dir, b.URL())
+	stackName, fromLegacy, err := getCurrentStackName(ws, dir, b)
 	if err != nil {
 		return nil, err
 	} else if stackName == "" {
@@ -62,7 +74,9 @@ func CurrentStackAt(
 	return b.GetStack(ctx, ref)
 }
 
-func getCurrentStackName(ws pkgWorkspace.Context, dir, backendURL string) (name string, fromLegacy bool, err error) {
+func getCurrentStackName(
+	ws pkgWorkspace.Context, dir string, b backend.Backend,
+) (name string, fromLegacy bool, err error) {
 	// PULUMI_STACK environment variable overrides any stack name in the workspace settings
 	if stackName, ok := os.LookupEnv("PULUMI_STACK"); ok {
 		return stackName, false, nil
@@ -74,7 +88,14 @@ func getCurrentStackName(ws pkgWorkspace.Context, dir, backendURL string) (name 
 		return "", false, err
 	}
 
-	name, fromLegacy = w.Settings().StackForBackend(backendURL)
+	settings := w.Settings()
+	// Legacy workspace.json files only have Stack. Skip BackendURLKey until a
+	// per-backend map exists so callers (and tests) without URL() still work.
+	if len(settings.Stacks) == 0 {
+		name, fromLegacy = settings.StackForBackend("")
+		return name, fromLegacy, nil
+	}
+	name, fromLegacy = settings.StackForBackend(BackendURLKey(b))
 	return name, fromLegacy, nil
 }
 

--- a/pkg/backend/state/stacks_test.go
+++ b/pkg/backend/state/stacks_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,7 @@ func TestCurrentStack(t *testing.T) {
 
 			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
+				URLF: func() string { return "https://api.pulumi.com" },
 				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 					assert.Equal(t, fullyQualifiedName, ref.FullyQualifiedName().String())
 					return &backend.MockStack{}, nil
@@ -61,6 +63,7 @@ func TestCurrentStack(t *testing.T) {
 
 			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
+				URLF: func() string { return "https://api.pulumi.com" },
 				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 					assert.Equal(t, orgQualifiedName, ref.FullyQualifiedName().String())
 					return &backend.MockStack{}, nil
@@ -83,6 +86,7 @@ func TestCurrentStack(t *testing.T) {
 
 			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
+				URLF: func() string { return backendURL },
 				SupportsOrganizationsF: func() bool {
 					return true
 				},
@@ -117,6 +121,7 @@ func TestCurrentStack(t *testing.T) {
 
 			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
+				URLF: func() string { return backendURL },
 				SupportsOrganizationsF: func() bool {
 					return true
 				},
@@ -135,6 +140,7 @@ func TestCurrentStack(t *testing.T) {
 
 			ws := &pkgWorkspace.MockContext{}
 			backend := &backend.MockBackend{
+				URLF: func() string { return "file://~" },
 				SupportsOrganizationsF: func() bool {
 					return false
 				},
@@ -147,6 +153,110 @@ func TestCurrentStack(t *testing.T) {
 			_, err := CurrentStack(ctx, ws, backend)
 			require.NoError(t, err)
 		})
+	})
+
+	t.Run("legacy cloud selection is ignored on local backend", func(t *testing.T) {
+		settings := &pkgWorkspace.Settings{
+			Stack: "cloud-org/my-project/my-stack",
+		}
+		ws := &pkgWorkspace.MockContext{
+			NewF: func(string) (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{
+					SettingsF: func() *pkgWorkspace.Settings { return settings },
+				}, nil
+			},
+		}
+		be := &backend.MockBackend{
+			URLF: func() string { return "file://~" },
+			SupportsOrganizationsF: func() bool {
+				return false
+			},
+			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+				assert.Equal(t, "cloud-org/my-project/my-stack", s)
+				return nil, fmt.Errorf("organization name must be 'organization'")
+			},
+			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+				t.Fatal("GetStack should not be called for a legacy selection from another backend")
+				return nil, nil
+			},
+		}
+
+		got, err := CurrentStack(ctx, ws, be)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("per-backend selections do not leak across backends", func(t *testing.T) {
+		settings := &pkgWorkspace.Settings{
+			Stacks: map[string]string{
+				"https://api.pulumi.com": "cloud-org/my-project/dev",
+				"file://~":               "organization/my-project/local",
+			},
+		}
+		ws := &pkgWorkspace.MockContext{
+			NewF: func(string) (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{
+					SettingsF: func() *pkgWorkspace.Settings { return settings },
+				}, nil
+			},
+		}
+
+		localBe := &backend.MockBackend{
+			URLF: func() string { return "file://~" },
+			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+				assert.Equal(t, "organization/my-project/local", s)
+				return &backend.MockStackReference{
+					FullyQualifiedNameV: tokens.QName(s),
+				}, nil
+			},
+			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+				return &backend.MockStack{}, nil
+			},
+		}
+		got, err := CurrentStack(ctx, ws, localBe)
+		require.NoError(t, err)
+		assert.NotNil(t, got)
+
+		cloudBe := &backend.MockBackend{
+			URLF: func() string { return "https://api.pulumi.com" },
+			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+				assert.Equal(t, "cloud-org/my-project/dev", s)
+				return &backend.MockStackReference{
+					FullyQualifiedNameV: tokens.QName(s),
+				}, nil
+			},
+			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+				return &backend.MockStack{}, nil
+			},
+		}
+		got, err = CurrentStack(ctx, ws, cloudBe)
+		require.NoError(t, err)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("invalid scoped selection still returns parse error", func(t *testing.T) {
+		settings := &pkgWorkspace.Settings{
+			Stacks: map[string]string{
+				"file://~": "cloud-org/my-project/dev",
+			},
+		}
+		ws := &pkgWorkspace.MockContext{
+			NewF: func(string) (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{
+					SettingsF: func() *pkgWorkspace.Settings { return settings },
+				}, nil
+			},
+		}
+		be := &backend.MockBackend{
+			URLF: func() string { return "file://~" },
+			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+				return nil, fmt.Errorf("organization name must be 'organization'")
+			},
+		}
+
+		_, err := CurrentStack(ctx, ws, be)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "organization name must be 'organization'")
 	})
 }
 

--- a/pkg/backend/state/stacks_test.go
+++ b/pkg/backend/state/stacks_test.go
@@ -16,6 +16,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -27,6 +28,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mockCloudBackend mimics httpstate.Backend: URL() is a console URL (possibly
+// user-scoped) while CloudURL() is the stable API URL used by credentials /
+// GetCurrentCloudURL.
+type mockCloudBackend struct {
+	backend.MockBackend
+	cloudURL string
+}
+
+func (b *mockCloudBackend) CloudURL() string { return b.cloudURL }
 
 func TestCurrentStack(t *testing.T) {
 	ctx := t.Context()
@@ -156,6 +167,7 @@ func TestCurrentStack(t *testing.T) {
 	})
 
 	t.Run("legacy cloud selection is ignored on local backend", func(t *testing.T) {
+		t.Parallel()
 		settings := &pkgWorkspace.Settings{
 			Stack: "cloud-org/my-project/my-stack",
 		}
@@ -173,7 +185,7 @@ func TestCurrentStack(t *testing.T) {
 			},
 			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
 				assert.Equal(t, "cloud-org/my-project/my-stack", s)
-				return nil, fmt.Errorf("organization name must be 'organization'")
+				return nil, errors.New("organization name must be 'organization'")
 			},
 			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
 				t.Fatal("GetStack should not be called for a legacy selection from another backend")
@@ -187,6 +199,7 @@ func TestCurrentStack(t *testing.T) {
 	})
 
 	t.Run("per-backend selections do not leak across backends", func(t *testing.T) {
+		t.Parallel()
 		settings := &pkgWorkspace.Settings{
 			Stacks: map[string]string{
 				"https://api.pulumi.com": "cloud-org/my-project/dev",
@@ -215,7 +228,7 @@ func TestCurrentStack(t *testing.T) {
 		}
 		got, err := CurrentStack(ctx, ws, localBe)
 		require.NoError(t, err)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 
 		cloudBe := &backend.MockBackend{
 			URLF: func() string { return "https://api.pulumi.com" },
@@ -231,10 +244,11 @@ func TestCurrentStack(t *testing.T) {
 		}
 		got, err = CurrentStack(ctx, ws, cloudBe)
 		require.NoError(t, err)
-		assert.NotNil(t, got)
+		require.NotNil(t, got)
 	})
 
 	t.Run("invalid scoped selection still returns parse error", func(t *testing.T) {
+		t.Parallel()
 		settings := &pkgWorkspace.Settings{
 			Stacks: map[string]string{
 				"file://~": "cloud-org/my-project/dev",
@@ -250,13 +264,59 @@ func TestCurrentStack(t *testing.T) {
 		be := &backend.MockBackend{
 			URLF: func() string { return "file://~" },
 			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
-				return nil, fmt.Errorf("organization name must be 'organization'")
+				return nil, errors.New("organization name must be 'organization'")
 			},
 		}
 
 		_, err := CurrentStack(ctx, ws, be)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "organization name must be 'organization'")
+	})
+
+	t.Run("cloud selection is keyed by API URL not console URL", func(t *testing.T) {
+		t.Parallel()
+		apiURL := "https://api.pulumi.com"
+		consoleURL := "https://app.pulumi.com/pulumi-bot"
+		stackName := "pulumi-bot/my-project/dev"
+
+		settings := &pkgWorkspace.Settings{}
+		ws := &pkgWorkspace.MockContext{
+			NewF: func(string) (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{
+					SettingsF: func() *pkgWorkspace.Settings { return settings },
+					SaveF:     func() error { return nil },
+				}, nil
+			},
+		}
+		be := &mockCloudBackend{
+			MockBackend: backend.MockBackend{
+				URLF: func() string { return consoleURL },
+				ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+					assert.Equal(t, stackName, s)
+					return &backend.MockStackReference{
+						FullyQualifiedNameV: tokens.QName(s),
+					}, nil
+				},
+				GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+					return &backend.MockStack{}, nil
+				},
+			},
+			cloudURL: apiURL,
+		}
+
+		require.Equal(t, apiURL, BackendURLKey(be))
+		require.NoError(t, SetCurrentStack(ws, BackendURLKey(be), stackName))
+		require.Equal(t, stackName, settings.Stacks[apiURL])
+		assert.Empty(t, settings.Stacks[consoleURL], "must not key selection by console URL")
+
+		// Readers that use GetCurrentCloudURL (API URL) must see the selection.
+		name, fromLegacy := settings.StackForBackend(apiURL)
+		require.Equal(t, stackName, name)
+		require.False(t, fromLegacy)
+
+		got, err := CurrentStack(ctx, ws, be)
+		require.NoError(t, err)
+		require.NotNil(t, got)
 	})
 }
 

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -486,7 +486,8 @@ func currentStackIdentity(ws pkgWorkspace.Context) (organization, stack string) 
 	if err != nil {
 		return "", ""
 	}
-	name := w.Settings().Stack
+	backendURL, _ := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), nil)
+	name, _ := w.Settings().StackForBackend(backendURL)
 	if name == "" {
 		return "", ""
 	}

--- a/pkg/cmd/pulumi/logs/decrypt.go
+++ b/pkg/cmd/pulumi/logs/decrypt.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -207,7 +208,9 @@ func currentStackName(ws pkgWorkspace.Context) string {
 	if err != nil {
 		return ""
 	}
-	return w.Settings().Stack
+	backendURL, _ := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), nil)
+	name, _ := w.Settings().StackForBackend(backendURL)
+	return name
 }
 
 var logTimestampRe = regexp.MustCompile(`(\d{8}T\d{6})`)

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -497,7 +497,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Ensure the stack is selected.
 	if !args.generateOnly && s != nil {
-		contract.IgnoreError(state.SetCurrentStack(ws, s.Ref().FullyQualifiedName().String()))
+		contract.IgnoreError(state.SetCurrentStack(ws, b.URL(), s.Ref().FullyQualifiedName().String()))
 	}
 
 	// Install dependencies, but only if we have a runtime to install with.

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -497,7 +497,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Ensure the stack is selected.
 	if !args.generateOnly && s != nil {
-		contract.IgnoreError(state.SetCurrentStack(ws, b.URL(), s.Ref().FullyQualifiedName().String()))
+		contract.IgnoreError(state.SetCurrentStack(ws, state.BackendURLKey(b), s.Ref().FullyQualifiedName().String()))
 	}
 
 	// Install dependencies, but only if we have a runtime to install with.

--- a/pkg/cmd/pulumi/project/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_acceptance_test.go
@@ -329,7 +329,10 @@ func currentUser(t *testing.T) string {
 func loadStackName(t *testing.T) string {
 	w, err := pkgWorkspace.Instance.New("")
 	require.NoError(t, err)
-	return w.Settings().Stack
+	backendURL, err := pkgWorkspace.GetCurrentCloudURL(pkgWorkspace.Instance, env.Global(), nil)
+	require.NoError(t, err)
+	name, _ := w.Settings().StackForBackend(backendURL)
+	return name
 }
 
 func removeStack(t *testing.T, dir, name string) {

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -325,7 +325,7 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 
 	// If setCurrent is true, we'll persist this choice so it'll be used for future CLI operations.
 	if lopt.SetCurrent() {
-		if err = state.SetCurrentStack(ws, stackRef.FullyQualifiedName().String()); err != nil {
+		if err = state.SetCurrentStack(ws, b.URL(), stackRef.FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}
@@ -433,7 +433,7 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	}
 
 	if setCurrent {
-		if err = state.SetCurrentStack(ws, stack.Ref().FullyQualifiedName().String()); err != nil {
+		if err = state.SetCurrentStack(ws, b.URL(), stack.Ref().FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -325,7 +325,7 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 
 	// If setCurrent is true, we'll persist this choice so it'll be used for future CLI operations.
 	if lopt.SetCurrent() {
-		if err = state.SetCurrentStack(ws, b.URL(), stackRef.FullyQualifiedName().String()); err != nil {
+		if err = state.SetCurrentStack(ws, state.BackendURLKey(b), stackRef.FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}
@@ -433,7 +433,7 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	}
 
 	if setCurrent {
-		if err = state.SetCurrentStack(ws, b.URL(), stack.Ref().FullyQualifiedName().String()); err != nil {
+		if err = state.SetCurrentStack(ws, state.BackendURLKey(b), stack.Ref().FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/pulumi/stack/stack_import_test.go
+++ b/pkg/cmd/pulumi/stack/stack_import_test.go
@@ -78,6 +78,7 @@ func TestStackImport_ChangeServiceSecrets(t *testing.T) {
 		},
 	}
 	be = &backend.MockBackend{
+		URLF: func() string { return "https://api.pulumi.com" },
 		GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 			assert.Equal(t, "org/proj/stk", ref.String())
 			return stk, nil
@@ -200,6 +201,7 @@ func TestStackImport_ServiceSecrets_DefaultSecretManagerMutatesProjectStack(t *t
 	}
 	importCalled := false
 	be = &backend.MockBackend{
+		URLF: func() string { return "https://api.pulumi.com" },
 		GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 			assert.Equal(t, "org/proj/stk", ref.String())
 			return stk, nil

--- a/pkg/cmd/pulumi/stack/stack_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_remove.go
@@ -120,7 +120,7 @@ func newStackRemoveCmd() *cobra.Command {
 			msg := fmt.Sprintf("%sStack '%s' has been removed!%s", colors.SpecAttention, s.Ref(), colors.Reset)
 			fmt.Fprintln(cmd.OutOrStdout(), opts.Color.Colorize(msg))
 
-			contract.IgnoreError(state.SetCurrentStack(ws, ""))
+			contract.IgnoreError(state.SetCurrentStack(ws, s.Backend().URL(), ""))
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_remove.go
@@ -120,7 +120,7 @@ func newStackRemoveCmd() *cobra.Command {
 			msg := fmt.Sprintf("%sStack '%s' has been removed!%s", colors.SpecAttention, s.Ref(), colors.Reset)
 			fmt.Fprintln(cmd.OutOrStdout(), opts.Color.Colorize(msg))
 
-			contract.IgnoreError(state.SetCurrentStack(ws, s.Backend().URL(), ""))
+			contract.IgnoreError(state.SetCurrentStack(ws, state.BackendURLKey(s.Backend()), ""))
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -98,7 +98,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Update the current workspace state to have selected the new stack.
-			if err := state.SetCurrentStack(ws, newStackRef.FullyQualifiedName().String()); err != nil {
+			if err := state.SetCurrentStack(ws, s.Backend().URL(), newStackRef.FullyQualifiedName().String()); err != nil {
 				return fmt.Errorf("setting current stack: %w", err)
 			}
 

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -98,7 +98,8 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Update the current workspace state to have selected the new stack.
-			if err := state.SetCurrentStack(ws, s.Backend().URL(), newStackRef.FullyQualifiedName().String()); err != nil {
+			backendURL := state.BackendURLKey(s.Backend())
+			if err := state.SetCurrentStack(ws, backendURL, newStackRef.FullyQualifiedName().String()); err != nil {
 				return fmt.Errorf("setting current stack: %w", err)
 			}
 

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -91,7 +91,7 @@ func newStackSelectCmd() *cobra.Command {
 					}
 					return stackErr
 				} else if s != nil {
-					return state.SetCurrentStack(ws, stackRef.FullyQualifiedName().String())
+					return state.SetCurrentStack(ws, b.URL(), stackRef.FullyQualifiedName().String())
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
@@ -99,7 +99,7 @@ func newStackSelectCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return state.SetCurrentStack(ws, s.Ref().FullyQualifiedName().String())
+					return state.SetCurrentStack(ws, b.URL(), s.Ref().FullyQualifiedName().String())
 				}
 
 				return backenderr.StackNotFoundError{StackName: stackRef.String()}
@@ -120,7 +120,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			contract.Assertf(stack != nil, "must select a stack")
-			return state.SetCurrentStack(ws, stack.Ref().FullyQualifiedName().String())
+			return state.SetCurrentStack(ws, b.URL(), stack.Ref().FullyQualifiedName().String())
 		},
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -91,7 +91,7 @@ func newStackSelectCmd() *cobra.Command {
 					}
 					return stackErr
 				} else if s != nil {
-					return state.SetCurrentStack(ws, b.URL(), stackRef.FullyQualifiedName().String())
+					return state.SetCurrentStack(ws, state.BackendURLKey(b), stackRef.FullyQualifiedName().String())
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
@@ -99,7 +99,7 @@ func newStackSelectCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return state.SetCurrentStack(ws, b.URL(), s.Ref().FullyQualifiedName().String())
+					return state.SetCurrentStack(ws, state.BackendURLKey(b), s.Ref().FullyQualifiedName().String())
 				}
 
 				return backenderr.StackNotFoundError{StackName: stackRef.String()}
@@ -120,7 +120,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			contract.Assertf(stack != nil, "must select a stack")
-			return state.SetCurrentStack(ws, b.URL(), stack.Ref().FullyQualifiedName().String())
+			return state.SetCurrentStack(ws, state.BackendURLKey(b), stack.Ref().FullyQualifiedName().String())
 		},
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -15,12 +15,16 @@
 package stack
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // Resets the currently selected stack from the current workspace such that
@@ -34,27 +38,32 @@ func newStackUnselectCmd() *cobra.Command {
 			"This way, next time pulumi needs to execute an operation, the user is prompted with one of the stacks to select\n" +
 			"from.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			currentWorkspace, err := pkgWorkspace.Instance.New("")
+			ws := pkgWorkspace.Instance
+			proj, _, err := ws.ReadProject("")
+			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+				return err
+			}
+
+			backendURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), proj)
 			if err != nil {
 				return err
 			}
 
-			settings := currentWorkspace.Settings()
-			if settings.Stack != "" {
-				// a stack is selected
-				// reset it
-				settings.Stack = ""
-				err = currentWorkspace.Save()
-				if err == nil {
-					// saving changes was successful
-					fmt.Fprintln(cmd.OutOrStdout(), "Stack was unselected")
-				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "Could not unselect the current stack from the workspace: %s", err)
-				}
-
+			currentWorkspace, err := ws.New("")
+			if err != nil {
 				return err
 			}
 
+			name, _ := currentWorkspace.Settings().StackForBackend(backendURL)
+			if name == "" {
+				return nil
+			}
+
+			if err := state.SetCurrentStack(ws, backendURL, ""); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Could not unselect the current stack from the workspace: %s", err)
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Stack was unselected")
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -60,10 +60,9 @@ func newStackUnselectCmd() *cobra.Command {
 			}
 
 			if err := state.SetCurrentStack(ws, backendURL, ""); err != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "Could not unselect the current stack from the workspace: %s", err)
-				return err
+				return fmt.Errorf("could not unselect the current stack from the workspace: %s", err)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Stack was unselected")
+			fmt.Fprintln(cmd.ErrOrStderr(), "Stack was unselected")
 			return nil
 		},
 	}

--- a/pkg/workspace/settings.go
+++ b/pkg/workspace/settings.go
@@ -16,12 +16,46 @@ package workspace
 
 // Settings defines workspace settings shared amongst many related projects.
 type Settings struct {
-	// Stack is an optional default stack to use.
+	// Stack is the legacy unscoped selected stack. Prefer Stacks[backendURL].
+	// Kept so older workspace.json files continue to load; new writes use Stacks.
 	Stack string `json:"stack,omitempty" yaml:"env,omitempty"`
+
+	// Stacks maps backend URL -> selected stack name for that backend.
+	Stacks map[string]string `json:"stacks,omitempty"`
 }
 
-// IsEmpty returns true when the settings object is logically empty (no selected stack and nothing in the deprecated
-// configuration bag).
+// IsEmpty returns true when the settings object is logically empty (no selected stack).
 func (s *Settings) IsEmpty() bool {
-	return s.Stack == ""
+	return s.Stack == "" && len(s.Stacks) == 0
+}
+
+// StackForBackend returns the selected stack for backendURL.
+// If there is no per-backend entry, it falls back to the legacy Stack field.
+func (s *Settings) StackForBackend(backendURL string) (name string, fromLegacy bool) {
+	if s.Stacks != nil {
+		if name, ok := s.Stacks[backendURL]; ok {
+			return name, false
+		}
+	}
+	return s.Stack, s.Stack != ""
+}
+
+// SetStackForBackend sets or clears the selected stack for backendURL.
+func (s *Settings) SetStackForBackend(backendURL, name string) {
+	if name == "" {
+		if s.Stacks != nil {
+			delete(s.Stacks, backendURL)
+			if len(s.Stacks) == 0 {
+				s.Stacks = nil
+			}
+		}
+		// Also clear the legacy field so unselect / remove still clear
+		// pre-migration workspace.json files that only have "stack".
+		s.Stack = ""
+		return
+	}
+	if s.Stacks == nil {
+		s.Stacks = map[string]string{}
+	}
+	s.Stacks[backendURL] = name
 }

--- a/pkg/workspace/settings.go
+++ b/pkg/workspace/settings.go
@@ -16,8 +16,10 @@ package workspace
 
 // Settings defines workspace settings shared amongst many related projects.
 type Settings struct {
-	// Stack is the legacy unscoped selected stack. Prefer Stacks[backendURL].
-	// Kept so older workspace.json files continue to load; new writes use Stacks.
+	// Stack is an optional default stack to use.
+
+	// Deprecated: Prefer Stacks[backendURL]. Kept so older
+	// workspace.json files continue to load; new writes use Stacks.
 	Stack string `json:"stack,omitempty" yaml:"env,omitempty"`
 
 	// Stacks maps backend URL -> selected stack name for that backend.
@@ -32,10 +34,8 @@ func (s *Settings) IsEmpty() bool {
 // StackForBackend returns the selected stack for backendURL.
 // If there is no per-backend entry, it falls back to the legacy Stack field.
 func (s *Settings) StackForBackend(backendURL string) (name string, fromLegacy bool) {
-	if s.Stacks != nil {
-		if name, ok := s.Stacks[backendURL]; ok {
-			return name, false
-		}
+	if name, ok := s.Stacks[backendURL]; ok {
+		return name, false
 	}
 	return s.Stack, s.Stack != ""
 }


### PR DESCRIPTION
## What

Scope the workspace's currently selected stack to the active backend URL, so switching backends no longer reuses an incompatible stack FQN.

## Why

Fixes #23819. After `pulumi login --local`, a leftover cloud-style stack FQN in workspace settings (for example `myorg/project/dev`) made `ParseStackReference` fail with:

```
error: organization name must be 'organization'
```

Per review feedback, the right fix is to key stack selection by backend (not discard parse errors).

## How

- Add `Settings.Stacks map[string]string` keyed by backend URL
- `SetCurrentStack` / `CurrentStack` read and write the scoped entry
- Legacy unscoped `stack` remains for migration; if it cannot parse for the current backend, treat as unset for that backend only
- Explicit scoped selections and `PULUMI_STACK` still return parse errors

## AI disclosure

AI-assisted implementation; manually reviewed the settings/backend URL model and verified `go test ./backend/state/`.