### PR TITLE
Send invoke dependencies to the engine in the Node.js SDK

### DIFF
--- a/changelog/pending/20260723--sdk-nodejs--invoke-depends-on.yaml
+++ b/changelog/pending/20260723--sdk-nodejs--invoke-depends-on.yaml
@@ -1,0 +1,7 @@
+component: sdk/nodejs
+kind: fix
+body: Defer output-form invokes that depend on a remote component whose resources
+  are pending creation, by declaring invoke dependencies to the engine
+time: 2026-07-23T00:00:00+00:00
+custom:
+  PR: "24042"

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -98,7 +98,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
-	"l2-invoke-depends-on-component":     "the SDK does not yet send dependsOn on invoke requests, so the invoke resolves during preview", //nolint:lll
 	"l1-expand-final":                    "Node.js program generation does not support `...` argument expansion",
 	"l3-deferred-outputs":                "Cannot find name '_arg0_'.",
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-depends-on-component
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/index.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+const target = new component.ComponentCustomRefOutput("target", {value: "checked"});
+const data = component.identityOutput({
+    input: "reachable",
+}, {
+    dependsOn: [target],
+});
+export const echoed = data.result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "l2-invoke-depends-on-component",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-depends-on-component/tsconfig.json
@@ -1,0 +1,29 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-invoke-depends-on-component
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/index.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+const target = new component.ComponentCustomRefOutput("target", {value: "checked"});
+const data = component.identityOutput({
+    input: "reachable",
+}, {
+    dependsOn: [target],
+});
+export const echoed = data.result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-invoke-depends-on-component",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-depends-on-component/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-invoke-depends-on-component
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/index.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as component from "@pulumi/component";
+
+const target = new component.ComponentCustomRefOutput("target", {value: "checked"});
+const data = component.identityOutput({
+    input: "reachable",
+}, {
+    dependsOn: [target],
+});
+export const echoed = data.result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-invoke-depends-on-component",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/component": "ROOT/artifacts/pulumi-component-13.3.7.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-depends-on-component/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -28,11 +28,16 @@ import {
     containsUnknownValues,
 } from "./rpc";
 import { awaitStackRegistrations, excessiveDebugOutput, getMonitor, rpcKeepAlive, terminateRpcs } from "./settings";
+import { getStore } from "./state";
 
 import { CustomResource, DependencyResource, ProviderResource, Resource } from "../resource";
 import * as utils from "../utils";
 import { PushableAsyncIterable } from "./asyncIterableUtil";
-import { gatherExplicitDependencies, getAllTransitivelyReferencedResources } from "./dependsOn";
+import {
+    gatherExplicitDependencies,
+    getAllTransitivelyReferencedResourceURNs,
+    getAllTransitivelyReferencedResources,
+} from "./dependsOn";
 
 import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
 import * as resourceproto from "../proto/resource_pb";
@@ -219,10 +224,8 @@ async function invokeAsync(
         // these should only receive plain arguments, but this is not strictly
         // enforced, and in practice people pass in outputs. This happens to
         // work because we serialize the arguments.
+        let invokeDependsOn: Set<string> | undefined;
         if (checkDependencies) {
-            // If we depend on any CustomResources, we need to ensure that their
-            // ID is known before proceeding. If it is not known, we will return
-            // an unknown result.
             const resourcesToWaitFor = new Set<Resource>(dependsOnDeps);
             // Add the dependencies from the inputs to the set of resources to wait for.
             for (const resourceDeps of deps.values()) {
@@ -230,20 +233,28 @@ async function invokeAsync(
                     resourcesToWaitFor.add(value);
                 }
             }
-            // The expanded set of dependencies, including children of components.
-            const expandedDeps = await getAllTransitivelyReferencedResources(resourcesToWaitFor, new Set());
-            // Ensure that all resource IDs are known before proceeding.
-            for (const dep of expandedDeps.values()) {
-                // DependencyResources inherit from CustomResource, but they don't set the id. Skip them.
-                if (CustomResource.isInstance(dep) && dep.id) {
-                    const known = await dep.id.isKnown;
-                    if (!known) {
-                        return {
-                            result: {},
-                            isKnown: false,
-                            containsSecrets: false,
-                            dependencies: [],
-                        };
+            if (getStore().supportsInvokeDependsOn) {
+                invokeDependsOn = await getAllTransitivelyReferencedResourceURNs(resourcesToWaitFor, new Set());
+            } else {
+                // Older engines cannot gate invokes: if we depend on any CustomResources, we need to ensure
+                // that their ID is known before proceeding. If it is not known, we will return an unknown
+                // result.
+                //
+                // The expanded set of dependencies, including children of components.
+                const expandedDeps = await getAllTransitivelyReferencedResources(resourcesToWaitFor, new Set());
+                // Ensure that all resource IDs are known before proceeding.
+                for (const dep of expandedDeps.values()) {
+                    // DependencyResources inherit from CustomResource, but they don't set the id. Skip them.
+                    if (CustomResource.isInstance(dep) && dep.id) {
+                        const known = await dep.id.isKnown;
+                        if (!known) {
+                            return {
+                                result: {},
+                                isKnown: false,
+                                containsSecrets: false,
+                                dependencies: [],
+                            };
+                        }
                     }
                 }
             }
@@ -260,7 +271,7 @@ async function invokeAsync(
         // keep track of the secretness of the inputs
         // if any of the inputs are secret, the invoke response should be marked as secret
         const [plainInputs, inputsContainSecrets] = unwrapSecretValues(serialized);
-        const req = await createInvokeRequest(tok, plainInputs, provider, opts, packageRef);
+        const req = await createInvokeRequest(tok, plainInputs, provider, opts, packageRef, invokeDependsOn);
 
         const resp: any = await debuggablePromise(
             new Promise((innerResolve, innerReject) =>
@@ -296,6 +307,17 @@ async function invokeAsync(
             }
         }
 
+        // The engine declines to service an invoke whose dependencies are pending creation: the result is
+        // wholly unknown.
+        if (resp.getUnknown?.()) {
+            return {
+                result: {},
+                isKnown: false,
+                containsSecrets: false,
+                dependencies: flatDependencies,
+            };
+        }
+
         // Finally propagate any other properties that were given to us as outputs.
         const deserialized = deserializeResponse(tok, resp);
         return {
@@ -315,6 +337,7 @@ async function createInvokeRequest(
     provider: string | undefined,
     opts: InvokeOptions,
     packageRef?: Promise<string | undefined>,
+    dependsOn?: Set<string>,
 ) {
     if (provider !== undefined && typeof provider !== "string") {
         throw new Error("Incorrect provider type.");
@@ -338,6 +361,10 @@ async function createInvokeRequest(
     req.setPlugindownloadurl(opts.pluginDownloadURL || "");
     req.setAcceptresources(!utils.disableResourceReferences);
     req.setPackageref(packageRefStr || "");
+    if (dependsOn !== undefined) {
+        req.setDependsonList(Array.from(dependsOn));
+        req.setAcceptsunknowns(true);
+    }
     return req;
 }
 

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -363,7 +363,6 @@ async function createInvokeRequest(
     req.setPackageref(packageRefStr || "");
     if (dependsOn !== undefined) {
         req.setDependsonList(Array.from(dependsOn));
-        req.setAcceptsunknowns(true);
     }
     return req;
 }

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -307,4 +307,6 @@ export async function setMocks(
     store.supportsParameterization = true;
     store.supportsResourceHooks = true;
     store.supportsErrorHooks = true;
+    // The mock monitor does not implement the engine's invoke dependency gate, so keep the client-side one.
+    store.supportsInvokeDependsOn = false;
 }

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -392,6 +392,9 @@ export async function awaitFeatureSupport(): Promise<void> {
         resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
     );
     store.supportsErrorHooks = features.includes(resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS);
+    store.supportsInvokeDependsOn = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON,
+    );
 }
 
 /**

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -200,6 +200,12 @@ export interface Store {
     supportsErrorHooks: boolean;
 
     /**
+     * Tells us if the resource monitor we are connected to gates invokes on
+     * the created-ness of their declared dependencies.
+     */
+    supportsInvokeDependsOn: boolean;
+
+    /**
      * The callback service running for this deployment. This registers
      * callbacks and forwards them to the engine.
      */
@@ -272,6 +278,7 @@ export class LocalStore implements Store {
     supportsParameterization = false;
     supportsResourceHooks = false;
     supportsErrorHooks = false;
+    supportsInvokeDependsOn = false;
     resourcePackages = new Map<string, ResourcePackage[]>();
     resourceModules = new Map<string, ResourceModule[]>();
     packageRefs = new Map<string, Promise<string>>();


### PR DESCRIPTION
When the engine advertises the `invokeDependsOn` feature, output-form invokes send their expanded dependency URNs and `acceptsUnknowns` on the request, and resolve as unknown when the engine declines to service them. The engine can see the children of remote components, which the client-side id-known gate cannot (#18299); that gate is kept as the fallback for older engines. The mock monitor implements no gate, so mock-based programs keep the client-side behavior.

Un-skips `l2-invoke-depends-on-component`.