### PR TITLE
Remove `Analyzer` method from `Host`

### DIFF
--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -357,7 +357,8 @@ func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plu
 	for _, pkg := range pkgs {
 		logging.V(preparePluginLog).Infof(
 			"gatherPackagesFromProgram(): package %s (%s) is required by language host",
-			pkg.String(), pkg.PluginDownloadURL)
+			pkg.String(), pkg.PluginDownloadURL,
+		)
 		set.Add(pkg)
 	}
 	return set, nil
@@ -377,7 +378,8 @@ func gatherPackagesFromSnapshot(plugctx *plugin.Context, target *deploy.Target) 
 		urn := res.URN
 		if !sdkproviders.IsProviderType(urn.Type()) {
 			logging.V(preparePluginVerboseLog).Infof(
-				"gatherPackagesFromSnapshot(): skipping %q, not a provider", urn)
+				"gatherPackagesFromSnapshot(): skipping %q, not a provider", urn,
+			)
 			continue
 		}
 		pkg := sdkproviders.GetProviderPackage(urn.Type())
@@ -412,7 +414,8 @@ func gatherPackagesFromSnapshot(plugctx *plugin.Context, target *deploy.Target) 
 		}
 
 		logging.V(preparePluginLog).Infof(
-			"gatherPackagesFromSnapshot(): package %s %s is required by first-class provider %q", name, version, urn)
+			"gatherPackagesFromSnapshot(): package %s %s is required by first-class provider %q", name, version, urn,
+		)
 		set.Add(workspace.PackageDescriptor{
 			PluginDescriptor: workspace.PluginDescriptor{
 				Name:              name.String(),
@@ -477,7 +480,8 @@ func ensurePluginsAreInstalled(ctx context.Context, opts *deploymentOptions, d d
 		path, err := pluginManager.GetPluginPath(ctx, d, plug, projectPlugins)
 		if err == nil && path != "" {
 			logging.V(preparePluginLog).Infof(
-				"ensurePluginsAreInstalled(): plugin %s %s already installed", plug.Name, plug.Version)
+				"ensurePluginsAreInstalled(): plugin %s %s already installed", plug.Name, plug.Version,
+			)
 
 			if !reinstall {
 				continue
@@ -522,7 +526,8 @@ func ensurePluginsAreInstalled(ctx context.Context, opts *deploymentOptions, d d
 		// Launch an install task asynchronously and add it to the current error group.
 		manager.InstallPlugin(func() error {
 			logging.V(preparePluginLog).Infof(
-				"EnsurePluginsAreInstalled(): plugin %s %s not installed, doing install", info.Name, info.Version)
+				"EnsurePluginsAreInstalled(): plugin %s %s not installed, doing install", info.Name, info.Version,
+			)
 			return installPlugin(ctx, opts, pluginManager, info)
 		})
 	}
@@ -540,13 +545,6 @@ func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins PluginSet, kinds pl
 	var result error
 	for _, p := range plugins {
 		switch p.Kind {
-		case apitype.AnalyzerPlugin:
-			if kinds&plugin.AnalyzerPlugins != 0 {
-				if _, err := host.Analyzer(plugctx, tokens.QName(p.Name)); err != nil {
-					result = multierror.Append(result,
-						fmt.Errorf("failed to load analyzer plugin %s: %w", p.Name, err))
-				}
-			}
 		case apitype.LanguagePlugin:
 			if kinds&plugin.LanguagePlugins != 0 {
 				if _, err := host.LanguageRuntime(plugctx, p.Name); err != nil {
@@ -561,7 +559,7 @@ func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins PluginSet, kinds pl
 						fmt.Errorf("failed to load resource plugin %s: %w", p.Name, err))
 				}
 			}
-		case apitype.ConverterPlugin, apitype.ToolPlugin:
+		case apitype.AnalyzerPlugin, apitype.ConverterPlugin, apitype.ToolPlugin:
 			contract.Failf("unexpected plugin kind: %s", p.Kind)
 		}
 	}
@@ -593,7 +591,8 @@ func installPlugin(
 	// If we don't have a version yet try and call GetLatestVersion to fill it in
 	if plugin.Version == nil {
 		logging.V(preparePluginVerboseLog).Infof(
-			"installPlugin(%s): version not specified, trying to lookup latest version", plugin.Name)
+			"installPlugin(%s): version not specified, trying to lookup latest version", plugin.Name,
+		)
 
 		version, err := pluginManager.GetLatestVersion(ctx, plugin)
 		if err != nil {
@@ -603,7 +602,8 @@ func installPlugin(
 	}
 
 	logging.V(preparePluginVerboseLog).Infof(
-		"installPlugin(%s, %s): initiating download", plugin.Name, plugin.Version)
+		"installPlugin(%s, %s): initiating download", plugin.Name, plugin.Version,
+	)
 
 	pluginID := fmt.Sprintf("%s-%s", plugin.Name, plugin.Version)
 	downloadMessage := "Downloading plugin " + pluginID
@@ -640,7 +640,8 @@ func installPlugin(
 	}
 	retry := func(err error, attempt int, limit int, delay time.Duration) {
 		logging.V(preparePluginVerboseLog).Infof(
-			"Error downloading plugin: %s\nWill retry in %v [%d/%d]", err, delay, attempt, limit)
+			"Error downloading plugin: %s\nWill retry in %v [%d/%d]", err, delay, attempt, limit,
+		)
 	}
 
 	tarball, size, err := pluginManager.DownloadPlugin(ctx, plugin, withDownloadProgress, retry)
@@ -650,7 +651,8 @@ func installPlugin(
 	defer contract.IgnoreClose(tarball)
 
 	logging.V(preparePluginVerboseLog).Infof(
-		"installPlugin(%s, %s): extracting tarball to installation directory", plugin.Name, plugin.Version)
+		"installPlugin(%s, %s): extracting tarball to installation directory", plugin.Name, plugin.Version,
+	)
 
 	// In a similar manner to downloads, we'll use a progress bar to show install
 	// progress by wrapping the download stream with a progress reporting
@@ -744,7 +746,8 @@ func (err ambigiousPluginSourceError) Error() string {
 			"  %s\n"+
 			"Remove one of the packages, or pass an explicit `provider` "+
 			"option on each resource to disambiguate.",
-		err.pkg, describePluginSource(err.a), describePluginSource(err.b))
+		err.pkg, describePluginSource(err.a), describePluginSource(err.b),
+	)
 }
 
 // computeDefaultProviderPackages computes, for every package, a mapping from packages to semver versions reflecting the
@@ -784,7 +787,8 @@ func computeDefaultProviderPackages(
 	sourceSet := languagePackages
 	if !languageReportedProviderPlugins {
 		logging.V(preparePluginLog).Infoln(
-			"computeDefaultProviderPlugins(): language host reported empty set of provider plugins, using all plugins")
+			"computeDefaultProviderPlugins(): language host reported empty set of provider plugins, using all plugins",
+		)
 		sourceSet = allPackages
 	}
 
@@ -806,7 +810,8 @@ func computeDefaultProviderPackages(
 		if p.Kind != apitype.ResourcePlugin {
 			// Default providers are only relevant for resource plugins.
 			logging.V(preparePluginVerboseLog).Infof(
-				"computeDefaultProviderPlugins(): skipping %s, not a resource provider", p)
+				"computeDefaultProviderPlugins(): skipping %s, not a resource provider", p,
+			)
 			continue
 		}
 
@@ -815,7 +820,8 @@ func computeDefaultProviderPackages(
 			// of their own: extension resources register against an explicit package ref,
 			// and the base plugin is installed via the plugin set, not from here.
 			logging.V(preparePluginVerboseLog).Infof(
-				"computeDefaultProviderPlugins(): skipping extension package %s", p.PackageName())
+				"computeDefaultProviderPlugins(): skipping extension package %s", p.PackageName(),
+			)
 			continue
 		}
 
@@ -829,7 +835,8 @@ func computeDefaultProviderPackages(
 			if seenPlugin.Version == nil {
 				logging.V(preparePluginLog).Infof(
 					"computeDefaultProviderPlugins(): plugin %s selected for package %s (override, previous was nil)",
-					p, p.Name)
+					p, p.Name,
+				)
 				defaultProviderPlugins[name] = p
 				continue
 			}
@@ -838,7 +845,8 @@ func computeDefaultProviderPackages(
 			if p.Version != nil && p.Version.GTE(*seenPlugin.Version) {
 				logging.V(preparePluginLog).Infof(
 					"computeDefaultProviderPlugins(): plugin %s selected for package %s (override, newer than previous %s)",
-					p, p.Name, seenPlugin.Version)
+					p, p.Name, seenPlugin.Version,
+				)
 				defaultProviderPlugins[name] = p
 				continue
 			}
@@ -849,7 +857,8 @@ func computeDefaultProviderPackages(
 		}
 
 		logging.V(preparePluginLog).Infof(
-			"computeDefaultProviderPlugins(): plugin %s selected for package %s (first seen)", p, p.Name)
+			"computeDefaultProviderPlugins(): plugin %s selected for package %s (first seen)", p, p.Name,
+		)
 		defaultProviderPlugins[name] = p
 	}
 

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -215,11 +215,10 @@ func (host *defaultHost) releaseContextServers(ctx *plugin.Context) error {
 // instead booted from an explicit path and configured by their options. A host shared across
 // workspaces must not serve one workspace's analyzer process to another.
 type analyzerPluginKey struct {
-	name             tokens.QName
-	policy           bool   // true for policy analyzers.
-	workingDirectory string // the workspace's working directory; empty for policy analyzers.
-	path             string // the policy pack path; empty for regular analyzers.
-	options          string // the policy analyzer's options, deterministically rendered; empty for regular analyzers.
+	name    tokens.QName
+	policy  bool   // true for policy analyzers.
+	path    string // the policy pack path; empty for regular analyzers.
+	options string // the policy analyzer's options, deterministically rendered; empty for regular analyzers.
 }
 
 type pluginLoadRequest struct {
@@ -304,38 +303,6 @@ func (host *defaultHost) loadPlugin(
 	return plugin, <-result
 }
 
-func (host *defaultHost) Analyzer(ctx *plugin.Context, name tokens.QName) (plugin.Analyzer, error) {
-	key := analyzerPluginKey{name: name, workingDirectory: ctx.Pwd}
-	hostedPlugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
-		// First see if we already loaded this plugin.
-		if plug, has := host.analyzerPlugins[key]; has {
-			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
-			plug.refs[ctx] = struct{}{}
-			return plug.Plugin, nil
-		}
-
-		// If not, try to load and bind to a plugin.
-		plug, err := plugin.NewAnalyzer(host, ctx, name)
-		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo(ctx.Request())
-			if infoerr != nil {
-				return nil, infoerr
-			}
-
-			// Memoize the result.
-			host.analyzerPlugins[key] = &analyzerPlugin{
-				Plugin: plug, Info: info, Name: string(name), refs: map[*plugin.Context]struct{}{ctx: {}},
-			}
-		}
-
-		return plug, err
-	})
-	if hostedPlugin == nil || err != nil {
-		return nil, err
-	}
-	return hostedPlugin.(plugin.Analyzer), nil
-}
-
 func (host *defaultHost) PolicyAnalyzer(
 	ctx *plugin.Context, name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
 ) (plugin.Analyzer, error) {
@@ -400,7 +367,8 @@ func (host *defaultHost) Provider(
 		}
 		plug, err := plugin.NewProvider(
 			host, ctx, descriptor,
-			ctx.RuntimeOptions(), ctx.DisableProviderPreview(), string(jsonConfig), ctx.ProjectName(), e)
+			ctx.RuntimeOptions(), ctx.DisableProviderPreview(), string(jsonConfig), ctx.ProjectName(), e,
+		)
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
@@ -418,7 +386,8 @@ func (host *defaultHost) Provider(
 						diag.Message("", /*urn*/
 							"resource plugin %s is expected to have version >=%s, but has %s; "+
 								"the wrong version may be on your path, or this may be a bug in the plugin"),
-						pkg, version.String(), v)
+						pkg, version.String(), v,
+					)
 				}
 			}
 
@@ -625,7 +594,8 @@ func (host *defaultHost) SignalCancellation() error {
 				if err := plug.Plugin.SignalCancellation(cancelCtx); err != nil {
 					mu.Lock()
 					errs = append(errs, fmt.Errorf(
-						"error signaling cancellation to resource provider '%s': %w", plug.Name, err))
+						"error signaling cancellation to resource provider '%s': %w", plug.Name, err,
+					))
 					mu.Unlock()
 				}
 			})
@@ -635,7 +605,8 @@ func (host *defaultHost) SignalCancellation() error {
 				if err := plug.Plugin.Cancel(cancelCtx); err != nil {
 					mu.Lock()
 					errs = append(errs, fmt.Errorf(
-						"error signaling cancellation to analyzer '%s': %w", plug.Name, err))
+						"error signaling cancellation to analyzer '%s': %w", plug.Name, err,
+					))
 					mu.Unlock()
 				}
 			})
@@ -647,7 +618,8 @@ func (host *defaultHost) SignalCancellation() error {
 				if err := plug.Plugin.Cancel(cancelCtx); err != nil {
 					mu.Lock()
 					errs = append(errs, fmt.Errorf(
-						"error signaling cancellation to language runtime '%s': %w", plug.Name, err))
+						"error signaling cancellation to language runtime '%s': %w", plug.Name, err,
+					))
 					mu.Unlock()
 				}
 			})

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -151,12 +151,6 @@ func TestPluginHostProvider(t *testing.T) {
 			err := host.SignalCancellation()
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
-		t.Run("Analyzer", func(t *testing.T) {
-			t.Parallel()
-			host := &pluginHost{closed: true}
-			_, err := host.Analyzer(nil, "")
-			assert.ErrorIs(t, err, ErrHostIsClosed)
-		})
 		t.Run("PolicyAnalyzer", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/blang/semver"
 	"google.golang.org/grpc"
@@ -63,40 +62,6 @@ type analyzer struct {
 }
 
 var _ Analyzer = (*analyzer)(nil)
-
-// NewAnalyzer binds to a given analyzer's plugin by name and creates a gRPC connection to it.  If the associated plugin
-// could not be found by name on the PATH, or an error occurs while creating the child process, an error is returned.
-func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
-	// Load the plugin's path by using the standard workspace logic.
-	path, err := workspace.GetPluginPath(
-		ctx.baseContext,
-		ctx.Diag,
-		workspace.PluginDescriptor{
-			Name: strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
-			Kind: apitype.AnalyzerPlugin,
-		},
-		ctx.ProjectPlugins())
-	if err != nil {
-		return nil, rpcerror.Convert(err)
-	}
-	contract.Assertf(path != "", "unexpected empty path for analyzer plugin %s", name)
-
-	dialOpts := rpcutil.TracingInterceptorDialOptions()
-
-	plug, _, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
-		apitype.AnalyzerPlugin, []string{host.ServerAddr(), ctx.Pwd}, nil, /*env*/
-		testConnection, dialOpts, host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
-	if err != nil {
-		return nil, err
-	}
-	contract.Assertf(plug != nil, "unexpected nil analyzer plugin for %s", name)
-
-	return &analyzer{
-		name:   name,
-		plug:   plug,
-		client: pulumirpc.NewAnalyzerClient(plug.Conn),
-	}, nil
-}
 
 // NewPolicyAnalyzer boots the analyzer plugin located at `policyPackpath`. `hasPlugin` is a function that allows the
 // caller to configure how it is determined if the language plugin is available. If nil it will default to looking for
@@ -152,7 +117,8 @@ func NewPolicyAnalyzer(
 				ctx.baseContext,
 				ctx.Diag,
 				spec,
-				ctx.ProjectPlugins())
+				ctx.ProjectPlugins(),
+			)
 			return err == nil && path != ""
 		}
 	}
@@ -168,7 +134,8 @@ func NewPolicyAnalyzer(
 		var pluginPath string
 		pluginPath, err = workspace.GetPluginPath(
 			ctx.baseContext, ctx.Diag,
-			workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, ctx.ProjectPlugins())
+			workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, ctx.ProjectPlugins(),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/plugin/host.go
+++ b/pkg/resource/plugin/host.go
@@ -54,11 +54,6 @@ type Host interface {
 	// have a resource URN associated with them.  If no urn is provided, the message is global.
 	LogStatus(sev diag.Severity, urn resource.URN, msg string, streamID int32)
 
-	// Analyzer fetches the analyzer with a given name, possibly lazily allocating the plugins for
-	// it.  If an analyzer could not be found, or an error occurred while creating it, a non-nil
-	// error is returned.
-	Analyzer(ctx *Context, nm tokens.QName) (Analyzer, error)
-
 	// PolicyAnalyzer boots the nodejs analyzer plugin located at a given path. This is useful
 	// because policy analyzers generally do not need to be "discovered" -- the engine is given a
 	// set of policies that are required to be run during an update, so they tend to be in a


### PR DESCRIPTION
This wasn't ever really used, we only ever start analysers up via `PolicyAnalyzer`.