### PR TITLE
fix on-preview error of conformance tests

### DIFF
--- a/pkg/pcl/runtime/builtinFunctions.go
+++ b/pkg/pcl/runtime/builtinFunctions.go
@@ -540,10 +540,14 @@ func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 				return cty.NilVal, errors.New("call self must have an id property of type string")
 			}
 
-			urn := urnVal.AsString()
+			// The ID is unknown when self is a resource still being created during a preview.
+			idPV := resource.MakeComputed(resource.NewProperty(""))
+			if id.IsKnown() {
+				idPV = resource.NewProperty(id.AsString())
+			}
 			argsPM["__self__"] = resource.NewProperty(resource.ResourceReference{
-				URN: resource.URN(urn),
-				ID:  resource.NewProperty(id.AsString()),
+				URN: resource.URN(urnVal.AsString()),
+				ID:  idPV,
 			})
 
 			marshalOpts := plugin.MarshalOptions{

--- a/pkg/pcl/runtime/interpreter.go
+++ b/pkg/pcl/runtime/interpreter.go
@@ -1970,7 +1970,13 @@ func (i *Interpreter) registerResourceWith(
 		return cty.NilVal, err
 	}
 
-	outputs["id"] = resource.NewProperty(resp.GetId())
+	// During previews a created resource has no ID yet; represent it as unknown
+	// rather than a known empty string so it can't be observed as a real value.
+	if id := resp.GetId(); id == "" && i.info.DryRun {
+		outputs["id"] = resource.MakeComputed(resource.NewProperty(""))
+	} else {
+		outputs["id"] = resource.NewProperty(id)
+	}
 	outputs["urn"] = resource.NewProperty(resp.GetUrn())
 	outputs["__name"] = resource.NewProperty(request.Name)
 	outputs["__type"] = resource.NewProperty(request.Type)

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -1681,7 +1681,7 @@ func runLanguageTests(
 			assertPreview = func(
 				l *tests.L, args tests.AssertPreviewArgs,
 			) {
-				require.NoErrorf(l, err, "expected no error in preview")
+				require.NoErrorf(l, args.Err, "expected no error in preview")
 			}
 		}
 

--- a/pkg/testing/pulumi-test-language/tests/l1_builtin_list.go
+++ b/pkg/testing/pulumi-test-language/tests/l1_builtin_list.go
@@ -73,9 +73,8 @@ func init() {
 					cfg[config.MustMakeKey("l1-builtin-list", "singleOrNoneList")] = config.NewObjectValue(`["a","b"]`)
 					return cfg
 				}(),
-				Assert: func(l *L, res AssertArgs) {
-					require.Error(l, res.Err)
-				},
+				AssertPreview: func(l *L, res AssertPreviewArgs) { require.Error(l, res.Err) },
+				Assert:        func(l *L, res AssertArgs) { require.Error(l, res.Err) },
 			},
 			{
 				// Run 3: singleOrNone with an empty list returns null.


### PR DESCRIPTION
We used the wrong error here. Lets use the right one.

Previously, we were asserting that we bound the PCL program correctly in our `AssertPreview` hook.