### PR TITLE
ci: fix protobuf lint under mise 2026.7.12 and slim the Performance Gate matrix job

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -96,10 +96,13 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/retry
+        env:
+          MISE_NPM_SHELL_OUT: "true"
         with:
           action: jdx/mise-action@v2
           with: |
             experimental: true
+            cache_key_prefix: mise-npm-shell-out-v0
       - name: Check Protobufs
         run: make check_proto
 

--- a/.github/workflows/ci-performance-gate.yml
+++ b/.github/workflows/ci-performance-gate.yml
@@ -71,18 +71,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-go@v6
-        with:
-          cache: true
-          cache-dependency-path: pkg/go.sum
-          go-version-file: pkg/go.mod
-      - uses: ./.github/actions/retry
-        with:
-          action: jdx/mise-action@v2
-          with: |
-            experimental: true
-      - name: Install CLI
-        run: SDKS='' make install
       - name: build matrix
         id: matrix
         env:


### PR DESCRIPTION
> [!NOTE]
> Diagnosed and authored by an AI (Claude Code), directed by @iwahbe.

mise v2026.7.12 installs `npm:` tools with its embedded aube package manager, which ignores `npm_args` and skips the postinstall scripts that `protoc-gen-js` and `grpc-tools` need to place their binaries, breaking `Lint Protobufs` on every PR since 2026-07-23. Set `MISE_NPM_SHELL_OUT=true` on that job so installs go through the npm CLI again, and change `cache_key_prefix` to stop restoring the poisoned cache; the setting cannot live in `.mise.toml` because every mise release before 2026.7.12 hard-fails parsing it. Also drop the vestigial `Install CLI`, mise, and `setup-go` steps from the `Performance Gate / matrix` job, unnecessary since #23857 — its matrix script needs only python3 and yq, saving ~4 minutes of serial setup.