### PR TITLE
Add `--runtime-options` to `pulumi policy new`

### DIFF
--- a/changelog/pending/cli-policy-feat-20260717-214312.yaml
+++ b/changelog/pending/cli-policy-feat-20260717-214312.yaml
@@ -1,0 +1,4 @@
+component: cli/policy
+kind: feat
+body: Add `--runtime-options` to `pulumi policy new`
+time: 2026-07-17T21:43:12.954891+02:00

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -44,6 +44,7 @@ type newPolicyArgs struct {
 	force             bool
 	generateOnly      bool
 	offline           bool
+	runtimeOptions    []string
 	templateNameOrURL string
 	stdout            io.Writer
 }
@@ -96,6 +97,10 @@ func newPolicyNewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&args.offline, "offline", "o", false,
 		"Use locally cached templates without making any network requests",
+	)
+	cmd.PersistentFlags().StringSliceVar(
+		&args.runtimeOptions, "runtime-options", []string{},
+		"Additional options for the language runtime (format: key1=value1,key2=value2)",
 	)
 
 	return cmd
@@ -191,6 +196,14 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 	proj, projPath, root, err := ReadPolicyProject(cwd)
 	if err != nil {
 		return err
+	}
+
+	for _, opt := range args.runtimeOptions {
+		parts := strings.Split(strings.TrimSpace(opt), "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid runtime option: %s", opt)
+		}
+		proj.Runtime.SetOption(parts[0], parts[1])
 	}
 
 	// Workaround for python, most of our templates don't specify a venv but we want to use one

--- a/pkg/cmd/pulumi/policy/policy_new_test.go
+++ b/pkg/cmd/pulumi/policy/policy_new_test.go
@@ -15,6 +15,8 @@
 package policy
 
 import (
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -38,6 +40,32 @@ func TestCreatingPolicyPackWithPromptedName(t *testing.T) {
 
 	assert.FileExists(t, filepath.Join(tempdir, "PulumiPolicy.yaml"))
 	assert.FileExists(t, filepath.Join(tempdir, "index.js"))
+}
+
+//nolint:paralleltest // changes directory for process
+func TestPolicyNewRuntimeOptions(t *testing.T) {
+	templateDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(templateDir, "PulumiPolicy.yaml"), []byte(`runtime: python
+version: 0.0.1
+`), 0o600)
+	require.NoError(t, err)
+
+	targetDir := t.TempDir()
+	t.Chdir(targetDir)
+	cmd := newPolicyNewCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		templateDir,
+		"--generate-only",
+		"--runtime-options", "toolchain=uv,virtualenv=.venv",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	proj, _, _, err := ReadPolicyProject(targetDir)
+	require.NoError(t, err)
+	assert.Equal(t, "uv", proj.Runtime.Options()["toolchain"])
+	assert.Equal(t, ".venv", proj.Runtime.Options()["virtualenv"])
 }
 
 //nolint:paralleltest // changes directory for process

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1282,15 +1282,14 @@ func TestPolicyPackNewGenerateOnly(t *testing.T) {
 }
 
 func TestPolicyPackNew(t *testing.T) {
-	t.Skip("https://github.com/pulumi/pulumi/issues/23969")
 	t.Parallel()
 
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 	require.False(t, e.PathExists("venv"))
-	stdout, _ := e.RunCommand("pulumi", "policy", "new", "aws-python", "--force")
+	stdout, _ := e.RunCommand(
+		"pulumi", "policy", "new", "aws-python", "--force", "--runtime-options", "toolchain=uv")
 	require.NotContains(t, stdout, "To install dependencies for the Policy Pack, run `pulumi install`")
-	require.Contains(t, stdout, "Finished creating virtual environment")
 	require.Contains(t, stdout, "Finished installing dependencies")
 	require.True(t, e.PathExists("venv"))
 }


### PR DESCRIPTION
Allow runtime-specific configuration when creating a Policy Pack, matching the support already available in `pulumi new`. For example, select the uv Python toolchain with:

```
pulumi policy new aws-python --runtime-options toolchain=uv
```

Also use this in `TestPolicyPackNew` so that the integration test uses `uv` and thus can use our dependency cooldown configuration.

Fixes https://github.com/pulumi/pulumi/issues/23969
