### PR TITLE
Moving some path logic to pkg

### DIFF
--- a/pkg/backend/diy/lock.go
+++ b/pkg/backend/diy/lock.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -163,7 +164,7 @@ func (b *diyBackend) Unlock(ctx context.Context, stackRef backend.StackReference
 }
 
 func lockDir() string {
-	return path.Join(workspace.BookkeepingDir, workspace.LockDir)
+	return path.Join(workspace.BookkeepingDir, pkgWorkspace.LockDir)
 }
 
 func stackLockDir(stack tokens.QName) string {

--- a/pkg/backend/diy/store.go
+++ b/pkg/backend/diy/store.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -37,15 +38,15 @@ import (
 var (
 	// StacksDir is a path under the state's root directory
 	// where the diy backend stores stack information.
-	StacksDir = filepath.Join(workspace.BookkeepingDir, workspace.StackDir)
+	StacksDir = filepath.Join(workspace.BookkeepingDir, pkgWorkspace.StackDir)
 
 	// HistoriesDir is a path under the state's root directory
 	// where the diy backend stores histories for all stacks.
-	HistoriesDir = filepath.Join(workspace.BookkeepingDir, workspace.HistoryDir)
+	HistoriesDir = filepath.Join(workspace.BookkeepingDir, pkgWorkspace.HistoryDir)
 
 	// BackupsDir is a path under the state's root directory
 	// where the diy backend stores backups of stacks.
-	BackupsDir = filepath.Join(workspace.BookkeepingDir, workspace.BackupDir)
+	BackupsDir = filepath.Join(workspace.BookkeepingDir, pkgWorkspace.BackupDir)
 )
 
 // referenceStore stores and provides access to stack information.

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -197,7 +197,8 @@ func NewUpCmd() *cobra.Command {
 		if skipConfigValidation {
 			// Still apply project config defaults onto the stack config, but skip validation.
 			if configErr := pkgWorkspace.ApplyProjectConfig(
-				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter,
+			); configErr != nil {
 				return fmt.Errorf("applying stack config: %w", configErr)
 			}
 		} else {
@@ -208,7 +209,8 @@ func NewUpCmd() *cobra.Command {
 				cfg.Environment,
 				cfg.Config,
 				encrypter,
-				decrypter)
+				decrypter,
+			)
 			if configErr != nil {
 				return fmt.Errorf("validating stack config: %w", configErr)
 			}
@@ -386,7 +388,8 @@ func NewUpCmd() *cobra.Command {
 		if name == "" {
 			defaultValue := pkgWorkspace.ValueOrSanitizedDefaultProjectName(name, template.ProjectName, template.Name)
 			name, err = ui.PromptForValue(
-				yes, "project name", defaultValue, false, pkgWorkspace.ValidateProjectName, opts.Display)
+				yes, "project name", defaultValue, false, pkgWorkspace.ValidateProjectName, opts.Display,
+			)
 			if err != nil {
 				return err
 			}
@@ -395,9 +398,11 @@ func NewUpCmd() *cobra.Command {
 		// Prompt for the project description, if we don't already have one from an existing stack.
 		if description == "" {
 			defaultValue := pkgWorkspace.ValueOrDefaultProjectDescription(
-				description, template.ProjectDescription, template.Description)
+				description, template.ProjectDescription, template.Description,
+			)
 			description, err = ui.PromptForValue(
-				yes, "project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts.Display)
+				yes, "project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts.Display,
+			)
 			if err != nil {
 				return err
 			}
@@ -416,7 +421,7 @@ func NewUpCmd() *cobra.Command {
 		proj.Name = tokens.PackageName(name)
 		proj.Description = &description
 		proj.Template = nil
-		if err = workspace.SaveProject(proj); err != nil {
+		if err = pkgWorkspace.SaveProject(proj); err != nil {
 			return fmt.Errorf("saving project: %w", err)
 		}
 
@@ -456,13 +461,15 @@ func NewUpCmd() *cobra.Command {
 		pluginHost, err := pkghost.New(
 			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
 			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext,
-			packageworkspace.NewResolverServer(reg))
+			packageworkspace.NewResolverServer(reg),
+		)
 		if err != nil {
 			return fmt.Errorf("building plugin host: %w", err)
 		}
 		defer contract.IgnoreClose(pluginHost) // host is owned here, closed after the context
 		_, main, pctx, err := engine.ProjectInfoContext(
-			ctx, projinfo, pluginHost, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil)
+			ctx, projinfo, pluginHost, cmdutil.Diag(), cmdutil.Diag(), false, nil, nil,
+		)
 		if err != nil {
 			return fmt.Errorf("building project context: %w", err)
 		}
@@ -492,7 +499,8 @@ func NewUpCmd() *cobra.Command {
 		if skipConfigValidation {
 			// Still apply project config defaults onto the stack config, but skip validation.
 			if configErr := pkgWorkspace.ApplyProjectConfig(
-				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter,
+			); configErr != nil {
 				return fmt.Errorf("applying stack config: %w", configErr)
 			}
 		} else {
@@ -503,7 +511,8 @@ func NewUpCmd() *cobra.Command {
 				cfg.Environment,
 				cfg.Config,
 				encrypter,
-				decrypter)
+				decrypter,
+			)
 			if configErr != nil {
 				return fmt.Errorf("validating stack config: %w", configErr)
 			}
@@ -741,60 +750,75 @@ func NewUpCmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,
-		"Print detailed debugging output during resource operations")
+		"Print detailed debugging output during resource operations",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&expectNop, "expect-no-changes", false,
-		"Return an error if any changes occur during this update. This check happens after the update is applied")
+		"Return an error if any changes occur during this update. This check happens after the update is applied",
+	)
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
+		"The name of the stack to operate on. Defaults to the current stack",
+	)
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
-		"Use the configuration values in the specified file rather than detecting the file name")
+		"Use the configuration values in the specified file rather than detecting the file name",
+	)
 	cmdConfig.OverrideEnvFlag(cmd, &envOverrides)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
-		"Config to use during the update and save to the stack config file")
+		"Config to use during the update and save to the stack config file",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&path, "config-path", false,
-		"Config keys contain a path to a property in a map or list to set")
+		"Config keys contain a path to a property in a map or list to set",
+	)
 	cmd.PersistentFlags().StringVar(
 		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
 			"decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault). Only "+
-			"used when creating a new stack from an existing template")
+			"used when creating a new stack from an existing template",
+	)
 
 	cmd.PersistentFlags().StringVar(
-		&client, "client", "", "The address of an existing language runtime host to connect to")
+		&client, "client", "", "The address of an existing language runtime host to connect to",
+	)
 	_ = cmd.PersistentFlags().MarkHidden("client")
 
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",
-		"Optional message to associate with the update operation")
+		"Optional message to associate with the update operation",
+	)
 
 	cmd.PersistentFlags().StringArrayVarP(
 		&targets, "target", "t", []string{},
 		"Specify a single resource URN to update. Other resources will not be updated."+
 			" Multiple resources can be specified using --target urn1 --target urn2."+
-			" Wildcards (*, **) are also supported")
+			" Wildcards (*, **) are also supported",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&excludes, "exclude", []string{},
 		"Specify a resource URN to ignore. These resources will not be updated."+
 			" Multiple resources can be specified using --exclude urn1 --exclude urn2."+
-			" Wildcards (*, **) are also supported")
+			" Wildcards (*, **) are also supported",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&replaces, "replace", []string{},
 		"Specify a single resource URN to replace. Multiple resources can be specified using --replace urn1 --replace urn2."+
-			" Wildcards (*, **) are also supported")
+			" Wildcards (*, **) are also supported",
+	)
 	cmd.PersistentFlags().StringArrayVar(
 		&targetReplaces, "target-replace", []string{},
 		"Specify a single resource URN to replace. Other resources will not be updated."+
-			" Shorthand for --target urn --replace urn.")
+			" Shorthand for --target urn --replace urn.",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&targetDependents, "target-dependents", false,
-		"Allows updating of dependent targets discovered but not specified in --target list")
+		"Allows updating of dependent targets discovered but not specified in --target list",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&excludeDependents, "exclude-dependents", false,
-		"Allows ignoring of dependent targets discovered but not specified in --exclude list")
+		"Allows ignoring of dependent targets discovered but not specified in --exclude list",
+	)
 
 	// Currently, we can't mix `--target` and `--exclude`.
 	cmd.MarkFlagsMutuallyExclusive("target", "exclude")
@@ -802,91 +826,115 @@ func NewUpCmd() *cobra.Command {
 	// Flags for engine.UpdateOptions.
 	cmd.PersistentFlags().StringSliceVar(
 		&policyPackPaths, "policy-pack", []string{},
-		"Run one or more policy packs as part of this update")
+		"Run one or more policy packs as part of this update",
+	)
 	cmd.PersistentFlags().StringSliceVar(
 		&policyPackConfigPaths, "policy-pack-config", []string{},
-		`Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag`)
+		`Path to JSON file containing the config for the policy pack of the corresponding "--policy-pack" flag`,
+	)
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
-		"Display operation as a rich diff showing the overall change")
+		"Display operation as a rich diff showing the overall change",
+	)
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
-		"Serialize the update diffs, operations, and overall output as JSON")
+		"Serialize the update diffs, operations, and overall output as JSON",
+	)
 	outputflag.Var(cmd.Flags(), &output)
 	// Hidden until --output is wired up across all operations (destroy, preview, refresh, ...).
 	contract.AssertNoErrorf(cmd.Flags().MarkHidden("output"), `Could not mark "output" as hidden`)
 	cmd.MarkFlagsMutuallyExclusive("json", "output")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),
-		"Allow P resource operations to run in parallel at once (1 for no parallelism).")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism).",
+	)
 	cmd.PersistentFlags().StringVarP(
 		&refresh, "refresh", "r", "",
-		"Refresh the state of the stack's resources before this update")
+		"Refresh the state of the stack's resources before this update",
+	)
 	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to refresh resources,"+
-			" this only applies if --refresh is set")
+			" this only applies if --refresh is set",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&skipConfigValidation, "skip-config-validation", false,
-		"Skip validation of stack config values against the project config schema")
+		"Skip validation of stack config values against the project config schema",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
-		"Show configuration keys and variables")
+		"Show configuration keys and variables",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showPolicyRemediations, "show-policy-remediations", false,
-		"Show per-resource policy remediation details instead of a summary")
+		"Show per-resource policy remediation details instead of a summary",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showReplacementSteps, "show-replacement-steps", false,
-		"Show detailed resource replacement creates and deletes instead of a single step")
+		"Show detailed resource replacement creates and deletes instead of a single step",
+	)
 
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
-		"Show resources that don't need be updated because they haven't changed, alongside those that do")
+		"Show resources that don't need be updated because they haven't changed, alongside those that do",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showSecrets, "show-secrets", false,
-		"Show secret outputs in the CLI output")
+		"Show secret outputs in the CLI output",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showReads, "show-reads", false,
-		"Show resources that are being read in, alongside those being managed directly in the stack")
+		"Show resources that are being read in, alongside those being managed directly in the stack",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showURNs, "urns", false,
-		"Display full URNs instead of short resource names")
+		"Display full URNs instead of short resource names",
+	)
 
 	cmd.PersistentFlags().BoolVarP(
 		&skipPreview, "skip-preview", "f", false,
-		"Do not calculate a preview before performing the update")
+		"Do not calculate a preview before performing the update",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
-		"Suppress display of stack outputs (in case they contain sensitive values)")
+		"Suppress display of stack outputs (in case they contain sensitive values)",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&suppressProgress, "suppress-progress", false,
-		"Suppress display of periodic progress dots")
+		"Suppress display of periodic progress dots",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&showFullOutput, "show-full-output", false,
-		"Display full length of inputs & outputs")
+		"Display full length of inputs & outputs",
+	)
 	cmd.PersistentFlags().StringVar(
 		&suppressPermalink, "suppress-permalink", "",
-		"Suppress display of the state permalink")
+		"Suppress display of the state permalink",
+	)
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
-		"Automatically approve and perform the update after previewing it")
+		"Automatically approve and perform the update after previewing it",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&continueOnError, "continue-on-error", env.ContinueOnError.Value(),
 		"Continue updating resources even if an error is encountered "+
-			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)")
+			"(can also be set with PULUMI_CONTINUE_ON_ERROR environment variable)",
+	)
 	//nolint:lll // long description
 	cmd.PersistentFlags().StringArrayVar(
 		&attachDebugger, "attach-debugger", []string{},
-		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin:<name>' or 'all'.")
+		"Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin:<name>' or 'all'.",
+	)
 	cmd.Flag("attach-debugger").NoOptDefVal = "program"
 
 	cmd.PersistentFlags().StringVar(
 		&planFilePath, "plan", "",
 		"[EXPERIMENTAL] Path to a plan file to use for the update. The update will not "+
 			"perform operations that exceed its plan (e.g. replacements instead of updates, or updates instead"+
-			"of sames).")
+			"of sames).",
+	)
 	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(cmd.PersistentFlags().MarkHidden("plan"), `Could not mark "plan" as hidden`)
 	}
@@ -894,32 +942,38 @@ func NewUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&strict, "strict", false,
 		"[EXPERIMENTAL] Enable strict plan behavior: generate a plan during preview and constrain the update "+
-			"to that plan (opt-in). Cannot be used with --skip-preview.")
+			"to that plan (opt-in). Cannot be used with --skip-preview.",
+	)
 
 	cmd.PersistentFlags().BoolVar(
 		&skipPluginPreInstall, "skip-plugin-pre-install", false,
 		"Skip the up-front provider plugin install step; missing plugins are installed lazily by the engine. "+
-			"When deploying from a template, also skips installing the project's runtime dependencies.")
+			"When deploying from a template, also skips installing the project's runtime dependencies.",
+	)
 
 	cmd.PersistentFlags().BoolVar(
 		&neoEnabled, "neo", false,
 		"Enable Pulumi Neo's assistance for improved CLI experience and insights "+
-			"(can also be set with PULUMI_NEO environment variable)")
+			"(can also be set with PULUMI_NEO environment variable)",
+	)
 
 	cmd.PersistentFlags().BoolVar(
 		&neoTaskOnFailure, "neo-task-on-failure", false,
-		"Start a Neo task to help debug errors that occur during the operation")
+		"Start a Neo task to help debug errors that occur during the operation",
+	)
 	if !env.Experimental.Value() {
 		contract.AssertNoErrorf(
 			cmd.PersistentFlags().MarkHidden("neo-task-on-failure"),
-			`Could not mark "neo-task-on-failure" as hidden`)
+			`Could not mark "neo-task-on-failure" as hidden`,
+		)
 	}
 
 	// Keep --copilot flag for backwards compatibility, but hide it
 	cmd.PersistentFlags().BoolVar(
 		&neoEnabled, "copilot", false,
 		"[DEPRECATED] Use --neo instead. Enable Pulumi Neo's assistance for improved CLI experience and insights "+
-			"(can also be set with PULUMI_COPILOT environment variable)")
+			"(can also be set with PULUMI_COPILOT environment variable)",
+	)
 	_ = cmd.PersistentFlags().MarkDeprecated("copilot", "please use --neo instead")
 
 	// Currently, we can't mix `--target` and `--exclude`.
@@ -931,7 +985,8 @@ func NewUpCmd() *cobra.Command {
 	if env.DebugCommands.Value() {
 		cmd.PersistentFlags().StringVar(
 			&eventLogPath, "event-log", "",
-			"Log events to a file at this path")
+			"Log events to a file at this path",
+		)
 	}
 
 	// internal flags
@@ -956,7 +1011,8 @@ func validatePolicyPackConfig(policyPackPaths []string, policyPackConfigPaths []
 		}
 		if len(policyPackConfigPaths) != len(policyPackPaths) {
 			return errors.New(
-				`the number of "--policy-pack-config" flags must match the number of "--policy-pack" flags`)
+				`the number of "--policy-pack-config" flags must match the number of "--policy-pack" flags`,
+			)
 		}
 	}
 	return nil

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -296,10 +296,12 @@ func runNew(ctx context.Context, args newArgs) error {
 		fmt.Fprintln(args.stdout,
 			opts.Color.Colorize(
 				colors.Highlight("Enter a value or leave blank to accept the (default), and press <ENTER>.",
-					"<ENTER>", colors.BrightCyan+colors.Bold)))
+					"<ENTER>", colors.BrightCyan+colors.Bold),
+			))
 		fmt.Fprintln(args.stdout,
 			opts.Color.Colorize(
-				colors.Highlight("Press ^C at any time to quit.", "^C", colors.BrightCyan+colors.Bold)))
+				colors.Highlight("Press ^C at any time to quit.", "^C", colors.BrightCyan+colors.Bold),
+			))
 		fmt.Fprintln(args.stdout)
 	}
 
@@ -307,7 +309,8 @@ func runNew(ctx context.Context, args newArgs) error {
 	if args.name == "" {
 		defaultValue := pkgWorkspace.ValueOrSanitizedDefaultProjectName(args.name, template.ProjectName, filepath.Base(cwd))
 		err := validateProjectName(
-			ctx, b, orgName, defaultValue, args.generateOnly, opts.WithIsInteractive(false))
+			ctx, b, orgName, defaultValue, args.generateOnly, opts.WithIsInteractive(false),
+		)
 		if err != nil {
 			// If --yes is given error out now that the default value is invalid. If we allow prompt to catch
 			// this case it can lead to a confusing error message because we set the defaultValue to "" below.
@@ -328,9 +331,11 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Prompt for the project description, if it wasn't already specified.
 	if args.description == "" {
 		defaultValue := pkgWorkspace.ValueOrDefaultProjectDescription(
-			args.description, template.ProjectDescription, template.Description)
+			args.description, template.ProjectDescription, template.Description,
+		)
 		args.description, err = args.prompt(
-			args.yes, "Project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts)
+			args.yes, "Project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts,
+		)
 		if err != nil {
 			return err
 		}
@@ -377,7 +382,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		proj.Runtime.SetOption(parts[0], parts[1])
 	}
 
-	if err = workspace.SaveProject(proj); err != nil {
+	if err = pkgWorkspace.SaveProject(proj); err != nil {
 		return fmt.Errorf("saving project: %w", err)
 	}
 	if b != nil {
@@ -404,11 +409,13 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
 	hostReg := cmdCmd.NewDefaultRegistry(
-		ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global())
+		ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global(),
+	)
 	pluginHost, err := pkghost.New(
 		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
 		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext,
-		packageworkspace.NewResolverServer(hostReg))
+		packageworkspace.NewResolverServer(hostReg),
+	)
 	if err != nil {
 		return err
 	}
@@ -450,7 +457,7 @@ func runNew(ctx context.Context, args newArgs) error {
 				for k, v := range options {
 					proj.Runtime.SetOption(k, v)
 				}
-				if err = workspace.SaveProject(proj); err != nil {
+				if err = pkgWorkspace.SaveProject(proj); err != nil {
 					return fmt.Errorf("saving project: %w", err)
 				}
 				// update programInfo to have the new options
@@ -495,7 +502,8 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Install dependencies, but only if we have a runtime to install with.
 	if !args.generateOnly && proj.Runtime.Name() != "" {
 		registry := cmdCmd.NewDefaultRegistry(
-			ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global())
+			ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global(),
+		)
 		if _, err := InstallPackagesFromProject(ctx, proj, root,
 			registry, -1, false, args.stderr, args.stderr, env.Global()); err != nil {
 			return err
@@ -507,7 +515,8 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	fmt.Fprintln(args.stdout,
 		opts.Color.Colorize(
-			colors.BrightGreen+colors.Bold+"Your new project is ready to go!"+colors.Reset)+
+			colors.BrightGreen+colors.Bold+"Your new project is ready to go!"+colors.Reset,
+		)+
 			" "+cmdutil.EmojiOr("✨", ""))
 	fmt.Fprintln(args.stdout)
 
@@ -640,40 +649,52 @@ func NewNewCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringArrayVarP(
 		&args.configArray, "config", "c", []string{},
-		"Config to save")
+		"Config to save",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&args.configPath, "config-path", false,
-		"Config keys contain a path to a property in a map or list to set")
+		"Config keys contain a path to a property in a map or list to set",
+	)
 	cmd.PersistentFlags().StringVarP(
 		&args.description, "description", "d", "",
-		"The project description; if not specified, a prompt will request it")
+		"The project description; if not specified, a prompt will request it",
+	)
 	cmd.PersistentFlags().StringVar(
 		&args.dir, "dir", "",
-		"The location to place the generated project; if not specified, the current directory is used")
+		"The location to place the generated project; if not specified, the current directory is used",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.force, "force", "f", false,
-		"Forces content to be generated even if it would change existing files")
+		"Forces content to be generated even if it would change existing files",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.generateOnly, "generate-only", "g", false,
-		"Generate the project only; do not create a stack, save config, or install dependencies")
+		"Generate the project only; do not create a stack, save config, or install dependencies",
+	)
 	cmd.PersistentFlags().StringVarP(
 		&args.name, "name", "n", "",
-		"The project name; if not specified, a prompt will request it")
+		"The project name; if not specified, a prompt will request it",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.offline, "offline", "o", false,
-		"Use locally cached templates without making any network requests")
+		"Use locally cached templates without making any network requests",
+	)
 	cmd.PersistentFlags().StringVarP(
 		&args.stack, "stack", "s", "",
-		"The stack name; either an existing stack or stack to create; if not specified, a prompt will request it")
+		"The stack name; either an existing stack or stack to create; if not specified, a prompt will request it",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.yes, "yes", "y", false,
-		"Skip prompts and proceed with default values")
+		"Skip prompts and proceed with default values",
+	)
 	cmd.PersistentFlags().StringVar(
 		&args.secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
-			"decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault)")
+			"decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault)",
+	)
 	cmd.PersistentFlags().BoolVarP(
 		&args.listTemplates, "list-templates", "l", false,
-		"List locally installed templates and exit")
+		"List locally installed templates and exit",
+	)
 	cmd.PersistentFlags().StringVar(
 		&args.aiPrompt, "ai", "", "Prompt to use for Pulumi AI",
 	)
@@ -722,7 +743,8 @@ func validateProjectName(ctx context.Context, b backend.Backend,
 		}
 	}
 	return validateProjectNameInternal(
-		ctx, b, orgName, projectName, generateOnly, opts, handleExistingProjectName)
+		ctx, b, orgName, projectName, generateOnly, opts, handleExistingProjectName,
+	)
 }
 
 func validateProjectNameInternal(ctx context.Context, b backend.Backend,
@@ -855,7 +877,8 @@ func promptForAIProjectURL(ctx context.Context, ws pkgWorkspace.Context, args ne
 
 	if args.aiPrompt == "" && !opts.IsInteractive {
 		return "", errors.New(
-			"the --ai <prompt> flag is required when running in non-interactive mode with the --language flag")
+			"the --ai <prompt> flag is required when running in non-interactive mode with the --language flag",
+		)
 	}
 
 	checkedBackend, ok := b.(httpstate.Backend)
@@ -865,7 +888,8 @@ func promptForAIProjectURL(ctx context.Context, ws pkgWorkspace.Context, args ne
 				"--language is used to generate a template with Pulumi AI. " +
 					"Please log in to Pulumi Cloud to use Pulumi AI.\n" +
 					"Use --template to create a project from a template, " +
-					"or no flags to choose one interactively.")
+					"or no flags to choose one interactively.",
+			)
 		}
 		return "", errors.New("please log in to Pulumi Cloud to use Pulumi AI")
 	}

--- a/pkg/cmd/pulumi/project/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_acceptance_test.go
@@ -226,7 +226,8 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 	assert.Equal(t, defaultProjectName, proj.Name.String())
 	// Expect the stack directory to have a checkpoint file for the stack.
 	_, err = os.Stat(filepath.Join(
-		backendDir, workspace.BookkeepingDir, workspace.StackDir, defaultProjectName, stackName+".json"))
+		backendDir, workspace.BookkeepingDir, pkgWorkspace.StackDir, defaultProjectName, stackName+".json",
+	))
 	require.NoError(t, err)
 
 	b, err = backend.CurrentBackend(ctx, pkgWorkspace.Instance, backend.DefaultLoginManager, nil, display.Options{})

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -851,7 +851,7 @@ func getCLIVersionInfo(
 
 // cacheVersionInfo saves version information in a cache file to be looked up later.
 func cacheVersionInfo(info cachedVersionInfo) error {
-	updateCheckFile, err := workspace.GetCachedVersionFilePath()
+	updateCheckFile, err := pkgWorkspace.GetCachedVersionFilePath()
 	if err != nil {
 		return err
 	}
@@ -867,7 +867,7 @@ func cacheVersionInfo(info cachedVersionInfo) error {
 
 // readVersionInfo reads version information from the cache file.
 func readVersionInfo() (cachedVersionInfo, error) {
-	updateCheckFile, err := workspace.GetCachedVersionFilePath()
+	updateCheckFile, err := pkgWorkspace.GetCachedVersionFilePath()
 	if err != nil {
 		return cachedVersionInfo{}, err
 	}
@@ -893,7 +893,7 @@ func readVersionInfo() (cachedVersionInfo, error) {
 // If we can't read the cached versions file, we return true and a zero time,
 // indicating that we want to possibly prompt the user for an upgrade.
 func checkVersionPrompt(devVersion bool) (bool, int64) {
-	updateCheckFile, err := workspace.GetCachedVersionFilePath()
+	updateCheckFile, err := pkgWorkspace.GetCachedVersionFilePath()
 	if err != nil {
 		return true, 0
 	}

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -72,7 +72,8 @@ func LoadProjectStack(
 		if err == nil {
 			sink.Warningf(
 				diag.Message("", "config file %s exists but will be ignored because this stack uses remote config"),
-				configFilePath)
+				configFilePath,
+			)
 		}
 		return stack.LoadRemoteConfig(ctx, project)
 	}
@@ -88,7 +89,7 @@ func SaveProjectStack(
 	if stack.ConfigLocation().IsRemote {
 		return stack.SaveRemoteConfig(ctx, ps)
 	}
-	return workspace.SaveProjectStack(stack.Ref().Name().Q(), ps)
+	return pkgWorkspace.SaveProjectStack(stack.Ref().Name().Q(), ps)
 }
 
 type LoadOption int
@@ -532,7 +533,8 @@ func SaveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 	if snapshot.PendingOperations != nil {
 		for _, op := range snapshot.PendingOperations {
 			msg := fmt.Sprintf(
-				"removing pending operation '%s' on '%s' from snapshot", op.Type, op.Resource.URN)
+				"removing pending operation '%s' on '%s' from snapshot", op.Type, op.Resource.URN,
+			)
 			cmdutil.Diag().Warningf(diag.Message(op.Resource.URN, msg))
 		}
 

--- a/pkg/cmd/pulumi/templates/project_templates.go
+++ b/pkg/cmd/pulumi/templates/project_templates.go
@@ -34,6 +34,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 )
 
 const (
@@ -203,7 +205,7 @@ func listTemplates[T any](
 		if info.IsDir() {
 			name := info.Name()
 
-			if name == workspace.GitDir {
+			if name == pkgWorkspace.GitDir {
 				continue
 			}
 
@@ -624,13 +626,13 @@ func GetTemplateDir(templateKind TemplateKind) (string, error) {
 	switch templateKind {
 	case TemplateKindPolicyPack:
 		override = env.PolicyTemplatePath.Value()
-		classicDir = workspace.TemplatePolicyDir
+		classicDir = pkgWorkspace.TemplatePolicyDir
 	case TemplateKindPackage:
 		override = env.PackageTemplatePath.Value()
-		classicDir = workspace.TemplatePackageDir
+		classicDir = pkgWorkspace.TemplatePackageDir
 	case TemplateKindPulumiProject:
 		override = env.TemplatePath.Value()
-		classicDir = workspace.TemplateDir
+		classicDir = pkgWorkspace.TemplateDir
 	default:
 		contract.Failf("unhandled TemplateKind: %v", templateKind)
 	}
@@ -660,7 +662,7 @@ func walkFiles(sourceDir string, destDir string, projectName string,
 
 		if entry.IsDir() {
 			// Ignore the .git directory.
-			if name == workspace.GitDir {
+			if name == pkgWorkspace.GitDir {
 				continue
 			}
 

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -1,0 +1,39 @@
+// Copyright 2016, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	sdkWorkspace "github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// SaveProject saves the project file on top of the existing one, using the standard location.
+func SaveProject(proj *sdkWorkspace.Project) error {
+	path, err := sdkWorkspace.DetectProjectPath()
+	if err != nil {
+		return err
+	}
+
+	return proj.Save(path)
+}
+
+func SaveProjectStack(stackName tokens.QName, stack *sdkWorkspace.ProjectStack) error {
+	_, path, err := sdkWorkspace.DetectProjectStackPath(stackName)
+	if err != nil {
+		return err
+	}
+
+	return stack.Save(path)
+}

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -20,8 +20,29 @@ import (
 )
 
 const (
+	// BackupDir is the name of the folder where backup stack information is stored.
+	BackupDir = "backups"
 	// CachedVersionFile is the name of the file we use to store when we last checked if the CLI was out of date
 	CachedVersionFile = ".cachedVersionInfo"
+	// GitDir is the name of the folder git uses to store information.
+	GitDir = ".git"
+	// HistoryDir is the name of the directory that holds historical information for projects.
+	HistoryDir = "history"
+	// StackDir is the name of the directory that holds stack information for projects.
+	StackDir = "stacks"
+	// LockDir is the name of the directory that holds locking information for projects.
+	LockDir = "locks"
+	// TemplateDir is the name of the directory containing templates.
+	TemplateDir = "templates"
+	// TemplatePolicyDir is the name of the directory containing templates for Policy Packs.
+	TemplatePolicyDir = "templates-policy"
+	// TemplatePackageDir is the name of the directory containing templates for Pulumi packages.
+	TemplatePackageDir = "templates-packages"
+	// WorkspaceDir is the name of the directory that holds workspace information for projects.
+	WorkspaceDir = "workspaces"
+
+	// WorkspaceFile is the name of the file that holds workspace information.
+	WorkspaceFile = "workspace.json"
 )
 
 // SaveProject saves the project file on top of the existing one, using the standard location.

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -19,6 +19,11 @@ import (
 	sdkWorkspace "github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+const (
+	// CachedVersionFile is the name of the file we use to store when we last checked if the CLI was out of date
+	CachedVersionFile = ".cachedVersionInfo"
+)
+
 // SaveProject saves the project file on top of the existing one, using the standard location.
 func SaveProject(proj *sdkWorkspace.Project) error {
 	path, err := sdkWorkspace.DetectProjectPath()
@@ -36,4 +41,10 @@ func SaveProjectStack(stackName tokens.QName, stack *sdkWorkspace.ProjectStack) 
 	}
 
 	return stack.Save(path)
+}
+
+// GetCachedVersionFilePath returns the location where the CLI caches information from pulumi.com on the newest
+// available version of the CLI
+func GetCachedVersionFilePath() (string, error) {
+	return sdkWorkspace.GetPulumiPath(CachedVersionFile)
 }

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -180,8 +180,8 @@ func (pw *projectWorkspace) readSettings() error {
 }
 
 func (pw *projectWorkspace) settingsPath() string {
-	uniqueFileName := string(pw.name) + "-" + sha1HexString(pw.project) + "-" + workspace.WorkspaceFile
-	path, err := workspace.GetPulumiPath(workspace.WorkspaceDir, uniqueFileName)
+	uniqueFileName := string(pw.name) + "-" + sha1HexString(pw.project) + "-" + WorkspaceFile
+	path, err := workspace.GetPulumiPath(WorkspaceDir, uniqueFileName)
 	contract.AssertNoErrorf(err, "could not get workspace path")
 	return path
 }

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -70,8 +70,6 @@ const (
 	RepoFile = "settings.json"
 	// WorkspaceFile is the name of the file that holds workspace information.
 	WorkspaceFile = "workspace.json"
-	// CachedVersionFile is the name of the file we use to store when we last checked if the CLI was out of date
-	CachedVersionFile = ".cachedVersionInfo"
 
 	// PulumiHomeEnvVar is a path to the '.pulumi' folder with plugins, access token, etc.
 	// The folder can have any name, not necessarily '.pulumi'.
@@ -316,12 +314,6 @@ func isMarkupFile(path string, expect string) bool {
 	}
 
 	return false
-}
-
-// GetCachedVersionFilePath returns the location where the CLI caches information from pulumi.com on the newest
-// available version of the CLI
-func GetCachedVersionFilePath() (string, error) {
-	return GetPulumiPath(CachedVersionFile)
 }
 
 // GetPulumiHomeDir returns the path of the '.pulumi' folder where Pulumi puts its artifacts.

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -38,8 +38,6 @@ const (
 	BackupDir = "backups"
 	// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
 	BookkeepingDir = ".pulumi"
-	// ConfigDir is the name of the folder that holds local configuration information.
-	ConfigDir = "config"
 	// GitDir is the name of the folder git uses to store information.
 	GitDir = ".git"
 	// HistoryDir is the name of the directory that holds historical information for projects.
@@ -58,16 +56,9 @@ const (
 	TemplatePolicyDir = "templates-policy"
 	// TemplatePackageDir is the name of the directory containing templates for Pulumi packages.
 	TemplatePackageDir = "templates-packages"
-	// WorkspaceDir is the name of the directory that holds workspace information for projects.
-	WorkspaceDir = "workspaces"
-
-	// IgnoreFile is the name of the file that we use to control what to upload to the service.
-	IgnoreFile = ".pulumiignore"
 
 	// ProjectFile is the base name of a project file.
 	ProjectFile = "Pulumi"
-	// RepoFile is the name of the file that holds information specific to the entire repository.
-	RepoFile = "settings.json"
 	// WorkspaceFile is the name of the file that holds workspace information.
 	WorkspaceFile = "workspace.json"
 

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -34,33 +34,15 @@ import (
 )
 
 const (
-	// BackupDir is the name of the folder where backup stack information is stored.
-	BackupDir = "backups"
 	// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
 	BookkeepingDir = ".pulumi"
-	// GitDir is the name of the folder git uses to store information.
-	GitDir = ".git"
-	// HistoryDir is the name of the directory that holds historical information for projects.
-	HistoryDir = "history"
 	// PluginDir is the name of the directory containing plugins.
 	PluginDir = "plugins"
 	// PolicyDir is the name of the directory that holds policy packs.
 	PolicyDir = "policies"
-	// StackDir is the name of the directory that holds stack information for projects.
-	StackDir = "stacks"
-	// LockDir is the name of the directory that holds locking information for projects.
-	LockDir = "locks"
-	// TemplateDir is the name of the directory containing templates.
-	TemplateDir = "templates"
-	// TemplatePolicyDir is the name of the directory containing templates for Policy Packs.
-	TemplatePolicyDir = "templates-policy"
-	// TemplatePackageDir is the name of the directory containing templates for Pulumi packages.
-	TemplatePackageDir = "templates-packages"
 
 	// ProjectFile is the base name of a project file.
 	ProjectFile = "Pulumi"
-	// WorkspaceFile is the name of the file that holds workspace information.
-	WorkspaceFile = "workspace.json"
 
 	// PulumiHomeEnvVar is a path to the '.pulumi' folder with plugins, access token, etc.
 	// The folder can have any name, not necessarily '.pulumi'.

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -105,7 +105,7 @@ func DetectProjectPath() (string, error) {
 // DetectProjectStackPath returns the name of the file to store stack specific project settings in. We place stack
 // specific settings next to the Pulumi.yaml file, named like: Pulumi.<stack-name>.yaml
 func DetectProjectStackPath(stackName tokens.QName) (*Project, string, error) {
-	proj, projPath, err := DetectProjectAndPath()
+	proj, projPath, err := detectProjectAndPath()
 	if err != nil {
 		return nil, "", err
 	}
@@ -224,7 +224,7 @@ func DetectPolicyPackPathAt(path string) (string, error) {
 
 // DetectProject loads the closest project from the current working directory, or an error if not found.
 func DetectProject() (*Project, error) {
-	proj, _, err := DetectProjectAndPath()
+	proj, _, err := detectProjectAndPath()
 	return proj, err
 }
 
@@ -237,9 +237,9 @@ func DetectProjectStack(diags diag.Sink, stackName tokens.QName) (*ProjectStack,
 	return LoadProjectStack(diags, project, path)
 }
 
-// DetectProjectAndPath loads the closest package from the current working directory, or an error if not found.  It
+// detectProjectAndPath loads the closest package from the current working directory, or an error if not found.  It
 // also returns the path where the package was found.
-func DetectProjectAndPath() (*Project, string, error) {
+func detectProjectAndPath() (*Project, string, error) {
 	path, err := DetectProjectPath()
 	if err != nil {
 		return nil, "", err

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -149,7 +149,8 @@ func DetectProjectPathFrom(dir string) (string, error) {
 		// Embed/wrap ErrProjectNotFound
 		return "", fmt.Errorf(
 			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
-				"created a project yet, use `pulumi new` to do so: %w", dir, ErrProjectNotFound)
+				"created a project yet, use `pulumi new` to do so: %w", dir, ErrProjectNotFound,
+		)
 	}
 	return path, nil
 }
@@ -247,25 +248,6 @@ func DetectProjectAndPath() (*Project, string, error) {
 
 	proj, err := LoadProject(path)
 	return proj, path, err
-}
-
-// SaveProject saves the project file on top of the existing one, using the standard location.
-func SaveProject(proj *Project) error {
-	path, err := DetectProjectPath()
-	if err != nil {
-		return err
-	}
-
-	return proj.Save(path)
-}
-
-func SaveProjectStack(stackName tokens.QName, stack *ProjectStack) error {
-	_, path, err := DetectProjectStackPath(stackName)
-	if err != nil {
-		return err
-	}
-
-	return stack.Save(path)
 }
 
 // Given a directory path search for files that appear to be a valid project that is satisfy [isProject].
@@ -391,7 +373,8 @@ func pulumiHomeDirForPath(homeDir string) (string, error) {
 	} else {
 		logging.V(7).Infof(
 			"Could not use default Pulumi home directory %q in agent mode (%s); using shared agent Pulumi directory: %v",
-			homeDir, agent, err)
+			homeDir, agent, err,
+		)
 	}
 	return getAgentPulumiDir()
 }

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// In the tests below we use temporary directories and then expect DetectProjectAndPath to return a path to
-// that directory. However DetectProjectAndPath will do symlink resolution, while t.TempDir() normally does
+// In the tests below we use temporary directories and then expect detectProjectAndPath to return a path to
+// that directory. However detectProjectAndPath will do symlink resolution, while t.TempDir() normally does
 // not. This can lead to asserts especially on macos where TmpDir will have returned /var/folders/XX, but
 // after sym link resolution that is /private/var/folders/XX.
 func mkTempDir(t *testing.T) string {
@@ -46,7 +46,7 @@ func TestDetectProjectAndPath(t *testing.T) {
 	err := os.WriteFile(yamlPath, []byte(yamlContents), 0o600)
 	require.NoError(t, err)
 
-	project, path, err := DetectProjectAndPath()
+	project, path, err := detectProjectAndPath()
 	require.NoError(t, err)
 	assert.Equal(t, yamlPath, path)
 	assert.Equal(t, tokens.PackageName("some_project"), project.Name)
@@ -154,7 +154,8 @@ func TestProjectStackPath(t *testing.T) {
 			err := os.WriteFile(
 				filepath.Join(tmpDir, "Pulumi.yaml"),
 				[]byte(tt.yamlContents),
-				0o600)
+				0o600,
+			)
 			require.NoError(t, err)
 
 			_, path, err := DetectProjectStackPath("my_stack")
@@ -184,7 +185,7 @@ func TestDetectProjectUnreadableParent(t *testing.T) {
 	t.Chdir(currentDir)
 	require.NoError(t, err)
 
-	_, _, err = DetectProjectAndPath()
+	_, _, err = detectProjectAndPath()
 	assert.ErrorIs(t, err, ErrProjectNotFound)
 }
 

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -31,6 +31,7 @@ import (
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -893,9 +894,10 @@ func assertBackupStackFile(t *testing.T, stackName string, file os.DirEntry, bef
 }
 
 func getStackProjectBackupDir(e *ptesting.Environment, projectName, stackName string) (string, error) {
-	return filepath.Join(e.RootPath,
+	return filepath.Join(
+		e.RootPath,
 		workspace.BookkeepingDir,
-		workspace.BackupDir,
+		pkgWorkspace.BackupDir,
 		projectName,
 		stackName,
 	), nil


### PR DESCRIPTION
There's more to move here, but trying to keep PRs manageable. This moves some of the logic from `paths.go` to pkg.