### PR TITLE
Make Python SDK tests runnable locally

### DIFF
--- a/sdk/python/lib/test/automation/conftest.py
+++ b/sdk/python/lib/test/automation/conftest.py
@@ -21,6 +21,12 @@ import pytest
 
 @pytest.fixture(scope="session", autouse=True)
 def test_backend() -> Iterator[None]:
+    """Configure an isolated backend for every Automation API test.
+
+    Use Pulumi Cloud when an access token is available and a temporary file backend otherwise. Because pytest-xdist runs
+    a separate session per worker, local tests also get separate backends. The fixture is automatic so every Pulumi
+    subprocess inherits the backend and Go workspace isolation consistently.
+    """
     # The standalone Go test programs must use their own modules, not the
     # repository's optional development go.work file.
     old_go_work = os.environ.get("GOWORK")

--- a/sdk/python/lib/test/automation/conftest.py
+++ b/sdk/python/lib/test/automation/conftest.py
@@ -24,11 +24,13 @@ def test_backend() -> Iterator[None]:
     """Configure an isolated backend for every Automation API test.
 
     Use Pulumi Cloud when an access token is available and a temporary file backend otherwise. Because pytest-xdist runs
-    a separate session per worker, local tests also get separate backends. The fixture is automatic so every Pulumi
-    subprocess inherits the backend and Go workspace isolation consistently.
+    a separate session per worker, local tests also get separate backends.
+
+    This also turns off go workspaces, so the test fixtures use their own modules, without interference from the
+    repository's optional development go.work file.
+
+    The fixture is automatic so every Pulumi subprocess inherits the backend and Go workspace isolation consistently.
     """
-    # The standalone Go test programs must use their own modules, not the
-    # repository's optional development go.work file.
     old_go_work = os.environ.get("GOWORK")
     os.environ["GOWORK"] = "off"
 

--- a/sdk/python/lib/test/automation/conftest.py
+++ b/sdk/python/lib/test/automation/conftest.py
@@ -1,0 +1,64 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_backend() -> Iterator[None]:
+    # The standalone Go test programs must use their own modules, not the
+    # repository's optional development go.work file.
+    old_go_work = os.environ.get("GOWORK")
+    os.environ["GOWORK"] = "off"
+
+    try:
+        if os.getenv("PULUMI_ACCESS_TOKEN"):
+            old_backend_url = os.environ.get("PULUMI_BACKEND_URL")
+            os.environ["PULUMI_BACKEND_URL"] = (
+                old_backend_url or "https://api.pulumi.com"
+            )
+            try:
+                yield
+            finally:
+                if old_backend_url is None:
+                    os.environ.pop("PULUMI_BACKEND_URL", None)
+                else:
+                    os.environ["PULUMI_BACKEND_URL"] = old_backend_url
+            return
+
+        with tempfile.TemporaryDirectory(prefix="python-tests-automation-") as backend:
+            old_backend_url = os.environ.get("PULUMI_BACKEND_URL")
+            old_passphrase = os.environ.get("PULUMI_CONFIG_PASSPHRASE")
+            os.environ["PULUMI_BACKEND_URL"] = f"file://{backend}"
+            os.environ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+            try:
+                yield
+            finally:
+                if old_backend_url is None:
+                    os.environ.pop("PULUMI_BACKEND_URL", None)
+                else:
+                    os.environ["PULUMI_BACKEND_URL"] = old_backend_url
+                if old_passphrase is None:
+                    os.environ.pop("PULUMI_CONFIG_PASSPHRASE", None)
+                else:
+                    os.environ["PULUMI_CONFIG_PASSPHRASE"] = old_passphrase
+    finally:
+        if old_go_work is None:
+            os.environ.pop("GOWORK", None)
+        else:
+            os.environ["GOWORK"] = old_go_work

--- a/sdk/python/lib/test/automation/errors/runtime_error/dotnet/adsfsdf.csproj
+++ b/sdk/python/lib/test/automation/errors/runtime_error/dotnet/adsfsdf.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="2.*" />
+    <PackageReference Include="Pulumi" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/sdk/python/lib/test/automation/test_config_file.py
+++ b/sdk/python/lib/test/automation/test_config_file.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -24,9 +25,12 @@ from .test_utils import stack_namer
 class TestConfigFile(unittest.IsolatedAsyncioTestCase):
     async def test_config_file_option(self):
         """Tests that the config_file option is correctly passed to the operations"""
-        config_file_path = os.path.join(
+        source_config_file = os.path.join(
             os.path.dirname(__file__), "data", "yaml", "Pulumi.local.yaml"
         )
+        config_dir = tempfile.mkdtemp()
+        config_file_path = os.path.join(config_dir, "Pulumi.local.yaml")
+        shutil.copyfile(source_config_file, config_file_path)
 
         def pulumi_program():
             from pulumi import Config, export

--- a/sdk/python/lib/test/automation/test_fork.py
+++ b/sdk/python/lib/test/automation/test_fork.py
@@ -21,6 +21,9 @@ import pytest
 
 # Note: this test is run as the first test via sdk/python/lib/test/conftest.py to avoid any other test setting up
 # grpc.aio before us.
+@pytest.mark.filterwarnings(
+    "ignore:This process .* is multi-threaded, use of fork\\(\\) may lead to deadlocks.*:DeprecationWarning"
+)
 def test_automation_api_in_forked_worker():
     """
     Test that Pulumi Automation API works in a forked process.

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from typing import List, Optional
@@ -138,11 +139,21 @@ class TestLocalWorkspace(unittest.TestCase):
         ws = LocalWorkspace(project_settings=project_settings)
         stack_1_name = get_test_org() + "/" + f"first_{get_test_suffix()}"
         stack_2_name = get_test_org() + "/" + f"second_{get_test_suffix()}"
+        listed_stack_1_name = (
+            stack_1_name
+            if os.getenv("PULUMI_ACCESS_TOKEN")
+            else stack_1_name.rsplit("/", 1)[-1]
+        )
+        listed_stack_2_name = (
+            stack_2_name
+            if os.getenv("PULUMI_ACCESS_TOKEN")
+            else stack_2_name.rsplit("/", 1)[-1]
+        )
 
         # Create a stack
         ws.create_stack(stack_1_name)
         stacks = ws.list_stacks()
-        stack_1 = get_stack(stacks, stack_1_name)
+        stack_1 = get_stack(stacks, listed_stack_1_name)
 
         # Check the stack exists
         self.assertIsNotNone(stack_1)
@@ -152,8 +163,8 @@ class TestLocalWorkspace(unittest.TestCase):
         # Create another stack
         ws.create_stack(stack_2_name)
         stacks = ws.list_stacks()
-        stack_1 = get_stack(stacks, stack_1_name)
-        stack_2 = get_stack(stacks, stack_2_name)
+        stack_1 = get_stack(stacks, listed_stack_1_name)
+        stack_2 = get_stack(stacks, listed_stack_2_name)
 
         # Check the second stack exists
         self.assertIsNotNone(stack_2)
@@ -164,7 +175,7 @@ class TestLocalWorkspace(unittest.TestCase):
         # Select the first stack again
         ws.select_stack(stack_1_name)
         stacks = ws.list_stacks()
-        stack_1 = get_stack(stacks, stack_1_name)
+        stack_1 = get_stack(stacks, listed_stack_1_name)
 
         # Check the first stack is now current
         self.assertTrue(stack_1.current)
@@ -173,14 +184,14 @@ class TestLocalWorkspace(unittest.TestCase):
         current_stack = ws.stack()
 
         # Check that the name matches stack 1
-        self.assertEqual(current_stack.name, stack_1_name)
+        self.assertEqual(current_stack.name, listed_stack_1_name)
 
         # Remove both stacks
         ws.remove_stack(stack_1_name)
         ws.remove_stack(stack_2_name)
         stacks = ws.list_stacks()
-        stack_1 = get_stack(stacks, stack_1_name)
-        stack_2 = get_stack(stacks, stack_2_name)
+        stack_1 = get_stack(stacks, listed_stack_1_name)
+        stack_2 = get_stack(stacks, listed_stack_2_name)
 
         # Check that they were both removed
         self.assertIsNone(stack_1)
@@ -192,6 +203,10 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertIsNotNone(result.user)
         self.assertIsNotNone(result.url)
 
+    @pytest.mark.skipif(
+        "PULUMI_ACCESS_TOKEN" not in os.environ,
+        reason="the local backend does not support organizations",
+    )
     def test_org_get_set_default_integration(self):
         ws = LocalWorkspace()
 
@@ -561,14 +576,16 @@ class TestLocalWorkspace(unittest.TestCase):
             self.assertEqual(all_config[f"{project_name}:numberKey"].value, "42")
             self.assertFalse(all_config[f"{project_name}:numberKey"].secret)
 
-    # This test requires the existence of a Pulumi.dev.yaml file because we are reading the nested
-    # config from the file. This means we can't remove the stack at the end of the test.
+    # This test requires a Pulumi.dev.yaml file because it reads nested config
+    # from the file. Work on a copy because Pulumi may update the stack config.
     # We should also not include secrets in this config, because the secret encryption is only valid within
     # the context of a stack and org, and running this test in different orgs will fail if there are secrets.
     def test_nested_config(self):
         project_name = "nested_config"
         stack_name = fully_qualified_stack_name(get_test_org(), project_name, "dev")
-        project_dir = get_test_path("data", project_name)
+        source_project_dir = get_test_path("data", project_name)
+        project_dir = tempfile.mkdtemp()
+        shutil.copytree(source_project_dir, project_dir, dirs_exist_ok=True)
         stack = create_or_select_stack(stack_name, work_dir=project_dir)
 
         all_config = stack.get_all_config()

--- a/sdk/python/lib/test/test_deprecated.py
+++ b/sdk/python/lib/test/test_deprecated.py
@@ -30,14 +30,21 @@ class Resource1(pulumi.Resource):
         return "bar"
 
 
+def new_resource() -> Resource1:
+    # Calling __new__ directly bypasses __init__. These tests exercise property
+    # decorators, not resource registration.
+    return Resource1.__new__(Resource1)
+
+
 class DeprecatedTests(unittest.TestCase):
     def test_deprecated_can_be_called(self):
         # Arrange.
-        r = Resource1("test", "test", True)
+        r = new_resource()
         expected = "bar"
 
         # Act.
-        actual = r.bar
+        with self.assertWarnsRegex(UserWarning, "bar is deprecated; use foo instead"):
+            actual = r.bar
 
         # Assert.
         self.assertEqual(expected, actual)
@@ -48,7 +55,8 @@ class DeprecatedTests(unittest.TestCase):
         expected = "bar"
 
         # Act.
-        actual = prop.fget(Resource1("test", "test", True))
+        with self.assertWarnsRegex(UserWarning, "bar is deprecated; use foo instead"):
+            actual = prop.fget(new_resource())
 
         # Assert.
         self.assertEqual(expected, actual)
@@ -70,7 +78,7 @@ class DeprecatedTests(unittest.TestCase):
         expected = "bar"
 
         # Act.
-        actual = f(Resource1("test", "test", True))
+        actual = f(new_resource())
 
         # Assert.
         self.assertEqual(expected, actual)
@@ -81,14 +89,14 @@ class DeprecatedTests(unittest.TestCase):
         prop = Resource1.__dict__["bar"]
 
         # Act.
-        prop.fget(Resource1("test", "test", True))
+        prop.fget(new_resource())
 
         # Assert.
         warnings_warn.assert_called_once()
 
     def test_non_deprecated_can_be_called(self):
         # Arrange.
-        r = Resource1("test", "test", True)
+        r = new_resource()
         expected = "foo"
 
         # Act.
@@ -103,7 +111,7 @@ class DeprecatedTests(unittest.TestCase):
         expected = "foo"
 
         # Act.
-        actual = prop.fget(Resource1("test", "test", True))
+        actual = prop.fget(new_resource())
 
         # Assert.
         self.assertEqual(expected, actual)

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -47,7 +47,6 @@ def clean_up_env_vars():
 
 
 @pulumi.runtime.test
-@pytest.mark.asyncio
 def test_depends_on_accepts_outputs(dep_tracker):
     dep1 = MockResource(name="dep1")
     dep2 = MockResource(name="dep2")
@@ -68,7 +67,6 @@ def test_depends_on_accepts_outputs(dep_tracker):
 
 
 @pulumi.runtime.test
-@pytest.mark.asyncio
 def test_depends_on_outputs_works_in_presence_of_unknowns(dep_tracker_preview):
     dep1 = MockResource(name="dep1")
     dep2 = MockResource(name="dep2")
@@ -87,7 +85,6 @@ def test_depends_on_outputs_works_in_presence_of_unknowns(dep_tracker_preview):
 
 
 @pulumi.runtime.test
-@pytest.mark.asyncio
 def test_depends_on_respects_top_level_implicit_dependencies(dep_tracker):
     dep1 = MockResource(name="dep1")
     dep2 = MockResource(name="dep2")
@@ -128,7 +125,6 @@ def depends_on_variations(dep: pulumi.Resource) -> List[pulumi.ResourceOptions]:
 
 
 @pulumi.runtime.test
-@pytest.mark.asyncio
 def test_depends_on_typing_variations(dep_tracker) -> None:
     dep: pulumi.Resource = MockResource(name="dep1")
 

--- a/sdk/python/lib/test/test_stack_reference.py
+++ b/sdk/python/lib/test/test_stack_reference.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import pytest_asyncio
 
 import pulumi
@@ -28,7 +27,6 @@ def compare_stack_ref_output(
 
 
 @pulumi.runtime.test
-@pytest.mark.asyncio
 async def test_stack_reference_output_details(simple_mock):
     ref = StackReference("ref")
 

--- a/sdk/python/lib/test/test_stack_registers_outputs.py
+++ b/sdk/python/lib/test/test_stack_registers_outputs.py
@@ -73,7 +73,6 @@ async def my_mocks():
 
 
 @pulumi.runtime.test
-@pytest.mark.asyncio
 async def test_component_registers_outputs(my_mocks):
     MockResource(name="res")
 

--- a/sdk/python/scripts/test_unit.sh
+++ b/sdk/python/scripts/test_unit.sh
@@ -12,7 +12,7 @@ ignore_args=(--ignore lib/test/automation)
 for arg in "$@"; do
     case "$arg" in
         --coverage)
-            coverage_args=(--cov pulumi --cov-append)
+            coverage_args=(--cov pulumi)
             ;;
         --fast)
             ignore_args+=(--ignore lib/test/langhost)
@@ -20,11 +20,16 @@ for arg in "$@"; do
     esac
 done
 if [[ -n "$PULUMI_TEST_COVERAGE_PATH" ]]; then
-    coverage_args=(--cov pulumi --cov-append)
+    coverage_args=(--cov pulumi)
 fi
 
 uv run -m pytest "${coverage_args[@]}" -n auto --junitxml "$JUNIT_DIR/python-test-unit.xml" lib/test \
     "${ignore_args[@]}"
+
+# Start with fresh coverage data above, then append coverage from subsequent test suites.
+if [[ ${#coverage_args[@]} -ne 0 ]]; then
+    coverage_args+=(--cov-append)
+fi
 
 uv run -m pytest "${coverage_args[@]}" --junitxml "$JUNIT_DIR/python-test-unit-with-mocks.xml" lib/test_with_mocks
 


### PR DESCRIPTION
Get rid of warnings from the Python tests and make everything runnable locally (test_fast and test_all).

- Avoid resource registration in tests that only exercise property decorators
- Assert expected deprecation warnings
- Remove redundant `pytest.mark.asyncio` markers from tests handled by `pulumi.runtime.test`
- Reset stale coverage data before aggregation
- Run Automation API tests against temporary local backends
- Isolate standalone Go fixtures from go.work
- Avoid mutating checked-in stack configs
- Update the .NET runtime-error fixture for Apple Silicon
