### PR TITLE
Parent invokes written inside a component to that component in nodejs

### DIFF
--- a/changelog/pending/20260722--programgen-nodejs--parent-invokes-in-components.yaml
+++ b/changelog/pending/20260722--programgen-nodejs--parent-invokes-in-components.yaml
@@ -1,0 +1,4 @@
+component: programgen/nodejs
+kind: fix
+body: Parent an invoke written inside a component to that component, so it resolves the component's providers
+time: 2026-07-22T00:00:00+00:00

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -610,6 +610,11 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		if isOut {
 			name = name + "Output"
 		}
+		invokeOptions, hasOptions := pcl.InvokeOptions(expr)
+		parentThis := g.isComponent && !pcl.InvokeOptionSet(expr, "parent")
+		// The options bag is positional, so it can only be emitted once the arguments before it are.
+		emitOptions := len(expr.Args) >= 2 && (hasOptions || parentThis)
+
 		g.Fprintf(w, "%s(", name)
 		if len(expr.Args) >= 2 {
 			if expr.Signature.MultiArgumentInputs {
@@ -622,15 +627,19 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 					invokeArgs = expr.Args[1].(*model.ObjectConsExpression)
 				}
 
-				pcl.GenerateMultiArguments(g.Formatter, w, "undefined", invokeArgs, pcl.SortedFunctionParameters(expr))
+				pcl.GenerateMultiArguments(
+					g.Formatter, w, "undefined", invokeArgs, pcl.SortedFunctionParameters(expr), emitOptions)
 			} else {
 				g.Fgenf(w, "%.v", expr.Args[1])
 			}
 		}
-		if len(expr.Args) == 3 {
-			if invokeOptions, ok := expr.Args[2].(*model.ObjectConsExpression); ok {
-				g.Fgen(w, ", {")
-				g.Indented(func() {
+		if emitOptions {
+			g.Fgen(w, ", {")
+			g.Indented(func() {
+				if parentThis {
+					g.Fgenf(w, "\n%sparent: this,", g.Indent)
+				}
+				if hasOptions {
 					for _, item := range invokeOptions.Items {
 						key := pcl.LiteralValueString(item.Key)
 						g.Fgenf(w, "\n%s", g.Indent)
@@ -643,9 +652,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 							g.Fgenf(w, "%s: %v,", key, item.Value)
 						}
 					}
-				})
-				g.Fgenf(w, "\n%s}", g.Indent)
-			}
+				}
+			})
+			g.Fgenf(w, "\n%s}", g.Indent)
 		}
 		g.Fprint(w, ")")
 	case "join":

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -28,6 +28,31 @@ import (
 // Invoke is the name of the PCL `invoke` intrinsic, which can be used to invoke provider functions.
 const Invoke = "invoke"
 
+// InvokeOptions returns the options object of a bound invoke call. A bound invoke always has a token
+// and an argument object, so the options are the third argument if present at all. ok is false if the
+// call has no options.
+func InvokeOptions(call *model.FunctionCallExpression) (opts *model.ObjectConsExpression, ok bool) {
+	if len(call.Args) != 3 {
+		return nil, false
+	}
+	opts, ok = call.Args[2].(*model.ObjectConsExpression)
+	return opts, ok
+}
+
+// InvokeOptionSet reports whether the given invoke call explicitly sets the named option.
+func InvokeOptionSet(call *model.FunctionCallExpression, name string) bool {
+	opts, ok := InvokeOptions(call)
+	if !ok {
+		return false
+	}
+	for _, item := range opts.Items {
+		if LiteralValueString(item.Key) == name {
+			return true
+		}
+	}
+	return false
+}
+
 func getInvokeToken(call *hclsyntax.FunctionCallExpr) (string, hcl.Range, bool) {
 	if call.Name != Invoke || len(call.Args) < 1 {
 		return "", hcl.Range{}, false

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -269,12 +269,16 @@ func SortedFunctionParameters(expr *model.FunctionCallExpression) []*schema.Prop
 // However, when optional parameters are omitted, then <undefinedLiteral> is used where they should be.
 // Take for example { a: 1, c: 3 } with multiInputArguments: ["a", "b", "c"], it becomes 1, <undefinedLiteral>, 3
 // because b was omitted and c was provided so b had to be the provided <undefinedLiteral>
+// trailingArgs reports whether the caller will emit a further positional argument after the spread
+// ones, such as an options bag. When it does, parameters the program left out can no longer be
+// omitted -- they must be filled with undefinedLiteral to keep the trailing argument in its slot.
 func GenerateMultiArguments(
 	f *format.Formatter,
 	w io.Writer,
 	undefinedLiteral string,
 	expr *model.ObjectConsExpression,
 	multiArguments []*schema.Property,
+	trailingArgs bool,
 ) {
 	items := make(map[string]model.Expression)
 	for _, item := range expr.Items {
@@ -297,13 +301,13 @@ func GenerateMultiArguments(
 		value, ok := items[arg.Name]
 		if ok {
 			f.Fgenf(w, "%.v", value)
-		} else if hasMoreArgs(index) {
+		} else if trailingArgs || hasMoreArgs(index) {
 			// a positional argument was not provided in the input bag
 			// assume it is optional
 			f.Fgen(w, undefinedLiteral)
 		}
 
-		if hasMoreArgs(index + 1) {
+		if hasMoreArgs(index+1) || (trailingArgs && index+1 < len(multiArguments)) {
 			f.Fgen(w, ", ")
 		}
 	}

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -591,7 +591,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			} else {
 				invokeArgs = expr.Args[1].(*model.ObjectConsExpression)
 			}
-			pcl.GenerateMultiArguments(g.Formatter, w, "None", invokeArgs, pcl.SortedFunctionParameters(expr))
+			pcl.GenerateMultiArguments(g.Formatter, w, "None", invokeArgs, pcl.SortedFunctionParameters(expr), false)
 		} else {
 			switch arg := expr.Args[1].(type) {
 			case *model.FunctionCallExpression:

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -100,7 +100,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 var expectedFailures = map[string]string{
 	"l1-expand-final":                    "Node.js program generation does not support `...` argument expansion",
 	"l3-deferred-outputs":                "Cannot find name '_arg0_'.",
-	"l3-component-invoke":                "invokes in a component are not parented to it, so they miss its providers",
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 	"l2-resource-schema-secret":          "does not preserve schema-secret unknown outputs",
 	"l3-range-invoke-output-traversal":   "pulumi#12507: range loop variable captured by reference; indexed output resolves with the wrong index",                  //nolint:lll

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/index.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as config from "@pulumi/config";
+import { InvokeComponent } from "./invokeComponent";
+
+const prov = new config.Provider("prov", {name: "my config"});
+const myComponent = new InvokeComponent("myComponent", {
+    providers: [prov],
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/invokeComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/invokeComponent.ts
@@ -1,0 +1,26 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as config from "@pulumi/config";
+import * as multi_argument_invoke from "@pulumi/multi-argument-invoke";
+
+export class InvokeComponent extends pulumi.ComponentResource {
+    public result: pulumi.Output<string>;
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:InvokeComponent", name, {}, opts);
+        // A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+        // out, so parenting it must not displace the options bag into an argument slot.
+        const greeting = multi_argument_invoke.multiArgumentInvokeOutput("hello", undefined, {
+            parent: this,
+        });
+
+        const providerConfig = config.getConfigOutput({
+            text: greeting.result,
+        }, {
+            parent: this,
+        });
+
+        this.result = providerConfig.text;
+        this.registerOutputs({
+            result: providerConfig.text,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "l3-component-invoke",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/config": "ROOT/artifacts/pulumi-config-9.0.0.tgz",
+		"@pulumi/multi-argument-invoke": "ROOT/artifacts/pulumi-multi-argument-invoke-44.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-invoke/tsconfig.json
@@ -1,0 +1,30 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+		"invokeComponent.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l3-component-invoke
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/index.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as config from "@pulumi/config";
+import { InvokeComponent } from "./invokeComponent";
+
+const prov = new config.Provider("prov", {name: "my config"});
+const myComponent = new InvokeComponent("myComponent", {
+    providers: [prov],
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/invokeComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/invokeComponent.ts
@@ -1,0 +1,26 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as config from "@pulumi/config";
+import * as multi_argument_invoke from "@pulumi/multi-argument-invoke";
+
+export class InvokeComponent extends pulumi.ComponentResource {
+    public result: pulumi.Output<string>;
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:InvokeComponent", name, {}, opts);
+        // A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+        // out, so parenting it must not displace the options bag into an argument slot.
+        const greeting = multi_argument_invoke.multiArgumentInvokeOutput("hello", undefined, {
+            parent: this,
+        });
+
+        const providerConfig = config.getConfigOutput({
+            text: greeting.result,
+        }, {
+            parent: this,
+        });
+
+        this.result = providerConfig.text;
+        this.registerOutputs({
+            result: providerConfig.text,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "l3-component-invoke",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/config": "ROOT/artifacts/pulumi-config-9.0.0.tgz",
+		"@pulumi/multi-argument-invoke": "ROOT/artifacts/pulumi-multi-argument-invoke-44.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-invoke/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+		"invokeComponent.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/index.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as config from "@pulumi/config";
+import { InvokeComponent } from "./invokeComponent";
+
+const prov = new config.Provider("prov", {name: "my config"});
+const myComponent = new InvokeComponent("myComponent", {
+    providers: [prov],
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/invokeComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/invokeComponent.ts
@@ -1,0 +1,26 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as config from "@pulumi/config";
+import * as multi_argument_invoke from "@pulumi/multi-argument-invoke";
+
+export class InvokeComponent extends pulumi.ComponentResource {
+    public result: pulumi.Output<string>;
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:InvokeComponent", name, {}, opts);
+        // A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+        // out, so parenting it must not displace the options bag into an argument slot.
+        const greeting = multi_argument_invoke.multiArgumentInvokeOutput("hello", undefined, {
+            parent: this,
+        });
+
+        const providerConfig = config.getConfigOutput({
+            text: greeting.result,
+        }, {
+            parent: this,
+        });
+
+        this.result = providerConfig.text;
+        this.registerOutputs({
+            result: providerConfig.text,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "l3-component-invoke",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/config": "ROOT/artifacts/pulumi-config-9.0.0.tgz",
+		"@pulumi/multi-argument-invoke": "ROOT/artifacts/pulumi-multi-argument-invoke-44.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-invoke/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+		"invokeComponent.ts",
+	]
+}


### PR DESCRIPTION
This PR adjusts our NodeJS codegen to correctly generate `parent: this` when generating an invoke inside a component. This matches PCLs semantics (as applied in #24016). It fixes a failing conformance test.