### PR TITLE
Add create to stateful do

### DIFF
--- a/changelog/pending/cli-do-feat-20260721-032930.yaml
+++ b/changelog/pending/cli-do-feat-20260721-032930.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: feat
+body: Add support for stateful create
+time: 2026-07-21T03:29:30.705192+01:00

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -458,7 +458,7 @@ to use another format.`,
 	cmd.PersistentFlags().BoolVar(&stateless, "stateless", false,
 		"Run create/patch/delete directly against the provider without persisting state. "+
 			"Required for now: the stateful (engine-driven) implementation is still in development, "+
-			"so create/patch/delete error out unless --stateless is set.")
+			"so patch/delete error out unless --stateless is set.")
 	cmd.PersistentFlags().StringVar(
 		&pkg, "package", "", "The package to load, in the form 'name@version' or "+
 			"a path to a plugin binary or folder. If the package supports "+

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -141,7 +141,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so create/patch/delete error out unless --stateless is set.
+      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so patch/delete error out unless --stateless is set.
 `
 	assert.Equal(t, expected, stdout.String())
 }

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -89,22 +89,57 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
 			"base of the provider configuration (requires a stack context)")
 	addPersistentInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties)
-	cmd.AddCommand(pc.newResourceCreateCommand(res))
+	// `create` and `upsert` have different UX between stateful (takes a resource <name> and adds a
+	// snippet to the stack) and stateless (uses the resource type's short name and calls the
+	// provider directly), so the command trees diverge here.
+	if pc.stateless {
+		cmd.AddCommand(pc.newStatelessResourceCreateCommand(res))
+	} else {
+		cmd.AddCommand(pc.newStatefulResourceCreateCommand(res))
+		cmd.AddCommand(pc.newResourceUpsertCommand(res))
+	}
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))
 	cmd.AddCommand(pc.newResourceDeleteCommand(res))
 	if res.ListInputs != nil {
 		cmd.AddCommand(pc.newResourceListCommand(res))
 	}
-	// `upsert` is stateful-only: it adds a snippet to the stack and runs the deployment engine.
-	// In stateless mode it isn't meaningful and shouldn't show up.
-	if !pc.stateless {
-		cmd.AddCommand(pc.newResourceUpsertCommand(res))
-	}
 	return cmd
 }
 
-func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.Command {
+// newStatefulResourceCreateCommand adds a snippet to the current stack and runs the deployment
+// engine targeting only that snippet. Errors if a snippet with the same (Name, Type) already
+// exists — `upsert` is the command for replacing one in place.
+func (pc *packageCommand) newStatefulResourceCreateCommand(res *schema.Resource) *cobra.Command {
+	var inputFile string
+	var inputFormat string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a resource",
+		Long: "Create a resource.\n\n" +
+			"The created resource is tracked in the stack, so Pulumi can manage its lifecycle. " +
+			"Fails if a resource with the given name already exists — use `upsert` to replace " +
+			"one in place.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contract.Assertf(!pc.stateless, "stateful create should not be registered in stateless mode")
+			return pc.runStatefulSnippetUpdate(cmd, statefulSnippetUpdate{
+				res:          res,
+				name:         args[0],
+				inputFile:    inputFile,
+				inputFormat:  inputFormat,
+				yes:          yes,
+				verb:         "created",
+				requireFresh: true,
+			})
+		},
+	}
+	addStatefulSnippetUpdateFlags(cmd, &inputFile, &inputFormat, &yes, res.InputProperties)
+	return cmd
+}
+
+func (pc *packageCommand) newStatelessResourceCreateCommand(res *schema.Resource) *cobra.Command {
 	var inputFile string
 	var yes bool
 	cmd := &cobra.Command{
@@ -112,9 +147,7 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 		Short: "Create a resource",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !pc.stateless {
-				return errStatefulNotImplemented("create")
-			}
+			contract.Assertf(pc.stateless, "stateless create should not be registered in stateful mode")
 			if err := pc.requireYesIfNonInteractive(yes); err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -150,7 +150,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so create/patch/delete error out unless --stateless is set.
+      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so patch/delete error out unless --stateless is set.
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
@@ -201,7 +201,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so create/patch/delete error out unless --stateless is set.
+      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so patch/delete error out unless --stateless is set.
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -91,110 +91,152 @@ func (pc *packageCommand) newResourceUpsertCommand(res *schema.Resource) *cobra.
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			contract.Assertf(!pc.stateless, "upsert should not be registered in stateless mode")
-			contract.Assertf(pc.runStatefulUpdate != nil, "stateful `upsert` is not wired up in this build")
-
-			if pc.proj == nil {
-				return errors.New("`upsert` requires a Pulumi project (run inside a project directory)")
-			}
-			if err := pc.requireYesIfNonInteractive(yes); err != nil {
-				return err
-			}
-			name := args[0]
-
-			ctx := cmd.Context()
-
-			// Merge --input-* flags into the file's PCL AST so the persisted snippet body
-			// matches what the user typed on the command line. If no file was provided,
-			// the flags become the snippet body by themselves.
-			inputFlags := collectInputFlags(cmd, "input", res.InputProperties)
-			code, _, err := parseFile(
-				ctx, inputFile, "input", inputFormat, res.Token,
-				pc.converter, pc.loaderTarget, pc.packageDescriptor, inputFlags,
-			)
-			if err != nil {
-				return fmt.Errorf("read input file: %w", err)
-			}
-
-			// Open the stack up front so we can look at the existing snapshot before deciding
-			// whether this upsert is a create (new snippet) or an update (existing snippet with
-			// the same Name+Type). The stack is threaded through to runStatefulUpdate so it
-			// doesn't re-load.
-			displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
-			stack, err := cmdStack.RequireStack(
-				ctx, pc.diagFwd, pc.ws, pc.lm,
-				"",                                 /*stackName — use currently selected*/
-				cmdStack.LoadOnly, displayOpts, "", /*configFile*/
-			)
-			if err != nil {
-				return fmt.Errorf("load stack: %w", err)
-			}
-			snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
-			if err != nil {
-				return fmt.Errorf("load stack snapshot: %w", err)
-			}
-
-			// Snippet identity in the snapshot is (Name, Type) — reuse the existing UUID so the
-			// engine's applySnippetUpdates path replaces the snippet in place rather than adding
-			// a duplicate that would then race to register the same URN.
-			snippetUUID, err := resolveSnippetUUID(snap, name, res.Token)
-			if err != nil {
-				return err
-			}
-			snippet := resource.Snippet{
-				UUID:       snippetUUID,
-				Name:       name,
-				Type:       res.Token,
-				Code:       string(code),
-				Descriptor: packageDescriptorFromProto(pc.packageDescriptor),
-			}
-
-			result, err := pc.runStatefulUpdate(ctx, cmd.Flags(), StatefulUpdateRequest{
-				Snippet:     snippet,
-				Stack:       stack,
-				DryRun:      pc.dryrun,
-				Yes:         yes,
-				ShowSecrets: pc.showSecrets,
-				Proj:        pc.proj,
-				Root:        pc.root,
-				Sink:        pc.diagFwd,
+			return pc.runStatefulSnippetUpdate(cmd, statefulSnippetUpdate{
+				res:          res,
+				name:         args[0],
+				inputFile:    inputFile,
+				inputFormat:  inputFormat,
+				yes:          yes,
+				verb:         "upserted",
+				requireFresh: false,
 			})
-			if err != nil {
-				return err
-			}
-			if result != nil && !pc.dryrun {
-				fmt.Fprintf(cmd.OutOrStdout(), "upserted %s (snippet %s)\n", name, result.SnippetUUID)
-			}
-			return nil
 		},
 	}
-	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
-	cmd.Flags().StringVar(&inputFormat, "input", "yaml",
-		"Format of the resource inputs file (any language name supported by an installed converter)")
-	cmd.Flags().BoolVar(&yes, "yes", false,
-		"Automatically approve and perform the operation without a confirmation prompt")
-	addInputFlags(cmd, "input", res.InputProperties)
+	addStatefulSnippetUpdateFlags(cmd, &inputFile, &inputFormat, &yes, res.InputProperties)
 	return cmd
 }
 
+// statefulSnippetUpdate carries the pieces of a stateful snippet-add operation (create / upsert)
+// that vary between commands. Everything else — parsing the input file, loading the stack,
+// resolving the snippet UUID, and dispatching to runStatefulUpdate — is shared.
+type statefulSnippetUpdate struct {
+	res         *schema.Resource
+	name        string
+	inputFile   string
+	inputFormat string
+	yes         bool
+	verb        string // completion-message verb, e.g. "created" or "upserted"
+	// requireFresh errors when a snippet with the same (Name, Type) already exists in the stack —
+	// the invariant `create` enforces to distinguish itself from `upsert`.
+	requireFresh bool
+}
+
+// runStatefulSnippetUpdate is the shared body of `create` (with requireFresh=true) and `upsert`
+// (with requireFresh=false). Both take the same inputs, differ only in the pre-run policy check
+// against any existing snippet with the same (Name, Type).
+func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args statefulSnippetUpdate) error {
+	contract.Assertf(pc.runStatefulUpdate != nil, "stateful snippet update is not wired up in this build")
+
+	if pc.proj == nil {
+		return fmt.Errorf("`%s` requires a Pulumi project (run inside a project directory)", cmd.Name())
+	}
+	if err := pc.requireYesIfNonInteractive(args.yes); err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	// Merge --input-* flags into the file's PCL AST so the persisted snippet body matches what
+	// the user typed on the command line. If no file was provided, the flags become the snippet
+	// body by themselves.
+	inputFlags := collectInputFlags(cmd, "input", args.res.InputProperties)
+	code, _, err := parseFile(
+		ctx, args.inputFile, "input", args.inputFormat, args.res.Token,
+		pc.converter, pc.loaderTarget, pc.packageDescriptor, inputFlags,
+	)
+	if err != nil {
+		return fmt.Errorf("read input file: %w", err)
+	}
+
+	// Open the stack up front so we can look at the existing snapshot before deciding whether
+	// this operation is legal (create requires a fresh snippet, upsert accepts either). The
+	// stack is threaded through to runStatefulUpdate so it doesn't re-load.
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	stack, err := cmdStack.RequireStack(
+		ctx, pc.diagFwd, pc.ws, pc.lm,
+		"",                                 /*stackName — use currently selected*/
+		cmdStack.LoadOnly, displayOpts, "", /*configFile*/
+	)
+	if err != nil {
+		return fmt.Errorf("load stack: %w", err)
+	}
+	snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
+	if err != nil {
+		return fmt.Errorf("load stack snapshot: %w", err)
+	}
+
+	// Snippet identity in the snapshot is (Name, Type) — reuse the existing UUID so the engine's
+	// applySnippetUpdates path replaces the snippet in place rather than adding a duplicate that
+	// would then race to register the same URN.
+	snippetUUID, existed, err := resolveSnippetUUID(snap, args.name, args.res.Token)
+	if err != nil {
+		return err
+	}
+	if args.requireFresh && existed {
+		return fmt.Errorf("resource %s %q already exists in stack %s; use `upsert` to replace it",
+			args.res.Token, args.name, stack.Ref())
+	}
+	snippet := resource.Snippet{
+		UUID:       snippetUUID,
+		Name:       args.name,
+		Type:       args.res.Token,
+		Code:       string(code),
+		Descriptor: packageDescriptorFromProto(pc.packageDescriptor),
+	}
+
+	result, err := pc.runStatefulUpdate(ctx, cmd.Flags(), StatefulUpdateRequest{
+		Snippet:     snippet,
+		Stack:       stack,
+		DryRun:      pc.dryrun,
+		Yes:         args.yes,
+		ShowSecrets: pc.showSecrets,
+		Proj:        pc.proj,
+		Root:        pc.root,
+		Sink:        pc.diagFwd,
+	})
+	if err != nil {
+		return err
+	}
+	if result != nil && !pc.dryrun {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s (snippet %s)\n", args.verb, args.name, result.SnippetUUID)
+	}
+	return nil
+}
+
+// addStatefulSnippetUpdateFlags installs the flag set shared by stateful `create` and `upsert`.
+func addStatefulSnippetUpdateFlags(
+	cmd *cobra.Command, inputFile, inputFormat *string, yes *bool, inputs []*schema.Property,
+) {
+	cmd.Flags().StringVar(inputFile, "input-file", "", "Path to a file containing resource inputs")
+	cmd.Flags().StringVar(inputFormat, "input", "yaml",
+		"Format of the resource inputs file (any language name supported by an installed converter)")
+	cmd.Flags().BoolVar(yes, "yes", false,
+		"Automatically approve and perform the operation without a confirmation prompt")
+	addInputFlags(cmd, "input", inputs)
+}
+
 // resolveSnippetUUID looks up an existing snippet in snap matching (name, resourceToken) and
-// returns its UUID for reuse; otherwise it mints a fresh UUIDv4.
+// returns its UUID for reuse (with existed=true); otherwise it mints a fresh UUIDv4 (existed=false).
+// Callers use existed to enforce operation-specific invariants: stateful `create` errors when a
+// snippet already exists, `upsert` doesn't care, and (future) stateful `delete` errors when it
+// doesn't.
 //
 // Snippet identity within a snapshot is (Name, Type): a second snippet with the same pair would
-// register the same resource URN and race with the first, so upsert always resolves to the
-// existing entry when one is present.
-func resolveSnippetUUID(snap *deploy.Snapshot, name, resourceToken string) (string, error) {
+// register the same resource URN and race with the first, so any resolver that reuses an existing
+// entry is preserving that invariant.
+func resolveSnippetUUID(snap *deploy.Snapshot, name, resourceToken string) (string, bool, error) {
 	if snap != nil {
 		for _, existing := range snap.Snippets {
 			if existing.Name == name && existing.Type == resourceToken {
-				return existing.UUID, nil
+				return existing.UUID, true, nil
 			}
 		}
 	}
 	fresh, err := uuid.NewV4()
 	if err != nil {
-		return "", fmt.Errorf("generate snippet uuid: %w", err)
+		return "", false, fmt.Errorf("generate snippet uuid: %w", err)
 	}
-	return fresh.String(), nil
+	return fresh.String(), false, nil
 }
 
 // DefaultRunStatefulUpdate is the production implementation of the runStatefulUpdate hook. The

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -318,6 +318,98 @@ func TestDoCmdResourceUpsertHiddenInStatelessMode(t *testing.T) {
 	assert.NotContains(t, stdout.String(), "upsert")
 }
 
+// TestDoCmdResourceStatefulCreateConstructsSnippet mirrors the upsert-constructs-snippet test but
+// for stateful `create`: the CLI takes a name arg, mints a fresh UUID, hands the snippet to
+// runStatefulUpdate, and the completion line uses "created" rather than "upserted".
+//
+//nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
+func TestDoCmdResourceStatefulCreateConstructsSnippet(t *testing.T) {
+	mws, mlm := installMockUpsertBackend(t, &deploy.Snapshot{})
+
+	var got StatefulUpdateRequest
+	var called bool
+	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
+	) (*StatefulUpdateResult, error) {
+		called = true
+		got = req
+		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+	}
+	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
+		return &testProvider{spec: doResourceSpec(false)}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, stub)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	inputFile := writeHCLFile(t, "create.pcl", `name = "example"`)
+	cmd.SetArgs([]string{
+		"azure:index:myResource", "create", "myres", "--yes",
+		"--input", "pcl", "--input-file", inputFile,
+	})
+	require.NoError(t, cmd.Execute())
+
+	require.True(t, called, "runStatefulUpdate should have been invoked")
+	assert.Equal(t, "myres", got.Snippet.Name)
+	assert.Equal(t, "azure:index:myResource", got.Snippet.Type)
+	assert.Contains(t, got.Snippet.Code, `name = "example"`)
+	require.NotEmpty(t, got.Snippet.UUID)
+	assert.Contains(t, stdout.String(), "created myres")
+	_ = stderr
+}
+
+// TestDoCmdResourceStatefulCreateRejectsExisting checks the invariant that distinguishes create
+// from upsert: if a snippet with the same (Name, Type) already lives in the snapshot, create
+// refuses rather than replacing it in place.
+//
+//nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
+func TestDoCmdResourceStatefulCreateRejectsExisting(t *testing.T) {
+	existing := resource.Snippet{
+		UUID: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+		Name: "myres", Type: "azure:index:myResource",
+		Code:       `name = "old"`,
+		Descriptor: resource.PackageDescriptor{Name: "azure"},
+	}
+	mws, mlm := installMockUpsertBackend(t, &deploy.Snapshot{Snippets: []resource.Snippet{existing}})
+
+	stub := func(_ context.Context, _ *pflag.FlagSet, _ StatefulUpdateRequest,
+	) (*StatefulUpdateResult, error) {
+		require.Fail(t, "runStatefulUpdate should not be called when the snippet already exists")
+		return nil, nil
+	}
+	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
+		return &testProvider{spec: doResourceSpec(false)}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, stub)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	inputFile := writeHCLFile(t, "create.pcl", `name = "new"`)
+	cmd.SetArgs([]string{
+		"azure:index:myResource", "create", "myres", "--yes",
+		"--input", "pcl", "--input-file", inputFile,
+	})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "already exists")
+	require.ErrorContains(t, err, "upsert")
+	_ = stdout
+	_ = stderr
+}
+
+// TestDoCmdResourceCreateStatelessTakesNoNameArg pins the diverging UX between the two `create`
+// variants: stateless `create` uses the resource type's short name (no positional arg), stateful
+// `create` requires an explicit `<name>`.
+func TestDoCmdResourceCreateStatelessTakesNoNameArg(t *testing.T) {
+	t.Parallel()
+
+	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
+	cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "create", "myres"})
+	err := cmd.Execute()
+	require.Error(t, err, "stateless create should reject a positional name arg")
+	_ = stdout
+}
+
 // TestDoCmdResourceUpsertMergesInputFlags verifies that --input-* flags are merged into the
 // snippet body at the PCL AST layer: the flag value replaces (or is added alongside) attributes
 // from --input-file so what the engine persists matches what the user typed on the command line.


### PR DESCRIPTION
This adds stateful support for `do`. This is very similar to `upsert` but we check the snippet is new. 

Refactors a load of upsert code to be shared.