### PR TITLE
Add modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - importas
     - lll
     - misspell
+    - modernize
     - nakedret
     - nolintlint
     - paralleltest
@@ -29,6 +30,16 @@ linters:
     - requiredfield
     - noosexit
   settings:
+    modernize:
+      disable:
+        # golangci-lint uses a newer x/tools modernize suite than Go 1.26's
+        # go fix. Disable analyzers that are not part of go fix to keep the
+        # two checks aligned.
+        - atomictypes
+        - slicesbackward
+        - unsafefuncs
+        # Some code reads omitempty tags at runtime, making this rewrite unsafe.
+        - omitzero
     custom:
       requiredfield:
         type: module


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/24003 which ran `go fix` on our codebase.

Enable the `modernize` linter to ensure we keep the code aligned with that. 

We skip the `omitzero` analyzer, because although there are cases where we have `omitempty` tags that do nothing for `json.Marshal/Unmarshal`, we do have code that [reflects over the tags](https://github.com/pulumi/pulumi/blob/2eef369dc885074c1dbd65f7b8474d86eef17e36/sdk/go/common/util/mapper/mapper.go#L126).

The linter and `go fix` use slightly different rules, depending on the versions used. Disable `atomictypes`,  `slicesbackward` and `unsafefuncs` to stay aligned with `go fix`. We can enable these separately if we want.

