### PR TITLE
Support inputs and outputs on resources in import files

### DIFF
--- a/changelog/pending/cli-import-improvement-20260720-134823.yaml
+++ b/changelog/pending/cli-import-improvement-20260720-134823.yaml
@@ -2,3 +2,5 @@ component: cli/import
 kind: improvement
 body: Support inputs and outputs on resources in import files, importing supplied state directly and skipping the provider read when outputs are given
 time: 2026-07-20T13:48:23.110153+01:00
+custom:
+    PR: "23984"

--- a/changelog/pending/cli-import-improvement-20260720-134823.yaml
+++ b/changelog/pending/cli-import-improvement-20260720-134823.yaml
@@ -1,0 +1,4 @@
+component: cli/import
+kind: improvement
+body: Support inputs and outputs on resources in import files, importing supplied state directly and skipping the provider read when outputs are given
+time: 2026-07-20T13:48:23.110153+01:00

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -1083,6 +1083,11 @@ func NewImportCmd() *cobra.Command {
 			decrypter := sm.Decrypter()
 			encrypter := sm.Encrypter()
 
+			if len(importFile.ProviderInputs) > 0 {
+				sink.Warningf(diag.Message("", "the 'providerInputs' field is deprecated: declare the "+
+					"provider in 'resources' and set its configuration via its 'inputs' instead"))
+			}
+
 			imports, nameTable, err := parseImportFile(
 				importFile, s.Ref().Name(), proj.Name, protectResources, decrypter)
 			if err != nil {

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -233,6 +233,8 @@ type importFile struct {
 	// ProviderInputs maps provider names (as used in NameTable and importSpec.Provider) to
 	// their serialized inputs. This allows the import system to create explicit providers
 	// that are not yet in state with the correct configuration. Secrets are encrypted.
+	//
+	// Deprecated: declare the provider in Resources and set its configuration via its Inputs instead.
 	ProviderInputs map[string]map[string]any `json:"providerInputs,omitempty"`
 }
 
@@ -375,13 +377,13 @@ func parseImportFile(
 			if spec.Parent != "" {
 				pusherrf("%v is a provider and may not have a parent", describeResource(i, spec))
 			}
+			if len(spec.Outputs) > 0 {
+				pusherrf("%v is a provider and may not have outputs", describeResource(i, spec))
+			}
 		} else if !spec.Component && spec.ID == "" {
 			pusherrf("%v has no ID", describeResource(i, spec))
 		} else if spec.Component && spec.ID != "" {
 			pusherrf("%v has an ID, but is marked as a component", describeResource(i, spec))
-		}
-		if len(spec.Outputs) > 0 && (spec.Component || providers.IsProviderType(spec.Type)) {
-			pusherrf("%v has outputs, but is not a custom resource", describeResource(i, spec))
 		}
 		if spec.Remote && !spec.Component {
 			pusherrf("%v is marked as remote, but not as a component", describeResource(i, spec))

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -190,6 +190,14 @@ type importSpec struct {
 	Component         bool        `json:"component,omitempty"`
 	Remote            bool        `json:"remote,omitempty"`
 
+	// Inputs holds input properties supplied for the resource. Values the provider's Read cannot return
+	// (e.g. write-only attributes) are taken from here instead. For a provider declared in the resources
+	// block, Inputs is its configuration.
+	Inputs map[string]any `json:"inputs,omitempty"`
+	// Outputs holds the resource's full output state. When set, the resource is imported from these
+	// values directly and the provider's Read is skipped entirely.
+	Outputs map[string]any `json:"outputs,omitempty"`
+
 	// LogicalName is the resources Pulumi name (i.e. the first argument to `new Resource`).
 	LogicalName string `json:"logicalName,omitempty"`
 
@@ -371,6 +379,9 @@ func parseImportFile(
 			pusherrf("%v has no ID", describeResource(i, spec))
 		} else if spec.Component && spec.ID != "" {
 			pusherrf("%v has an ID, but is marked as a component", describeResource(i, spec))
+		}
+		if len(spec.Outputs) > 0 && (spec.Component || providers.IsProviderType(spec.Type)) {
+			pusherrf("%v has outputs, but is not a custom resource", describeResource(i, spec))
 		}
 		if spec.Remote && !spec.Component {
 			pusherrf("%v is marked as remote, but not as a component", describeResource(i, spec))
@@ -559,13 +570,34 @@ func parseImportFile(
 		}
 
 		if providers.IsProviderType(spec.Type) {
-			if serializedInputs, ok := f.ProviderInputs[spec.Name]; ok {
+			serializedInputs, ok := f.ProviderInputs[spec.Name]
+			if spec.Inputs != nil {
+				serializedInputs, ok = spec.Inputs, true
+			}
+			if ok {
 				providerInputs, err := resourcestack.DeserializeProperties(serializedInputs, dec)
 				if err != nil {
 					pusherrf("could not deserialize provider inputs for %v: %w",
 						describeResource(i, spec), err)
 				} else {
 					imp.ProviderInputs = providerInputs
+				}
+			}
+		} else {
+			if spec.Inputs != nil {
+				inputs, err := resourcestack.DeserializeProperties(spec.Inputs, dec)
+				if err != nil {
+					pusherrf("could not deserialize inputs for %v: %w", describeResource(i, spec), err)
+				} else {
+					imp.Inputs = inputs
+				}
+			}
+			if spec.Outputs != nil {
+				outputs, err := resourcestack.DeserializeProperties(spec.Outputs, dec)
+				if err != nil {
+					pusherrf("could not deserialize outputs for %v: %w", describeResource(i, spec), err)
+				} else {
+					imp.Outputs = outputs
 				}
 			}
 		}

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -315,6 +315,31 @@ func TestParseImportFile_errors(t *testing.T) {
 			},
 		},
 		{
+			desc: "component with outputs",
+			give: importFile{Resources: []importSpec{{
+				Name:      "comp",
+				Type:      "foo:bar:baz",
+				Component: true,
+				Outputs:   map[string]any{"foo": "bar"},
+			}}},
+			wantErrs: []string{
+				"1 error occurred",
+				"resource 'comp' of type 'foo:bar:baz' has outputs, but is not a custom resource",
+			},
+		},
+		{
+			desc: "provider with outputs",
+			give: importFile{Resources: []importSpec{{
+				Name:    "prov",
+				Type:    "pulumi:providers:aws",
+				Outputs: map[string]any{"foo": "bar"},
+			}}},
+			wantErrs: []string{
+				"1 error occurred",
+				"resource 'prov' of type 'pulumi:providers:aws' has outputs, but is not a custom resource",
+			},
+		},
+		{
 			desc: "component with ID",
 			give: importFile{Resources: []importSpec{{
 				Name:      "comp",
@@ -601,6 +626,45 @@ func TestParseImportFileProviderInputs(t *testing.T) {
 	require.NotNil(t, imports[0].ProviderInputs)
 	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[0].ProviderInputs["region"])
 	assert.Equal(t, resource.NewProperty("6.0.0"), imports[0].ProviderInputs["version"])
+}
+
+func TestParseImportFileInputsOutputs(t *testing.T) {
+	t.Parallel()
+
+	f := importFile{
+		Resources: []importSpec{
+			{
+				Name: "my-prov",
+				Type: "pulumi:providers:aws",
+				Inputs: map[string]any{
+					"region": "eu-west-1",
+				},
+			},
+			{
+				Name:     "thing",
+				ID:       "thing-id",
+				Type:     "aws:s3:Bucket",
+				Provider: "my-prov",
+				Inputs: map[string]any{
+					"bucket": "my-bucket",
+				},
+				Outputs: map[string]any{
+					"bucket": "my-bucket",
+					"arn":    "arn:aws:s3:::my-bucket",
+				},
+			},
+		},
+	}
+	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
+	require.NoError(t, err)
+	require.Len(t, imports, 2)
+
+	// A provider spec's inputs become its configuration.
+	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[0].ProviderInputs["region"])
+	require.Nil(t, imports[0].Inputs)
+
+	assert.Equal(t, resource.NewProperty("my-bucket"), imports[1].Inputs["bucket"])
+	assert.Equal(t, resource.NewProperty("arn:aws:s3:::my-bucket"), imports[1].Outputs["arn"])
 }
 
 func TestParseImportFileDeclaredProvider(t *testing.T) {

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -315,19 +315,6 @@ func TestParseImportFile_errors(t *testing.T) {
 			},
 		},
 		{
-			desc: "component with outputs",
-			give: importFile{Resources: []importSpec{{
-				Name:      "comp",
-				Type:      "foo:bar:baz",
-				Component: true,
-				Outputs:   map[string]any{"foo": "bar"},
-			}}},
-			wantErrs: []string{
-				"1 error occurred",
-				"resource 'comp' of type 'foo:bar:baz' has outputs, but is not a custom resource",
-			},
-		},
-		{
 			desc: "provider with outputs",
 			give: importFile{Resources: []importSpec{{
 				Name:    "prov",
@@ -336,7 +323,7 @@ func TestParseImportFile_errors(t *testing.T) {
 			}}},
 			wantErrs: []string{
 				"1 error occurred",
-				"resource 'prov' of type 'pulumi:providers:aws' has outputs, but is not a custom resource",
+				"resource 'prov' of type 'pulumi:providers:aws' is a provider and may not have outputs",
 			},
 		},
 		{

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -937,6 +937,9 @@ func TestImportPlanSuppliedOutputs(t *testing.T) {
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
 
+	componentInputs := resource.PropertyMap{
+		"size": resource.NewProperty(3.0),
+	}
 	componentOutputs := resource.PropertyMap{
 		"result": resource.NewProperty("value"),
 	}
@@ -946,6 +949,7 @@ func TestImportPlanSuppliedOutputs(t *testing.T) {
 		Type:      "my:module:Component",
 		Name:      "comp",
 		Component: true,
+		Inputs:    componentInputs,
 		Outputs:   componentOutputs,
 	}, {
 		Type:    "pkgA:m:typA",
@@ -959,20 +963,21 @@ func TestImportPlanSuppliedOutputs(t *testing.T) {
 	require.Len(t, snap.Resources, 4)
 
 	// Import steps run in parallel, so look resources up by name rather than snapshot position.
-	byName := func(name string) int {
-		for i, r := range snap.Resources {
+	byName := func(name string) *pkgresource.State {
+		for _, r := range snap.Resources {
 			if r.URN.Name() == name {
-				return i
+				return r
 			}
 		}
 		t.Fatalf("resource %q not found in snapshot", name)
-		return -1
+		return nil
 	}
 
-	comp := snap.Resources[byName("comp")]
+	comp := byName("comp")
+	assert.Equal(t, componentInputs, comp.Inputs)
 	assert.Equal(t, componentOutputs, comp.Outputs)
 
-	resB := snap.Resources[byName("resB")]
+	resB := byName("resB")
 	assert.Equal(t, resource.ID("imported-id"), resB.ID)
 	assert.Equal(t, suppliedInputs, resB.Inputs)
 	assert.Equal(t, suppliedOutputs, resB.Outputs)

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -958,12 +958,24 @@ func TestImportPlanSuppliedOutputs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, snap.Resources, 4)
 
-	assert.Equal(t, tokens.Type("my:module:Component"), snap.Resources[2].Type)
-	assert.Equal(t, componentOutputs, snap.Resources[2].Outputs)
+	// Import steps run in parallel, so look resources up by name rather than snapshot position.
+	byName := func(name string) int {
+		for i, r := range snap.Resources {
+			if r.URN.Name() == name {
+				return i
+			}
+		}
+		t.Fatalf("resource %q not found in snapshot", name)
+		return -1
+	}
 
-	assert.Equal(t, resource.ID("imported-id"), snap.Resources[3].ID)
-	assert.Equal(t, suppliedInputs, snap.Resources[3].Inputs)
-	assert.Equal(t, suppliedOutputs, snap.Resources[3].Outputs)
+	comp := snap.Resources[byName("comp")]
+	assert.Equal(t, componentOutputs, comp.Outputs)
+
+	resB := snap.Resources[byName("resB")]
+	assert.Equal(t, resource.ID("imported-id"), resB.ID)
+	assert.Equal(t, suppliedInputs, resB.Inputs)
+	assert.Equal(t, suppliedOutputs, resB.Outputs)
 }
 
 func TestImportPlanSuppliedInputsMerge(t *testing.T) {

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -937,8 +937,17 @@ func TestImportPlanSuppliedOutputs(t *testing.T) {
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
 
+	componentOutputs := resource.PropertyMap{
+		"result": resource.NewProperty("value"),
+	}
+
 	project := p.GetProject()
 	snap, err := lt.ImportOp([]deploy.Import{{
+		Type:      "my:module:Component",
+		Name:      "comp",
+		Component: true,
+		Outputs:   componentOutputs,
+	}, {
 		Type:    "pkgA:m:typA",
 		Name:    "resB",
 		ID:      "imported-id",
@@ -947,11 +956,14 @@ func TestImportPlanSuppliedOutputs(t *testing.T) {
 	}}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
 
 	require.NoError(t, err)
-	require.Len(t, snap.Resources, 3)
+	require.Len(t, snap.Resources, 4)
 
-	assert.Equal(t, resource.ID("imported-id"), snap.Resources[2].ID)
-	assert.Equal(t, suppliedInputs, snap.Resources[2].Inputs)
-	assert.Equal(t, suppliedOutputs, snap.Resources[2].Outputs)
+	assert.Equal(t, tokens.Type("my:module:Component"), snap.Resources[2].Type)
+	assert.Equal(t, componentOutputs, snap.Resources[2].Outputs)
+
+	assert.Equal(t, resource.ID("imported-id"), snap.Resources[3].ID)
+	assert.Equal(t, suppliedInputs, snap.Resources[3].Inputs)
+	assert.Equal(t, suppliedOutputs, snap.Resources[3].Outputs)
 }
 
 func TestImportPlanSuppliedInputsMerge(t *testing.T) {

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -904,6 +904,116 @@ func TestImportPlanExistingImport(t *testing.T) {
 	require.Len(t, snap.Resources, 3)
 }
 
+func TestImportPlanSuppliedOutputs(t *testing.T) {
+	t.Parallel()
+
+	suppliedInputs := resource.PropertyMap{
+		"foo":  resource.NewProperty("bar"),
+		"frob": resource.MakeSecret(resource.NewProperty(1.0)),
+	}
+	suppliedOutputs := resource.PropertyMap{
+		"foo":  resource.NewProperty("bar"),
+		"frob": resource.MakeSecret(resource.NewProperty(1.0)),
+	}
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(context.Context, plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(importSchema)}, nil
+				},
+				DiffF: diffImportResource,
+				ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
+					t.Fatal("Read should not be called when outputs are supplied")
+					return plugin.ReadResponse{}, nil
+				},
+			}, nil
+		}),
+	}
+	programF := deploytest.NewLanguageRuntimeF(nil)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+
+	project := p.GetProject()
+	snap, err := lt.ImportOp([]deploy.Import{{
+		Type:    "pkgA:m:typA",
+		Name:    "resB",
+		ID:      "imported-id",
+		Inputs:  suppliedInputs,
+		Outputs: suppliedOutputs,
+	}}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+
+	require.NoError(t, err)
+	require.Len(t, snap.Resources, 3)
+
+	assert.Equal(t, resource.ID("imported-id"), snap.Resources[2].ID)
+	assert.Equal(t, suppliedInputs, snap.Resources[2].Inputs)
+	assert.Equal(t, suppliedOutputs, snap.Resources[2].Outputs)
+}
+
+func TestImportPlanSuppliedInputsMerge(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(context.Context, plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(importSchema)}, nil
+				},
+				DiffF: diffImportResource,
+				ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
+					// "foo" is a write-only attribute the importer cannot return; "frob" comes back
+					// in plain text even though it was supplied as a secret.
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID: "actual-id",
+							Inputs: resource.PropertyMap{
+								"foo":  resource.NewNullProperty(),
+								"frob": resource.NewProperty(1.0),
+							},
+							Outputs: resource.PropertyMap{
+								"frob": resource.NewProperty(1.0),
+							},
+						},
+						Status: resource.StatusOK,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+	programF := deploytest.NewLanguageRuntimeF(nil)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+
+	project := p.GetProject()
+	snap, err := lt.ImportOp([]deploy.Import{{
+		Type: "pkgA:m:typA",
+		Name: "resB",
+		ID:   "imported-id",
+		Inputs: resource.PropertyMap{
+			"foo":  resource.NewProperty("supplied"),
+			"frob": resource.MakeSecret(resource.NewProperty(2.0)),
+		},
+	}}).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+
+	require.NoError(t, err)
+	require.Len(t, snap.Resources, 3)
+
+	// The provider's Read wins where it returned a value, lifted to a secret where the supplied value
+	// was one; the supplied value fills the null.
+	assert.Equal(t, resource.ID("actual-id"), snap.Resources[2].ID)
+	assert.Equal(t, resource.PropertyMap{
+		"foo":  resource.NewProperty("supplied"),
+		"frob": resource.MakeSecret(resource.NewProperty(1.0)),
+	}, snap.Resources[2].Inputs)
+}
+
 func TestImportPlanEmptyState(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -88,6 +88,13 @@ type Import struct {
 	// are configured solely from these inputs.
 	ProviderInputs resource.PropertyMap
 
+	// Inputs holds input properties supplied for the resource, if any. When the provider's Read cannot
+	// return a property supplied here (e.g. a write-only attribute), the supplied value is used instead.
+	Inputs resource.PropertyMap
+	// Outputs holds the full output state supplied for the resource, if any. When set, the resource is
+	// imported from these values directly and the provider's Read is skipped entirely.
+	Outputs resource.PropertyMap
+
 	// True if this import should create an empty component resource. ID must not be set if this is used.
 	Component bool
 	// True if this is a remote component resource. Component must be true if this is true.
@@ -715,6 +722,11 @@ func (i *importer) importResources(ctx context.Context) error {
 			contract.Assertf(ok, "provider reference for URN %v not found", providerURN)
 		}
 
+		inputs := imp.Inputs
+		if inputs == nil {
+			inputs = resource.PropertyMap{}
+		}
+
 		// Create the new desired state. Note that the resource is protected. Provider might be "" at this point.
 		new := pkgresource.NewState{
 			Type:                    urn.Type(),
@@ -722,8 +734,8 @@ func (i *importer) importResources(ctx context.Context) error {
 			Custom:                  !imp.Component,
 			Delete:                  false,
 			ID:                      "",
-			Inputs:                  resource.PropertyMap{},
-			Outputs:                 nil,
+			Inputs:                  inputs,
+			Outputs:                 imp.Outputs,
 			Parent:                  parent,
 			Protect:                 imp.Protect,
 			Taint:                   false,

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1956,11 +1956,18 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		}
 	}
 
-	// Only need to do anything here for custom resources, components just import as empty
 	suppliedInputs := s.new.Inputs
 	suppliedOutputs := s.new.Outputs
 	inputs := resource.PropertyMap{}
 	outputs := resource.PropertyMap{}
+	if s.planned {
+		if suppliedInputs != nil {
+			inputs = suppliedInputs
+		}
+		if suppliedOutputs != nil {
+			outputs = suppliedOutputs
+		}
+	}
 	var prov plugin.Provider
 	rst := resource.StatusOK
 	if s.new.Custom && s.planned && len(suppliedOutputs) > 0 {
@@ -1975,8 +1982,6 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		s.new.Lock.Lock()
 		defer s.new.Lock.Unlock()
 
-		inputs = suppliedInputs
-		outputs = suppliedOutputs
 		s.new.ID = s.new.ImportID
 	} else if s.new.Custom {
 		// Read the current state of the resource to import. If the provider does not hand us back any inputs for the

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1871,8 +1871,6 @@ func newImportDeploymentStep(deployment *Deployment, new *pkgresource.State, ran
 	contract.Requiref(!new.Delete, "new", "must not be marked for deletion")
 	contract.Requiref(!new.External, "new", "must not be external")
 	contract.Requiref(!new.Custom || randomSeed != nil, "randomSeed", "must not be nil")
-	contract.Assertf(len(new.Inputs) == 0, "import resource cannot have existing inputs")
-
 	contract.Requiref(new.ViewOf == "", "new", "must not be a view")
 
 	return &ImportStep{
@@ -1900,6 +1898,26 @@ func (s *ImportStep) Original() *pkgresource.State { return s.original }
 func (s *ImportStep) New() *pkgresource.State      { return s.new }
 func (s *ImportStep) Res() *pkgresource.State      { return s.new }
 func (s *ImportStep) Logical() bool                { return !s.replacing }
+
+// mergeSuppliedProperties fills the gaps in properties read from the provider with properties supplied
+// by the import: a supplied value is used where the read one is missing or null, so values a provider's
+// importer cannot return (e.g. write-only attributes) survive, while the provider stays authoritative
+// for everything it does return. A value that was supplied as a secret stays secret even if the
+// provider returns it in plain text.
+func mergeSuppliedProperties(read, supplied resource.PropertyMap) resource.PropertyMap {
+	if len(supplied) == 0 {
+		return read
+	}
+	merged := read.Copy()
+	for k, v := range supplied {
+		if r, has := read[k]; !has || r.IsNull() {
+			merged[k] = v
+		} else if v.IsSecret() && !r.IsSecret() {
+			merged[k] = resource.MakeSecret(r)
+		}
+	}
+	return merged
+}
 
 func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) {
 	defer func() {
@@ -1939,11 +1957,28 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 	}
 
 	// Only need to do anything here for custom resources, components just import as empty
+	suppliedInputs := s.new.Inputs
+	suppliedOutputs := s.new.Outputs
 	inputs := resource.PropertyMap{}
 	outputs := resource.PropertyMap{}
 	var prov plugin.Provider
 	rst := resource.StatusOK
-	if s.new.Custom {
+	if s.new.Custom && s.planned && len(suppliedOutputs) > 0 {
+		// The import supplied the resource's full state (e.g. from a state converter): trust it rather
+		// than reading from the provider, so the import can run without access to the underlying cloud.
+		var err error
+		prov, err = getProvider(s, s.provider)
+		if err != nil {
+			return resource.StatusOK, nil, err
+		}
+
+		s.new.Lock.Lock()
+		defer s.new.Lock.Unlock()
+
+		inputs = suppliedInputs
+		outputs = suppliedOutputs
+		s.new.ID = s.new.ImportID
+	} else if s.new.Custom {
 		// Read the current state of the resource to import. If the provider does not hand us back any inputs for the
 		// resource, it probably needs to be updated. If the resource does not exist at all, fail the import.
 		var err error
@@ -2000,6 +2035,9 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		}
 		inputs = read.Inputs
 		outputs = read.Outputs
+		if s.planned {
+			inputs = mergeSuppliedProperties(read.Inputs, suppliedInputs)
+		}
 		s.new.RefreshBeforeUpdate = read.RefreshBeforeUpdate
 	} else {
 		s.new.Lock.Lock()

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1970,19 +1970,23 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 	}
 	var prov plugin.Provider
 	rst := resource.StatusOK
-	if s.new.Custom && s.planned && len(suppliedOutputs) > 0 {
+	if s.planned && len(suppliedOutputs) > 0 {
 		// The import supplied the resource's full state (e.g. from a state converter): trust it rather
 		// than reading from the provider, so the import can run without access to the underlying cloud.
-		var err error
-		prov, err = getProvider(s, s.provider)
-		if err != nil {
-			return resource.StatusOK, nil, err
+		if s.new.Custom {
+			var err error
+			prov, err = getProvider(s, s.provider)
+			if err != nil {
+				return resource.StatusOK, nil, err
+			}
 		}
 
 		s.new.Lock.Lock()
 		defer s.new.Lock.Unlock()
 
-		s.new.ID = s.new.ImportID
+		if s.new.Custom {
+			s.new.ID = s.new.ImportID
+		}
 	} else if s.new.Custom {
 		// Read the current state of the resource to import. If the provider does not hand us back any inputs for the
 		// resource, it probably needs to be updated. If the resource does not exist at all, fail the import.

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1960,19 +1960,13 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 	suppliedOutputs := s.new.Outputs
 	inputs := resource.PropertyMap{}
 	outputs := resource.PropertyMap{}
-	if s.planned {
-		if suppliedInputs != nil {
-			inputs = suppliedInputs
-		}
-		if suppliedOutputs != nil {
-			outputs = suppliedOutputs
-		}
-	}
 	var prov plugin.Provider
 	rst := resource.StatusOK
-	if s.planned && len(suppliedOutputs) > 0 {
+	if len(suppliedOutputs) > 0 {
 		// The import supplied the resource's full state (e.g. from a state converter): trust it rather
 		// than reading from the provider, so the import can run without access to the underlying cloud.
+		contract.Assertf(s.planned, "only planned imports may supply outputs")
+
 		if s.new.Custom {
 			var err error
 			prov, err = getProvider(s, s.provider)
@@ -1984,6 +1978,10 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		s.new.Lock.Lock()
 		defer s.new.Lock.Unlock()
 
+		if suppliedInputs != nil {
+			inputs = suppliedInputs
+		}
+		outputs = suppliedOutputs
 		if s.new.Custom {
 			s.new.ID = s.new.ImportID
 		}
@@ -2051,13 +2049,18 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 	} else {
 		s.new.Lock.Lock()
 		defer s.new.Lock.Unlock()
+
+		// Local components have no state to read; keep any inputs the import supplied.
+		if s.planned && suppliedInputs != nil {
+			inputs = suppliedInputs
+		}
 	}
 
 	s.new.Inputs = inputs
 	s.new.Outputs = outputs
-	// Magic up an old state so the frontend can display a proper diff. This state is the output of the just-executed
-	// `Read` combined with the resource identity and metadata from the desired state. This ensures that the only
-	// differences between the old and new states are between the inputs and outputs.
+	// Magic up an old state so the frontend can display a proper diff. The old state takes the same inputs and
+	// outputs as the new state (assigned just above), so any diff shown comes from later adjustments to the new
+	// state's inputs.
 	s.old = pkgresource.NewState{
 		Type:                    s.new.Type,
 		URN:                     s.new.URN,


### PR DESCRIPTION
As discussed in ideation: if outputs are supplied in the imported state, we can skip the `Read`. If outputs are not supplied, we attempt to merge the values, and always prefer the higher level of secret-ness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)