### PR TITLE
do: implement `upsert` in stateless mode

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -93,15 +93,17 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
 			"base of the provider configuration (requires a stack context)")
 	addPersistentInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties)
-	// `create` and `upsert` have different UX between stateful (takes a resource <name> and adds a
-	// snippet to the stack) and stateless (uses the resource type's short name and calls the
-	// provider directly), so the command trees diverge here.
+	// `create` has different UX between stateful (takes a resource <name> and adds a snippet to
+	// the stack) and stateless (uses the resource type's short name and calls the provider
+	// directly), so the command trees diverge here. `upsert` is stateful-only, but stays
+	// registered (hidden) in stateless mode so `upsert --stateless` reports the mode conflict
+	// instead of whichever upsert flag cobra fails to find on the parent command.
 	if pc.stateless {
 		cmd.AddCommand(pc.newStatelessResourceCreateCommand(res))
 	} else {
 		cmd.AddCommand(pc.newStatefulResourceCreateCommand(res))
-		cmd.AddCommand(pc.newResourceUpsertCommand(res))
 	}
+	cmd.AddCommand(pc.newResourceUpsertCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))
 	cmd.AddCommand(pc.newResourceDeleteCommand(res))

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -93,17 +93,16 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
 			"base of the provider configuration (requires a stack context)")
 	addPersistentInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties)
-	// `create` has different UX between stateful (takes a resource <name> and adds a snippet to
-	// the stack) and stateless (uses the resource type's short name and calls the provider
-	// directly), so the command trees diverge here. `upsert` is stateful-only, but stays
-	// registered (hidden) in stateless mode so `upsert --stateless` reports the mode conflict
-	// instead of whichever upsert flag cobra fails to find on the parent command.
+	// `create` and `upsert` have different UX between stateful (takes a resource <name> and adds a
+	// snippet to the stack) and stateless (uses the resource type's short name and calls the
+	// provider directly), so the command trees diverge here.
 	if pc.stateless {
 		cmd.AddCommand(pc.newStatelessResourceCreateCommand(res))
+		cmd.AddCommand(pc.newStatelessResourceUpsertCommand(res))
 	} else {
 		cmd.AddCommand(pc.newStatefulResourceCreateCommand(res))
+		cmd.AddCommand(pc.newResourceUpsertCommand(res))
 	}
-	cmd.AddCommand(pc.newResourceUpsertCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))
 	cmd.AddCommand(pc.newResourceDeleteCommand(res))
@@ -158,9 +157,7 @@ func (pc *packageCommand) newStatelessResourceCreateCommand(res *schema.Resource
 				return err
 			}
 			ctx := cmd.Context()
-			urn := resourceURN(res)
-			var checked resource.PropertyMap
-			prepare := func() (*pkgresource.State, error) {
+			return pc.runStatelessCreate(cmd, res, yes, func() (resource.PropertyMap, error) {
 				if err := pc.configureProvider(cmd, ctx); err != nil {
 					return nil, err
 				}
@@ -171,54 +168,8 @@ func (pc *packageCommand) newStatelessResourceCreateCommand(res *schema.Resource
 				if err != nil {
 					return nil, fmt.Errorf("parse input file: %w", err)
 				}
-				checked, err = pc.checkResourceInputs(ctx, urn, res, nil, inputs)
-				if err != nil {
-					return nil, err
-				}
-				return operationState(urn, "", checked, nil), nil
-			}
-			create := func() (*pkgresource.State, error) {
-				response, err := pc.provider.Create(ctx, plugin.CreateRequest{
-					URN:        urn,
-					Name:       urn.Name(),
-					Type:       urn.Type(),
-					Properties: checked,
-					Preview:    pc.dryrun,
-				})
-				if err != nil {
-					return nil, err
-				}
-				id := response.ID
-				if id == "" {
-					id = resource.ID("[unknown]")
-				}
-				return resultState(urn, id, nil, response.Properties, res), nil
-			}
-			if pc.dryrun {
-				return pc.runDisplayedStep(cmd, displayedStep{
-					Op:  deploy.OpCreate,
-					New: operationState(urn, "", nil, nil),
-				}, func() (*pkgresource.State, error) {
-					if _, err := prepare(); err != nil {
-						return nil, err
-					}
-					return create()
-				})
-			}
-			if err := pc.runDisplayedStep(cmd, displayedStep{
-				Op:      deploy.OpCreate,
-				New:     operationState(urn, "", nil, nil),
-				Preview: true,
-			}, prepare); err != nil {
-				return err
-			}
-			if err := pc.confirm(cmd, "", "create", yes); err != nil {
-				return err
-			}
-			return pc.runDisplayedStep(cmd, displayedStep{
-				Op:  deploy.OpCreate,
-				New: operationState(urn, "", checked, nil),
-			}, create)
+				return inputs, nil
+			})
 		},
 	}
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
@@ -226,6 +177,68 @@ func (pc *packageCommand) newStatelessResourceCreateCommand(res *schema.Resource
 		"Automatically approve and perform the operation without a confirmation prompt")
 	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
+}
+
+func (pc *packageCommand) runStatelessCreate(
+	cmd *cobra.Command, res *schema.Resource, yes bool,
+	prepareInputs func() (resource.PropertyMap, error),
+) error {
+	ctx := cmd.Context()
+	urn := resourceURN(res)
+	var checked resource.PropertyMap
+	prepare := func() (*pkgresource.State, error) {
+		inputs, err := prepareInputs()
+		if err != nil {
+			return nil, err
+		}
+		checked, err = pc.checkResourceInputs(ctx, urn, res, nil, inputs)
+		if err != nil {
+			return nil, err
+		}
+		return operationState(urn, "", checked, nil), nil
+	}
+	create := func() (*pkgresource.State, error) {
+		response, err := pc.provider.Create(ctx, plugin.CreateRequest{
+			URN:        urn,
+			Name:       urn.Name(),
+			Type:       urn.Type(),
+			Properties: checked,
+			Preview:    pc.dryrun,
+		})
+		if err != nil {
+			return nil, err
+		}
+		id := response.ID
+		if id == "" {
+			id = resource.ID("[unknown]")
+		}
+		return resultState(urn, id, nil, response.Properties, res), nil
+	}
+	if pc.dryrun {
+		return pc.runDisplayedStep(cmd, displayedStep{
+			Op:  deploy.OpCreate,
+			New: operationState(urn, "", nil, nil),
+		}, func() (*pkgresource.State, error) {
+			if _, err := prepare(); err != nil {
+				return nil, err
+			}
+			return create()
+		})
+	}
+	if err := pc.runDisplayedStep(cmd, displayedStep{
+		Op:      deploy.OpCreate,
+		New:     operationState(urn, "", nil, nil),
+		Preview: true,
+	}, prepare); err != nil {
+		return err
+	}
+	if err := pc.confirm(cmd, "", "create", yes); err != nil {
+		return err
+	}
+	return pc.runDisplayedStep(cmd, displayedStep{
+		Op:  deploy.OpCreate,
+		New: operationState(urn, "", checked, nil),
+	}, create)
 }
 
 func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Command {
@@ -312,54 +325,9 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 				return fmt.Errorf("parse input file: %w", err)
 			}
 
-			oldInputs := read.Inputs
-			newInputs := oldInputs.Copy()
+			newInputs := read.Inputs.Copy()
 			maps.Copy(newInputs, patch)
-			checked, err := pc.checkResourceInputs(ctx, urn, res, oldInputs, newInputs)
-			if err != nil {
-				return err
-			}
-
-			diff, err := pc.provider.Diff(ctx, plugin.DiffRequest{
-				URN:        urn,
-				Name:       urn.Name(),
-				Type:       urn.Type(),
-				ID:         id,
-				OldInputs:  oldInputs,
-				OldOutputs: read.Outputs,
-				NewInputs:  checked,
-			})
-			if err != nil {
-				return fmt.Errorf("diff: %w", err)
-			}
-			summary := formatPatchSummary(
-				res, id, oldInputs, checked, diff, pc.showSecrets, cmdutil.GetGlobalColorization())
-			if err := pc.confirm(cmd, summary, "patch", yes); err != nil {
-				return err
-			}
-
-			return pc.runDisplayedStep(cmd, displayedStep{
-				Op:           deploy.OpUpdate,
-				Old:          operationState(urn, id, oldInputs, read.Outputs),
-				New:          operationState(urn, id, checked, nil),
-				Diffs:        diff.ChangedKeys,
-				DetailedDiff: diff.DetailedDiff,
-			}, func() (*pkgresource.State, error) {
-				response, err := pc.provider.Update(ctx, plugin.UpdateRequest{
-					URN:        urn,
-					Name:       urn.Name(),
-					Type:       urn.Type(),
-					ID:         id,
-					OldInputs:  oldInputs,
-					OldOutputs: read.Outputs,
-					NewInputs:  checked,
-					Preview:    pc.dryrun,
-				})
-				if err != nil {
-					return nil, err
-				}
-				return resultState(urn, id, checked, response.Properties, res), nil
-			})
+			return pc.runStatelessUpdate(cmd, res, id, read, newInputs, "patch", yes)
 		},
 	}
 	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Format of the configuration files")
@@ -368,6 +336,60 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 		"Automatically approve and perform the operation without a confirmation prompt")
 	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
+}
+
+func (pc *packageCommand) runStatelessUpdate(
+	cmd *cobra.Command, res *schema.Resource, id resource.ID,
+	read plugin.ReadResponse, newInputs resource.PropertyMap, operation string, yes bool,
+) error {
+	ctx := cmd.Context()
+	urn := resourceURN(res)
+	oldInputs := read.Inputs
+	checked, err := pc.checkResourceInputs(ctx, urn, res, oldInputs, newInputs)
+	if err != nil {
+		return err
+	}
+
+	diff, err := pc.provider.Diff(ctx, plugin.DiffRequest{
+		URN:        urn,
+		Name:       urn.Name(),
+		Type:       urn.Type(),
+		ID:         id,
+		OldInputs:  oldInputs,
+		OldOutputs: read.Outputs,
+		NewInputs:  checked,
+	})
+	if err != nil {
+		return fmt.Errorf("diff: %w", err)
+	}
+	summary := formatPatchSummary(
+		res, id, oldInputs, checked, diff, pc.showSecrets, cmdutil.GetGlobalColorization())
+	if err := pc.confirm(cmd, summary, operation, yes); err != nil {
+		return err
+	}
+
+	return pc.runDisplayedStep(cmd, displayedStep{
+		Op:           deploy.OpUpdate,
+		Old:          operationState(urn, id, oldInputs, read.Outputs),
+		New:          operationState(urn, id, checked, nil),
+		Diffs:        diff.ChangedKeys,
+		DetailedDiff: diff.DetailedDiff,
+	}, func() (*pkgresource.State, error) {
+		response, err := pc.provider.Update(ctx, plugin.UpdateRequest{
+			URN:        urn,
+			Name:       urn.Name(),
+			Type:       urn.Type(),
+			ID:         id,
+			OldInputs:  oldInputs,
+			OldOutputs: read.Outputs,
+			NewInputs:  checked,
+			Preview:    pc.dryrun,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return resultState(urn, id, checked, response.Properties, res), nil
+	})
 }
 
 func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.Command {

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -101,7 +101,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		cmd.AddCommand(pc.newStatelessResourceUpsertCommand(res))
 	} else {
 		cmd.AddCommand(pc.newStatefulResourceCreateCommand(res))
-		cmd.AddCommand(pc.newResourceUpsertCommand(res))
+		cmd.AddCommand(pc.newStatefulResourceUpsertCommand(res))
 	}
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -89,13 +90,9 @@ func (pc *packageCommand) newResourceUpsertCommand(res *schema.Resource) *cobra.
 			"The resource created or updated is tracked in the stack, " +
 			"so Pulumi can manage its lifecycle. No other resources in " +
 			"the stack are affected when running this command.",
-		Args:   cobra.ExactArgs(1),
-		Hidden: pc.stateless,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if pc.stateless {
-				return errors.New("`upsert` is not supported in stateless mode; remove --stateless, " +
-					"or use `create` or `patch` to call the provider directly")
-			}
+			contract.Assertf(!pc.stateless, "upsert should not be registered in stateless mode")
 			return pc.runStatefulSnippetUpdate(cmd, statefulSnippetUpdate{
 				res:          res,
 				name:         args[0],
@@ -107,11 +104,68 @@ func (pc *packageCommand) newResourceUpsertCommand(res *schema.Resource) *cobra.
 			})
 		},
 	}
-	if pc.stateless {
-		cmd.Args = cobra.ArbitraryArgs
-		cmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
-	}
 	addStatefulSnippetUpdateFlags(cmd, &inputFile, &inputFormat, &yes, res.InputProperties)
+	return cmd
+}
+
+func (pc *packageCommand) newStatelessResourceUpsertCommand(res *schema.Resource) *cobra.Command {
+	var inputFile string
+	var inputFormat string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "upsert <id>",
+		Short: "Create a resource or fully update an existing one",
+		Long: "Create a resource or fully update an existing one.\n\n" +
+			"Reads the resource with the given ID: if it exists, its inputs are fully " +
+			"replaced with the given inputs (unlike `patch`, which merges them into the " +
+			"existing inputs); otherwise a new resource is created, with an ID assigned " +
+			"by the provider.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contract.Assertf(pc.stateless, "stateless upsert should not be registered in stateful mode")
+			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if err := pc.configureProvider(cmd, ctx); err != nil {
+				return err
+			}
+			urn := resourceURN(res)
+			id := resource.ID(args[0])
+			read, err := pc.provider.Read(ctx, plugin.ReadRequest{
+				URN:    urn,
+				Name:   urn.Name(),
+				Type:   urn.Type(),
+				ID:     id,
+				Inputs: resource.PropertyMap{},
+				State:  resource.PropertyMap{},
+			})
+			if err != nil {
+				return err
+			}
+			inputs, err := evaluateResourceFile(
+				ctx, inputFile, "input", inputFormat, res, pc.evalContext(),
+				pc.converter, pc.loaderTarget, pc.packageDescriptor,
+				collectInputFlags(cmd, "input", res.InputProperties))
+			if err != nil {
+				return fmt.Errorf("parse input file: %w", err)
+			}
+			if read.Outputs == nil {
+				return pc.runStatelessCreate(cmd, res, yes, func() (resource.PropertyMap, error) {
+					return inputs, nil
+				})
+			}
+			if read.ID != "" {
+				id = read.ID
+			}
+			return pc.runStatelessUpdate(cmd, res, id, read, inputs, "update", yes)
+		},
+	}
+	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Format of the resource inputs file")
+	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
+	cmd.Flags().BoolVar(&yes, "yes", false,
+		"Automatically approve and perform the operation without a confirmation prompt")
+	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -89,9 +89,13 @@ func (pc *packageCommand) newResourceUpsertCommand(res *schema.Resource) *cobra.
 			"The resource created or updated is tracked in the stack, " +
 			"so Pulumi can manage its lifecycle. No other resources in " +
 			"the stack are affected when running this command.",
-		Args: cobra.ExactArgs(1),
+		Args:   cobra.ExactArgs(1),
+		Hidden: pc.stateless,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			contract.Assertf(!pc.stateless, "upsert should not be registered in stateless mode")
+			if pc.stateless {
+				return errors.New("`upsert` is not supported in stateless mode; remove --stateless, " +
+					"or use `create` or `patch` to call the provider directly")
+			}
 			return pc.runStatefulSnippetUpdate(cmd, statefulSnippetUpdate{
 				res:          res,
 				name:         args[0],
@@ -102,6 +106,10 @@ func (pc *packageCommand) newResourceUpsertCommand(res *schema.Resource) *cobra.
 				requireFresh: false,
 			})
 		},
+	}
+	if pc.stateless {
+		cmd.Args = cobra.ArbitraryArgs
+		cmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
 	}
 	addStatefulSnippetUpdateFlags(cmd, &inputFile, &inputFormat, &yes, res.InputProperties)
 	return cmd

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -79,7 +79,7 @@ type RunStatefulUpdateFunc func(
 	ctx context.Context, flags *pflag.FlagSet, req StatefulUpdateRequest,
 ) (*StatefulUpdateResult, error)
 
-func (pc *packageCommand) newResourceUpsertCommand(res *schema.Resource) *cobra.Command {
+func (pc *packageCommand) newStatefulResourceUpsertCommand(res *schema.Resource) *cobra.Command {
 	var inputFile string
 	var inputFormat string
 	var yes bool

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -307,47 +307,124 @@ size = 3
 	_ = stderr
 }
 
-// TestDoCmdResourceUpsertHiddenInStatelessMode verifies that `upsert` is hidden from help when the
-// user opts into stateless mode. The subcommand tree shouldn't advertise commands the user can't
-// actually run.
-func TestDoCmdResourceUpsertHiddenInStatelessMode(t *testing.T) {
+// TestDoCmdResourceUpsertStateless drives `upsert` in stateless mode: the given ID is read from
+// the provider, and the resource is either fully updated (existing) or created (missing).
+func TestDoCmdResourceUpsertStateless(t *testing.T) {
 	t.Parallel()
 
-	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
-	cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "--help"})
-	require.NoError(t, cmd.Execute())
-	assert.NotContains(t, stdout.String(), "upsert")
-}
+	t.Run("fully updates an existing resource", func(t *testing.T) {
+		t.Parallel()
+		var calls []string
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					calls = append(calls, "read")
+					assert.Equal(t, resource.ID("res-1"), req.ID)
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID: "res-1",
+							Inputs: resource.PropertyMap{
+								"name":    resource.NewProperty("old"),
+								"size":    resource.NewProperty(1.0),
+								"enabled": resource.NewProperty(true),
+							},
+							Outputs: resource.PropertyMap{
+								"name":    resource.NewProperty("old"),
+								"size":    resource.NewProperty(1.0),
+								"enabled": resource.NewProperty(true),
+							},
+						},
+					}, nil
+				},
+				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					calls = append(calls, "check")
+					assert.Equal(t, "old", req.Olds["name"].StringValue())
+					assert.Equal(t, "new", req.News["name"].StringValue())
+					assert.Equal(t, 2.0, req.News["size"].NumberValue())
+					_, hasEnabled := req.News["enabled"]
+					assert.False(t, hasEnabled, "inputs should be fully replaced, not merged")
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
+					calls = append(calls, "diff")
+					return plugin.DiffResponse{
+						Changes:     plugin.DiffSome,
+						ChangedKeys: []resource.PropertyKey{"name", "size", "enabled"},
+					}, nil
+				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					calls = append(calls, "update")
+					assert.Equal(t, "new", req.NewInputs["name"].StringValue())
+					assert.Equal(t, 2.0, req.NewInputs["size"].NumberValue())
+					_, hasEnabled := req.NewInputs["enabled"]
+					assert.False(t, hasEnabled, "inputs should be fully replaced, not merged")
+					return plugin.UpdateResponse{
+						Properties: resource.PropertyMap{
+							"name": resource.NewProperty("new"),
+							"size": resource.NewProperty(2.0),
+						},
+					}, nil
+				},
+			},
+		})
 
-// TestDoCmdResourceUpsertStatelessErrors verifies that running `upsert` with --stateless fails
-// with an error that names the incompatible flag rather than tripping over upsert's own flags
-// (which used to be reported as unknown because the subcommand wasn't registered at all).
-func TestDoCmdResourceUpsertStatelessErrors(t *testing.T) {
-	t.Parallel()
-
-	cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
-	cmd.SetArgs([]string{
-		"--stateless", "azure:index:myResource", "upsert", "myres",
-		"--input-file", "inputs.yaml",
+		inputFile := writeHCLFile(t, "upsert.pcl", `
+name = "new"
+size = 2
+`)
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "upsert", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile, "--output", "json",
+		})
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, []string{"read", "check", "diff", "update"}, calls)
+		assert.JSONEq(t, `{"id":"res-1","name":"new","size":2}`, stdout.String())
 	})
-	err := cmd.Execute()
-	require.ErrorContains(t, err, "`upsert` is not supported in stateless mode")
-	require.ErrorContains(t, err, "--stateless")
-}
 
-// TestDoCmdResourceUpsertStatelessErrorBeatsUnknownFlag verifies that the stateless-mode error
-// takes priority over flag diagnostics: the whole invocation is invalid, so an unknown flag like
-// --timeout shouldn't be reported before the real problem.
-func TestDoCmdResourceUpsertStatelessErrorBeatsUnknownFlag(t *testing.T) {
-	t.Parallel()
+	t.Run("creates a missing resource", func(t *testing.T) {
+		t.Parallel()
+		var calls []string
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					calls = append(calls, "read")
+					assert.Equal(t, resource.ID("res-1"), req.ID)
+					return plugin.ReadResponse{}, nil
+				},
+				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					calls = append(calls, "check")
+					assert.Empty(t, req.Olds)
+					assert.Equal(t, "new", req.News["name"].StringValue())
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					calls = append(calls, "create")
+					assert.Equal(t, "new", req.Properties["name"].StringValue())
+					return plugin.CreateResponse{
+						ID: "res-2",
+						Properties: resource.PropertyMap{
+							"name": resource.NewProperty("new"),
+							"size": resource.NewProperty(2.0),
+						},
+					}, nil
+				},
+			},
+		})
 
-	cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
-	cmd.SetArgs([]string{
-		"--stateless", "azure:index:myResource", "upsert", "myres",
-		"--input-file", "inputs.yaml", "--timeout", "10s",
+		inputFile := writeHCLFile(t, "upsert.pcl", `
+name = "new"
+size = 2
+`)
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "upsert", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile, "--output", "json",
+		})
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, []string{"read", "check", "create"}, calls)
+		assert.JSONEq(t, `{"id":"res-2","name":"new","size":2}`, stdout.String())
 	})
-	err := cmd.Execute()
-	require.ErrorContains(t, err, "`upsert` is not supported in stateless mode")
 }
 
 // TestDoCmdResourceStatefulCreateConstructsSnippet mirrors the upsert-constructs-snippet test but

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -307,9 +307,9 @@ size = 3
 	_ = stderr
 }
 
-// TestDoCmdResourceUpsertHiddenInStatelessMode verifies that `upsert` is not registered as a
-// subcommand when the user opts into stateless mode. The subcommand tree shouldn't advertise
-// commands the user can't actually run.
+// TestDoCmdResourceUpsertHiddenInStatelessMode verifies that `upsert` is hidden from help when the
+// user opts into stateless mode. The subcommand tree shouldn't advertise commands the user can't
+// actually run.
 func TestDoCmdResourceUpsertHiddenInStatelessMode(t *testing.T) {
 	t.Parallel()
 
@@ -317,6 +317,37 @@ func TestDoCmdResourceUpsertHiddenInStatelessMode(t *testing.T) {
 	cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "--help"})
 	require.NoError(t, cmd.Execute())
 	assert.NotContains(t, stdout.String(), "upsert")
+}
+
+// TestDoCmdResourceUpsertStatelessErrors verifies that running `upsert` with --stateless fails
+// with an error that names the incompatible flag rather than tripping over upsert's own flags
+// (which used to be reported as unknown because the subcommand wasn't registered at all).
+func TestDoCmdResourceUpsertStatelessErrors(t *testing.T) {
+	t.Parallel()
+
+	cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
+	cmd.SetArgs([]string{
+		"--stateless", "azure:index:myResource", "upsert", "myres",
+		"--input-file", "inputs.yaml",
+	})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "`upsert` is not supported in stateless mode")
+	require.ErrorContains(t, err, "--stateless")
+}
+
+// TestDoCmdResourceUpsertStatelessErrorBeatsUnknownFlag verifies that the stateless-mode error
+// takes priority over flag diagnostics: the whole invocation is invalid, so an unknown flag like
+// --timeout shouldn't be reported before the real problem.
+func TestDoCmdResourceUpsertStatelessErrorBeatsUnknownFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
+	cmd.SetArgs([]string{
+		"--stateless", "azure:index:myResource", "upsert", "myres",
+		"--input-file", "inputs.yaml", "--timeout", "10s",
+	})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "`upsert` is not supported in stateless mode")
 }
 
 // TestDoCmdResourceStatefulCreateConstructsSnippet mirrors the upsert-constructs-snippet test but


### PR DESCRIPTION
We can make upsert work in stateless mode as well, by taking an ID, reading the resource and then creating or updating it, depending on whether it exists or not.