### PR TITLE
perf: avoid sending engine events for untargeted resources

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -286,6 +286,20 @@ func isDebugDiagEvent(e engine.Event) bool {
 	return e.Type == engine.DiagEvent && (e.Payload().(engine.DiagEventPayload)).Severity == diag.Debug
 }
 
+// isUntargetedEvent reports if a resource that was not included in a target-constrained operation.
+// Such resources are untouched by the operation, so their same-step events carry no information
+// beyond the summary counts and need not be persisted.
+func isUntargetedEvent(e engine.Event) bool {
+	switch p := e.Payload().(type) {
+	case engine.ResourcePreEventPayload:
+		return p.Metadata.Untargeted
+	case engine.ResourceOutputsEventPayload:
+		return p.Metadata.Untargeted
+	default:
+		return false
+	}
+}
+
 type engineEventBatch struct {
 	sequenceStart int
 	events        []engine.Event
@@ -327,7 +341,7 @@ func (b *cloudBackend) persistEngineEvents(
 	// We need to filter the engine events here to exclude any internal and
 	// ephemeral events, since these by definition should not be persisted.
 	events = channel.FilterRead(events, func(e engine.Event) bool {
-		return !e.Internal() && !e.Ephemeral()
+		return !e.Internal() && !e.Ephemeral() && !isUntargetedEvent(e)
 	})
 
 	var eventBatch []engine.Event

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -528,11 +528,6 @@ func makeStepEventMetadata(op display.StepOp, step deploy.Step, debug bool, show
 		detailedDiff = detailedDiffer.DetailedDiff()
 	}
 
-	var untargeted bool
-	if u, hasUntargeted := step.(interface{ IsUntargeted() bool }); hasUntargeted {
-		untargeted = u.IsUntargeted()
-	}
-
 	return StepEventMetadata{
 		Op:           op,
 		URN:          step.URN(),
@@ -545,7 +540,7 @@ func makeStepEventMetadata(op display.StepOp, step deploy.Step, debug bool, show
 		Res:          makeStepEventStateMetadata(step.Res(), debug, showSecrets),
 		Logical:      step.Logical(),
 		Provider:     step.Provider(),
-		Untargeted:   untargeted,
+		Untargeted:   step.IsUntargeted(),
 	}
 }
 

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -351,6 +351,7 @@ type StepEventMetadata struct {
 	DetailedDiff map[string]plugin.PropertyDiff // the rich, structured diff
 	Logical      bool                           // true if this step represents a logical operation in the program.
 	Provider     string                         // the provider that performed this step.
+	Untargeted   bool                           // true if this same-step's resource was not included in the operation.
 }
 
 func (m *StepEventMetadata) LockState() {
@@ -527,6 +528,11 @@ func makeStepEventMetadata(op display.StepOp, step deploy.Step, debug bool, show
 		detailedDiff = detailedDiffer.DetailedDiff()
 	}
 
+	var untargeted bool
+	if u, hasUntargeted := step.(interface{ IsUntargeted() bool }); hasUntargeted {
+		untargeted = u.IsUntargeted()
+	}
+
 	return StepEventMetadata{
 		Op:           op,
 		URN:          step.URN(),
@@ -539,6 +545,7 @@ func makeStepEventMetadata(op display.StepOp, step deploy.Step, debug bool, show
 		Res:          makeStepEventStateMetadata(step.Res(), debug, showSecrets),
 		Logical:      step.Logical(),
 		Provider:     step.Provider(),
+		Untargeted:   untargeted,
 	}
 }
 

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -73,6 +73,10 @@ type Step interface {
 	Res() *pkgresource.State
 	// true if this step represents a logical operation in the program.
 	Logical() bool
+	// IsUntargeted returns true if this step was generated solely because its resource was not
+	// included in a target-constrained operation rather than because a diff found the resource
+	// unchanged. Such steps leave their resource untouched, carrying its old state forward verbatim.
+	IsUntargeted() bool
 	// the deployment to which this step belongs.
 	Deployment() *Deployment
 
@@ -312,6 +316,7 @@ func (s *CreateStep) Keys() []resource.PropertyKey                 { return s.ke
 func (s *CreateStep) Diffs() []resource.PropertyKey                { return s.diffs }
 func (s *CreateStep) DetailedDiff() map[string]plugin.PropertyDiff { return s.detailedDiff }
 func (s *CreateStep) Logical() bool                                { return !s.replacing }
+func (s *CreateStep) IsUntargeted() bool                           { return false }
 
 func (s *CreateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	if err := s.Deployment().RunHooks(
@@ -593,6 +598,7 @@ func (s *DeleteStep) Old() *pkgresource.State { return s.old }
 func (s *DeleteStep) New() *pkgresource.State { return nil }
 func (s *DeleteStep) Res() *pkgresource.State { return s.old }
 func (s *DeleteStep) Logical() bool           { return !s.replacing }
+func (s *DeleteStep) IsUntargeted() bool      { return false }
 
 func isDeletedWith(with resource.URN, otherDeletions map[resource.URN]bool) bool {
 	if with == "" {
@@ -871,6 +877,7 @@ func (s *RemovePendingReplaceStep) Old() *pkgresource.State { return s.old }
 func (s *RemovePendingReplaceStep) New() *pkgresource.State { return nil }
 func (s *RemovePendingReplaceStep) Res() *pkgresource.State { return s.old }
 func (s *RemovePendingReplaceStep) Logical() bool           { return false }
+func (s *RemovePendingReplaceStep) IsUntargeted() bool      { return false }
 
 func (s *RemovePendingReplaceStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	return resource.StatusOK, nil, nil
@@ -945,6 +952,7 @@ func (s *UpdateStep) Old() *pkgresource.State                      { return s.ol
 func (s *UpdateStep) New() *pkgresource.State                      { return s.new }
 func (s *UpdateStep) Res() *pkgresource.State                      { return s.new }
 func (s *UpdateStep) Logical() bool                                { return true }
+func (s *UpdateStep) IsUntargeted() bool                           { return false }
 func (s *UpdateStep) Diffs() []resource.PropertyKey                { return s.diffs }
 func (s *UpdateStep) DetailedDiff() map[string]plugin.PropertyDiff { return s.detailedDiff }
 
@@ -1191,6 +1199,7 @@ func (s *ReplaceStep) Keys() []resource.PropertyKey                 { return s.k
 func (s *ReplaceStep) Diffs() []resource.PropertyKey                { return s.diffs }
 func (s *ReplaceStep) DetailedDiff() map[string]plugin.PropertyDiff { return s.detailedDiff }
 func (s *ReplaceStep) Logical() bool                                { return true }
+func (s *ReplaceStep) IsUntargeted() bool                           { return false }
 
 func (s *ReplaceStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	// If this is a pending delete, we should have marked the old resource for deletion in the CreateReplacement step.
@@ -1293,6 +1302,7 @@ func (s *ReadStep) Old() *pkgresource.State { return s.old }
 func (s *ReadStep) New() *pkgresource.State { return s.new }
 func (s *ReadStep) Res() *pkgresource.State { return s.new }
 func (s *ReadStep) Logical() bool           { return !s.replacing }
+func (s *ReadStep) IsUntargeted() bool      { return false }
 
 func (s *ReadStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	urn := s.new.URN
@@ -1487,6 +1497,7 @@ func (s *RefreshStep) New() *pkgresource.State {
 }
 func (s *RefreshStep) Res() *pkgresource.State                      { return s.old }
 func (s *RefreshStep) Logical() bool                                { return false }
+func (s *RefreshStep) IsUntargeted() bool                           { return false }
 func (s *RefreshStep) Diffs() []resource.PropertyKey                { return s.diff.ChangedKeys }
 func (s *RefreshStep) DetailedDiff() map[string]plugin.PropertyDiff { return s.diff.DetailedDiff }
 
@@ -1806,6 +1817,7 @@ func (s *ExtensionParameterizeStep) Old() *pkgresource.State { return nil }
 func (s *ExtensionParameterizeStep) New() *pkgresource.State { return nil }
 func (s *ExtensionParameterizeStep) Res() *pkgresource.State { return nil }
 func (s *ExtensionParameterizeStep) Logical() bool           { return false }
+func (s *ExtensionParameterizeStep) IsUntargeted() bool      { return false }
 func (s *ExtensionParameterizeStep) Deployment() *Deployment { return s.deployment }
 func (s *ExtensionParameterizeStep) Fail()                   {}
 func (s *ExtensionParameterizeStep) Skip()                   {}
@@ -1916,6 +1928,7 @@ func (s *ImportStep) Original() *pkgresource.State { return s.original }
 func (s *ImportStep) New() *pkgresource.State      { return s.new }
 func (s *ImportStep) Res() *pkgresource.State      { return s.new }
 func (s *ImportStep) Logical() bool                { return !s.replacing }
+func (s *ImportStep) IsUntargeted() bool           { return false }
 
 // mergeSuppliedProperties fills the gaps in properties read from the provider with properties supplied
 // by the import: a supplied value is used where the read one is missing or null, so values a provider's
@@ -2462,6 +2475,7 @@ func (s *DiffStep) Old() *pkgresource.State { return s.old }
 func (s *DiffStep) New() *pkgresource.State { return s.new }
 func (s *DiffStep) Res() *pkgresource.State { return s.new }
 func (s *DiffStep) Logical() bool           { return true }
+func (s *DiffStep) IsUntargeted() bool      { return false }
 
 func (s *DiffStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	// DiffStep is a special step in that we're just using it as a way to get access to the parallel step
@@ -2579,6 +2593,8 @@ func (s *ViewStep) Logical() bool {
 	}
 	return true
 }
+
+func (s *ViewStep) IsUntargeted() bool { return false }
 
 func (s *ViewStep) ResultOp() display.StepOp {
 	return s.resultOp

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -92,6 +92,10 @@ type SameStep struct {
 	// If this is a same-step for a resource being created but which was not --target'ed by the user
 	// (and thus was skipped).
 	skippedCreate bool
+
+	// If this is a same-step emitted for a resource that was not included in a
+	// target-constrained operation.
+	untargeted bool
 }
 
 var _ Step = (*SameStep)(nil)
@@ -117,6 +121,14 @@ func NewSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *pk
 		old:        old,
 		new:        new,
 	}
+}
+
+// NewUntargetedSameStep produces a SameStep for a resource that is only "same" because it was not
+// included in a target-constrained operation, as opposed to having been diffed and found unchanged.
+func NewUntargetedSameStep(deployment *Deployment, reg RegisterResourceEvent, old, new *pkgresource.State) Step {
+	step := NewSameStep(deployment, reg, old, new).(*SameStep)
+	step.untargeted = true
+	return step
 }
 
 // NewSkippedCreateStep produces a SameStep for a resource that was created but not targeted
@@ -199,6 +211,10 @@ func (s *SameStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 func (s *SameStep) IsSkippedCreate() bool {
 	return s.skippedCreate
+}
+
+func (s *SameStep) IsUntargeted() bool {
+	return s.untargeted
 }
 
 func (s *SameStep) Fail() {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1708,7 +1708,7 @@ func (sg *stepGenerator) continueStepsFromImport(
 
 				new := old.Copy()
 				new.ID = ""
-				rootStep := NewSameStep(sg.deployment, event, old, new)
+				rootStep := NewUntargetedSameStep(sg.deployment, event, old, new)
 				steps = append(steps, rootStep)
 				return steps, nil
 			}
@@ -2383,7 +2383,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt UrnTargets, excludesOpt UrnT
 				if !sg.isOperatedOn(res.URN) {
 					new := res.Copy()
 					new.ID = ""
-					sameSteps = append(sameSteps, NewSameStep(sg.deployment, nil, res, new))
+					sameSteps = append(sameSteps, NewUntargetedSameStep(sg.deployment, nil, res, new))
 				}
 			}
 		}


### PR DESCRIPTION
These engine events are not actually needed anywhere (none of the display code shows them on the service side), and the summary event with the number of unchanged resources is sent separately.

Especially for untargeted resources, sending all the events can actually slow pulumi operations down significantly.  E.g. `pulumi do` in a stack with 4000 resources takes 22s locally without this change, and 7s with this change.
