### PR TITLE
GetSchema: only unmarshal spec when necessary

### DIFF
--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -536,7 +536,7 @@ func (p pluginProvider) GetSchema(
 	ctx, span := tracer.Start(ctx, "packageworkspace.injectSchemaMetadata")
 	defer span.End()
 
-	var pkgSpec schema.PackageSpec
+	var pkgSpec schema.PartialPackageSpec
 	_, unmarshalSpan := tracer.Start(ctx, "packageworkspace.unmarshalSchema")
 	unmarshalErr := json.Unmarshal(resp.Schema, &pkgSpec)
 	unmarshalSpan.End()
@@ -560,7 +560,7 @@ func (p pluginProvider) GetSchema(
 	_, marshalSpan := tracer.Start(ctx, "packageworkspace.marshalSchema")
 	bytes, err := json.Marshal(pkgSpec)
 	marshalSpan.End()
-	contract.AssertNoErrorf(err, "schema.PackageSpec is safe to marshal")
+	contract.AssertNoErrorf(err, "schema.PartialPackageSpec is safe to marshal")
 	return plugin.GetSchemaResponse{Schema: bytes}, nil
 }
 

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -523,32 +523,43 @@ func (p pluginProvider) GetSchema(
 	//
 	// TODO[https://github.com/pulumi/pulumi/issues/21258]: Download lock files would
 	// allow us to push this deeper through the plugin loading process.
-
-	var pkgSpec schema.PackageSpec
-	if json.Unmarshal(resp.Schema, &pkgSpec) != nil {
-		// If we can't un-marshal, give up.
-		return resp, nil
-	}
 	source := p.originalSpec.Source
 	if p.originalSpec.Version != "" {
 		source += "@" + p.originalSpec.Version
 	}
 	pd, err := workspace.NewPluginDescriptor(ctx, source, apitype.ResourcePlugin, nil, "", nil)
-	if err == nil && pd.IsGitPlugin() {
-		pkgSpec.PluginDownloadURL = pd.PluginDownloadURL
-		if pd.Version != nil {
-			pkgSpec.Version = pd.Version.String()
-		}
+	if err != nil || !pd.IsGitPlugin() {
+		return resp, nil
+	}
 
-		if pkgSpec.Namespace == "" {
-			namespaceRegex := regexp.MustCompile(`git://[^/]+/([^/]+)/`)
-			matches := namespaceRegex.FindStringSubmatch(pd.PluginDownloadURL)
-			if len(matches) == 2 {
-				pkgSpec.Namespace = strings.ToLower(matches[1])
-			}
+	tracer := otel.Tracer("pulumi-cli")
+	ctx, span := tracer.Start(ctx, "packageworkspace.injectSchemaMetadata")
+	defer span.End()
+
+	var pkgSpec schema.PackageSpec
+	_, unmarshalSpan := tracer.Start(ctx, "packageworkspace.unmarshalSchema")
+	unmarshalErr := json.Unmarshal(resp.Schema, &pkgSpec)
+	unmarshalSpan.End()
+	if unmarshalErr != nil {
+		// If we can't un-marshal, give up.
+		return resp, nil
+	}
+
+	pkgSpec.PluginDownloadURL = pd.PluginDownloadURL
+	if pd.Version != nil {
+		pkgSpec.Version = pd.Version.String()
+	}
+	if pkgSpec.Namespace == "" {
+		namespaceRegex := regexp.MustCompile(`git://[^/]+/([^/]+)/`)
+		matches := namespaceRegex.FindStringSubmatch(pd.PluginDownloadURL)
+		if len(matches) == 2 {
+			pkgSpec.Namespace = strings.ToLower(matches[1])
 		}
 	}
+
+	_, marshalSpan := tracer.Start(ctx, "packageworkspace.marshalSchema")
 	bytes, err := json.Marshal(pkgSpec)
+	marshalSpan.End()
 	contract.AssertNoErrorf(err, "schema.PackageSpec is safe to marshal")
 	return plugin.GetSchemaResponse{Schema: bytes}, nil
 }


### PR DESCRIPTION
In GetSchema, we currently always unmarshal the spec, and then
re-marshal it, changing some fields *only* if we have a git plugin.
If we don't have a git plugin, there's on real reason to unmarshal the
spec, so don't do that to save some time.

Locally this saves about 600ms with aws@7.37.0.