### PR TITLE
Resolve provider-option tokens against the passed provider's package

### DIFF
--- a/changelog/pending/20260722--programgen--resolve-provider-option-tokens.yaml
+++ b/changelog/pending/20260722--programgen--resolve-provider-option-tokens.yaml
@@ -1,0 +1,7 @@
+component: programgen
+kind: fix
+body: Resolve a PCL resource or invoke that passes the provider option against that
+    provider's package, so members whose token names a package declared in
+    allowedPackageNames can be used and are served by the package that defines them
+custom:
+    PR: "23999"

--- a/pkg/codegen/pcl/README.md
+++ b/pkg/codegen/pcl/README.md
@@ -54,6 +54,46 @@ resource "r" "pkg:index:Resource" {
 }
 ```
 
+(pcl-token-resolution)=
+#### Type token resolution and the `provider` option
+
+A resource's type token normally names the package whose schema defines it:
+binding `pkg:index:Resource` loads the schema for `pkg` and looks the token up
+there.
+
+A schema may however declare resources, functions, and types whose tokens name
+a *different* package, provided that package is listed in the schema's
+`allowedPackageNames`. To instantiate such a resource, the program must say
+which package's schema defines the token by passing the `provider` resource
+option: when `provider` is set, the resource's token is resolved against the
+schema of the passed provider's package rather than the package named by the
+token. `provider` accepts either an explicit provider resource or a bare
+reference to a [`package` block](pcl-package):
+
+```hcl
+package {
+    baseProviderName    = "extra"
+    baseProviderVersion = "1.0.0"
+}
+
+resource "explicit" "pulumi:providers:extra" {}
+
+// Resolved against extra's schema via the explicit provider resource.
+resource "r1" "other:index:Resource" {
+    options { provider = explicit }
+}
+
+// Resolved against extra's schema via the package block, referenced by the
+// package's name; the resource is served by the default provider for the
+// extra package.
+resource "r2" "other:index:Resource" {
+    options { provider = extra }
+}
+```
+
+The same rule applies to provider function calls, via the `provider` [invoke
+option](pcl-invoke).
+
 (pcl-component)=
 ### Components
 
@@ -118,6 +158,32 @@ config "key" "string" {
   default     = ""
 }
 ```
+
+(pcl-package)=
+### Packages
+
+*Package blocks* declare a package used by the program together with the
+information required to load its schema: the plugin that provides it
+(`baseProviderName`, `baseProviderVersion`, and optionally
+`baseProviderDownloadUrl`) and, for parameterized packages, a
+`parameterization` block carrying the sub-package's name, version, and
+base64-encoded parameter value. See
+[`ReadPackageDescriptors`](gh-file:pulumi#pkg/codegen/pcl/binder.go) for the
+full format.
+
+```hcl
+package {
+    baseProviderName    = "extra"
+    baseProviderVersion = "1.0.0"
+}
+```
+
+Most programs do not need package blocks -- referencing a token such as
+`pkg:index:Resource` loads the `pkg` schema implicitly. They are required when
+the schema cannot be located from a token alone: parameterized packages, and
+resources whose tokens name a foreign package (see [token
+resolution](pcl-token-resolution)), where a bare reference to the package
+block may also be passed as the `provider` option.
 
 ### Pulumi
 

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -500,6 +500,14 @@ func BindProgram(files []*syntax.File, loader schema.Loader, opts ...BindOption)
 		diagnostics = append(diagnostics, fileDiags...)
 	}
 
+	// Declare package blocks once every program node has been declared, so that
+	// a node owning the same name keeps it. A resource or invoke may reference
+	// what remains as its provider option, which resolves its token against
+	// that package (see resolveSchemaResourceForBind).
+	for _, f := range files {
+		b.declarePackageVariables(f)
+	}
+
 	// Now bind the nodes.
 	for _, n := range b.nodes {
 		diagnostics = append(diagnostics, b.bindNode(ctx, n)...)
@@ -661,6 +669,44 @@ func makeObjectPropertiesOptional(objectType *model.ObjectType) *model.ObjectTyp
 	}
 
 	return objectType
+}
+
+// declarePackageVariables defines a scope entry for each of the file's package
+// blocks, under the name of the package it declares, and records the package as
+// referenced by the program. A name already claimed by a program node is left
+// alone: package variables are scope definitions only, not program nodes.
+func (b *binder) declarePackageVariables(file *syntax.File) {
+	for _, item := range model.SourceOrderBody(file.Body) {
+		block, ok := item.(*hclsyntax.Block)
+		if !ok || block.Type != "package" {
+			continue
+		}
+		// Diagnostics for invalid package blocks are reported when the binder
+		// reads the program's package descriptors.
+		descriptor, name, _ := readPackageBlock(block)
+		if descriptor == nil {
+			continue
+		}
+		// Declaring a package is what makes the program depend on it. A resource
+		// or invoke that redirects to it through the provider option contributes
+		// no package of its own, since its token names a different one.
+		// A package that fails to load is reported where it is used, so that an
+		// unused declaration is not an error on its own.
+		if _, ok := b.referencedPackages[name]; !ok {
+			if pkg, err := b.options.packageCache.loadPackageSchemaFromDescriptor(
+				b.options.loader, descriptor); err == nil {
+				b.referencedPackages[name] = pkg.schema
+			}
+		}
+		if _, declared := b.root.BindReference(name); declared {
+			continue
+		}
+		b.root.Define(name, &PackageVariable{
+			syntax:     block,
+			LocalName:  name,
+			Descriptor: descriptor,
+		})
+	}
 }
 
 // declareNodes declares all of the top-level nodes in the given file. This includes config, resources, outputs, and
@@ -965,97 +1011,10 @@ func ReadPackageDescriptors(file *syntax.File) (map[string]*schema.PackageDescri
 				continue
 			}
 
-			labels := node.Labels
-			if len(labels) > 1 {
-				diagnostics = append(diagnostics,
-					labelsErrorf(node, "package blocks must have at most one label"))
+			packageDescriptor, _, diags := readPackageBlock(node)
+			diagnostics = append(diagnostics, diags...)
+			if packageDescriptor == nil {
 				continue
-			}
-
-			if len(labels) == 1 {
-				labelRange := node.LabelRanges[0]
-				diagnostics = append(diagnostics, &hcl.Diagnostic{
-					Severity: hcl.DiagWarning,
-					Summary:  "package block label is deprecated",
-					Detail:   "Package block labels should be replaced by baseProviderName.",
-					Subject:  &labelRange,
-				})
-			}
-
-			// read the attributes of the package block to fill in the package descriptor data
-			packageDescriptor := &schema.PackageDescriptor{}
-
-			if node.Body == nil {
-				diagnostics = append(diagnostics,
-					errorf(node.Range(), "package blocks must set base provider information"))
-				continue
-			}
-
-			for _, attribute := range node.Body.Attributes {
-				switch attribute.Name {
-				case "baseProviderName":
-					baseProviderName, err := evaluateLiteralExpr(attribute.Expr)
-					if err != nil {
-						diagnostics = append(diagnostics,
-							errorf(attribute.Range(), "invalid base provider name for package: %v", err))
-						continue
-					}
-
-					packageDescriptor.Name = baseProviderName
-				case "baseProviderVersion":
-					version, _ := evaluateLiteralExpr(attribute.Expr)
-					parsedVersion, err := semver.Make(version)
-					if err != nil {
-						// parsing the version failed, error out and skip this package
-						diagnostics = append(diagnostics,
-							errorf(attribute.Range(),
-								"invalid baseProviderVersion %q for package: %v", version, err))
-						continue
-					}
-					packageDescriptor.Version = &parsedVersion
-				case "baseProviderDownloadUrl":
-					downloadURLValue, err := evaluateLiteralExpr(attribute.Expr)
-					if err != nil {
-						diagnostics = append(diagnostics,
-							errorf(attribute.Range(), "invalid download URL for package: %v", err))
-						continue
-					}
-
-					if _, err := url.ParseRequestURI(downloadURLValue); err != nil {
-						diagnostics = append(diagnostics,
-							errorf(attribute.Range(), "invalid download URL for package: %v", err))
-						continue
-					}
-					packageDescriptor.DownloadURL = downloadURLValue
-				}
-			}
-
-			if packageDescriptor.Name == "" && len(labels) == 1 {
-				// Backwards compatibility: if the package block has a single label and doesn't set baseProviderName,
-				// use the label as the package name
-				packageDescriptor.Name = labels[0]
-			}
-
-			if packageDescriptor.Name == "" {
-				diagnostics = append(diagnostics,
-					errorf(node.Range(), "package blocks must set baseProviderName"))
-				continue
-			}
-
-			for _, block := range node.Body.Blocks {
-				switch block.Type {
-				case "parameterization":
-					attributes := map[string]hclsyntax.Expression{}
-					for _, item := range block.Body.Attributes {
-						attributes[item.Name] = item.Expr
-					}
-					descriptor, diag := readParameterizationDescriptor(packageDescriptor.Name, attributes)
-					if diag != nil {
-						diagnostics = append(diagnostics, diag)
-						continue
-					}
-					packageDescriptor.Parameterization = descriptor
-				}
 			}
 
 			packageName := packageDescriptor.PackageName()
@@ -1075,6 +1034,104 @@ func ReadPackageDescriptors(file *syntax.File) (map[string]*schema.PackageDescri
 		}
 	}
 	return packageDescriptors, diagnostics
+}
+
+// readPackageBlock reads a single package block into a package descriptor. The
+// second return value is the package's name, by which the block can be
+// referenced as a resource or invoke `provider` option (see PackageVariable).
+// A nil descriptor indicates the block was invalid.
+func readPackageBlock(node *hclsyntax.Block) (*schema.PackageDescriptor, string, hcl.Diagnostics) {
+	var diagnostics hcl.Diagnostics
+
+	labels := node.Labels
+	if len(labels) > 1 {
+		return nil, "", hcl.Diagnostics{labelsErrorf(node, "package blocks must have at most one label")}
+	}
+
+	if len(labels) == 1 {
+		labelRange := node.LabelRanges[0]
+		diagnostics = append(diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "package block label is deprecated",
+			Detail:   "Package block labels should be replaced by baseProviderName.",
+			Subject:  &labelRange,
+		})
+	}
+
+	// read the attributes of the package block to fill in the package descriptor data
+	packageDescriptor := &schema.PackageDescriptor{}
+
+	if node.Body == nil {
+		return nil, "", hcl.Diagnostics{errorf(node.Range(), "package blocks must set base provider information")}
+	}
+
+	for _, attribute := range node.Body.Attributes {
+		switch attribute.Name {
+		case "baseProviderName":
+			baseProviderName, err := evaluateLiteralExpr(attribute.Expr)
+			if err != nil {
+				diagnostics = append(diagnostics,
+					errorf(attribute.Range(), "invalid base provider name for package: %v", err))
+				continue
+			}
+
+			packageDescriptor.Name = baseProviderName
+		case "baseProviderVersion":
+			version, _ := evaluateLiteralExpr(attribute.Expr)
+			parsedVersion, err := semver.Make(version)
+			if err != nil {
+				// parsing the version failed, error out and skip this package
+				diagnostics = append(diagnostics,
+					errorf(attribute.Range(),
+						"invalid baseProviderVersion %q for package: %v", version, err))
+				continue
+			}
+			packageDescriptor.Version = &parsedVersion
+		case "baseProviderDownloadUrl":
+			downloadURLValue, err := evaluateLiteralExpr(attribute.Expr)
+			if err != nil {
+				diagnostics = append(diagnostics,
+					errorf(attribute.Range(), "invalid download URL for package: %v", err))
+				continue
+			}
+
+			if _, err := url.ParseRequestURI(downloadURLValue); err != nil {
+				diagnostics = append(diagnostics,
+					errorf(attribute.Range(), "invalid download URL for package: %v", err))
+				continue
+			}
+			packageDescriptor.DownloadURL = downloadURLValue
+		}
+	}
+
+	if packageDescriptor.Name == "" && len(labels) == 1 {
+		// Backwards compatibility: if the package block has a single label and doesn't set baseProviderName,
+		// use the label as the package name
+		packageDescriptor.Name = labels[0]
+	}
+
+	if packageDescriptor.Name == "" {
+		return nil, "", append(diagnostics,
+			errorf(node.Range(), "package blocks must set baseProviderName"))
+	}
+
+	for _, block := range node.Body.Blocks {
+		switch block.Type {
+		case "parameterization":
+			attributes := map[string]hclsyntax.Expression{}
+			for _, item := range block.Body.Attributes {
+				attributes[item.Name] = item.Expr
+			}
+			descriptor, diag := readParameterizationDescriptor(packageDescriptor.Name, attributes)
+			if diag != nil {
+				diagnostics = append(diagnostics, diag)
+				continue
+			}
+			packageDescriptor.Parameterization = descriptor
+		}
+	}
+
+	return packageDescriptor, packageDescriptor.PackageName(), diagnostics
 }
 
 // extensionDescriptorsForBase returns the descriptors that extend the given base

--- a/pkg/codegen/pcl/binder_provider_redirect_test.go
+++ b/pkg/codegen/pcl/binder_provider_redirect_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcl_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// redirectLoader serves a package that declares members under a foreign package
+// name, the way allowedPackageNames permits. "other:mod:Res" has no package of
+// its own to resolve against; only a provider option can reach it.
+type redirectLoader struct{}
+
+func (l redirectLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {
+	return l.LoadPackageV2(context.TODO(), &schema.PackageDescriptor{Name: pkg, Version: version})
+}
+
+func (redirectLoader) LoadPackageV2(_ context.Context, d *schema.PackageDescriptor) (*schema.Package, error) {
+	if d.Name != "redirected" {
+		return nil, unknownPackageError{d.Name}
+	}
+	spec := schema.PackageSpec{
+		Name:                "redirected",
+		Version:             "1.0.0",
+		AllowedPackageNames: []string{"other"},
+		Resources: map[string]schema.ResourceSpec{
+			"other:mod:Res": {ObjectTypeSpec: schema.ObjectTypeSpec{Type: "object"}},
+		},
+	}
+	pkg, diags, err := schema.BindSpec(spec, schema.NewNullLoader(), schema.ValidationOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	return pkg, nil
+}
+
+type unknownPackageError struct{ name string }
+
+func (e unknownPackageError) Error() string { return "unknown package " + e.name }
+
+func bindRedirectProgram(t *testing.T, source string) (*pcl.Program, error) {
+	t.Helper()
+
+	parser := syntax.NewParser()
+	require.NoError(t, parser.ParseFile(bytes.NewReader([]byte(source)), "program.pp"))
+	require.False(t, parser.Diagnostics.HasErrors(), "parse: %v", parser.Diagnostics)
+
+	program, diags, err := pcl.BindProgram(parser.Files, redirectLoader{})
+	if err != nil {
+		return nil, err
+	}
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	return program, nil
+}
+
+// A token naming a foreign package binds against the package named by the
+// provider option, and the program depends on that package rather than on the
+// phantom package the token names.
+func TestBindForeignTokenThroughProviderOption(t *testing.T) {
+	t.Parallel()
+
+	program, err := bindRedirectProgram(t, `
+package {
+    baseProviderName = "redirected"
+    baseProviderVersion = "1.0.0"
+}
+
+resource "res" "other:mod:Res" {
+    options {
+        provider = redirected
+    }
+}
+`)
+	require.NoError(t, err)
+
+	packages, err := program.PackageSnapshots()
+	require.NoError(t, err)
+	names := make([]string, 0, len(packages))
+	for _, p := range packages {
+		names = append(names, p.Name)
+	}
+	require.Equal(t, []string{"redirected"}, names)
+}
+
+// The provider option decides where the token is looked up, so a token the
+// named package does not define is an error. It must not fall back to
+// resolving the token by its own package portion.
+func TestBindUnknownTokenThroughProviderOptionFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := bindRedirectProgram(t, `
+package {
+    baseProviderName = "redirected"
+    baseProviderVersion = "1.0.0"
+}
+
+resource "res" "other:mod:Missing" {
+    options {
+        provider = redirected
+    }
+}
+`)
+	require.ErrorContains(t, err, "unknown resource type 'other:mod:Missing'")
+}

--- a/pkg/codegen/pcl/binder_read_resource.go
+++ b/pkg/codegen/pcl/binder_read_resource.go
@@ -49,7 +49,7 @@ func (b *binder) bindReadResourceTypes(ctx context.Context, node *ReadResource) 
 	}
 
 	res, resolvedToken, diagnostics := b.resolveSchemaResourceForBind(
-		ctx, token, tokenRange, false, false, makeResourceDynamic)
+		ctx, token, tokenRange, false, false, makeResourceDynamic, b.providerRedirectSchema(ctx, node.syntax))
 	if diagnostics.HasErrors() || res == nil {
 		return diagnostics
 	}

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -55,6 +55,96 @@ func (b *binder) bindResource(ctx context.Context, node *Resource) hcl.Diagnosti
 	return diagnostics
 }
 
+// SyntacticProviderOption returns the name of the single identifier assigned
+// to the block's options.provider attribute, if any. It operates on raw syntax
+// so that it can run before the resource's body is bound.
+func SyntacticProviderOption(block *hclsyntax.Block) (string, bool) {
+	if block.Body == nil {
+		return "", false
+	}
+	for _, options := range block.Body.Blocks {
+		if options.Type != "options" || options.Body == nil {
+			continue
+		}
+		provider, ok := options.Body.Attributes["provider"]
+		if !ok {
+			continue
+		}
+		traversal, ok := provider.Expr.(*hclsyntax.ScopeTraversalExpr)
+		if !ok || len(traversal.Traversal) != 1 {
+			return "", false
+		}
+		return traversal.Traversal.RootName(), true
+	}
+	return "", false
+}
+
+// SyntacticInvokeProviderOption reports whether an invoke call passes the
+// provider invoke option. Like SyntacticProviderOption it operates on raw
+// syntax, so that it can run before the call's arguments are bound.
+func SyntacticInvokeProviderOption(call *hclsyntax.FunctionCallExpr) bool {
+	if len(call.Args) < 3 {
+		return false
+	}
+	obj, ok := call.Args[2].(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return false
+	}
+	for _, item := range obj.Items {
+		key, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
+		if !ok {
+			continue
+		}
+		traversal, ok := key.Wrapped.(*hclsyntax.ScopeTraversalExpr)
+		if ok && len(traversal.Traversal) == 1 && traversal.Traversal.RootName() == "provider" {
+			return true
+		}
+	}
+	return false
+}
+
+// providerRedirectSchema resolves the schema a block's options.provider
+// redirects token resolution to: the passed provider's package. The provider
+// option may name an explicit provider resource or a package block. A nil
+// result means the token resolves normally, by its package portion; any
+// binding error is then reported by the normal path.
+func (b *binder) providerRedirectSchema(ctx context.Context, block *hclsyntax.Block) *packageSchema {
+	name, ok := SyntacticProviderOption(block)
+	if !ok {
+		return nil
+	}
+	def, ok := b.root.BindReference(name)
+	if !ok {
+		return nil
+	}
+	return b.redirectSchemaForDefinition(ctx, def)
+}
+
+// redirectSchemaForDefinition resolves the package schema a provider option's
+// referent redirects token resolution to: the package of an explicit provider
+// resource, or the package a package block declares.
+func (b *binder) redirectSchemaForDefinition(ctx context.Context, def model.Definition) *packageSchema {
+	switch def := def.(type) {
+	case *PackageVariable:
+		schema, err := b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, def.Descriptor)
+		if err != nil {
+			return nil
+		}
+		return schema
+	case *Resource:
+		pkg, module, providerName, diags := DecomposeToken(def.syntax.Labels[1], def.syntax.LabelRanges[1])
+		if diags.HasErrors() || pkg != pulumiPackage || module != "providers" {
+			return nil
+		}
+		schema, err := b.loadDeclaredOrBarePackageSchema(ctx, providerName, "", "")
+		if err != nil {
+			return nil
+		}
+		return schema
+	}
+	return nil
+}
+
 func (b *binder) resolveSchemaResourceForBind(
 	ctx context.Context,
 	token string,
@@ -62,6 +152,7 @@ func (b *binder) resolveSchemaResourceForBind(
 	allowProviderToken bool,
 	allowComponent bool,
 	makeResourceDynamic func(),
+	redirect *packageSchema,
 ) (*schema.Resource, string, hcl.Diagnostics) {
 	pkg, module, name, diagnostics := DecomposeToken(token, tokenRange)
 	if diagnostics.HasErrors() {
@@ -74,6 +165,14 @@ func (b *binder) resolveSchemaResourceForBind(
 			return nil, token, hcl.Diagnostics{errorf(tokenRange, "provider resources cannot be read: '%s'", token)}
 		}
 		pkg, isProvider = name, true
+	}
+
+	// A resource that passes the provider option resolves its token against the
+	// passed provider's package rather than against the package the token names.
+	// That is what lets a token name a foreign package declared via
+	// allowedPackageNames, whose own name has no schema behind it.
+	if redirect != nil && !isProvider {
+		pkg = redirect.schema.Name()
 	}
 
 	// It is important that we call `loadPackageSchema`/`loadPackageSchemaFromDescriptor`
@@ -643,7 +742,7 @@ func (b *binder) bindResourceTypes(ctx context.Context, node *Resource) hcl.Diag
 	}
 
 	res, resolvedToken, diagnostics := b.resolveSchemaResourceForBind(
-		ctx, token, tokenRange, true, true, makeResourceDynamic)
+		ctx, token, tokenRange, true, true, makeResourceDynamic, b.providerRedirectSchema(ctx, node.syntax))
 	if diagnostics.HasErrors() || res == nil {
 		return diagnostics
 	}

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -339,23 +339,31 @@ func (b *binder) loadReferencedPackageSchemas(ctx context.Context, n Node) error
 	var pkgOpts packageOpts
 	packageNames := codegen.StringSet{}
 
+	// A resource or invoke that passes the provider option resolves its token
+	// against that provider's package, so the package its token names is not
+	// referenced. The provider option's referent — a package block or a provider
+	// resource — contributes the package instead.
 	switch r := n.(type) {
 	case *Resource:
-		token, tokenRange := r.GetToken()
-		packageName, mod, name, _ := DecomposeToken(token, tokenRange)
-		if packageName == "pulumi" && mod == "providers" {
-			packageNames.Add(name)
-		} else {
-			packageNames.Add(packageName)
+		if _, redirected := SyntacticProviderOption(r.syntax); !redirected {
+			token, tokenRange := r.GetToken()
+			packageName, mod, name, _ := DecomposeToken(token, tokenRange)
+			if packageName == "pulumi" && mod == "providers" {
+				packageNames.Add(name)
+			} else {
+				packageNames.Add(packageName)
+			}
 		}
 		pkgOpts = b.getPkgOpts(r)
 	case *ReadResource:
-		token, tokenRange := r.GetToken()
-		packageName, mod, name, _ := DecomposeToken(token, tokenRange)
-		if packageName == "pulumi" && mod == "providers" {
-			packageNames.Add(name)
-		} else {
-			packageNames.Add(packageName)
+		if _, redirected := SyntacticProviderOption(r.syntax); !redirected {
+			token, tokenRange := r.GetToken()
+			packageName, mod, name, _ := DecomposeToken(token, tokenRange)
+			if packageName == "pulumi" && mod == "providers" {
+				packageNames.Add(name)
+			} else {
+				packageNames.Add(packageName)
+			}
 		}
 		pkgOpts = b.getReadPkgOpts(r)
 	}
@@ -367,6 +375,9 @@ func (b *binder) loadReferencedPackageSchemas(ctx context.Context, n Node) error
 		}
 		token, tokenRange, ok := getInvokeToken(call)
 		if !ok {
+			return nil
+		}
+		if SyntacticInvokeProviderOption(call) {
 			return nil
 		}
 		packageName, mod, name, _ := DecomposeToken(token, tokenRange)

--- a/pkg/codegen/pcl/binding.md
+++ b/pkg/codegen/pcl/binding.md
@@ -33,7 +33,12 @@ the binding process would encompass the following tasks:
     giving the name of the output being exported.
 
 * Resolving the `random` package (as referenced by the `random:index:RandomString`
-  type in the `r` resource node) and loading its schema.
+  type in the `r` resource node) and loading its schema. When the resource
+  passes the `provider` option -- either an explicit provider resource or a
+  bare reference to a `package` block -- the token is instead resolved against
+  the schema of the passed provider's package, which allows instantiating
+  resources whose tokens name a foreign package declared via that schema's
+  `allowedPackageNames` (see [token resolution](pcl-token-resolution)).
 
 * Using the resolved schema to construct an object type comprising the
   `RandomString` resource's input properties and using a scope containing this

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -149,6 +149,14 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), diagnostics
 	}
 
+	// An invoke that passes the provider option resolves its token against the
+	// passed provider's package rather than against the package the token names.
+	// That is what lets a token name a foreign package declared via
+	// allowedPackageNames, whose own name has no schema behind it.
+	if redirect := b.invokeProviderRedirect(args); redirect != nil {
+		pkg = redirect.schema.Name()
+	}
+
 	// The function token's package portion may be a plain package or a base
 	// provider whose functions are supplied by an extension layered on it; the
 	// function is defined by whichever candidate schema contains the token.
@@ -192,6 +200,43 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 
 	lit.Value = cty.StringVal(canonicalToken)
 
+	return b.invokeSignature(fn, token, tokenRange, args)
+}
+
+// invokeProviderRedirect resolves the schema an invoke's provider option
+// redirects token resolution to, mirroring providerRedirectSchema for
+// resources. The invoke's arguments are already bound, so the provider option
+// is inspected semantically.
+func (b *binder) invokeProviderRedirect(args []model.Expression) *packageSchema {
+	if len(args) < 3 {
+		return nil
+	}
+	options, ok := args[2].(*model.ObjectConsExpression)
+	if !ok {
+		return nil
+	}
+	for _, item := range options.Items {
+		if key, ok := literalExprValue(item.Key); !ok || key.Type() != cty.String || key.AsString() != "provider" {
+			continue
+		}
+		traversal, ok := item.Value.(*model.ScopeTraversalExpression)
+		if !ok || len(traversal.Parts) != 1 {
+			return nil
+		}
+		def, ok := traversal.Parts[0].(model.Definition)
+		if !ok {
+			return nil
+		}
+		return b.redirectSchemaForDefinition(context.TODO(), def)
+	}
+	return nil
+}
+
+// invokeSignature computes the signature for a bound function, shared by the
+// provider-redirected and token-package resolution paths.
+func (b *binder) invokeSignature(
+	fn *schema.Function, token string, tokenRange hcl.Range, args []model.Expression,
+) (model.StaticFunctionSignature, hcl.Diagnostics) {
 	if len(args) < 2 {
 		return b.zeroSignature(), hcl.Diagnostics{errorf(tokenRange, "missing second arg")}
 	}

--- a/pkg/codegen/pcl/package_variable.go
+++ b/pkg/codegen/pcl/package_variable.go
@@ -1,0 +1,87 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcl
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// PackageReferenceType is the type of a bare reference to a package block,
+// valid only as a resource or invoke `provider` option.
+var PackageReferenceType model.Type = model.NewOpaqueType("PackageReference")
+
+// PackageVariable represents a package block. Referencing it by name as a
+// resource or invoke `provider` option resolves the token against the
+// referenced package's schema and routes the registration to that package's
+// default provider. Package variables are scope definitions rather than
+// program nodes: they can be referenced by expressions but do not appear in
+// Program.Nodes.
+type PackageVariable struct {
+	syntax *hclsyntax.Block
+
+	// LocalName is the name by which the package block is referenced in the
+	// program: the name of the package it declares.
+	LocalName string
+
+	// Descriptor describes the package the block declares.
+	Descriptor *schema.PackageDescriptor
+}
+
+// SyntaxNode returns the syntax node associated with the package variable.
+func (pv *PackageVariable) SyntaxNode() hclsyntax.Node {
+	return pv.syntax
+}
+
+func (pv *PackageVariable) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	return PackageReferenceType.Traverse(traverser)
+}
+
+func (pv *PackageVariable) Name() string {
+	return pv.LocalName
+}
+
+// Type returns the type of the package variable.
+func (pv *PackageVariable) Type() model.Type {
+	return PackageReferenceType
+}
+
+// ReferencesPackageBlock reports whether the expression is a bare reference to
+// a package block (see PackageVariable).
+func ReferencesPackageBlock(expr model.Expression) bool {
+	traversal, ok := expr.(*model.ScopeTraversalExpression)
+	if !ok || len(traversal.Parts) != 1 {
+		return false
+	}
+	_, ok = traversal.Parts[0].(*PackageVariable)
+	return ok
+}
+
+// GeneratedInvokeOptions returns the invoke option items that have a generated
+// form. A provider option naming a package block selects the package the
+// token resolves against, which the SDK carries as the package reference
+// rather than an invoke option.
+func GeneratedInvokeOptions(options *model.ObjectConsExpression) []model.ObjectConsItem {
+	items := make([]model.ObjectConsItem, 0, len(options.Items))
+	for _, item := range options.Items {
+		if LiteralValueString(item.Key) == "provider" && ReferencesPackageBlock(item.Value) {
+			continue
+		}
+		items = append(items, item)
+	}
+	return items
+}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -951,6 +951,37 @@ func (pkg *Package) Equals(other *Package) bool {
 	return pkg == other || pkg.Identity() == other.Identity()
 }
 
+// IsForeignToken reports whether tok names a package other than the one
+// defining it, which schemas may do for members declared under
+// allowedPackageNames. Registrations for such members carry the defining
+// package's reference, since their token does not name the package that
+// serves them.
+func (pkg *Package) IsForeignToken(tok string) bool {
+	tokenPkg, _, _, ok := decomposeToken(tok)
+	// The pulumi namespace holds built-in tokens such as pulumi:providers:<name>,
+	// which belong to the package they name rather than to a foreign one.
+	return ok && tokenPkg != pkg.Name && tokenPkg != "pulumi"
+}
+
+// HasForeignTokens reports whether any resource or function of the package is
+// declared under a foreign package name (see IsForeignToken).
+func (pkg *Package) HasForeignTokens() bool {
+	if len(pkg.AllowedPackageNames) == 0 {
+		return false
+	}
+	for _, r := range pkg.Resources {
+		if pkg.IsForeignToken(r.Token) {
+			return true
+		}
+	}
+	for _, f := range pkg.Functions {
+		if pkg.IsForeignToken(f.Token) {
+			return true
+		}
+	}
+	return false
+}
+
 var defaultModuleFormat = regexp.MustCompile("(.*)")
 
 func (pkg *Package) CanonicalizeToken(tok string) string {

--- a/pkg/pcl/runtime/builtinFunctions.go
+++ b/pkg/pcl/runtime/builtinFunctions.go
@@ -403,18 +403,22 @@ func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 
 				provider := options.GetAttr("provider")
 				if !provider.IsNull() && provider.IsKnown() {
-					if !provider.Type().IsObjectType() {
-						return cty.NilVal, errors.New("invoke options provider must be a resource object")
+					// A package block reference routes the invoke through the
+					// package reference rather than an explicit provider.
+					if !provider.Type().Equals(packageBlockType) {
+						if !provider.Type().IsObjectType() {
+							return cty.NilVal, errors.New("invoke options provider must be a resource object")
+						}
+						urnAttr := provider.GetAttr("urn")
+						if urnAttr.IsNull() || !urnAttr.IsKnown() || urnAttr.Type() != cty.String {
+							return cty.NilVal, errors.New("invoke options provider must be a resource object with known urn property")
+						}
+						idAttr := provider.GetAttr("id")
+						if idAttr.IsNull() || !idAttr.IsKnown() || idAttr.Type() != cty.String {
+							return cty.NilVal, errors.New("invoke options provider must be a resource object with known id property")
+						}
+						request.Provider = fmt.Sprintf("%s::%s", urnAttr.AsString(), idAttr.AsString())
 					}
-					urnAttr := provider.GetAttr("urn")
-					if urnAttr.IsNull() || !urnAttr.IsKnown() || urnAttr.Type() != cty.String {
-						return cty.NilVal, errors.New("invoke options provider must be a resource object with known urn property")
-					}
-					idAttr := provider.GetAttr("id")
-					if idAttr.IsNull() || !idAttr.IsKnown() || idAttr.Type() != cty.String {
-						return cty.NilVal, errors.New("invoke options provider must be a resource object with known id property")
-					}
-					request.Provider = fmt.Sprintf("%s::%s", urnAttr.AsString(), idAttr.AsString())
 				}
 			}
 

--- a/pkg/pcl/runtime/interpreter.go
+++ b/pkg/pcl/runtime/interpreter.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -87,6 +88,12 @@ type Interpreter struct {
 	// to the default provider.
 	packageRefs map[string]string
 
+	// packageResources and packageFunctions index the resources and functions
+	// of every registered package block by token, letting tokens naming a
+	// foreign package (allowedPackageNames) resolve to their defining package.
+	packageResources map[string]*schema.Resource
+	packageFunctions map[string]*schema.Function
+
 	// callbacks is the server that handles resource hook callbacks.
 	callbacks     *pclCallbackServer
 	callbacksOnce sync.Once
@@ -99,9 +106,11 @@ type Interpreter struct {
 
 func NewInterpreter(program *pcl.Program, info RunInfo) *Interpreter {
 	return &Interpreter{
-		program:     program,
-		info:        info,
-		packageRefs: map[string]string{},
+		program:          program,
+		info:             info,
+		packageRefs:      map[string]string{},
+		packageResources: map[string]*schema.Resource{},
+		packageFunctions: map[string]*schema.Function{},
 	}
 }
 
@@ -718,6 +727,10 @@ func (i *Interpreter) lookupResource(ctx context.Context, token string) (*schema
 		pkgName = typ
 	}
 
+	if schemaResource, ok := i.packageResources[token]; ok && pkgName == pkg {
+		return schemaResource, nil
+	}
+
 	var loadErr error
 	for _, descriptor := range i.lookupPackageDescriptors(pkgName) {
 		pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
@@ -747,6 +760,10 @@ func (i *Interpreter) lookupFunction(ctx context.Context, token string) (*schema
 	contract.Assertf(!diags.HasErrors(), "invalid token format for function token %s", token)
 
 	token = fmt.Sprintf("%s:%s:%s", pkg, mod, typ)
+
+	if schemaFunction, ok := i.packageFunctions[token]; ok {
+		return schemaFunction, nil
+	}
 
 	var loadErr error
 	for _, descriptor := range i.lookupPackageDescriptors(pkg) {
@@ -808,6 +825,12 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 	if i.monitor == nil {
 		return nil
 	}
+	if i.packageResources == nil {
+		i.packageResources = map[string]*schema.Resource{}
+	}
+	if i.packageFunctions == nil {
+		i.packageFunctions = map[string]*schema.Function{}
+	}
 
 	keys := make([]string, 0, len(i.info.PackageDescriptors))
 	for k := range i.info.PackageDescriptors {
@@ -820,7 +843,36 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 		if descriptor == nil {
 			continue
 		}
-		if descriptor.Parameterization == nil {
+
+		// Let bare references to the package block evaluate: the provider option
+		// recognizes the marker as selecting the package. A program node of the
+		// same name owns the name, and a reference to it binds to that node.
+		name := descriptor.PackageName()
+		if i.evalContext != nil && !i.programDeclares(name) {
+			i.evalContext.SetVariable(name, packageBlockMarker(name))
+		}
+
+		// A package is registered when its members cannot be reached without a
+		// package reference: a parameterized package, whose plugin serves a
+		// different package than it is named by, and a package declaring members
+		// whose tokens name a foreign package (allowedPackageNames), which the
+		// engine would otherwise route to a provider for that phantom package.
+		parameterized := descriptor.Parameterization != nil
+		pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
+		if err != nil {
+			if !parameterized {
+				continue
+			}
+			return fmt.Errorf("load package %q for register: %w", key, err)
+		}
+		def, err := pkgref.Definition()
+		if err != nil {
+			if !parameterized {
+				continue
+			}
+			return fmt.Errorf("load definition for package %q: %w", key, err)
+		}
+		if !parameterized && !def.HasForeignTokens() {
 			continue
 		}
 
@@ -831,24 +883,18 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 		if descriptor.Version != nil {
 			request.Version = descriptor.Version.String()
 		}
-		param := &pulumirpc.Parameterization{
-			Name:    descriptor.Parameterization.Name,
-			Version: descriptor.Parameterization.Version.String(),
-			Value:   descriptor.Parameterization.Value,
-		}
-		// Route to the wire field matching the schema's parameterization flavor.
-		pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
-		if err != nil {
-			return fmt.Errorf("load package %q for register: %w", key, err)
-		}
-		def, err := pkgref.Definition()
-		if err != nil {
-			return fmt.Errorf("load definition for package %q: %w", key, err)
-		}
-		if def.ExtensionParameterization != nil {
-			request.Extension = param
-		} else {
-			request.Parameterization = param
+		if parameterized {
+			param := &pulumirpc.Parameterization{
+				Name:    descriptor.Parameterization.Name,
+				Version: descriptor.Parameterization.Version.String(),
+				Value:   descriptor.Parameterization.Value,
+			}
+			// Route to the wire field matching the schema's parameterization flavor.
+			if def.ExtensionParameterization != nil {
+				request.Extension = param
+			} else {
+				request.Parameterization = param
+			}
 		}
 
 		resp, err := i.monitor.RegisterPackage(ctx, request)
@@ -864,13 +910,45 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 		i.packageRefs["pulumi:providers:"+descriptor.PackageName()] = ref
 		for _, r := range def.Resources {
 			i.packageRefs[r.Token] = ref
+			i.packageResources[r.Token] = r
 		}
 		for _, f := range def.Functions {
 			i.packageRefs[f.Token] = ref
+			i.packageFunctions[f.Token] = f
 		}
 	}
 
 	return nil
+}
+
+// packageBlockRef is what a bare reference to a `package` block evaluates to.
+// It names the package the block declares, so that a provider option holding it
+// selects the package a token resolves against rather than an explicit
+// provider. It is a capsule type because it is a value of its own kind, not a
+// resource: nothing may read attributes off it. Compare assetType and
+// archiveType in convert.go.
+type packageBlockRef struct {
+	name string
+}
+
+var packageBlockType = cty.Capsule("package block", reflect.TypeFor[packageBlockRef]())
+
+// programDeclares reports whether the program declares a node with the given
+// name, which then owns that name in the evaluation scope.
+func (i *Interpreter) programDeclares(name string) bool {
+	if i.program == nil {
+		return false
+	}
+	for _, node := range i.program.Nodes {
+		if node.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func packageBlockMarker(name string) cty.Value {
+	return cty.CapsuleVal(packageBlockType, &packageBlockRef{name: name})
 }
 
 // requiredVersionGate returns the pulumi block that enforces a required engine version, or nil if the
@@ -1776,7 +1854,10 @@ func (i *Interpreter) registerResourceWith(
 				request.Parent = urn
 			}
 		}
-		if res.Options.Provider != nil {
+		// A provider option referencing a package block selects the package the
+		// resource's token resolves against; the registration routes through the
+		// package reference rather than an explicit provider.
+		if res.Options.Provider != nil && !pcl.ReferencesPackageBlock(res.Options.Provider) {
 			provider, poison, diags := evalCtx.Evaluate(res.Options.Provider)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
@@ -2096,15 +2177,17 @@ func (i *Interpreter) registerComponent(ctx context.Context, component *pcl.Comp
 		i.call,
 	)
 	componentInterpreter := &Interpreter{
-		program:     component.Program,
-		info:        i.info,
-		monitor:     i.monitor,
-		engine:      i.engine,
-		loader:      i.loader,
-		evalContext: componentEval,
-		stackURN:    resp.GetUrn(),
-		namePrefix:  componentName,
-		packageRefs: i.packageRefs,
+		program:          component.Program,
+		info:             i.info,
+		monitor:          i.monitor,
+		engine:           i.engine,
+		loader:           i.loader,
+		evalContext:      componentEval,
+		stackURN:         resp.GetUrn(),
+		namePrefix:       componentName,
+		packageRefs:      i.packageRefs,
+		packageResources: i.packageResources,
+		packageFunctions: i.packageFunctions,
 	}
 
 	for k, v := range inputs {

--- a/pkg/testing/pulumi-test-language/providers/extra_package_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/extra_package_names_provider.go
@@ -1,0 +1,201 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// A provider whose schema declares a resource, function, enum type, and
+// object type whose tokens all name a foreign package ("other"), declared via
+// allowedPackageNames.
+type ExtraPackageNamesProvider struct {
+	plugin.UnimplementedProvider
+}
+
+var _ plugin.Provider = (*ExtraPackageNamesProvider)(nil)
+
+func (p *ExtraPackageNamesProvider) pkg() tokens.Package {
+	return "extra-package-names"
+}
+
+func (*ExtraPackageNamesProvider) version() semver.Version {
+	return semver.Version{Major: 47}
+}
+
+func (p *ExtraPackageNamesProvider) GetSchema(
+	context.Context, plugin.GetSchemaRequest,
+) (plugin.GetSchemaResponse, error) {
+	choiceToken := "other:mod:Choice" //nolint:gosec // not a credential
+	objToken := "other:mod:Obj"       //nolint:gosec // not a credential
+
+	pkg := schema.PackageSpec{
+		Name:                p.pkg().String(),
+		Version:             p.version().String(),
+		AllowedPackageNames: []string{"other"},
+		Types: map[string]schema.ComplexTypeSpec{
+			choiceToken: {
+				ObjectTypeSpec: schema.ObjectTypeSpec{Type: "string"},
+				Enum: []schema.EnumValueSpec{
+					{Name: "First", Value: "first"},
+					{Name: "Second", Value: "second"},
+				},
+			},
+			objToken: {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"label":  {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"choice": {TypeSpec: schema.TypeSpec{Ref: "#/types/" + choiceToken}},
+					},
+				},
+			},
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"other:mod:Res": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"choice": {TypeSpec: schema.TypeSpec{Ref: "#/types/" + choiceToken}},
+						"obj":    {TypeSpec: schema.TypeSpec{Ref: "#/types/" + objToken}},
+					},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"choice": {TypeSpec: schema.TypeSpec{Ref: "#/types/" + choiceToken}},
+					"obj":    {TypeSpec: schema.TypeSpec{Ref: "#/types/" + objToken}},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"other:mod:getThing": {
+				Inputs: &schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"text": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					Required: []string{"text"},
+				},
+				ReturnType: &schema.ReturnTypeSpec{
+					ObjectTypeSpec: &schema.ObjectTypeSpec{
+						Type: "object",
+						Properties: map[string]schema.PropertySpec{
+							"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						Required: []string{"result"},
+					},
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(pkg)
+	return plugin.GetSchemaResponse{Schema: jsonBytes}, err
+}
+
+func (p *ExtraPackageNamesProvider) Close() error {
+	return nil
+}
+
+func (p *ExtraPackageNamesProvider) Configure(
+	context.Context, plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
+}
+
+func (p *ExtraPackageNamesProvider) CheckConfig(
+	_ context.Context, req plugin.CheckConfigRequest,
+) (plugin.CheckConfigResponse, error) {
+	return plugin.CheckConfigResponse{Properties: req.News}, nil
+}
+
+func (p *ExtraPackageNamesProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
+	return plugin.PluginInfo{
+		Version: ptr(p.version()),
+	}, nil
+}
+
+func (p *ExtraPackageNamesProvider) SignalCancellation(context.Context) error {
+	return nil
+}
+
+func (p *ExtraPackageNamesProvider) GetMapping(
+	context.Context, plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
+}
+
+func (p *ExtraPackageNamesProvider) GetMappings(
+	context.Context, plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
+}
+
+func (p *ExtraPackageNamesProvider) DiffConfig(
+	context.Context, plugin.DiffConfigRequest,
+) (plugin.DiffConfigResponse, error) {
+	return plugin.DiffResult{}, nil
+}
+
+func (p *ExtraPackageNamesProvider) Check(
+	_ context.Context, req plugin.CheckRequest,
+) (plugin.CheckResponse, error) {
+	if req.URN.Type() != "other:mod:Res" {
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
+		}, nil
+	}
+	return plugin.CheckResponse{Properties: req.News}, nil
+}
+
+func (p *ExtraPackageNamesProvider) Create(
+	_ context.Context, req plugin.CreateRequest,
+) (plugin.CreateResponse, error) {
+	if req.URN.Type() != "other:mod:Res" {
+		return plugin.CreateResponse{Status: resource.StatusUnknown},
+			fmt.Errorf("invalid URN type: %s", req.URN.Type())
+	}
+	return plugin.CreateResponse{
+		ID:         resource.ID("new-resource-id"),
+		Properties: req.Properties,
+		Status:     resource.StatusOK,
+	}, nil
+}
+
+func (p *ExtraPackageNamesProvider) Invoke(
+	_ context.Context, req plugin.InvokeRequest,
+) (plugin.InvokeResponse, error) {
+	if req.Tok != "other:mod:getThing" {
+		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
+	}
+	text, ok := req.Args["text"]
+	if !ok || !text.IsString() {
+		return plugin.InvokeResponse{
+			Failures: makeCheckFailure("text", "missing string property text"),
+		}, nil
+	}
+	return plugin.InvokeResponse{
+		Properties: resource.PropertyMap{
+			"result": resource.NewProperty("got: " + text.StringValue()),
+		},
+	}, nil
+}

--- a/pkg/testing/pulumi-test-language/tests/l2_allowed_package_name.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_allowed_package_name.go
@@ -1,0 +1,71 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l2-allowed-package-name"] = LanguageTest{
+		Providers: []func() plugin.Provider{
+			func() plugin.Provider { return &providers.ExtraPackageNamesProvider{} },
+		},
+		Runs: []TestRun{{
+			Assert: func(l *L, res AssertArgs) {
+				err, snapshot, changes := res.Err, res.Snap, res.Changes
+				RequireStackResource(l, err, changes)
+
+				require.Len(l, snapshot.Resources, 5,
+					"stack, explicit provider, default provider, and 2 resources")
+
+				viaProvider := RequireSingleNamedResource(l, snapshot.Resources, "viaProvider")
+				assert.Equal(l, resource.PropertyMap{
+					"choice": resource.NewProperty("first"),
+					"obj": resource.NewProperty(resource.PropertyMap{
+						"label":  resource.NewProperty("explicit"),
+						"choice": resource.NewProperty("second"),
+					}),
+				}, viaProvider.Outputs)
+
+				explicitProvider := RequireSingleNamedResource(l, snapshot.Resources, "prov")
+				assert.Equal(l, viaProvider.Provider, string(explicitProvider.URN)+"::"+string(explicitProvider.ID))
+
+				viaPackage := RequireSingleNamedResource(l, snapshot.Resources, "viaPackage")
+				assert.Equal(l, resource.PropertyMap{
+					"choice": resource.NewProperty("second"),
+					"obj": resource.NewProperty(resource.PropertyMap{
+						"label":  resource.NewProperty("bare"),
+						"choice": resource.NewProperty("first"),
+					}),
+				}, viaPackage.Outputs)
+
+				defaultProvider := RequireSingleNamedResource(l, snapshot.Resources, "default_47_0_0")
+				assert.Equal(l, viaPackage.Provider, string(defaultProvider.URN)+"::"+string(defaultProvider.ID))
+
+				// The stack is not reliably the first resource; a default provider can
+				// register ahead of it. See pulumi/pulumi#17816.
+				stack := RequireSingleResource(l, snapshot.Resources, resource.RootStackType)
+				assert.Equal(l, resource.PropertyMap{
+					"result": resource.NewProperty("got: hello"),
+				}, stack.Outputs)
+			},
+		}},
+	}
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-allowed-package-name/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-allowed-package-name/main.pp
@@ -1,0 +1,36 @@
+package {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}
+
+resource "prov" "pulumi:providers:extra-package-names" {}
+
+resource "viaProvider" "other:mod:Res" {
+  choice = "first"
+  obj = {
+    label  = "explicit"
+    choice = "second"
+  }
+
+  options {
+    provider = prov
+  }
+}
+
+resource "viaPackage" "other:mod:Res" {
+  choice = "second"
+  obj = {
+    label  = "bare"
+    choice = "first"
+  }
+
+  options {
+    provider = extra-package-names
+  }
+}
+
+thing = invoke("other:mod:getThing", { text = "hello" }, { provider = extra-package-names })
+
+output "result" {
+  value = thing.result
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -113,6 +113,7 @@ var expectedFailures = map[string]string{
 	"l2-resource-config-primitives": "cannot convert secretBool (variable of struct type pulumi.BoolOutput) to type pulumi.Bool, etc", //nolint:lll
 	"l2-resource-config-objects":    "cannot convert plainBooleanMap (variable of type string) to type pulumi.BoolMap",
 	"l2-resource-schema-secret":     "does not preserve schema-secret unknown outputs",
+	"l2-allowed-package-name":       "codegen does not yet resolve members declared under an allowed package name",
 
 	"l2-plain": "map literals nested in plain list elements render without a type; generated code does not compile",
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -103,6 +103,7 @@ var expectedFailures = map[string]string{
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 	"l2-resource-schema-secret":          "does not preserve schema-secret unknown outputs",
 	"l3-range-invoke-output-traversal":   "pulumi#12507: range loop variable captured by reference; indexed output resolves with the wrong index", //nolint:lll
+	"l2-allowed-package-name":            "codegen does not yet resolve members declared under an allowed package name",
 }
 
 // testLanguage runs the language conformance tests for the given runtime ("nodejs" or "bun").

--- a/sdk/pcl/cmd/pulumi-language-pcl/main.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/main.go
@@ -411,6 +411,12 @@ func getPclDependencies(parser *hclsyntax.Parser) ([]*schema.PackageDescriptor, 
 			if !ok || block.Type != "resource" || len(block.Labels) < 2 {
 				continue
 			}
+			if _, redirected := pcl.SyntacticProviderOption(block); redirected {
+				// The resource's token resolves against the passed provider's
+				// package, which is declared by its own resource block or
+				// package block.
+				continue
+			}
 			pkg, err := pclruntime.PackageNameFromToken(block.Labels[1])
 			if err != nil {
 				return nil, err
@@ -427,6 +433,12 @@ func getPclDependencies(parser *hclsyntax.Parser) ([]*schema.PackageDescriptor, 
 			}
 			token, ok := invokeToken(call)
 			if !ok {
+				return nil
+			}
+			if pcl.SyntacticInvokeProviderOption(call) {
+				// The invoke's token resolves against the passed provider's
+				// package, which is declared by its own resource block or
+				// package block.
 				return nil
 			}
 			pkg, err := pclruntime.PackageNameFromToken(token)

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-allowed-package-name/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-allowed-package-name/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-allowed-package-name
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-allowed-package-name/extra-package-names.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-allowed-package-name/extra-package-names.pp
@@ -1,0 +1,4 @@
+package "extra-package-names" {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-allowed-package-name/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-allowed-package-name/main.pp
@@ -1,0 +1,36 @@
+package {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}
+
+resource "prov" "pulumi:providers:extra-package-names" {}
+
+resource "viaProvider" "other:mod:Res" {
+  choice = "first"
+  obj = {
+    label  = "explicit"
+    choice = "second"
+  }
+
+  options {
+    provider = prov
+  }
+}
+
+resource "viaPackage" "other:mod:Res" {
+  choice = "second"
+  obj = {
+    label  = "bare"
+    choice = "first"
+  }
+
+  options {
+    provider = extra-package-names
+  }
+}
+
+thing = invoke("other:mod:getThing", { text = "hello" }, { provider = extra-package-names })
+
+output "result" {
+  value = thing.result
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-allowed-package-name/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-allowed-package-name/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-allowed-package-name
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-allowed-package-name/extra-package-names.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-allowed-package-name/extra-package-names.pp
@@ -1,0 +1,4 @@
+package "extra-package-names" {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-allowed-package-name/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-allowed-package-name/main.pp
@@ -1,0 +1,36 @@
+package {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}
+
+resource "prov" "pulumi:providers:extra-package-names" {}
+
+resource "viaProvider" "other:mod:Res" {
+  choice = "first"
+  obj = {
+    label  = "explicit"
+    choice = "second"
+  }
+
+  options {
+    provider = prov
+  }
+}
+
+resource "viaPackage" "other:mod:Res" {
+  choice = "second"
+  obj = {
+    label  = "bare"
+    choice = "first"
+  }
+
+  options {
+    provider = extra-package-names
+  }
+}
+
+thing = invoke("other:mod:getThing", { text = "hello" }, { provider = extra-package-names })
+
+output "result" {
+  value = thing.result
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-allowed-package-name/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-allowed-package-name/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-allowed-package-name
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-allowed-package-name/extra-package-names.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-allowed-package-name/extra-package-names.pp
@@ -1,0 +1,4 @@
+package "extra-package-names" {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-allowed-package-name/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-allowed-package-name/main.pp
@@ -1,0 +1,36 @@
+package {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}
+
+resource "prov" "pulumi:providers:extra-package-names" {}
+
+resource "viaProvider" "other:mod:Res" {
+  choice = "first"
+  obj = {
+    label  = "explicit"
+    choice = "second"
+  }
+
+  options {
+    provider = prov
+  }
+}
+
+resource "viaPackage" "other:mod:Res" {
+  choice = "second"
+  obj = {
+    label  = "bare"
+    choice = "first"
+  }
+
+  options {
+    provider = extra-package-names
+  }
+}
+
+thing = invoke("other:mod:getThing", { text = "hello" }, { provider = extra-package-names })
+
+output "result" {
+  value = thing.result
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/sdks/extra-package-names-47.0.0/extra-package-names-47.0.0.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/sdks/extra-package-names-47.0.0/extra-package-names-47.0.0.pp
@@ -1,0 +1,4 @@
+package "extra-package-names" {
+  baseProviderName    = "extra-package-names"
+  baseProviderVersion = "47.0.0"
+}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -102,6 +102,7 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l2-config-default-from-invoke":      "config default from an invoke is Output[Any], not str | None; fails mypy",
+	"l2-allowed-package-name":            "codegen does not yet resolve members declared under an allowed package name",
 	"l1-builtin-try":                     "Temporarily disabled until pr #18915 is submitted",
 	"l1-expand-final":                    "Python program generation does not support `...` argument expansion",
 	"l1-builtin-can":                     "Temporarily disabled until pr #18916 is submitted",


### PR DESCRIPTION
A schema may declare resources, functions and types whose token names a
different package, provided that package is listed in `allowedPackageNames`.
Such members could not be referenced by a PCL program: binding resolves the
token by its package portion, which names a package with no schema of its own,
and registrations route to a default provider for that phantom package.

## New syntax

A resource or invoke that passes the `provider` option resolves its token
against the schema of **the passed provider's package**, rather than the
package named by the token. The option accepts either form:

```hcl
package {
    baseProviderName    = "extra-package-names"
    baseProviderVersion = "47.0.0"
}

resource "prov" "pulumi:providers:extra-package-names" {}

// via an explicit provider resource
resource "viaProvider" "other:mod:Res" {
    options { provider = prov }
}

// via a bare reference to the package block; served by that package's default provider
resource "viaPackage" "other:mod:Res" {
    options { provider = extra-package-names }
}
```

A package block may be referenced by name only when no program node already
claims that name; program nodes keep their names.

Registrations for such members carry the defining package's reference, which is
the only field on the wire that distinguishes the serving package from the one
the token names. Package references are now requested for unparameterized
packages when, and only when, the package declares foreign tokens.

## Test plan

Adds the `extra-package-names` conformance provider and the
`l2-allowed-package-name` test, covering a resource, function, enum type and
object type declared under a foreign package name. The test passes in PCL. Go,
Node.js and Python are marked as expected failures here and enabled one language
per PR on top of this one:

- #24010 Go
- #24011 Node.js
- #24012 Python