### PR TITLE
Use NoTags option in shallow git clone

### DIFF
--- a/sdk/go/auto/git.go
+++ b/sdk/go/auto/git.go
@@ -38,6 +38,7 @@ func setupGitRepo(ctx context.Context, workDir string, repoArgs *GitRepo) (strin
 	if repoArgs.Shallow {
 		cloneOptions.Depth = 1
 		cloneOptions.SingleBranch = true
+		cloneOptions.Tags = git.NoTags
 	}
 
 	if repoArgs.Auth != nil {


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

On large repos, pulling all tags can take a LONG time - when doing shallow clone I don't think this is necessary.

