### PR TITLE
do: use string flags verbatim; add --flag+ for expressions

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -413,10 +413,9 @@ Provider configuration can be supplied via:
 Function inputs come from --input-file. YAML is the default; pass --input
 to use another format.
 
-Simple properties can also be set with flags and are parsed as expressions in
-the input format, except string values, which are taken verbatim; append + to
-a string flag (--<property>+ <value>) to parse its value as an expression too
-(e.g. YAML interpolations or fn:: invocations).`,
+Simple properties can also be set with flags: --<property> <value> takes the
+value as a literal, while --<property>+ <value> parses the value as an
+expression in the input format (e.g. YAML interpolations or fn:: invocations).`,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			subcmd, cleanup, err := buildSubcommand(cmd, args)

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -411,7 +411,12 @@ Provider configuration can be supplied via:
     set --input to use another format)
 
 Function inputs come from --input-file. YAML is the default; pass --input
-to use another format.`,
+to use another format.
+
+Simple properties can also be set with flags and are parsed as expressions in
+the input format, except string values, which are taken verbatim; append + to
+a string flag (--<property>+ <value>) to parse its value as an expression too
+(e.g. YAML interpolations or fn:: invocations).`,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			subcmd, cleanup, err := buildSubcommand(cmd, args)

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -69,6 +69,9 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 	if schemaHelp := functionSchemaHelp(fn); schemaHelp != "" {
 		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, schemaHelp)
 	}
+	if fn.Inputs != nil && len(fn.Inputs.Properties) > 0 {
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, inputFlagsHelp)
+	}
 
 	var inputFile string
 

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -127,6 +127,10 @@ Outputs:
  - output3 (boolean*): Whether it worked.
 Outputs marked with '*' are always present
 
+Simple inputs can be set with flags and are parsed as expressions in the
+input format, except string values, which are taken verbatim; append + to a
+string flag (--<input>+ <value>) to parse its value as an expression too.
+
 Usage:
   do azure:myModule:myOtherFunction [flags]
 
@@ -2613,9 +2617,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 				switch filepath.Base(req.Filename) {
 				case "provider.yaml":
 					assert.Equal(t, "opt1: val1\n", string(req.Source))
-					assert.Equal(t, map[string]string{
-						"optTwo": "val2",
-					}, req.Attributes)
+					assert.Empty(t, req.Attributes)
 					// The converter should be told this is a provider-config snippet via the provider's resource token,
 					// not the function token.
 					assert.Equal(t, "pulumi:providers:azure", req.Token)
@@ -2624,26 +2626,21 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 					return &plugin.ConvertSnippetResponse{
 						Filename: "provider.pp",
 						Source:   []byte(`opt1 = "val1"` + "\n"),
-						Attributes: map[string]string{
-							"optTwo": "\"val2\"",
-						},
 					}, nil
 				case "inputs.yaml":
-					assert.Equal(t, "in1: file\n", string(req.Source))
+					assert.Equal(t, "in1: file\ninTwo: fromfile\n", string(req.Source))
 					assert.Equal(t, map[string]string{
 						"dryRun": "true",
 						"in1":    "p1",
-						"inTwo":  "p2",
 					}, req.Attributes)
 					assert.Equal(t, "azure:index:myFunction", req.Token)
 					require.NotNil(t, req.Package)
 					assert.Equal(t, "azure", req.Package.Package)
 					return &plugin.ConvertSnippetResponse{
 						Filename: "inputs.pp",
-						Source:   []byte(`in1 = "file"` + "\n"),
+						Source:   []byte("in1 = \"file\"\ninTwo = \"fromfile\"\n"),
 						Attributes: map[string]string{
 							"in1":    "\"p1\"",
-							"inTwo":  "\"p2\"",
 							"dryRun": "true",
 						},
 					}, nil
@@ -2704,7 +2701,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	}
 
 	providerFile := writeHCLFile(t, "provider.yaml", "opt1: val1\n")
-	inputFile := writeHCLFile(t, "inputs.yaml", "in1: file\n")
+	inputFile := writeHCLFile(t, "inputs.yaml", "in1: file\ninTwo: fromfile\n")
 
 	var stdout bytes.Buffer
 	cmd := NewDoCmd(mlm, mws, loader, yamlHost, loadConverter, nil)
@@ -2715,7 +2712,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 		"--provider-file", providerFile,
 		"--input-file", inputFile, "--input", "yaml",
 		"--azure:opt-two", "val2",
-		"--in1", "p1",
+		"--in1+", "p1",
 		"--input:in-two", "p2",
 		"--input:dry-run",
 	})
@@ -2807,11 +2804,64 @@ func TestDoCmdFunctionInvokeWithYAMLInputFlagsNoInputFile(t *testing.T) {
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
 		"--input", "yaml",
-		"--input:message", "instring",
+		"--input:message+", "instring",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
-	assert.True(t, converterCalled, "ConvertSnippet should be called for YAML flags even without --input-file")
+	assert.True(t, converterCalled, "ConvertSnippet should be called for expression flags even without --input-file")
+	assert.JSONEq(t, `{"output1": "world"}`, stdout.String())
+}
+
+func TestDoCmdFunctionInvokeWithPlainFlagsSkipsConverter(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"message": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						Required: []string{"message"},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					assert.Equal(t,
+						"convert: allow empty files):\nwith ${not.interpolated} and %{no.directive}",
+						req.Args["message"].StringValue())
+					return plugin.InvokeResponse{
+						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+					}, nil
+				},
+			},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"azure:index:myFunction",
+		"--input:message", "convert: allow empty files):\nwith ${not.interpolated} and %{no.directive}",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
 	assert.JSONEq(t, `{"output1": "world"}`, stdout.String())
 }
 
@@ -2915,6 +2965,6 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
-	assert.True(t, converterCalled, "ConvertSnippet should be called for YAML flags even without --input-file")
+	assert.True(t, converterCalled, "ConvertSnippet should be called for non-string flags even without --input-file")
 	assert.JSONEq(t, `{"output1": "world"}`, stdout.String())
 }

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -127,9 +127,9 @@ Outputs:
  - output3 (boolean*): Whether it worked.
 Outputs marked with '*' are always present
 
-Simple inputs can be set with flags and are parsed as expressions in the
-input format, except string values, which are taken verbatim; append + to a
-string flag (--<input>+ <value>) to parse its value as an expression too.
+Simple inputs can be set with flags: --<input> <value> takes the value as a
+literal, while --<input>+ <value> parses the value as an expression in the
+input format.
 
 Usage:
   do azure:myModule:myOtherFunction [flags]
@@ -2630,8 +2630,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 				case "inputs.yaml":
 					assert.Equal(t, "in1: file\ninTwo: fromfile\n", string(req.Source))
 					assert.Equal(t, map[string]string{
-						"dryRun": "true",
-						"in1":    "p1",
+						"in1": "p1",
 					}, req.Attributes)
 					assert.Equal(t, "azure:index:myFunction", req.Token)
 					require.NotNil(t, req.Package)
@@ -2640,8 +2639,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 						Filename: "inputs.pp",
 						Source:   []byte("in1 = \"file\"\ninTwo = \"fromfile\"\n"),
 						Attributes: map[string]string{
-							"in1":    "\"p1\"",
-							"dryRun": "true",
+							"in1": "\"p1\"",
 						},
 					}, nil
 				default:
@@ -2853,7 +2851,7 @@ func TestDoCmdFunctionInvokeWithPlainFlagsSkipsConverter(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, nil)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{
@@ -2959,12 +2957,12 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
 		"--input", "yaml",
-		"--input:number", "0o45",
-		"--input:expr", "{\"fn::secret\": 45}",
-		"--input:flag=no",
+		"--input:number+", "0o45",
+		"--input:expr+", "{\"fn::secret\": 45}",
+		"--input:flag+=no",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
-	assert.True(t, converterCalled, "ConvertSnippet should be called for non-string flags even without --input-file")
+	assert.True(t, converterCalled, "ConvertSnippet should be called for expression flags even without --input-file")
 	assert.JSONEq(t, `{"output1": "world"}`, stdout.String())
 }

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -73,6 +73,9 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 	if schemaHelp := resourceSchemaHelp(res); schemaHelp != "" {
 		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, schemaHelp)
 	}
+	if len(res.InputProperties) > 0 {
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, inputFlagsHelp)
+	}
 
 	cmd := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -130,6 +130,10 @@ Outputs:
 List Inputs:
  - prefix (string)
 
+Simple inputs can be set with flags and are parsed as expressions in the
+input format, except string values, which are taken verbatim; append + to a
+string flag (--<input>+ <value>) to parse its value as an expression too.
+
 Usage:
   do azure:index:myResource [command]
 
@@ -181,6 +185,10 @@ Outputs:
  - extra (string)
  - name (string)
  - size (integer)
+
+Simple inputs can be set with flags and are parsed as expressions in the
+input format, except string values, which are taken verbatim; append + to a
+string flag (--<input>+ <value>) to parse its value as an expression too.
 
 Usage:
   do azure:index:myResource [command]

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -130,9 +130,9 @@ Outputs:
 List Inputs:
  - prefix (string)
 
-Simple inputs can be set with flags and are parsed as expressions in the
-input format, except string values, which are taken verbatim; append + to a
-string flag (--<input>+ <value>) to parse its value as an expression too.
+Simple inputs can be set with flags: --<input> <value> takes the value as a
+literal, while --<input>+ <value> parses the value as an expression in the
+input format.
 
 Usage:
   do azure:index:myResource [command]
@@ -186,9 +186,9 @@ Outputs:
  - name (string)
  - size (integer)
 
-Simple inputs can be set with flags and are parsed as expressions in the
-input format, except string values, which are taken verbatim; append + to a
-string flag (--<input>+ <value>) to parse its value as an expression too.
+Simple inputs can be set with flags: --<input> <value> takes the value as a
+literal, while --<input>+ <value> parses the value as an expression in the
+input format.
 
 Usage:
   do azure:index:myResource [command]

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -483,9 +485,7 @@ func collectInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Pr
 		}
 		for _, name := range names {
 			if flag := cmd.Flag(name); flag != nil && flag.Changed {
-				values[input.Name] = inputFlagValue{
-					value: flag.Value.String(), typ: typ, expr: typ != schema.StringType,
-				}
+				values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
 				break
 			}
 			if flag := cmd.Flag(name + "+"); flag != nil && flag.Changed {
@@ -516,7 +516,7 @@ func inputFlagLiterals(inputFlags map[string]inputFlagValue) (map[string]string,
 	for name, flag := range inputFlags {
 		literal, err := pclLiteral(flag)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("--%s: %w", inputFlagName(name), err)
 		}
 		attrs[name] = literal
 	}
@@ -572,8 +572,24 @@ func pclLiteral(flag inputFlagValue) (string, error) {
 	switch flag.typ {
 	case schema.StringType:
 		return string(hclwrite.TokensForValue(cty.StringVal(flag.value)).Bytes()), nil
-	case schema.BoolType, schema.IntType, schema.NumberType:
-		return flag.value, nil
+	case schema.BoolType:
+		v, err := strconv.ParseBool(flag.value)
+		if err != nil {
+			return "", fmt.Errorf("invalid boolean value %q", flag.value)
+		}
+		return string(hclwrite.TokensForValue(cty.BoolVal(v)).Bytes()), nil
+	case schema.IntType:
+		v, err := strconv.ParseInt(flag.value, 10, 64)
+		if err != nil {
+			return "", fmt.Errorf("invalid integer value %q", flag.value)
+		}
+		return string(hclwrite.TokensForValue(cty.NumberIntVal(v)).Bytes()), nil
+	case schema.NumberType:
+		v, err := strconv.ParseFloat(flag.value, 64)
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+			return "", fmt.Errorf("invalid number value %q", flag.value)
+		}
+		return string(hclwrite.TokensForValue(cty.NumberFloatVal(v)).Bytes()), nil
 	default:
 		return "", fmt.Errorf("unsupported flag type %s", flag.typ)
 	}
@@ -581,9 +597,9 @@ func pclLiteral(flag inputFlagValue) (string, error) {
 
 const exprFlagHelp = " (value is parsed as an expression in the input format)"
 
-const inputFlagsHelp = "Simple inputs can be set with flags and are parsed as expressions in the\n" +
-	"input format, except string values, which are taken verbatim; append + to a\n" +
-	"string flag (--<input>+ <value>) to parse its value as an expression too."
+const inputFlagsHelp = "Simple inputs can be set with flags: --<input> <value> takes the value as a\n" +
+	"literal, while --<input>+ <value> parses the value as an expression in the\n" +
+	"input format."
 
 func addInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Property) {
 	addInputFlagsTo(cmd, cmd.Flags(), namespace, inputs)
@@ -603,11 +619,6 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		switch typ {
 		case schema.BoolType:
 			flagFunc = func(name, extraHelp string) {
-				// N.B. This is hardcoded in the engine to the literal string "true/false" for the literal true/false.
-				// This works for PCL, and happens to also work for YAML, but if we add any new converters that _don't_
-				// use the string "true" for their boolean true literal (for example Python uses "True"), then we'll
-				// need to add something here to support that. Probably pre-fetching the literal text from the
-				// converter plugin to create the flag values to match.
 				flags.String(name, "false", comment+extraHelp)
 				flags.Lookup(name).NoOptDefVal = "true"
 			}
@@ -623,24 +634,17 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 			}
 			flagName := inputFlagName(input.Name)
 			key := fmt.Sprintf("%s:%s", namespace, flagName)
-			hasExpr := typ == schema.StringType
 			flagFunc(key, "")
-			if hasExpr {
-				exprFunc(key+"+", exprFlagHelp)
-				flags.Lookup(key + "+").Hidden = true
-			}
+			exprFunc(key+"+", exprFlagHelp)
+			flags.Lookup(key + "+").Hidden = true
 			if namespace == "input" && flags.Lookup(flagName) == nil {
 				flagFunc(flagName, " (alias for --"+key+")")
-				if hasExpr {
-					exprFunc(flagName+"+", exprFlagHelp)
-					flags.Lookup(flagName + "+").Hidden = true
-					cmd.MarkFlagsMutuallyExclusive(key, flagName, key+"+", flagName+"+")
-				} else {
-					cmd.MarkFlagsMutuallyExclusive(key, flagName)
-				}
+				exprFunc(flagName+"+", exprFlagHelp)
+				flags.Lookup(flagName + "+").Hidden = true
+				cmd.MarkFlagsMutuallyExclusive(key, flagName, key+"+", flagName+"+")
 				// Mark the namespaced flag as hidden
 				flags.Lookup(key).Hidden = true
-			} else if hasExpr {
+			} else {
 				cmd.MarkFlagsMutuallyExclusive(key, key+"+")
 			}
 		}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -23,7 +23,6 @@ import (
 	"maps"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -33,6 +32,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -97,6 +97,7 @@ type functionEvalContext struct {
 type inputFlagValue struct {
 	value string
 	typ   schema.Type
+	expr  bool
 }
 
 func jsonifyPropertyValue(v resource.PropertyValue, showSecrets bool) (any, error) {
@@ -338,16 +339,29 @@ func parseFile(
 		}
 	}
 
-	var literals map[string]string
-	if len(pcl) == 0 && len(inputFlags) == 0 {
-		// No input provided; pcl and literals are empty
-	} else if inputFormat == "pcl" {
-		var err error
-		literals, err = inputFlagLiterals(inputFlags)
-		if err != nil {
-			return nil, "", err
+	plainFlags := map[string]inputFlagValue{}
+	exprFlags := map[string]inputFlagValue{}
+	for name, flag := range inputFlags {
+		if flag.expr {
+			exprFlags[name] = flag
+		} else {
+			plainFlags[name] = flag
 		}
-	} else {
+	}
+
+	literals, err := inputFlagLiterals(plainFlags)
+	if err != nil {
+		return nil, "", err
+	}
+	if literals == nil {
+		literals = map[string]string{}
+	}
+
+	if inputFormat == "pcl" {
+		for name, flag := range exprFlags {
+			literals[name] = flag.value
+		}
+	} else if len(pcl) > 0 || len(exprFlags) > 0 {
 		converter, err := loadConverter(inputFormat)
 		if err != nil {
 			return nil, "", fmt.Errorf("load %s input converter: %w", inputFormat, err)
@@ -360,7 +374,7 @@ func parseFile(
 			TargetLoader: loaderTarget,
 			Package:      packageDescriptor,
 			Token:        token,
-			Attributes:   inputFlagAttributes(inputFlags),
+			Attributes:   inputFlagAttributes(exprFlags),
 		})
 		if err != nil {
 			if status.Code(err) == codes.Unimplemented {
@@ -379,7 +393,9 @@ func parseFile(
 		if filename == "" {
 			filename = fmt.Sprintf("<converted %s>", fileType)
 		}
-		literals = resp.Attributes
+		for name, attr := range resp.Attributes {
+			literals[name] = attr
+		}
 	}
 
 	merged, err := mergeAttributeLiteralsIntoPCL(pcl, filename, fileType, literals)
@@ -392,9 +408,9 @@ func parseFile(
 
 // evaluateFile reads an input file in the given format and evaluates it. For non-PCL formats the source is routed
 // through the named converter plugin's ConvertSnippet RPC and the resulting PCL is fed into the same bind pipeline.
-// An empty path with no input flags is treated as "no input provided"; converter-backed formats still run for
-// resource/function input flags so those flags are interpreted by the selected converter before the bind step's
-// missing-required check runs.
+// Plain input flags are merged into the PCL as literal values without converter involvement; expression flags
+// (--<flag>+) are interpreted by the selected converter, or merged as PCL expressions when the input format is pcl.
+// The converter only runs when there is file source or at least one expression flag.
 func evaluateFile(
 	ctx context.Context,
 	path, fileType, inputFormat, token string,
@@ -461,13 +477,20 @@ func collectInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Pr
 		}
 
 		flagName := inputFlagName(input.Name)
-		if flag := cmd.Flag(fmt.Sprintf("%s:%s", namespace, flagName)); flag != nil && flag.Changed {
-			values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
-			continue
-		}
+		names := []string{fmt.Sprintf("%s:%s", namespace, flagName)}
 		if namespace == "input" {
-			if flag := cmd.Flag(flagName); flag != nil && flag.Changed {
-				values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
+			names = append(names, flagName)
+		}
+		for _, name := range names {
+			if flag := cmd.Flag(name); flag != nil && flag.Changed {
+				values[input.Name] = inputFlagValue{
+					value: flag.Value.String(), typ: typ, expr: typ != schema.StringType,
+				}
+				break
+			}
+			if flag := cmd.Flag(name + "+"); flag != nil && flag.Changed {
+				values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ, expr: true}
+				break
 			}
 		}
 	}
@@ -548,13 +571,19 @@ func mergeAttributeLiteralsIntoPCL(
 func pclLiteral(flag inputFlagValue) (string, error) {
 	switch flag.typ {
 	case schema.StringType:
-		return strconv.Quote(flag.value), nil
+		return string(hclwrite.TokensForValue(cty.StringVal(flag.value)).Bytes()), nil
 	case schema.BoolType, schema.IntType, schema.NumberType:
 		return flag.value, nil
 	default:
 		return "", fmt.Errorf("unsupported flag type %s", flag.typ)
 	}
 }
+
+const exprFlagHelp = " (value is parsed as an expression in the input format)"
+
+const inputFlagsHelp = "Simple inputs can be set with flags and are parsed as expressions in the\n" +
+	"input format, except string values, which are taken verbatim; append + to a\n" +
+	"string flag (--<input>+ <value>) to parse its value as an expression too."
 
 func addInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Property) {
 	addInputFlagsTo(cmd, cmd.Flags(), namespace, inputs)
@@ -589,14 +618,30 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		}
 
 		if flagFunc != nil {
+			exprFunc := func(name, extraHelp string) {
+				flags.String(name, "", comment+extraHelp)
+			}
 			flagName := inputFlagName(input.Name)
 			key := fmt.Sprintf("%s:%s", namespace, flagName)
+			hasExpr := typ == schema.StringType
 			flagFunc(key, "")
+			if hasExpr {
+				exprFunc(key+"+", exprFlagHelp)
+				flags.Lookup(key + "+").Hidden = true
+			}
 			if namespace == "input" && flags.Lookup(flagName) == nil {
 				flagFunc(flagName, " (alias for --"+key+")")
-				cmd.MarkFlagsMutuallyExclusive(key, flagName)
+				if hasExpr {
+					exprFunc(flagName+"+", exprFlagHelp)
+					flags.Lookup(flagName + "+").Hidden = true
+					cmd.MarkFlagsMutuallyExclusive(key, flagName, key+"+", flagName+"+")
+				} else {
+					cmd.MarkFlagsMutuallyExclusive(key, flagName)
+				}
 				// Mark the namespaced flag as hidden
 				flags.Lookup(key).Hidden = true
+			} else if hasExpr {
+				cmd.MarkFlagsMutuallyExclusive(key, key+"+")
 			}
 		}
 	}

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -1125,6 +1125,39 @@ func TestFlagUsage(t *testing.T) {
 	}
 }
 
+func TestInputFlagLiterals(t *testing.T) {
+	t.Parallel()
+
+	literals, err := inputFlagLiterals(map[string]inputFlagValue{
+		"name":    {value: "convert: ${not.a.template}\nline two", typ: schema.StringType},
+		"size":    {value: "42", typ: schema.IntType},
+		"ratio":   {value: "1.5", typ: schema.NumberType},
+		"enabled": {value: "true", typ: schema.BoolType},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"name":    `"convert: $${not.a.template}\nline two"`,
+		"size":    "42",
+		"ratio":   "1.5",
+		"enabled": "true",
+	}, literals)
+
+	_, err = inputFlagLiterals(map[string]inputFlagValue{
+		"intValue": {value: "0o45", typ: schema.IntType},
+	})
+	assert.ErrorContains(t, err, `--int-value: invalid integer value "0o45"`)
+
+	_, err = inputFlagLiterals(map[string]inputFlagValue{
+		"enabled": {value: "no", typ: schema.BoolType},
+	})
+	assert.ErrorContains(t, err, `--enabled: invalid boolean value "no"`)
+
+	_, err = inputFlagLiterals(map[string]inputFlagValue{
+		"ratio": {value: "1.5.3", typ: schema.NumberType},
+	})
+	assert.ErrorContains(t, err, `--ratio: invalid number value "1.5.3"`)
+}
+
 func TestMergeAttributeLiteralsIntoPCL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
String flags being expressions by default can be quite confusing. E.g. passing a string with multiple lines, if a line ends with a `:`, it's interpreted as YAML, but then it's invalid because it was never meant to be YAML.

Instead make the plain `--<input>` flag just use the verbatim input, while we add a `--<input>+` flag, which takes an actual expression.  For `bool` and `number` inputs, we will use `strconv` to try to convert the input (with `--<flag>+` values always going to the converter).  For `--any` flags, we will start off with erroring out, and only allowing the `+` variant.  Note that this is not implemented in this  PR yet, as we don't have `--any` flags yet.
