### PR TITLE
Only create Outputs when we have dependencies

### DIFF
--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -71,10 +71,12 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 		})
 	case v.IsNull():
 		r = NewNullProperty()
+	case v.IsComputed():
+		r = MakeComputed(NewProperty(""))
 	}
 
 	switch {
-	case len(v.Dependencies()) > 0 || (v.Secret() && v.IsComputed()):
+	case len(v.Dependencies()) > 0:
 		r = NewProperty(Output{
 			Element:      r,
 			Known:        !v.IsComputed(),
@@ -83,8 +85,6 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 		})
 	case v.Secret():
 		r = MakeSecret(r)
-	case v.IsComputed():
-		r = MakeComputed(NewProperty(""))
 	}
 
 	return r


### PR DESCRIPTION
The `property.Value` to `PropertyValue` compatibility converter would turn secret unknowns into `Output` values. That's not needed, we can just return them as secret computed values.