### PR TITLE
Migrate Views to property.Map

### DIFF
--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -87,12 +87,12 @@ func TestViewsBasic(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -108,8 +108,8 @@ func TestViewsBasic(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -136,12 +136,12 @@ func TestViewsBasic(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("baz"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("baz"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -157,8 +157,8 @@ func TestViewsBasic(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -331,12 +331,12 @@ func TestViewsUpdateError(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -353,14 +353,14 @@ func TestViewsUpdateError(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -493,12 +493,12 @@ func TestViewsUpdateDelete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -514,8 +514,8 @@ func TestViewsUpdateDelete(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -644,12 +644,12 @@ func TestViewsRefreshSame(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -664,14 +664,14 @@ func TestViewsRefreshSame(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -778,12 +778,12 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -798,14 +798,14 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -912,12 +912,12 @@ func TestViewsRefreshUpdate(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -932,8 +932,8 @@ func TestViewsRefreshUpdate(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: req.OldViews[0].Type,
@@ -1051,12 +1051,12 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -1071,8 +1071,8 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: req.OldViews[0].Type,
@@ -1189,12 +1189,12 @@ func TestViewsRefreshDelete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -1209,8 +1209,8 @@ func TestViewsRefreshDelete(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -1309,12 +1309,12 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -1329,8 +1329,8 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -1531,12 +1531,12 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -1552,8 +1552,8 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 						{
@@ -1562,8 +1562,8 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -1733,12 +1733,12 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -1754,8 +1754,8 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -1774,8 +1774,8 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -1794,8 +1794,8 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -1935,12 +1935,12 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -1955,8 +1955,8 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -2101,12 +2101,12 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -2121,8 +2121,8 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -2271,12 +2271,12 @@ func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
-							},
-							Outputs: resource.PropertyMap{
+							}),
+							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
-							},
+							}),
 						},
 					}, req.OldViews)
 
@@ -2291,8 +2291,8 @@ func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  req.OldViews[0].Inputs,
-								Outputs: req.OldViews[0].Outputs,
+								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
 							},
 						},
 					})

--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // TestViewsBasic tests the basic functionality of views in a resource lifecycle, doing an update to create
@@ -87,11 +88,11 @@ func TestViewsBasic(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -136,11 +137,11 @@ func TestViewsBasic(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("baz"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("baz"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("baz"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("baz"),
 							}),
 						},
 					}, req.OldViews)
@@ -331,11 +332,11 @@ func TestViewsUpdateError(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -493,11 +494,11 @@ func TestViewsUpdateDelete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -644,11 +645,11 @@ func TestViewsRefreshSame(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -778,11 +779,11 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -912,11 +913,11 @@ func TestViewsRefreshUpdate(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -1051,11 +1052,11 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -1189,11 +1190,11 @@ func TestViewsRefreshDelete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -1309,11 +1310,11 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -1531,11 +1532,11 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -1733,11 +1734,11 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -1935,11 +1936,11 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -2101,11 +2102,11 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)
@@ -2271,11 +2272,11 @@ func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"input": resource.NewProperty("bar"),
+							Inputs: property.NewMap(map[string]property.Value{
+								"input": property.New("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
-								"result": resource.NewProperty("bar"),
+							Outputs: property.NewMap(map[string]property.Value{
+								"result": property.New("bar"),
 							}),
 						},
 					}, req.OldViews)

--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -87,10 +87,10 @@ func TestViewsBasic(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -108,8 +108,8 @@ func TestViewsBasic(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -136,10 +136,10 @@ func TestViewsBasic(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("baz"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("baz"),
 							}),
 						},
@@ -157,8 +157,8 @@ func TestViewsBasic(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -331,10 +331,10 @@ func TestViewsUpdateError(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -353,14 +353,14 @@ func TestViewsUpdateError(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -493,10 +493,10 @@ func TestViewsUpdateDelete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -514,8 +514,8 @@ func TestViewsUpdateDelete(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -644,10 +644,10 @@ func TestViewsRefreshSame(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -664,14 +664,14 @@ func TestViewsRefreshSame(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -778,10 +778,10 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -798,14 +798,14 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -912,10 +912,10 @@ func TestViewsRefreshUpdate(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -932,8 +932,8 @@ func TestViewsRefreshUpdate(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: req.OldViews[0].Type,
@@ -1051,10 +1051,10 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -1071,8 +1071,8 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: req.OldViews[0].Type,
@@ -1189,10 +1189,10 @@ func TestViewsRefreshDelete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -1209,8 +1209,8 @@ func TestViewsRefreshDelete(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -1309,10 +1309,10 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -1329,8 +1329,8 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -1531,10 +1531,10 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -1552,8 +1552,8 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 						{
@@ -1562,8 +1562,8 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -1733,10 +1733,10 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -1754,8 +1754,8 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -1774,8 +1774,8 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 							New: &deploytest.ViewStepState{
 								Type: tokens.Type("pkgA:m:typAView"),
@@ -1794,8 +1794,8 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -1935,10 +1935,10 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -1955,8 +1955,8 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -2101,10 +2101,10 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -2121,8 +2121,8 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})
@@ -2271,10 +2271,10 @@ func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
 						{
 							Type: tokens.Type("pkgA:m:typAView"),
 							Name: req.URN.Name() + "-child",
-							Inputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Inputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"input": resource.NewProperty("bar"),
 							}),
-							Outputs: resource.FromResourcePropertyMapPtr(resource.PropertyMap{
+							Outputs: resource.FromResourcePropertyMap(resource.PropertyMap{
 								"result": resource.NewProperty("bar"),
 							}),
 						},
@@ -2291,8 +2291,8 @@ func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
 							Old: &deploytest.ViewStepState{
 								Type:    req.OldViews[0].Type,
 								Name:    req.OldViews[0].Name,
-								Inputs:  resource.ToResourcePropertyMap(*req.OldViews[0].Inputs),
-								Outputs: resource.ToResourcePropertyMap(*req.OldViews[0].Outputs),
+								Inputs:  resource.ToResourcePropertyMap(req.OldViews[0].Inputs),
+								Outputs: resource.ToResourcePropertyMap(req.OldViews[0].Outputs),
 							},
 						},
 					})

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -770,8 +770,8 @@ func (d *Deployment) GetOldViews(urn resource.URN) []plugin.View {
 		view := plugin.View{
 			Type:    res.URN.Type(),
 			Name:    res.URN.Name(),
-			Inputs:  resource.FromResourcePropertyMapPtr(res.Inputs),
-			Outputs: resource.FromResourcePropertyMapPtr(res.Outputs),
+			Inputs:  resource.FromResourcePropertyMap(res.Inputs),
+			Outputs: resource.FromResourcePropertyMap(res.Outputs),
 		}
 		if res.Parent != "" && res.Parent != res.ViewOf {
 			view.ParentType = res.Parent.Type()

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -770,8 +770,8 @@ func (d *Deployment) GetOldViews(urn resource.URN) []plugin.View {
 		view := plugin.View{
 			Type:    res.URN.Type(),
 			Name:    res.URN.Name(),
-			Inputs:  res.Inputs,
-			Outputs: res.Outputs,
+			Inputs:  resource.FromResourcePropertyMapPtr(res.Inputs),
+			Outputs: resource.FromResourcePropertyMapPtr(res.Outputs),
 		}
 		if res.Parent != "" && res.Parent != res.ViewOf {
 			view.ParentType = res.Parent.Type()

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -1011,8 +1011,8 @@ type View struct {
 	ParentName string
 
 	// The view resource's inputs.
-	Inputs resource.PropertyMap
+	Inputs *property.Map
 
 	// The view resource's outputs.
-	Outputs resource.PropertyMap
+	Outputs *property.Map
 }

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -1011,8 +1011,8 @@ type View struct {
 	ParentName string
 
 	// The view resource's inputs.
-	Inputs *property.Map
+	Inputs property.Map
 
 	// The view resource's outputs.
-	Outputs *property.Map
+	Outputs property.Map
 }

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -2624,22 +2624,14 @@ func marshalViews(views []View, opts MarshalOptions) ([]*pulumirpc.View, error) 
 
 // marshalView is a helper that marshals a view into the gRPC equivalent.
 func marshalView(v View, opts MarshalOptions) (*pulumirpc.View, error) {
-	var err error
-
-	var inputs *structpb.Struct
-	if v.Inputs != nil {
-		inputs, err = MarshalProperties(resource.ToResourcePropertyMap(*v.Inputs), opts)
-		if err != nil {
-			return nil, err
-		}
+	inputs, err := MarshalProperties(resource.ToResourcePropertyMap(v.Inputs), opts)
+	if err != nil {
+		return nil, err
 	}
 
-	var outputs *structpb.Struct
-	if v.Outputs != nil {
-		outputs, err = MarshalProperties(resource.ToResourcePropertyMap(*v.Outputs), opts)
-		if err != nil {
-			return nil, err
-		}
+	outputs, err := MarshalProperties(resource.ToResourcePropertyMap(v.Outputs), opts)
+	if err != nil {
+		return nil, err
 	}
 
 	return &pulumirpc.View{

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -2628,7 +2628,7 @@ func marshalView(v View, opts MarshalOptions) (*pulumirpc.View, error) {
 
 	var inputs *structpb.Struct
 	if v.Inputs != nil {
-		inputs, err = MarshalProperties(v.Inputs, opts)
+		inputs, err = MarshalProperties(resource.ToResourcePropertyMap(*v.Inputs), opts)
 		if err != nil {
 			return nil, err
 		}
@@ -2636,7 +2636,7 @@ func marshalView(v View, opts MarshalOptions) (*pulumirpc.View, error) {
 
 	var outputs *structpb.Struct
 	if v.Outputs != nil {
-		outputs, err = MarshalProperties(v.Outputs, opts)
+		outputs, err = MarshalProperties(resource.ToResourcePropertyMap(*v.Outputs), opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -324,22 +324,19 @@ func (p *providerServer) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequ
 	}
 
 	oldInputs, err := UnmarshalProperties(
-		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */),
-	)
+		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	oldOutputs, err := UnmarshalProperties(
-		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */),
-	)
+		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	newInputs, err := UnmarshalProperties(
-		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */),
-	)
+		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
@@ -507,22 +504,19 @@ func (p *providerServer) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (
 	}
 
 	oldInputs, err := UnmarshalProperties(
-		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */),
-	)
+		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	oldOutputs, err := UnmarshalProperties(
-		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */),
-	)
+		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	newInputs, err := UnmarshalProperties(
-		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */),
-	)
+		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
@@ -728,29 +722,25 @@ func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateReques
 	}
 
 	oldOutputs, err := UnmarshalProperties(
-		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */),
-	)
+		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	oldInputs, err := UnmarshalProperties(
-		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */),
-	)
+		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	newInputs, err := UnmarshalProperties(
-		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */),
-	)
+		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
 
 	oldViews, err := unmarshalViews(
-		req.GetOldViews(), p.unmarshalOptions("oldViews", false /* keepOutputValues */),
-	)
+		req.GetOldViews(), p.unmarshalOptions("oldViews", false /* keepOutputValues */))
 	if err != nil {
 		return nil, err
 	}
@@ -931,8 +921,7 @@ func (p *providerServer) Construct(ctx context.Context,
 	var replacementTrigger resource.PropertyValue
 	if trigger := req.GetReplacementTrigger(); trigger != nil {
 		rt, err := UnmarshalPropertyValue("replacementTrigger", trigger, p.unmarshalOptions(
-			"replacementTrigger", true, /* keepOutputValues */
-		))
+			"replacementTrigger", true /* keepOutputValues */))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -324,19 +324,22 @@ func (p *providerServer) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequ
 	}
 
 	oldInputs, err := UnmarshalProperties(
-		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */))
+		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	oldOutputs, err := UnmarshalProperties(
-		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */))
+		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	newInputs, err := UnmarshalProperties(
-		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */))
+		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -504,19 +507,22 @@ func (p *providerServer) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (
 	}
 
 	oldInputs, err := UnmarshalProperties(
-		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */))
+		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	oldOutputs, err := UnmarshalProperties(
-		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */))
+		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	newInputs, err := UnmarshalProperties(
-		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */))
+		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -722,25 +728,29 @@ func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateReques
 	}
 
 	oldOutputs, err := UnmarshalProperties(
-		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */))
+		req.GetOlds(), p.unmarshalOptions("oldOutputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	oldInputs, err := UnmarshalProperties(
-		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */))
+		req.GetOldInputs(), p.unmarshalOptions("oldInputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	newInputs, err := UnmarshalProperties(
-		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */))
+		req.GetNews(), p.unmarshalOptions("newInputs", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	oldViews, err := unmarshalViews(
-		req.GetOldViews(), p.unmarshalOptions("oldViews", false /* keepOutputValues */))
+		req.GetOldViews(), p.unmarshalOptions("oldViews", false /* keepOutputValues */),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -921,7 +931,8 @@ func (p *providerServer) Construct(ctx context.Context,
 	var replacementTrigger resource.PropertyValue
 	if trigger := req.GetReplacementTrigger(); trigger != nil {
 		rt, err := UnmarshalPropertyValue("replacementTrigger", trigger, p.unmarshalOptions(
-			"replacementTrigger", true /* keepOutputValues */))
+			"replacementTrigger", true, /* keepOutputValues */
+		))
 		if err != nil {
 			return nil, err
 		}
@@ -1118,22 +1129,22 @@ func unmarshalViews(views []*pulumirpc.View, opts MarshalOptions) ([]View, error
 
 // unmarshalView is a helper that unmarshals a single view from gRPC into a View struct.
 func unmarshalView(v *pulumirpc.View, opts MarshalOptions) (View, error) {
-	var inputs *property.Map
+	var inputs property.Map
 	if v.Inputs != nil {
 		minputs, err := UnmarshalProperties(v.Inputs, opts)
 		if err != nil {
 			return View{}, err
 		}
-		inputs = resource.FromResourcePropertyMapPtr(minputs)
+		inputs = resource.FromResourcePropertyMap(minputs)
 	}
 
-	var outputs *property.Map
+	var outputs property.Map
 	if v.Outputs != nil {
 		moutputs, err := UnmarshalProperties(v.Outputs, opts)
 		if err != nil {
 			return View{}, err
 		}
-		outputs = resource.FromResourcePropertyMapPtr(moutputs)
+		outputs = resource.FromResourcePropertyMap(moutputs)
 	}
 
 	return View{

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -1117,22 +1118,22 @@ func unmarshalViews(views []*pulumirpc.View, opts MarshalOptions) ([]View, error
 
 // unmarshalView is a helper that unmarshals a single view from gRPC into a View struct.
 func unmarshalView(v *pulumirpc.View, opts MarshalOptions) (View, error) {
-	var err error
-
-	var inputs resource.PropertyMap
+	var inputs *property.Map
 	if v.Inputs != nil {
-		inputs, err = UnmarshalProperties(v.Inputs, opts)
+		minputs, err := UnmarshalProperties(v.Inputs, opts)
 		if err != nil {
 			return View{}, err
 		}
+		inputs = resource.FromResourcePropertyMapPtr(minputs)
 	}
 
-	var outputs resource.PropertyMap
+	var outputs *property.Map
 	if v.Outputs != nil {
-		outputs, err = UnmarshalProperties(v.Outputs, opts)
+		moutputs, err := UnmarshalProperties(v.Outputs, opts)
 		if err != nil {
 			return View{}, err
 		}
+		outputs = resource.FromResourcePropertyMapPtr(moutputs)
 	}
 
 	return View{

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -104,17 +104,6 @@ func FromResourcePropertyMap(v PropertyMap) property.Map {
 	return property.NewMap(rMap)
 }
 
-// Translate a [PropertyMap] into a [*property.Map].
-//
-// See FromResourcePropertyMap for details on the translation.
-func FromResourcePropertyMapPtr(v PropertyMap) *property.Map {
-	if v == nil {
-		return nil
-	}
-	m := FromResourcePropertyMap(v)
-	return &m
-}
-
 // Translate a [PropertyValue] into a [property.Value].
 //
 // This is a normalizing transition, such that the last expression will be true:

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -104,6 +104,17 @@ func FromResourcePropertyMap(v PropertyMap) property.Map {
 	return property.NewMap(rMap)
 }
 
+// Translate a [PropertyMap] into a [*property.Map].
+//
+// See FromResourcePropertyMap for details on the translation.
+func FromResourcePropertyMapPtr(v PropertyMap) *property.Map {
+	if v == nil {
+		return nil
+	}
+	m := FromResourcePropertyMap(v)
+	return &m
+}
+
 // Translate a [PropertyValue] into a [property.Value].
 //
 // This is a normalizing transition, such that the last expression will be true:
@@ -149,7 +160,8 @@ func FromResourcePropertyValue(v PropertyValue) property.Value {
 	case v.IsComputed():
 		return property.New(property.Computed).WithSecret(
 			v.Input().Element.IsSecret() ||
-				(v.Input().Element.IsOutput() && v.Input().Element.OutputValue().Secret))
+				(v.Input().Element.IsOutput() && v.Input().Element.OutputValue().Secret),
+		)
 	case v.IsSecret():
 		return FromResourcePropertyValue(v.SecretValue().Element).WithSecret(true)
 	case v.IsOutput():

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -149,8 +149,7 @@ func FromResourcePropertyValue(v PropertyValue) property.Value {
 	case v.IsComputed():
 		return property.New(property.Computed).WithSecret(
 			v.Input().Element.IsSecret() ||
-				(v.Input().Element.IsOutput() && v.Input().Element.OutputValue().Secret),
-		)
+				(v.Input().Element.IsOutput() && v.Input().Element.OutputValue().Secret))
 	case v.IsSecret():
 		return FromResourcePropertyValue(v.SecretValue().Element).WithSecret(true)
 	case v.IsOutput():


### PR DESCRIPTION
Migrates the Inputs and Outputs on Views to `property.Map`.

There is a small semantic change here (in fact everywhere where we switch from `PropertyMap` to `property.Map`) which is that `nil` is no longer a valid value. I don't think that really changes anything here meaningfully but the provider interface used to be able to send/recv `nil` for inputs and outputs, while now it will always send a `Struct` never `nil`, and will translate `nil` on the wire to an empty `Map`.