### PR TITLE
Remove some outdated dependencies

### DIFF
--- a/pkg/cmd/esc/analysis/common_test.go
+++ b/pkg/cmd/esc/analysis/common_test.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/eval"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/schema"
-	"golang.org/x/exp/maps"
 )
 
 var testProviderSchema = schema.Object().
@@ -129,9 +129,7 @@ values:
 `
 
 func sortedKeys[T any](m map[string]T) []string {
-	keys := maps.Keys(m)
-	sort.Strings(keys)
-	return keys
+	return slices.Sorted(maps.Keys(m))
 }
 
 func visitExprs(env *esc.Environment, visitor func(path string, x esc.Expr)) {

--- a/pkg/cmd/esc/cli/prepare.go
+++ b/pkg/cmd/esc/cli/prepare.go
@@ -16,18 +16,17 @@ package cli
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"golang.org/x/exp/maps"
 )
 
 func getEnvironmentVariables(env *esc.Environment, quote, redact bool) (environ, secrets []string) {
 	vars := env.GetEnvironmentVariables()
-	keys := maps.Keys(vars)
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(vars))
 
 	for _, k := range keys {
 		v := vars[k]
@@ -72,8 +71,7 @@ func removeTemporaryFiles(fs escFS, paths []string) {
 
 func createTemporaryFiles(e *esc.Environment, opts PrepareOptions) (paths, environ, secrets []string, err error) {
 	files := e.GetTemporaryFiles()
-	keys := maps.Keys(files)
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(files))
 
 	for _, k := range keys {
 		v := files[k]

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
-	"github.com/acarl005/stripansi"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -265,5 +265,5 @@ func newConfigEnvCmdForInitTest(
 // cleanStdout strips ANSI escape codes and carriage returns from captured output so
 // assertions can compare plain text.
 func cleanStdout(stdout string) string {
-	return strings.ReplaceAll(stripansi.Strip(stdout), "\r", "")
+	return strings.ReplaceAll(ansi.Strip(stdout), "\r", "")
 }

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -57,9 +57,7 @@ func panicHandler(finished *bool) {
 }
 
 func main() {
-	// Fix for https://github.com/pulumi/pulumi/issues/18814, set GOMAXPROCs to the number of CPUs available
-	// taking into account quotas and cgroup limits.
-	maxprocs.Set() //nolint:errcheck // we don't care if this fails
+	maxprocs.Set() //nolint:errcheck
 
 	finished := new(bool)
 	defer panicHandler(finished)

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -25,7 +25,7 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/acarl005/stripansi"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -240,7 +240,7 @@ func TestNewModel_InitialViewDoesNotWrapPlaceholderToTinyWidth(t *testing.T) {
 	t.Parallel()
 
 	m := NewModel(ModelConfig{Busy: true, InitialWidth: 215})
-	view := stripansi.Strip(m.viewString())
+	view := ansi.Strip(m.viewString())
 
 	assert.Equal(t, 215, m.width)
 	assert.Equal(t, 211, m.liveWidth())
@@ -248,13 +248,13 @@ func TestNewModel_InitialViewDoesNotWrapPlaceholderToTinyWidth(t *testing.T) {
 		"first frame before WindowSizeMsg must render the full placeholder")
 
 	m.textInput.SetWidth(2)
-	view = stripansi.Strip(m.viewString())
+	view = ansi.Strip(m.viewString())
 	assert.Contains(t, view, "Send a message...",
 		"empty input render must not trust a stale tiny textarea viewport")
 
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 4, Height: 79})
 	um := updated.(Model)
-	view = stripansi.Strip(um.viewString())
+	view = ansi.Strip(um.viewString())
 
 	assert.Equal(t, 215, um.width)
 	assert.Equal(t, 211, um.liveWidth())
@@ -2328,7 +2328,7 @@ func TestModel_LiveView_OnlyShowsLiveBlocks(t *testing.T) {
 	view := m.viewString()
 	// Live blocks are visible. Shimmer styles each char with its own ANSI
 	// run, so strip escapes before substring-matching the label.
-	assert.Contains(t, stripansi.Strip(view), "Thinking", "busy label must appear in View")
+	assert.Contains(t, ansi.Strip(view), "Thinking", "busy label must appear in View")
 	// Committed blocks are NOT visible — they were emitted to scrollback.
 	assert.NotContains(t, view, "USERSCROLLBACK")
 	assert.NotContains(t, view, "TOOLCOMPLETESCROLLBACK")
@@ -2672,7 +2672,7 @@ func TestModel_PrepareInitialScrollbackSuppressesFirstFlush(t *testing.T) {
 	})
 
 	prepared, rendered := m.prepareInitialScrollback(100, 30)
-	stripped := stripansi.Strip(rendered)
+	stripped := ansi.Strip(rendered)
 	assert.Contains(t, stripped, "historical prompt")
 	assert.Contains(t, stripped, "historical answer")
 	assert.True(t, prepared.sizeReceived)
@@ -2794,7 +2794,7 @@ func TestView_LeadingBlankLine_Idle(t *testing.T) {
 	// After the leading blank, the next thing must be the prompt — not a
 	// second blank line. The textarea wraps the "❯ " prompt in ANSI escapes,
 	// so strip them before doing the prefix check.
-	stripped := stripansi.Strip(view)
+	stripped := ansi.Strip(view)
 	assert.True(t, strings.HasPrefix(stripped, "\n❯ "),
 		"idle View() must put the prompt immediately after the leading blank; got: %q", stripped)
 }
@@ -2807,7 +2807,7 @@ func TestView_LeadingBlankLine_Busy_SpinnerFlushWithPrompt(t *testing.T) {
 	m.height = 24
 	m.blocks = []block{{kind: blockBusy, label: "Thinking...", shimmer: shimmerVerb}}
 
-	view := stripansi.Strip(m.viewString())
+	view := ansi.Strip(m.viewString())
 	require.True(t, strings.HasPrefix(view, "\n"),
 		"View() must start with a blank line above the live frame; got: %q", view)
 
@@ -2834,7 +2834,7 @@ func TestLiveView_BlankBetweenLiveBlocks(t *testing.T) {
 		{kind: blockBusy, label: "Thinking...", shimmer: shimmerVerb},
 	}
 
-	live := stripansi.Strip(m.liveView())
+	live := ansi.Strip(m.liveView())
 	require.Contains(t, live, "PULUMI_LIVE")
 	require.Contains(t, live, "Thinking")
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -57,10 +57,9 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/chroma/v2 v2.13.0
 	github.com/aws/aws-sdk-go-v2 v1.41.11
 	github.com/aws/aws-sdk-go-v2/config v1.32.20
@@ -72,6 +71,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.3
 	github.com/ccojocar/zxcvbn-go v1.0.1
 	github.com/charmbracelet/glamour v0.6.0
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/deckarep/golang-set/v2 v2.5.0
 	github.com/edsrzf/mmap-go v1.1.0
@@ -115,7 +115,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/automaxprocs v1.6.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/mod v0.37.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
@@ -136,8 +135,6 @@ require (
 	cloud.google.com/go/longrunning v0.8.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -178,7 +175,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -38,10 +38,6 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 h1:m/sWOGCREuSBqg2htVQTBY8nOZpyajYztF0vUvSZTuM=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0/go.mod h1:Pu5Zksi2KrU7LPbZbNINx6fuVrUp/ffvpxdDj+i8LeE=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGluTesZZ+ttN/MDsnMmQP36OSnDuSXqw=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=
@@ -76,8 +72,6 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=

--- a/pkg/secrets/cloud/azure_test.go
+++ b/pkg/secrets/cloud/azure_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +47,7 @@ func createAzureKey(ctx context.Context, t *testing.T, credentials *azidentity.D
 	require.NoError(t, err)
 	keyName := "test-key-" + randomName(t)
 	keySize := int32(2048)
-	kty := azkeys.JSONWebKeyTypeRSA
+	kty := azkeys.KeyTypeRSA
 	params := azkeys.CreateKeyParameters{
 		KeySize: &keySize,
 		Kty:     &kty,

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -64,7 +64,6 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.opentelemetry.io/proto/otlp v1.10.0
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	lukechampine.com/frand v1.4.2
@@ -121,6 +120,7 @@ require (
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/sdk/go/common/esc/eval/value.go
+++ b/sdk/go/common/esc/eval/value.go
@@ -17,7 +17,8 @@ package eval
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/ast"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/syntax"
-	"golang.org/x/exp/maps"
 )
 
 // A value represents the result of evaluating an expr.
@@ -196,7 +196,7 @@ func (v *value) keys() []string {
 
 		baseKeys := v.base.keys()
 		if len(baseKeys) == 0 {
-			v.mergedKeys = maps.Keys(m)
+			v.mergedKeys = slices.Sorted(maps.Keys(m))
 		} else {
 			l := len(baseKeys)
 			if l < len(m) {
@@ -210,9 +210,8 @@ func (v *value) keys() []string {
 			for k := range m {
 				keySet[k] = struct{}{}
 			}
-			v.mergedKeys = maps.Keys(keySet)
+			v.mergedKeys = slices.Sorted(maps.Keys(keySet))
 		}
-		sort.Strings(v.mergedKeys)
 	}
 	return v.mergedKeys
 }
@@ -306,8 +305,7 @@ func (v *value) toString() (str string, unknown bool, secret bool) {
 		}
 		s = strings.Join(vals, ",")
 	case map[string]*value:
-		keys := maps.Keys(repr)
-		sort.Strings(keys)
+		keys := slices.Sorted(maps.Keys(repr))
 
 		pairs := make([]string, len(repr))
 		for i, k := range keys {

--- a/sdk/go/common/esc/schema/objects.go
+++ b/sdk/go/common/esc/schema/objects.go
@@ -16,10 +16,9 @@ package schema
 
 import (
 	"encoding/json"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
-
-	"golang.org/x/exp/maps"
 )
 
 type ObjectBuilder struct {
@@ -33,8 +32,7 @@ func Object() *ObjectBuilder {
 func Record(m MapBuilder) *ObjectBuilder {
 	props := m.Build()
 
-	names := maps.Keys(props)
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(props))
 
 	return Object().Properties(SchemaMap(props)).Required(names...)
 }

--- a/sdk/go/common/esc/syntax/encoding/yaml_edit_test.go
+++ b/sdk/go/common/esc/syntax/encoding/yaml_edit_test.go
@@ -15,14 +15,16 @@
 package encoding
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -63,7 +65,7 @@ func TestYAMLEdit(t *testing.T) {
 
 			docNode := YAMLSyntax{Node: &doc}
 			for _, edit := range edits.Edits {
-				pathStr := maps.Keys(edit)[0]
+				pathStr := slices.Collect(maps.Keys(edit))[0]
 
 				path, err := resource.ParsePropertyPath(pathStr)
 				require.NoError(t, err)

--- a/sdk/go/common/esc/value.go
+++ b/sdk/go/common/esc/value.go
@@ -18,12 +18,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/internal/util"
-	"golang.org/x/exp/maps"
 )
 
 // ValueType defines the types of concrete values stored inside a Value.
@@ -172,8 +172,7 @@ func fromJSON(path string, v any) (Value, error) {
 		}
 		return NewValue(vs), nil
 	case map[string]any:
-		keys := maps.Keys(v)
-		sort.Strings(keys)
+		keys := slices.Sorted(maps.Keys(v))
 		vs := make(map[string]Value, len(keys))
 		for _, k := range keys {
 			vv, err := fromJSON(util.JoinKey(path, k), v[k])
@@ -242,8 +241,7 @@ func (v Value) ToString(redact bool) string {
 		}
 		return strings.Join(vals, ",")
 	case map[string]Value:
-		keys := maps.Keys(pv)
-		sort.Strings(keys)
+		keys := slices.Sorted(maps.Keys(pv))
 
 		pairs := make([]string, len(pv))
 		for i, k := range keys {

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -121,7 +121,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -124,7 +124,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/sdk/pcl/go.mod
+++ b/sdk/pcl/go.mod
@@ -118,7 +118,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -124,7 +124,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,13 +11,11 @@ replace (
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/aws/aws-sdk-go-v2 v1.41.11
 	github.com/aws/aws-sdk-go-v2/config v1.32.20
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.3
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.24
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-dap v0.12.0
 	github.com/grapl-security/pulumi-hcp/sdk v0.1.14
 	github.com/hexops/autogold v1.3.0
@@ -118,7 +116,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
@@ -281,7 +279,6 @@ require (
 	gocloud.dev v0.46.0 // indirect
 	gocloud.dev/secrets/hashivault v0.46.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2654,10 +2654,6 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 h1:m/sWOGCREuSBqg2htVQTBY8nOZpyajYztF0vUvSZTuM=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0/go.mod h1:Pu5Zksi2KrU7LPbZbNINx6fuVrUp/ffvpxdDj+i8LeE=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGluTesZZ+ttN/MDsnMmQP36OSnDuSXqw=
-github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=
@@ -2718,8 +2714,6 @@ github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/tests/integration/construct_component_id_output/testcomponent-go/main.go
+++ b/tests/integration/construct_component_id_output/testcomponent-go/main.go
@@ -9,14 +9,14 @@ import (
 	"fmt"
 	"reflect"
 
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
 )
 
 type Resource struct {
@@ -212,18 +212,18 @@ func (p *Provider) Update(ctx context.Context,
 	}, nil
 }
 
-func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
+func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
 }
 
-func (p *Provider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
+func (p *Provider) GetPluginInfo(context.Context, *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
 	return &pulumirpc.PluginInfo{
 		Version: p.version,
 	}, nil
 }
 
-func (p *Provider) Attach(ctx context.Context, req *pulumirpc.PluginAttach) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
+func (p *Provider) Attach(ctx context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
 }
 
 func (p *Provider) GetSchema(ctx context.Context,
@@ -232,8 +232,8 @@ func (p *Provider) GetSchema(ctx context.Context,
 	return &pulumirpc.GetSchemaResponse{}, nil
 }
 
-func (p *Provider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
+func (p *Provider) Cancel(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
 }
 
 func (p *Provider) GetMapping(context.Context, *pulumirpc.GetMappingRequest) (*pulumirpc.GetMappingResponse, error) {

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -99,7 +99,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -99,7 +99,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -100,7 +100,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/acarl005/stripansi"
 	"github.com/blang/semver"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
@@ -2768,7 +2768,7 @@ func TestNodejsSourcemapTest(t *testing.T) {
 
       at willThrow (index.ts:3:15)
 `
-	require.Contains(t, stripansi.Strip(stderr), expectedTrace)
+	require.Contains(t, ansi.Strip(stderr), expectedTrace)
 }
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()

--- a/tests/integration/run_plugin/go/go.mod
+++ b/tests/integration/run_plugin/go/go.mod
@@ -101,7 +101,6 @@ require (
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect


### PR DESCRIPTION
ESC was still using `golang.org/x/exp`, we can use the stdlib `maps` package instead.

Remove some libraries that show up as `outdated` on https://github.com/pulumi/pulumi/issues/21045:

* github.com/golang/protobuf -> google.golang.org/protobuf (only used in a single test, everything else is using the new lib)
* github.com/acarl005/stripansi -> github.com/charmbracelet/x/ansi (already depended on)
* github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys -> github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys (only used in a single test)
