### PR TITLE
show outputs for stateful do

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -131,6 +131,12 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 		return plan, changes, err
 	}
 
+	if op.Opts.Display.ShowDiff {
+		diffOpts := op.Opts.Display
+		diffOpts.Type = display.DisplayDiff
+		contract.IgnoreError(printDiff(events, diffOpts))
+	}
+
 	// If there are no changes, or we're auto-approving or just previewing, we can skip the confirmation prompt.
 	if op.Opts.AutoApprove || kind == apitype.PreviewUpdate {
 		close(eventsChannel)
@@ -171,6 +177,20 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	return plan, changes, err
 }
 
+func printDiff(events []engine.Event, displayOpts display.Options) error {
+	displayOpts.TruncateOutput = false // We want to always show the full details
+	diff, err := display.CreateDiff(events, displayOpts)
+	if err != nil {
+		return err
+	}
+	stdout := displayOpts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	_, err = fmt.Fprintln(stdout, diff)
+	return err
+}
+
 // confirmBeforeUpdating asks the user whether to proceed. A nil error means yes.
 func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRef StackReference, op UpdateOperation,
 	events []engine.Event, plan *deploy.Plan, explainer Explainer,
@@ -187,7 +207,9 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 
 		// For non-previews, we can also offer a detailed summary.
 		if !opts.SkipPreview {
-			choices = append(choices, string(details))
+			if !opts.Display.ShowDiff {
+				choices = append(choices, string(details))
+			}
 
 			// If we have an explainer (pulumi-cloud) we can offer to explain the changes.
 			if explainer != nil && explainer.IsExplainPreviewEnabled(ctx, opts.Display) {
@@ -226,14 +248,9 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 		}
 
 		if response == string(details) {
-			displayOpts := opts.Display
-			displayOpts.TruncateOutput = false // We want to always show the full details
-			diff, err := display.CreateDiff(events, displayOpts)
-			if err != nil {
+			if err := printDiff(events, opts.Display); err != nil {
 				return nil, err
 			}
-			_, err = os.Stdout.WriteString(diff + "\n")
-			contract.IgnoreError(err)
 			continue
 		}
 
@@ -300,7 +317,37 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 	// No need to generate a plan at this stage, there's no way for the system or user to extract the plan
 	// after here.
 	op.Opts.Engine.GeneratePlan = false
-	_, changes, res := apply(ctx, kind, stack, op, opts, events)
+
+	if !op.Opts.Display.ShowDiff {
+		_, changes, res := apply(ctx, kind, stack, op, opts, events)
+		return changes, res
+	}
+
+	// Collect the update's events so we can render the resolved diff afterwards, mirroring the
+	// preview diff shown before the confirmation.
+	collected := make(chan engine.Event)
+	var updateEvents []engine.Event
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range collected {
+			if !e.Internal() && (e.Type == engine.ResourcePreEvent || e.Type == engine.ResourceOutputsEvent ||
+				e.Type == engine.PolicyRemediationEvent) {
+				updateEvents = append(updateEvents, e)
+			}
+			if events != nil {
+				events <- e
+			}
+		}
+	}()
+	_, changes, res := apply(ctx, kind, stack, op, opts, collected)
+	close(collected)
+	<-done
+	if res == nil {
+		diffOpts := op.Opts.Display
+		diffOpts.Type = display.DisplayDiff
+		contract.IgnoreError(printDiff(updateEvents, diffOpts))
+	}
 	return changes, res
 }
 

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -103,14 +103,7 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	go func() {
 		// Pull out relevant events we will want to display in the confirmation below.
 		for e := range eventsChannel {
-			// Don't include internal events in the confirmation stats.
-			if e.Internal() {
-				continue
-			}
-			if e.Type == engine.ResourcePreEvent ||
-				e.Type == engine.ResourceOutputsEvent ||
-				e.Type == engine.PolicyRemediationEvent ||
-				e.Type == engine.SummaryEvent {
+			if diffEvent(e) {
 				events = append(events, e)
 			}
 		}
@@ -319,7 +312,7 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 	op.Opts.Engine.GeneratePlan = false
 
 	var changes sdkDisplay.ResourceChanges
-	err := runCollectingDiff(op.Opts.Display, events, func(ev chan<- engine.Event) error {
+	err := RunCollectingDiff(op.Opts.Display, events, func(ev chan<- engine.Event) error {
 		var res error
 		_, changes, res = apply(ctx, kind, stack, op, opts, ev)
 		return res
@@ -327,7 +320,18 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 	return changes, err
 }
 
-func runCollectingDiff(displayOpts display.Options, callerEvents chan<- engine.Event,
+// diffEvent reports whether e is one of the resource step events CreateDiff renders — the set both
+// the pre-confirmation preview diff and the post-operation diff collect.
+func diffEvent(e engine.Event) bool {
+	return !e.Internal() && (e.Type == engine.ResourcePreEvent ||
+		e.Type == engine.ResourceOutputsEvent ||
+		e.Type == engine.PolicyRemediationEvent ||
+		e.Type == engine.SummaryEvent)
+}
+
+// RunCollectingDiff runs an apply or preview operation and, when ShowDiff is set, prints the diff
+// afterwards from the events it emitted. Events are forwarded to callerEvents when it is non-nil.
+func RunCollectingDiff(displayOpts display.Options, callerEvents chan<- engine.Event,
 	run func(events chan<- engine.Event) error,
 ) error {
 	if !displayOpts.ShowDiff {
@@ -340,10 +344,7 @@ func runCollectingDiff(displayOpts display.Options, callerEvents chan<- engine.E
 	go func() {
 		defer close(done)
 		for e := range collected {
-			// Keep only the resource step events CreateDiff renders — the same set PreviewThenPrompt
-			// collects for its pre-confirmation diff; everything else is display-only noise.
-			if !e.Internal() && (e.Type == engine.ResourcePreEvent || e.Type == engine.ResourceOutputsEvent ||
-				e.Type == engine.PolicyRemediationEvent) {
+			if diffEvent(e) {
 				events = append(events, e)
 			}
 			if callerEvents != nil {

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -318,37 +318,48 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 	// after here.
 	op.Opts.Engine.GeneratePlan = false
 
-	if !op.Opts.Display.ShowDiff {
-		_, changes, res := apply(ctx, kind, stack, op, opts, events)
-		return changes, res
+	var changes sdkDisplay.ResourceChanges
+	err := runCollectingDiff(op.Opts.Display, events, func(ev chan<- engine.Event) error {
+		var res error
+		_, changes, res = apply(ctx, kind, stack, op, opts, ev)
+		return res
+	})
+	return changes, err
+}
+
+func runCollectingDiff(displayOpts display.Options, callerEvents chan<- engine.Event,
+	run func(events chan<- engine.Event) error,
+) error {
+	if !displayOpts.ShowDiff {
+		return run(callerEvents)
 	}
 
-	// Collect the update's events so we can render the resolved diff afterwards, mirroring the
-	// preview diff shown before the confirmation.
 	collected := make(chan engine.Event)
-	var updateEvents []engine.Event
+	var events []engine.Event
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for e := range collected {
+			// Keep only the resource step events CreateDiff renders — the same set PreviewThenPrompt
+			// collects for its pre-confirmation diff; everything else is display-only noise.
 			if !e.Internal() && (e.Type == engine.ResourcePreEvent || e.Type == engine.ResourceOutputsEvent ||
 				e.Type == engine.PolicyRemediationEvent) {
-				updateEvents = append(updateEvents, e)
+				events = append(events, e)
 			}
-			if events != nil {
-				events <- e
+			if callerEvents != nil {
+				callerEvents <- e
 			}
 		}
 	}()
-	_, changes, res := apply(ctx, kind, stack, op, opts, collected)
+	err := run(collected)
 	close(collected)
 	<-done
-	if res == nil {
-		diffOpts := op.Opts.Display
+	if err == nil {
+		diffOpts := displayOpts
 		diffOpts.Type = display.DisplayDiff
-		contract.IgnoreError(printDiff(updateEvents, diffOpts))
+		contract.IgnoreError(printDiff(events, diffOpts))
 	}
-	return changes, res
+	return err
 }
 
 type updateStats struct {

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -63,6 +63,8 @@ type Options struct {
 
 	SuppressStackRow bool // true to hide the synthetic stack row when no stack is involved.
 
+	ShowDiff bool // true to print the full diff after the preview and the update, and omit the "details" prompt choice.
+
 	// Neo options
 	ShowLinkToNeo       bool // true to display a 'explainFailure' link to Neo.
 	ShowNeoFeatures     bool // true to display Neo features like summaries and explanations.

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -82,7 +82,14 @@ func PreviewStack(
 	op UpdateOperation,
 	events chan<- engine.Event,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	return s.Backend().Preview(ctx, s, op, events)
+	var plan *deploy.Plan
+	var changes display.ResourceChanges
+	err := runCollectingDiff(op.Opts.Display, events, func(ev chan<- engine.Event) error {
+		var e error
+		plan, changes, e = s.Backend().Preview(ctx, s, op, ev)
+		return e
+	})
+	return plan, changes, err
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -82,14 +82,7 @@ func PreviewStack(
 	op UpdateOperation,
 	events chan<- engine.Event,
 ) (*deploy.Plan, display.ResourceChanges, error) {
-	var plan *deploy.Plan
-	var changes display.ResourceChanges
-	err := runCollectingDiff(op.Opts.Display, events, func(ev chan<- engine.Event) error {
-		var e error
-		plan, changes, e = s.Backend().Preview(ctx, s, op, ev)
-		return e
-	})
-	return plan, changes, err
+	return s.Backend().Preview(ctx, s, op, events)
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -60,9 +60,7 @@ type StatefulUpdateRequest struct {
 	Sink        diag.Sink
 }
 
-// StatefulUpdateResult carries whatever the caller wants to render after the update. For the first
-// cut we only echo the snippet identity — the resource's post-update outputs will be plumbed
-// through once we're reading them out of the returned snapshot.
+// StatefulUpdateResult carries whatever the caller wants to render after the update.
 type StatefulUpdateResult struct {
 	SnippetUUID string
 }
@@ -311,6 +309,11 @@ func DefaultRunStatefulUpdate(
 	displayOpts := display.Options{
 		Color:       cmdutil.GetGlobalColorization(),
 		ShowSecrets: req.ShowSecrets,
+	}
+	if req.DryRun {
+		displayOpts.Type = display.DisplayDiff
+	} else {
+		displayOpts.ShowDiff = true
 	}
 
 	ssml := cmdStack.SecretsManagerLoader{FallbackToState: true}

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -352,7 +352,10 @@ func DefaultRunStatefulUpdate(
 	}
 
 	if req.DryRun {
-		_, _, err = backend.PreviewStack(ctx, req.Stack, op, nil /* events */)
+		err = backend.RunCollectingDiff(op.Opts.Display, nil, func(events chan<- engine.Event) error {
+			_, _, e := backend.PreviewStack(ctx, req.Stack, op, events)
+			return e
+		})
 	} else {
 		_, err = backend.UpdateStack(ctx, req.Stack, op, nil /* events */)
 	}

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -307,13 +307,10 @@ func DefaultRunStatefulUpdate(
 		return nil, errors.New("stateful update requires a loaded stack")
 	}
 	displayOpts := display.Options{
-		Color:       cmdutil.GetGlobalColorization(),
-		ShowSecrets: req.ShowSecrets,
-	}
-	if req.DryRun {
-		displayOpts.Type = display.DisplayDiff
-	} else {
-		displayOpts.ShowDiff = true
+		Color:         cmdutil.GetGlobalColorization(),
+		ShowSecrets:   req.ShowSecrets,
+		IsInteractive: cmdutil.Interactive(),
+		ShowDiff:      true,
 	}
 
 	ssml := cmdStack.SecretsManagerLoader{FallbackToState: true}


### PR DESCRIPTION
For stateful do, we also want to show the outputs before and after creating the resource, so the user can know some more details about what they just created.  Display the diff for what is going to be created before the user can choose whether they want to go ahead, and after the create/update is done.  This is the same thing that's usually displayed in the "Details" view, so we also drop the ability to select that.

Example output: 
<img width="1127" height="842" alt="image" src="https://github.com/user-attachments/assets/9c4e484c-c998-40a7-bacb-325a8b5d7100" />
