### PR TITLE
Add modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - importas
     - lll
     - misspell
+    - modernize
     - nakedret
     - nolintlint
     - paralleltest
@@ -29,6 +30,12 @@ linters:
     - requiredfield
     - noosexit
   settings:
+    modernize:
+      disable:
+        # This modernizer is not enabled by Go 1.26's go fix.
+        - unsafefuncs
+        # Some code reads omitempty tags at runtime, making this rewrite unsafe.
+        - omitzero
     custom:
       requiredfield:
         type: module
@@ -233,6 +240,11 @@ linters:
           - forbidigo
         path: _test\.go$
         text: 'use (cmd\.OutOrStdout|cmd\.ErrOrStderr|fmt\.Fprint\*)'
+      # These modernizers are not enabled by Go 1.26's go fix. golangci-lint
+      # runs them but does not accept their names in modernize.disable.
+      - linters:
+          - modernize
+        text: '^(atomictypes|slicesbackward):'
     paths:
       - Godeps$
       - builtin$

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -15,6 +15,8 @@
 package graph
 
 import (
+	"slices"
+
 	mapset "github.com/deckarep/golang-set/v2"
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
@@ -156,10 +158,8 @@ func (dg *DependencyGraph) OnlyDependsOn(res *pkgresource.State) []*pkgresource.
 		if provider != "" {
 			ref, err := providers.ParseReference(provider)
 			contract.AssertNoErrorf(err, "cannot parse provider reference %q", provider)
-			for _, id := range dependentSet[ref.URN()] {
-				if id == ref.ID() {
-					return true
-				}
+			if slices.Contains(dependentSet[ref.URN()], ref.ID()) {
+				return true
 			}
 		}
 


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/24003 which ran `go fix` on our codebase.

Enable the `modernize` linter to ensure we keep the code aligned with that.

We skip the `omitzero` analyzer, because although there are cases where we have `omitempty` tags that do nothing for `json.Marshal/Unmarshal`, we do have code that [reflects over the tags](https://github.com/pulumi/pulumi/blob/2eef369dc885074c1dbd65f7b8474d86eef17e36/sdk/go/common/util/mapper/mapper.go#L126).

Disable `atomictypes`,  `slicesbackward` and `unsafefuncs` to stay aligned with `go fix`.

