### PR TITLE
Regenerate the automation APIs automatically when the CLI changes

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -40,3 +40,15 @@ jobs:
       queue-merge: true
       run-dispatch-commands: true
     secrets: inherit
+
+  update-dotnet-automation-api:
+    name: update-dotnet-automation-api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger pulumi-dotnet automation API update
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        run: |
+          gh api repos/pulumi/pulumi-dotnet/dispatches \
+            -f event_type=update-automation-api \
+            -f "client_payload[ref]=${{ github.event.release.tag_name }}"

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -1,0 +1,67 @@
+name: Update Automation APIs
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  regenerate:
+    name: Regenerate automation APIs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      - uses: ./.github/actions/retry
+        with:
+          action: jdx/mise-action@v2
+          with: |
+            experimental: true
+      - name: Regenerate
+        run: make generate-automation-apis
+      - name: Create or update PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Automation APIs are up to date."
+            exit 0
+          fi
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git switch --create automation/update-automation-api
+          git commit -m "Regenerate automation APIs from the CLI specification"
+          git push --force -u origin HEAD
+          if [ -z "$(gh pr list --head automation/update-automation-api --state open --json number --jq '.[].number')" ]; then
+            gh pr create --draft \
+              --label impact/no-changelog-required \
+              --title "Regenerate automation APIs" \
+              --body "The CLI specification no longer matches the generated automation APIs. This PR regenerates them from ${GITHUB_SHA}."
+          fi
+
+  dispatch-dotnet:
+    name: Trigger pulumi-dotnet update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        run: |
+          gh api repos/pulumi/pulumi-dotnet/dispatches \
+            -f event_type=update-automation-api \
+            -f "client_payload[sha]=${GITHUB_SHA}"

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -65,10 +65,3 @@ jobs:
           payload: |
             channel: "#team-iac-core"
             text: "The `pulumi` automation APIs have drifted from the CLI; a regeneration PR is ready for review: ${{ steps.pr.outputs.url }}"
-      - name: Trigger pulumi-dotnet update
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        run: |
-          gh api repos/pulumi/pulumi-dotnet/dispatches \
-            -f event_type=update-automation-api \
-            -f "client_payload[sha]=${GITHUB_SHA}"

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -13,10 +13,6 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   regenerate:
     name: Regenerate automation APIs

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -42,19 +42,14 @@ jobs:
           git config user.email github-actions@github.com
           git switch --create automation/update-automation-api
           git commit -m "Regenerate automation APIs from the CLI specification"
-          git push --force -u origin HEAD
+          git push --force origin HEAD
           if [ -z "$(gh pr list --head automation/update-automation-api --state open --json number --jq '.[].number')" ]; then
             gh pr create --draft \
               --label impact/no-changelog-required \
               --title "Regenerate automation APIs" \
               --body "The CLI specification no longer matches the generated automation APIs. This PR regenerates them from ${GITHUB_SHA}."
           fi
-
-  dispatch-dotnet:
-    name: Trigger pulumi-dotnet update
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch
+      - name: Trigger pulumi-dotnet update
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Regenerate
         run: make generate-automation-apis
       - name: Create or update PR
+        id: pr
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
@@ -43,12 +44,27 @@ jobs:
           git switch --create automation/update-automation-api
           git commit -m "Regenerate automation APIs from the CLI specification"
           git push --force origin HEAD
-          if [ -z "$(gh pr list --head automation/update-automation-api --state open --json number --jq '.[].number')" ]; then
-            gh pr create --draft \
-              --label impact/no-changelog-required \
-              --title "Regenerate automation APIs" \
-              --body "The CLI specification no longer matches the generated automation APIs. This PR regenerates them from ${GITHUB_SHA}."
+          # If a PR is already open for this branch, the force-push above refreshed it; reuse its URL.
+          existing=$(gh pr list --head automation/update-automation-api --state open --json url --jq '.[0].url')
+          if [ -n "$existing" ]; then
+            echo "PR already open: ${existing}; refreshed the branch."
+            echo "url=${existing}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          pr_url=$(gh pr create --draft \
+            --label impact/no-changelog-required \
+            --title "Regenerate automation APIs" \
+            --body "The CLI specification no longer matches the generated automation APIs. This PR regenerates them from ${GITHUB_SHA}.")
+          echo "url=${pr_url}" >> "$GITHUB_OUTPUT"
+      - name: Notify Slack
+        if: steps.pr.outputs.url != ''
+        uses: slackapi/slack-github-action@v2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+          payload: |
+            channel: "#team-iac-core"
+            text: "The `pulumi` automation APIs have drifted from the CLI; a regeneration PR is ready for review: ${{ steps.pr.outputs.url }}"
       - name: Trigger pulumi-dotnet update
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ test-nodejs-automation-api:: generate-cli-spec
 .PHONY: generate-python-automation-api
 generate-python-automation-api:: generate-cli-spec
 	cd sdk/python/tools/automation && pip install -q -r requirements.txt && python main.py ../../../../tools/automation/specification.json boilerplate/standard.py ../../lib/pulumi/automation/interface
+	cd sdk/python && uv run --frozen -m ruff format lib/pulumi/automation/interface
 
 .PHONY: test-python-automation-api
 test-python-automation-api::
@@ -106,6 +107,9 @@ generate-go-automation-api:: generate-cli-spec
 .PHONY: test-go-automation-api
 test-go-automation-api::
 	cd sdk && go test ./go/tools/automation/...
+
+.PHONY: generate-automation-apis
+generate-automation-apis:: generate-nodejs-automation-api generate-python-automation-api generate-go-automation-api
 
 # For the `pulumi` CLI, building grpc with grpcnotrace has no effect since there other imports that end up disabling
 # dead code elimation due to the usage of certain reflection methods.


### PR DESCRIPTION
We want to regenerate the Automation API without blocking people's PRs (nor adding noise to their PRs by forcing them to regenerate the API in the same PR). To this end, this PR adds a trigger to pushes to `master` to attempt a regeneration of the API, and if something has changed, a PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)