### PR TITLE
Support exe analyzers

### DIFF
--- a/changelog/pending/engine-improvement-20260723-214238.yaml
+++ b/changelog/pending/engine-improvement-20260723-214238.yaml
@@ -1,4 +1,4 @@
 component: engine
 kind: improvement
-body: policy packs can now point to executable binaries, not just script folders
+body: Allow policy packs to point to executable binaries, not just script folders
 time: 2026-07-23T21:42:38.123963+01:00

--- a/changelog/pending/engine-improvement-20260723-214238.yaml
+++ b/changelog/pending/engine-improvement-20260723-214238.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: improvement
+body: policy packs can now point to executable binaries, not just script folders
+time: 2026-07-23T21:42:38.123963+01:00

--- a/pkg/host/analyzer_test.go
+++ b/pkg/host/analyzer_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
@@ -94,6 +95,83 @@ func TestAnalyzerSpawnNoConfig(t *testing.T) {
 
 	err = analyzer.Close()
 	require.NoError(t, err)
+}
+
+// TestAnalyzerSpawnBinary verifies that NewPolicyAnalyzer can launch an analyzer plugin
+// that is provided as a bare executable binary (no PulumiPolicy.yaml alongside it), mirroring
+// the behavior of NewProvider.
+func TestAnalyzerSpawnBinary(t *testing.T) {
+	t.Parallel()
+
+	d := diagtest.LogSink(t)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, h.Close()) }()
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
+
+	// Build a tiny go program that exits with a non-zero code; we only need to prove that
+	// NewPolicyAnalyzer actually executed the binary (rather than failing while looking for
+	// a PulumiPolicy.yaml).
+	tmp := t.TempDir()
+	err = os.WriteFile(filepath.Join(tmp, "main.go"), []byte(`
+	package main
+	import "os"
+
+	func main() {
+		os.Exit(1)
+	}
+	`), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(`
+	module test-analyzer-exit
+	go 1.24
+	`), 0o600)
+	require.NoError(t, err)
+
+	bin := "test-analyzer-exit"
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = tmp
+	stdout, err := cmd.CombinedOutput()
+	t.Log(string(stdout))
+	require.NoError(t, err)
+
+	_, err = plugin.NewPolicyAnalyzer(ctx.Host, ctx, "binary-analyzer", filepath.Join(tmp, bin), nil, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "exit status 1")
+}
+
+// TestAnalyzerBinaryVersionFromYaml verifies that when a binary analyzer plugin ships alongside a
+// PulumiPolicy.yaml, GetAnalyzerInfo reports the version from the yaml rather than the version the
+// plugin returns over the wire.
+func TestAnalyzerBinaryVersionFromYaml(t *testing.T) {
+	t.Parallel()
+
+	d := diagtest.LogSink(t)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, h.Close()) }()
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
+
+	binName := "pulumi-analyzer-binary"
+	if runtime.GOOS == "windows" {
+		binName += ".cmd"
+	}
+	pluginPath, err := filepath.Abs(filepath.Join("./testdata/analyzer-binary", binName))
+	require.NoError(t, err)
+
+	analyzer, err := plugin.NewPolicyAnalyzer(ctx.Host, ctx, "binary-analyzer", pluginPath, nil, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, analyzer.Close()) }()
+
+	info, err := analyzer.GetAnalyzerInfo(t.Context())
+	require.NoError(t, err)
+	// The binary reports "999.999.999" from GetAnalyzerInfo; the sibling PulumiPolicy.yaml pins 1.2.3.
+	require.Equal(t, "1.2.3", info.Version)
 }
 
 func TestAnalyzerSpawnViaLanguage(t *testing.T) {

--- a/pkg/host/testdata/analyzer-binary/PulumiPolicy.yaml
+++ b/pkg/host/testdata/analyzer-binary/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+runtime: binary
+version: 1.2.3

--- a/pkg/host/testdata/analyzer-binary/main.go
+++ b/pkg/host/testdata/analyzer-binary/main.go
@@ -1,0 +1,52 @@
+// A minimal analyzer plugin used by TestAnalyzerBinaryVersionFromYaml. It reports a distinctive
+// version from GetAnalyzerInfo so the test can verify the yaml-provided version wins.
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type analyzer struct {
+	pulumirpc.UnimplementedAnalyzerServer
+}
+
+func (a *analyzer) Handshake(
+	ctx context.Context, req *pulumirpc.AnalyzerHandshakeRequest,
+) (*pulumirpc.AnalyzerHandshakeResponse, error) {
+	return &pulumirpc.AnalyzerHandshakeResponse{}, nil
+}
+
+func (a *analyzer) GetAnalyzerInfo(ctx context.Context, req *emptypb.Empty) (*pulumirpc.AnalyzerInfo, error) {
+	return &pulumirpc.AnalyzerInfo{
+		Name:    "binary-analyzer",
+		Version: "999.999.999",
+	}, nil
+}
+
+func (a *analyzer) Cancel(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func main() {
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterAnalyzerServer(srv, &analyzer{})
+			return nil
+		},
+		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+	})
+	if err != nil {
+		fmt.Printf("fatal: %v\n", err)
+		return
+	}
+	fmt.Printf("%d\n", handle.Port)
+	if err := <-handle.Done; err != nil {
+		fmt.Printf("fatal: %v\n", err)
+	}
+}

--- a/pkg/host/testdata/analyzer-binary/pulumi-analyzer-binary
+++ b/pkg/host/testdata/analyzer-binary/pulumi-analyzer-binary
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Absolute path to this script, e.g. /home/user/bin/foo.sh
+SCRIPT=$(readlink -f "$0")
+# Absolute path this script is in, thus /home/user/bin
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+go run $SCRIPTPATH

--- a/pkg/host/testdata/analyzer-binary/pulumi-analyzer-binary.cmd
+++ b/pkg/host/testdata/analyzer-binary/pulumi-analyzer-binary.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+REM Get this script's directory without a trailing backslash.
+for %%I in ("%~dp0.") do set SCRIPT=%%~fI
+
+REM Run the Go program in the script's directory
+go run "%SCRIPT%"

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -71,18 +72,13 @@ func NewPolicyAnalyzer(
 	host Host, ctx *Context, name tokens.QName, policyPackPath string, opts *PolicyAnalyzerOptions,
 	hasPlugin func(workspace.PluginDescriptor) bool,
 ) (Analyzer, error) {
-	projPath := filepath.Join(policyPackPath, "PulumiPolicy.yaml")
-	proj, err := workspace.LoadPolicyPack(projPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load Pulumi policy project located at %q: %w", policyPackPath, err)
-	}
+	// For analyzers the root directory and program directory are the location of the PulumiPolicy.yaml _not_ the
+	// location of the shim plugin.
+	dir := policyPackPath
 
 	handshake := func(
 		ctx context.Context, bin string, prefix string, conn *grpc.ClientConn,
 	) (*pulumirpc.AnalyzerHandshakeResponse, error) {
-		// For analyzers the root directory and program directory are the location of the PulumiPolicy.yaml _not_ the
-		// location of the shim plugin.
-		dir := policyPackPath
 		client := pulumirpc.NewAnalyzerClient(conn)
 
 		req := pulumirpc.AnalyzerHandshakeRequest{
@@ -106,79 +102,110 @@ func NewPolicyAnalyzer(
 		return res, nil
 	}
 
-	// This first section is a back compatibility bit for the old way of running analyzer plugins where we
-	// would look for a plugin called "pulumi-analyzer-policy-<runtime>" and invoke that plugin with two
-	// arguments, the engine address and the policy pack path. We don't do this for actual "languages" (i.e.
-	// things with language plugins), but have to leave this in to ensure things like
-	// https://github.com/pulumi/pulumi-policy-opa continue to work (although in time they could probably be
-	// moved to just be language runtimes like the rest).
-	if hasPlugin == nil {
-		hasPlugin = func(spec workspace.PluginDescriptor) bool {
-			path, err := workspace.GetPluginPath(
-				ctx.baseContext,
-				ctx.Diag,
-				spec,
-				ctx.ProjectPlugins(),
-			)
-			return err == nil && path != ""
-		}
+	analyzerEnv := env.Global()
+	if opts != nil && len(opts.AdditionalEnv) > 0 {
+		additionalStore := envutil.MapStore{}
+		// Inject per-pack environment variables (e.g., from ESC environments).
+		maps.Copy(additionalStore, opts.AdditionalEnv)
+		analyzerEnv = envutil.NewEnv(envutil.JoinStore(additionalStore, analyzerEnv.GetStore()))
 	}
-	foundLanguagePlugin := hasPlugin(workspace.PluginDescriptor{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin})
 
 	var plug *Plugin
-	if !foundLanguagePlugin {
-		// Couldn't get a language plugin, fall back to the old behavior, of trying to run
-		// "pulumi-analyzer-policy-<runtime>".
-		policyAnalyzerName := "policy-" + proj.Runtime.Name()
+	var proj *workspace.PolicyPackProject
 
-		// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
-		var pluginPath string
-		pluginPath, err = workspace.GetPluginPath(
-			ctx.baseContext, ctx.Diag,
-			workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, ctx.ProjectPlugins(),
-		)
-		if err != nil {
-			return nil, err
+	// If policyPackPath points at an executable file rather than a directory containing a PulumiPolicy.yaml, launch it
+	// directly as a binary analyzer plugin, mirroring how providers are launched.
+	stat, err := os.Stat(policyPackPath)
+	if err == nil && !stat.IsDir() {
+		// repoint handshake dir to the directory containing the binary
+		dir = filepath.Dir(policyPackPath)
+
+		// It's valid for a binary to _also_ ship a PulumiPolicy.yaml, so we try to load it if it exists. If it doesn't
+		// exist, we just continue with a nil proj.
+		projPath := filepath.Join(dir, "PulumiPolicy.yaml")
+		proj, err = workspace.LoadPolicyPack(projPath)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("failed to load Pulumi policy project located at %q: %w", dir, err)
 		}
 
-		// The `pulumi-analyzer-policy` plugin is a script that looks for the '@pulumi/pulumi/cmd/run-policy-pack'
-		// node module and runs it with node. To allow non-node Pulumi programs (e.g. Python, .NET, Go, etc.) to
-		// run node policy packs, we must set the plugin's pwd to the policy pack directory instead of the Pulumi
-		// program directory, so that the '@pulumi/pulumi/cmd/run-policy-pack' module from the policy pack's
-		// node_modules is used.
-		pwd := policyPackPath
-
-		args := []string{host.ServerAddr(), "."}
-		for k, v := range proj.Runtime.Options() {
-			if vstr := fmt.Sprintf("%v", v); vstr != "" {
-				args = append(args, fmt.Sprintf("-%s=%s", k, vstr))
-			}
-		}
-
-		// Create the environment variables from the options.
-		var environment env.Env
-		environment, err = constructEnv(opts, proj.Runtime.Name())
-		if err != nil {
-			return nil, err
-		}
-
-		plug, _, err = newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
-			apitype.AnalyzerPlugin, args, environment, handshake,
-			analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)),
-			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
-	} else {
-		// Else we _did_ get a language plugin so just use RunPlugin to invoke the policy pack.
-		analyzerEnv := env.Global()
-		if opts != nil && len(opts.AdditionalEnv) > 0 {
-			additionalStore := envutil.MapStore{}
-			maps.Copy(additionalStore, opts.AdditionalEnv)
-			analyzerEnv = envutil.NewEnv(envutil.JoinStore(additionalStore, env.Global().GetStore()))
-		}
-
-		plug, _, err = newPlugin(ctx, ctx.Pwd, policyPackPath, fmt.Sprintf("%v (analyzer)", name),
+		plug, _, err = newPlugin(
+			ctx, ctx.Pwd, policyPackPath, fmt.Sprintf("%v (analyzer)", name),
 			apitype.AnalyzerPlugin, []string{host.ServerAddr()}, analyzerEnv,
 			handshake, analyzerPluginDialOptions(ctx, string(name)),
-			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
+			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}),
+		)
+	} else {
+		projPath := filepath.Join(policyPackPath, "PulumiPolicy.yaml")
+		proj, err = workspace.LoadPolicyPack(projPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load Pulumi policy project located at %q: %w", policyPackPath, err)
+		}
+
+		// This first section is a back compatibility bit for the old way of running analyzer plugins where we
+		// would look for a plugin called "pulumi-analyzer-policy-<runtime>" and invoke that plugin with two
+		// arguments, the engine address and the policy pack path. We don't do this for actual "languages" (i.e.
+		// things with language plugins), but have to leave this in to ensure things like
+		// https://github.com/pulumi/pulumi-policy-opa continue to work (although in time they could probably be
+		// moved to just be language runtimes like the rest).
+		if hasPlugin == nil {
+			hasPlugin = func(spec workspace.PluginDescriptor) bool {
+				path, err := workspace.GetPluginPath(
+					ctx.baseContext,
+					ctx.Diag,
+					spec,
+					ctx.ProjectPlugins(),
+				)
+				return err == nil && path != ""
+			}
+		}
+		foundLanguagePlugin := hasPlugin(workspace.PluginDescriptor{Name: proj.Runtime.Name(), Kind: apitype.LanguagePlugin})
+
+		if !foundLanguagePlugin {
+			// Couldn't get a language plugin, fall back to the old behavior, of trying to run
+			// "pulumi-analyzer-policy-<runtime>".
+			policyAnalyzerName := "policy-" + proj.Runtime.Name()
+
+			// Load the policy-booting analyzer plugin (i.e., `pulumi-analyzer-${policyAnalyzerName}`).
+			var pluginPath string
+			pluginPath, err = workspace.GetPluginPath(
+				ctx.baseContext, ctx.Diag,
+				workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, ctx.ProjectPlugins(),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			// The `pulumi-analyzer-policy` plugin is a script that looks for the '@pulumi/pulumi/cmd/run-policy-pack'
+			// node module and runs it with node. To allow non-node Pulumi programs (e.g. Python, .NET, Go, etc.) to
+			// run node policy packs, we must set the plugin's pwd to the policy pack directory instead of the Pulumi
+			// program directory, so that the '@pulumi/pulumi/cmd/run-policy-pack' module from the policy pack's
+			// node_modules is used.
+			pwd := policyPackPath
+
+			args := []string{host.ServerAddr(), "."}
+			for k, v := range proj.Runtime.Options() {
+				if vstr := fmt.Sprintf("%v", v); vstr != "" {
+					args = append(args, fmt.Sprintf("-%s=%s", k, vstr))
+				}
+			}
+
+			// Create the environment variables from the options.
+			analyzerEnv, err = constructEnv(analyzerEnv, opts, proj.Runtime.Name())
+			if err != nil {
+				return nil, err
+			}
+
+			plug, _, err = newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
+				apitype.AnalyzerPlugin, args, analyzerEnv, handshake,
+				analyzerPluginDialOptions(ctx, fmt.Sprintf("%v", name)),
+				host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
+		} else {
+			// Else we _did_ get a language plugin so just use RunPlugin to invoke the policy pack.
+			plug, _, err = newPlugin(ctx, ctx.Pwd, policyPackPath, fmt.Sprintf("%v (analyzer)", name),
+				apitype.AnalyzerPlugin, []string{host.ServerAddr()}, analyzerEnv,
+				handshake, analyzerPluginDialOptions(ctx, string(name)),
+				host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
+		}
 	}
 
 	if err != nil {
@@ -236,15 +263,19 @@ func NewPolicyAnalyzer(
 	}
 
 	var description string
-	if proj.Description != nil {
-		description = *proj.Description
+	var version string
+	if proj != nil {
+		if proj.Description != nil {
+			description = *proj.Description
+		}
+		version = proj.Version
 	}
 
 	return &analyzer{
 		name:        name,
 		plug:        plug,
 		client:      client,
-		version:     proj.Version,
+		version:     version,
 		description: description,
 	}, nil
 }
@@ -927,7 +958,7 @@ func convertNotApplicable(protoNotApplicable []*pulumirpc.PolicyNotApplicable) [
 // constructEnv creates an Environment containing a store of key/value pairs to be used for the policy pack process.
 // Config is passed as an environment variable (including unencrypted secrets), similar to
 // how config is passed to each language runtime plugin.
-func constructEnv(opts *PolicyAnalyzerOptions, runtime string) (env.Env, error) {
+func constructEnv(analyzerEnv env.Env, opts *PolicyAnalyzerOptions, runtime string) (env.Env, error) {
 	store := envutil.MapStore{}
 
 	maybeAppendEnv := func(k, v string) {
@@ -958,12 +989,9 @@ func constructEnv(opts *PolicyAnalyzerOptions, runtime string) (env.Env, error) 
 		maybeAppendEnv("PULUMI_PROJECT", opts.Project)
 		maybeAppendEnv("PULUMI_STACK", opts.Stack)
 		maybeAppendEnv("PULUMI_DRY_RUN", strconv.FormatBool(opts.DryRun))
-
-		// Inject per-pack environment variables (e.g., from ESC environments).
-		maps.Copy(store, opts.AdditionalEnv)
 	}
 
-	return envutil.NewEnv(envutil.JoinStore(store, env.Global().GetStore())), nil
+	return envutil.NewEnv(envutil.JoinStore(store, analyzerEnv.GetStore())), nil
 }
 
 // constructConfig JSON-serializes the configuration data.

--- a/pkg/resource/plugin/analyzer_plugin_test.go
+++ b/pkg/resource/plugin/analyzer_plugin_test.go
@@ -17,42 +17,11 @@ package plugin
 import (
 	"testing"
 
+	envutil "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/stretchr/testify/require"
 )
 
-func TestConstructEnvWithAdditionalEnv(t *testing.T) {
-	t.Parallel()
-
-	opts := &PolicyAnalyzerOptions{
-		Organization: "test-org",
-		Project:      "test-project",
-		Stack:        "test-stack",
-		DryRun:       false,
-		AdditionalEnv: map[string]string{
-			"MY_SECRET":  "secret-value",
-			"AWS_REGION": "us-west-2",
-		},
-	}
-
-	result, err := constructEnv(opts, "nodejs")
-	require.NoError(t, err)
-
-	// Verify standard env vars are set.
-	val, found := result.GetStore().Raw("PULUMI_ORGANIZATION")
-	require.True(t, found)
-	require.Equal(t, "test-org", val)
-
-	// Verify AdditionalEnv vars are injected.
-	val, found = result.GetStore().Raw("MY_SECRET")
-	require.True(t, found)
-	require.Equal(t, "secret-value", val)
-
-	val, found = result.GetStore().Raw("AWS_REGION")
-	require.True(t, found)
-	require.Equal(t, "us-west-2", val)
-}
-
-func TestConstructEnvWithoutAdditionalEnv(t *testing.T) {
+func TestConstructEnv(t *testing.T) {
 	t.Parallel()
 
 	opts := &PolicyAnalyzerOptions{
@@ -62,7 +31,8 @@ func TestConstructEnvWithoutAdditionalEnv(t *testing.T) {
 		DryRun:       true,
 	}
 
-	result, err := constructEnv(opts, "python")
+	env := envutil.NewEnv(envutil.MapStore{})
+	result, err := constructEnv(env, opts, "python")
 	require.NoError(t, err)
 
 	// Standard vars should still be set.


### PR DESCRIPTION
Updates NewPolicyAnalyzer to first check if the path given is a file, and if so run that exe directly rather than going through the language runtime lookup.

If we're running an exe we still look for a side by side PulumiPolicy.yaml and will respect the "version" and "description" values from that the same as for a script style policy pack.