### PR TITLE
upgrade uv to latest version

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -13,7 +13,7 @@ node = "22"
 "npm:yarn" = "1.22.22"
 bun = "1.3.14"
 python = '3.11'
-uv = "0.10.0"
+uv = "0.11.28"
 # This is a dev only dependency that fails to install on windows
 "go:github.com/mitranim/gow" = { version = "0.0.0-20260515002309-3b8e4d082711", os = ["linux", "macos"] }
 protoc = "29.5"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -418,7 +418,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Noticed that locally `uv.lock` always changes when I run make dist. Eventually we need to upgrade this anyway, so let's do it now.