### PR TITLE
ci: drop CLI build and toolchain setup from Performance Gate matrix job

### DIFF
--- a/.github/workflows/ci-performance-gate.yml
+++ b/.github/workflows/ci-performance-gate.yml
@@ -71,18 +71,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-go@v6
-        with:
-          cache: true
-          cache-dependency-path: pkg/go.sum
-          go-version-file: pkg/go.mod
-      - uses: ./.github/actions/retry
-        with:
-          action: jdx/mise-action@v2
-          with: |
-            experimental: true
-      - name: Install CLI
-        run: SDKS='' make install
       - name: build matrix
         id: matrix
         env:


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI agent (Claude Code), directed by @iwahbe.

Removes three steps from the `Performance Gate / matrix` job: `Install CLI` (`SDKS='' make install`), the mise toolchain setup, and `setup-go`.

## Why they are vestigial

- `Install CLI` was added in #19580 because test partitioning runs `go test --list .`, whose `TestMain` in `tests/integration`/`tests/smoke` executed `pulumi install`. #23857 made those `TestMain`s no-op under `-test.list` and removed the step from the `ci.yml` matrix job — this copy was left behind.
- The Performance Gate matrix invocation passes no `--partition-module`/`--partition-package` arguments, so `get-job-matrix.py --kind performance-test` never runs `go list`, `go test --list`, or `gotestsum` at all — it emits the static `make test_performance` suite from the script's hardcoded list. This job never needed the CLI even before #23857.
- With the CLI build gone, nothing left needs Go or the mise toolchain. The remaining `build matrix` step uses only `python3` and `yq`, both preinstalled on `ubuntu-latest`.

## Verification

Both script invocations from the workflow run successfully with `PATH` restricted to `/usr/bin:/bin` (no go, no pulumi, no mise):

```
$ env -i PATH=/usr/bin:/bin python3 scripts/get-job-matrix.py generate-matrix --kind performance-test --platform ubuntu-latest --version-set minimum current
{"test-suite": [{"name": "performance tests", "command": "./scripts/retry make test_performance"}], ...}
$ env -i PATH=/usr/bin:/bin python3 scripts/get-job-matrix.py generate-version-set --version-set current
{"name": "current", "dotnet": "9", "go": "1.26.x", "nodejs": "26.x", "python": "3.14.x"}
```

`make lint_actions` passes. This removes the CLI build (~140s) and mise setup (~115s) plus the Go setup from the serial prefix of every Performance Gate run.

Follow-up candidate: `ci-dev-release.yml` has the same leftover `Install CLI` step, removable since #23857.