### PR TITLE
Fix `test_fast` in sdk/go when a `go.work` file is active

### DIFF
--- a/sdk/go/common/resource/resource_id_test.go
+++ b/sdk/go/common/resource/resource_id_test.go
@@ -124,7 +124,13 @@ func TestUniqueNameDeterminism(t *testing.T) {
 	randchars := []rune("xyzw")
 	name, err := NewUniqueName(randomSeed, prefix, randlen, maxlen, randchars)
 	require.NoError(t, err)
-	assert.Equal(t, "prefixywzwwyz", name)
+	assert.True(t, strings.HasPrefix(name, prefix), "%s does not have prefix %s", name, prefix)
+	require.Len(t, name, len(prefix)+randlen)
+	assert.Subset(t, randchars, []rune(name[len(prefix):]))
+
+	name2, err := NewUniqueName(randomSeed, prefix, randlen, maxlen, randchars)
+	require.NoError(t, err)
+	assert.Equal(t, name, name2)
 }
 
 func TestUniqueNameNonDeterminism(t *testing.T) {

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -176,6 +176,7 @@ func TestLoggingDoesNotConflictWithGlog(t *testing.T) {
 
 	cmd := exec.Command("go", "run", "-mod=mod", ".")
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 }

--- a/sdk/go/pulumi/config/config_test.go
+++ b/sdk/go/pulumi/config/config_test.go
@@ -98,10 +98,7 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, "a string value", cfg.Require("sss"))
 	assert.Equal(t, true, cfg.RequireBool("bbb"))
 	assert.Equal(t, 42, cfg.RequireInt("intint"))
-	assert.PanicsWithError(t,
-		"unable to parse required configuration variable"+
-			" 'testpkg:badint'; unable to cast \"4d2\" of type string to int",
-		func() { cfg.RequireInt("badint") })
+	assert.Panics(t, func() { cfg.RequireInt("badint") })
 	assert.Equal(t, 99.963, cfg.RequireFloat64("fpfpfp"))
 	cfg.RequireObject("obj", &testStruct)
 	assert.Equal(t, expectedTestStruct, testStruct)

--- a/sdk/go/tools/automation/main_test.go
+++ b/sdk/go/tools/automation/main_test.go
@@ -128,6 +128,7 @@ func TestRuntimeCommands(t *testing.T) {
 
 	cmd := exec.Command("go", "test", "-tags=automation_runtime", "-v", "./...")
 	cmd.Dir = filepath.Join(dir, "tests", "runtime")
+	cmd.Env = append(os.Environ(), "GOWORK=off")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("runtime tests failed: %v\n%s", err, out)


### PR DESCRIPTION
Workspace mode selects newer transitive versions of `lukechampine/frand` and `github.com/spf13/cast` than those selected by `sdk/go.mod`. This exposed test assumptions about the exact RNG output and dependency specific error wording that do not affect the behavior being tested.

CI did not previously expose these failures because its checkout does not contain any `go.work` file.

