### PR TITLE
[esc] Project files to disk for all esc open output formats

### DIFF
--- a/changelog/pending/esc-open-detailed-file-projection.yaml
+++ b/changelog/pending/esc-open-detailed-file-projection.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: feat
+body: Project files to disk and surface their paths as environment variables for all output formats when opening an ESC environment
+time: 2026-07-20T00:00:00.000000+00:00
+custom:
+  PR: "23993"

--- a/pkg/cmd/esc/cli/env_open.go
+++ b/pkg/cmd/esc/cli/env_open.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/esc/cli/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/spf13/cobra"
@@ -120,6 +121,23 @@ func (env *envCommand) renderValue(
 		}
 	}
 
+	// Filesystem projection: materialize the environment's `files` to disk (unless path provided)
+	var environ []string
+	if len(path) == 0 {
+		var filesByKey map[string]string
+		var err error
+		_, environ, _, filesByKey, err = env.prepareEnvironment(
+			e,
+			PrepareOptions{Pretend: pretend, Quote: true, Redact: !showSecrets},
+		)
+		if err != nil {
+			// If we fail to write temporary files, print warning and continue
+			msg := fmt.Sprintf("%swarning: %v%s\n", colors.SpecWarning, err, colors.Reset)
+			fmt.Fprint(env.esc.stderr, env.esc.colors.Colorize(msg))
+		}
+		projectFilesToEnvironmentVariables(&val, filesByKey)
+	}
+
 	switch format {
 	case "json":
 		body := val.ToJSON(!showSecrets)
@@ -136,25 +154,11 @@ func (env *envCommand) renderValue(
 		enc.SetIndent("", "  ")
 		return enc.Encode(val)
 	case "dotenv":
-		_, environ, _, err := env.prepareEnvironment(
-			e,
-			PrepareOptions{Pretend: pretend, Quote: true, Redact: !showSecrets},
-		)
-		if err != nil {
-			return err
-		}
 		for _, kvp := range environ {
 			fmt.Fprintln(out, kvp)
 		}
 		return nil
 	case "shell":
-		_, environ, _, err := env.prepareEnvironment(
-			e,
-			PrepareOptions{Pretend: pretend, Quote: true, Redact: !showSecrets},
-		)
-		if err != nil {
-			return err
-		}
 		for _, kvp := range environ {
 			fmt.Fprintf(out, "export %v\n", kvp)
 		}
@@ -173,12 +177,40 @@ func (env *envCommand) renderValue(
 	}
 }
 
+// projectFilesToEnvironmentVariables adds an entry to the environmentVariables map for each projected file.
+func projectFilesToEnvironmentVariables(val *esc.Value, filesByKey map[string]string) {
+	if len(filesByKey) == 0 {
+		return
+	}
+	top, ok := val.Value.(map[string]esc.Value)
+	if !ok {
+		return
+	}
+	files, _ := top["files"].Value.(map[string]esc.Value)
+
+	envVars, ok := top["environmentVariables"].Value.(map[string]esc.Value)
+	if !ok {
+		envVars = map[string]esc.Value{}
+		top["environmentVariables"] = esc.NewValue(envVars)
+	}
+
+	for k, path := range filesByKey {
+		node := esc.NewValue(path)
+		if files[k].Secret {
+			node = esc.NewSecret(path)
+		}
+		node.Trace = files[k].Trace
+		envVars[k] = node
+	}
+}
+
 // prepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
-// temporary files, environment variable pairs, and secret values.
+// temporary files, environment variable pairs, secret values, and a map from each temporary file's environment
+// variable name to its projected path.
 func (env *envCommand) prepareEnvironment(
 	e *esc.Environment,
 	opts PrepareOptions,
-) (files, environ, secrets []string, err error) {
+) (files, environ, secrets []string, filesByKey map[string]string, err error) {
 	opts.fs = env.esc.fs
 	return PrepareEnvironment(e, &opts)
 }

--- a/pkg/cmd/esc/cli/env_run.go
+++ b/pkg/cmd/esc/cli/env_run.go
@@ -165,7 +165,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return envcmd.writePropertyEnvironmentDiagnostics(envcmd.esc.stderr, diags)
 			}
 
-			files, environ, secrets, err := envcmd.prepareEnvironment(env, PrepareOptions{})
+			files, environ, secrets, _, err := envcmd.prepareEnvironment(env, PrepareOptions{})
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/esc/cli/prepare.go
+++ b/pkg/cmd/esc/cli/prepare.go
@@ -70,11 +70,15 @@ func removeTemporaryFiles(fs escFS, paths []string) {
 	}
 }
 
-func createTemporaryFiles(e *esc.Environment, opts PrepareOptions) (paths, environ, secrets []string, err error) {
+func createTemporaryFiles(
+	e *esc.Environment,
+	opts PrepareOptions,
+) (paths, environ, secrets []string, filesByKey map[string]string, err error) {
 	files := e.GetTemporaryFiles()
 	keys := maps.Keys(files)
 	sort.Strings(keys)
 
+	filesByKey = make(map[string]string, len(keys))
 	for _, k := range keys {
 		v := files[k]
 		s := v.Value.(string)
@@ -88,16 +92,17 @@ func createTemporaryFiles(e *esc.Environment, opts PrepareOptions) (paths, envir
 			path, err = createTemporaryFile(opts.fs, []byte(s))
 			if err != nil {
 				removeTemporaryFiles(opts.fs, paths)
-				return nil, nil, nil, err
+				return nil, nil, nil, nil, err
 			}
 			paths = append(paths, path)
 		}
+		filesByKey[k] = path
 		if opts.Quote {
 			path = strconv.Quote(path)
 		}
 		environ = append(environ, fmt.Sprintf("%v=%v", k, path))
 	}
-	return paths, environ, secrets, nil
+	return paths, environ, secrets, filesByKey, nil
 }
 
 // PrepareOptions contains options for PrepareEnvironment.
@@ -110,8 +115,12 @@ type PrepareOptions struct {
 }
 
 // PrepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
-// temporary files, environment variable pairs, and secret values.
-func PrepareEnvironment(e *esc.Environment, opts *PrepareOptions) (files, environ, secrets []string, err error) {
+// temporary files, environment variable pairs, secret values, and a map from each temporary file's environment
+// variable name to its projected path.
+func PrepareEnvironment(
+	e *esc.Environment,
+	opts *PrepareOptions,
+) (files, environ, secrets []string, filesByKey map[string]string, err error) {
 	if opts == nil {
 		opts = &PrepareOptions{}
 	}
@@ -121,12 +130,12 @@ func PrepareEnvironment(e *esc.Environment, opts *PrepareOptions) (files, enviro
 
 	envVars, envSecrets := getEnvironmentVariables(e, opts.Quote, opts.Redact)
 
-	filePaths, fileVars, fileSecrets, err := createTemporaryFiles(e, *opts)
+	filePaths, fileVars, fileSecrets, filesByKey, err := createTemporaryFiles(e, *opts)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("creating temporary files: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("creating temporary files: %v", err)
 	}
 
 	environ = append(envVars, fileVars...)
 	secrets = append(envSecrets, fileSecrets...)
-	return filePaths, environ, secrets, nil
+	return filePaths, environ, secrets, filesByKey, nil
 }

--- a/pkg/cmd/esc/cli/testdata/open-detailed-files.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-detailed-files.yaml
@@ -1,0 +1,143 @@
+run: esc open default/test --format detailed
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      environmentVariables:
+        FOO: ${foo}
+      files:
+        FILE: hello
+
+---
+> esc open default/test --format detailed
+{
+  "value": {
+    "environmentVariables": {
+      "value": {
+        "FILE": {
+          "value": "temp/esc-temp-0",
+          "trace": {
+            "def": {
+              "environment": "test",
+              "begin": {
+                "line": 6,
+                "column": 15,
+                "byte": 92
+              },
+              "end": {
+                "line": 6,
+                "column": 20,
+                "byte": 97
+              }
+            }
+          }
+        },
+        "FOO": {
+          "value": "bar",
+          "trace": {
+            "def": {
+              "environment": "test",
+              "begin": {
+                "line": 4,
+                "column": 14,
+                "byte": 60
+              },
+              "end": {
+                "line": 4,
+                "column": 20,
+                "byte": 66
+              }
+            }
+          }
+        }
+      },
+      "trace": {
+        "def": {
+          "environment": "test",
+          "begin": {
+            "line": 4,
+            "column": 9,
+            "byte": 55
+          },
+          "end": {
+            "line": 4,
+            "column": 20,
+            "byte": 66
+          }
+        }
+      }
+    },
+    "files": {
+      "value": {
+        "FILE": {
+          "value": "hello",
+          "trace": {
+            "def": {
+              "environment": "test",
+              "begin": {
+                "line": 6,
+                "column": 15,
+                "byte": 92
+              },
+              "end": {
+                "line": 6,
+                "column": 20,
+                "byte": 97
+              }
+            }
+          }
+        }
+      },
+      "trace": {
+        "def": {
+          "environment": "test",
+          "begin": {
+            "line": 6,
+            "column": 9,
+            "byte": 86
+          },
+          "end": {
+            "line": 6,
+            "column": 20,
+            "byte": 97
+          }
+        }
+      }
+    },
+    "foo": {
+      "value": "bar",
+      "trace": {
+        "def": {
+          "environment": "test",
+          "begin": {
+            "line": 2,
+            "column": 10,
+            "byte": 17
+          },
+          "end": {
+            "line": 2,
+            "column": 13,
+            "byte": 20
+          }
+        }
+      }
+    }
+  },
+  "trace": {
+    "def": {
+      "begin": {
+        "line": 0,
+        "column": 0,
+        "byte": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 0,
+        "byte": 0
+      }
+    }
+  }
+}
+
+---
+> esc open default/test --format detailed

--- a/pkg/cmd/esc/cli/testdata/open-json-files.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-json-files.yaml
@@ -1,0 +1,25 @@
+run: esc open default/test --format json
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      environmentVariables:
+        FOO: ${foo}
+      files:
+        FILE: hello
+
+---
+> esc open default/test --format json
+{
+  "environmentVariables": {
+    "FILE": "temp/esc-temp-0",
+    "FOO": "bar"
+  },
+  "files": {
+    "FILE": "hello"
+  },
+  "foo": "bar"
+}
+
+---
+> esc open default/test --format json

--- a/pkg/cmd/esc/cli/testdata/open-string-files.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-string-files.yaml
@@ -1,0 +1,16 @@
+run: esc open default/test --format string
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      environmentVariables:
+        FOO: ${foo}
+      files:
+        FILE: hello
+
+---
+> esc open default/test --format string
+"environmentVariables"="\"FILE\"=\"temp/esc-temp-0\",\"FOO\"=\"bar\"","files"="\"FILE\"=\"hello\"","foo"="bar"
+
+---
+> esc open default/test --format string

--- a/pkg/cmd/esc/cli/testdata/open-yaml-files.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-yaml-files.yaml
@@ -1,0 +1,21 @@
+run: esc open default/test --format yaml
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      environmentVariables:
+        FOO: ${foo}
+      files:
+        FILE: hello
+
+---
+> esc open default/test --format yaml
+environmentVariables:
+   FILE: temp/esc-temp-0
+   FOO: bar
+files:
+   FILE: hello
+foo: bar
+
+---
+> esc open default/test --format yaml

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -1253,7 +1253,7 @@ func listConfig(
 		}, nil)
 
 		if env != nil {
-			_, environ, _, err := cli.PrepareEnvironment(env, &cli.PrepareOptions{
+			_, environ, _, _, err := cli.PrepareEnvironment(env, &cli.PrepareOptions{
 				Pretend: !openEnvironment,
 				Redact:  !showSecrets,
 			})

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -151,7 +151,7 @@ func getStackConfigurationFromProjectStack(
 
 		pulumiEnv = env.Properties["pulumiConfig"]
 
-		_, environ, secrets, err := cli.PrepareEnvironment(env, nil)
+		_, environ, secrets, _, err := cli.PrepareEnvironment(env, nil)
 		if err != nil {
 			return backend.StackConfiguration{}, fmt.Errorf("preparing environment: %w", err)
 		}


### PR DESCRIPTION
Perform filesystem projection on all esc open formats

Also show warning (but continue with open) if writing temp files fails.

## Testing
Tested with the following env
```
values:
  files:
    FILE1: hello
    FILE2:
      fn::secret:
        ciphertext: xxx
    ENV_VAR2: from file
  environmentVariables:
    ENV_VAR1: hi
    ENV_VAR2: hi
```

Tested with various formats, file projection works
```
❯ pulumi env open delme/aaa/test-files --format detailed
{
  "value": {
    "environmentVariables": {
      "value": {
        "ENV_VAR1": {
          "value": "hi",
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 9,
                "column": 15,
                "byte": 246
              },
              "end": {
                "line": 9,
                "column": 17,
                "byte": 248
              }
            }
          }
        },
        "ENV_VAR2": {
          "value": "/var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-3388321017",
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 7,
                "column": 15,
                "byte": 198
              },
              "end": {
                "line": 7,
                "column": 24,
                "byte": 207
              }
            }
          }
        },
        "FILE1": {
          "value": "/var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-1530806547",
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 3,
                "column": 12,
                "byte": 28
              },
              "end": {
                "line": 3,
                "column": 17,
                "byte": 33
              }
            }
          }
        },
        "FILE2": {
          "value": "/var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-3916225905",
          "secret": true,
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 5,
                "column": 7,
                "byte": 51
              },
              "end": {
                "line": 6,
                "column": 121,
                "byte": 183
              }
            }
          }
        }
      },
      "trace": {
        "def": {
          "environment": "aaa/test-files",
          "begin": {
            "line": 9,
            "column": 5,
            "byte": 236
          },
          "end": {
            "line": 10,
            "column": 17,
            "byte": 265
          }
        }
      }
    },
    "files": {
      "value": {
        "ENV_VAR2": {
          "value": "from file",
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 7,
                "column": 15,
                "byte": 198
              },
              "end": {
                "line": 7,
                "column": 24,
                "byte": 207
              }
            }
          }
        },
        "FILE1": {
          "value": "hello",
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 3,
                "column": 12,
                "byte": 28
              },
              "end": {
                "line": 3,
                "column": 17,
                "byte": 33
              }
            }
          }
        },
        "FILE2": {
          "value": "my-secret-value",
          "secret": true,
          "trace": {
            "def": {
              "environment": "aaa/test-files",
              "begin": {
                "line": 5,
                "column": 7,
                "byte": 51
              },
              "end": {
                "line": 6,
                "column": 121,
                "byte": 183
              }
            }
          }
        }
      },
      "trace": {
        "def": {
          "environment": "aaa/test-files",
          "begin": {
            "line": 3,
            "column": 5,
            "byte": 21
          },
          "end": {
            "line": 7,
            "column": 24,
            "byte": 207
          }
        }
      }
    }
  },
  "trace": {
    "def": {
      "begin": {
        "line": 0,
        "column": 0,
        "byte": 0
      },
      "end": {
        "line": 0,
        "column": 0,
        "byte": 0
      }
    }
  }
```

```
❯ \cat /var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-3388321017
from file%
```

```
❮ pulumi env open delme/aaa/test-files --format yaml
environmentVariables:
   ENV_VAR1: hi
   ENV_VAR2: /var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-4178311273
   FILE1: /var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-1816440638
   FILE2: /var/folders/5k/mrkdtb8928ggg6_gv_jctgp00000gn/T/esc-3231041547
files:
   ENV_VAR2: from file
   FILE1: hello
   FILE2: my-secret-value
```

making the create temp files fail will now show a warning on open
```
❯ TMPDIR=<read-only-directory> pulumi env open delme/aaa/test-files --format yaml
warning: creating temporary files: open <read-only-directory>: permission denied
environmentVariables:
   ENV_VAR1: hi
   ENV_VAR2: hi
files:
   ENV_VAR2: from file
   FILE1: hello
   FILE2: my-secret-value
```


