### PR TITLE
do: let engine do UUID resolution

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -32,7 +32,6 @@ import (
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -46,35 +45,34 @@ import (
 // converts this into a backend.UpdateOperation targeting only the named snippet, so existing state
 // in the stack is untouched.
 //
-// The stack is opened and its snapshot inspected by the CLI layer (so it can resolve the snippet's
-// UUID against any existing snippet of the same Name+Type); the resolved Stack is passed through
-// here so the hook doesn't repeat the load.
+// The stack is opened by the CLI layer and passed through here so the hook doesn't repeat the
+// load; Snippet.UUID carries a freshly minted proposal that the engine resolves against any
+// existing snippet of the same Name+Type.
 type StatefulUpdateRequest struct {
-	Snippet     resource.Snippet
-	Stack       backend.Stack
-	DryRun      bool
-	Yes         bool
-	ShowSecrets bool
-	Delete      bool
-	Proj        *workspace.Project
-	Root        string
-	Sink        diag.Sink
+	Snippet      resource.Snippet
+	Stack        backend.Stack
+	DryRun       bool
+	Yes          bool
+	ShowSecrets  bool
+	Delete       bool
+	RequireFresh bool
+	Proj         *workspace.Project
+	Root         string
+	Sink         diag.Sink
 }
 
 // StatefulUpdateResult carries whatever the caller wants to render after the update. For the first
-// cut we only echo the snippet identity — the resource's post-update outputs will be plumbed
-// through once we're reading them out of the returned snapshot.
-type StatefulUpdateResult struct {
-	SnippetUUID string
-}
+// cut it is empty — the resource's post-update outputs will be plumbed through once we're reading
+// them out of the returned snapshot.
+type StatefulUpdateResult struct{}
 
 // RunStatefulUpdateFunc is the injection point for driving the backend update/preview operation.
 // NewDoCmd assigns the default implementation (real backend + engine); tests substitute a capturing
 // stub so the CLI-level construction of the snippet and target can be exercised without a live
 // backend.
 //
-// The stack is passed in via req rather than looked up here — the CLI layer needs the snapshot
-// first (to resolve the snippet UUID) so it holds the stack open and hands it through.
+// The stack is passed in via req rather than looked up here — the CLI layer holds the stack open
+// and hands it through.
 type RunStatefulUpdateFunc func(
 	ctx context.Context, flags *pflag.FlagSet, req StatefulUpdateRequest,
 ) (*StatefulUpdateResult, error)
@@ -170,8 +168,8 @@ func (pc *packageCommand) newStatelessResourceUpsertCommand(res *schema.Resource
 }
 
 // statefulSnippetUpdate carries the pieces of a stateful snippet-add operation (create / upsert)
-// that vary between commands. Everything else — parsing the input file, loading the stack,
-// resolving the snippet UUID, and dispatching to runStatefulUpdate — is shared.
+// that vary between commands. Everything else — parsing the input file, loading the stack, and
+// dispatching to runStatefulUpdate — is shared.
 type statefulSnippetUpdate struct {
 	res         *schema.Resource
 	name        string
@@ -185,7 +183,7 @@ type statefulSnippetUpdate struct {
 }
 
 // runStatefulSnippetUpdate is the shared body of `create` (with requireFresh=true) and `upsert`
-// (with requireFresh=false). Both take the same inputs, differ only in the pre-run policy check
+// (with requireFresh=false). Both take the same inputs, differ only in the policy check
 // against any existing snippet with the same (Name, Type).
 func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args statefulSnippetUpdate) error {
 	contract.Assertf(pc.runStatefulUpdate != nil, "stateful snippet update is not wired up in this build")
@@ -211,9 +209,6 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 		return fmt.Errorf("read input file: %w", err)
 	}
 
-	// Open the stack up front so we can look at the existing snapshot before deciding whether
-	// this operation is legal (create requires a fresh snippet, upsert accepts either). The
-	// stack is threaded through to runStatefulUpdate so it doesn't re-load.
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
 	stack, err := cmdStack.RequireStack(
 		ctx, pc.diagFwd, pc.ws, pc.lm,
@@ -223,24 +218,13 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 	if err != nil {
 		return fmt.Errorf("load stack: %w", err)
 	}
-	snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
-	if err != nil {
-		return fmt.Errorf("load stack snapshot: %w", err)
-	}
 
-	// Snippet identity in the snapshot is (Name, Type) — reuse the existing UUID so the engine's
-	// applySnippetUpdates path replaces the snippet in place rather than adding a duplicate that
-	// would then race to register the same URN.
-	snippetUUID, existed, err := resolveSnippetUUID(snap, args.name, args.res.Token)
+	proposed, err := uuid.NewV4()
 	if err != nil {
-		return err
-	}
-	if args.requireFresh && existed {
-		return fmt.Errorf("resource %s %q already exists in stack %s; use `upsert` to replace it",
-			args.res.Token, args.name, stack.Ref())
+		return fmt.Errorf("generate snippet uuid: %w", err)
 	}
 	snippet := resource.Snippet{
-		UUID:       snippetUUID,
+		UUID:       proposed.String(),
 		Name:       args.name,
 		Type:       args.res.Token,
 		Code:       string(code),
@@ -248,20 +232,25 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 	}
 
 	result, err := pc.runStatefulUpdate(ctx, cmd.Flags(), StatefulUpdateRequest{
-		Snippet:     snippet,
-		Stack:       stack,
-		DryRun:      pc.dryrun,
-		Yes:         args.yes,
-		ShowSecrets: pc.showSecrets,
-		Proj:        pc.proj,
-		Root:        pc.root,
-		Sink:        pc.diagFwd,
+		Snippet:      snippet,
+		Stack:        stack,
+		DryRun:       pc.dryrun,
+		Yes:          args.yes,
+		ShowSecrets:  pc.showSecrets,
+		RequireFresh: args.requireFresh,
+		Proj:         pc.proj,
+		Root:         pc.root,
+		Sink:         pc.diagFwd,
 	})
 	if err != nil {
+		if errors.Is(err, engine.ErrSnippetExists) {
+			return fmt.Errorf("resource %s %q already exists in stack %s; use `upsert` to replace it",
+				args.res.Token, args.name, stack.Ref())
+		}
 		return err
 	}
 	if result != nil && !pc.dryrun {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s %s (snippet %s)\n", args.verb, args.name, result.SnippetUUID)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", args.verb, args.name)
 	}
 	return nil
 }
@@ -288,22 +277,15 @@ func (pc *packageCommand) runStatefulSnippetDelete(
 	if err != nil {
 		return fmt.Errorf("load stack: %w", err)
 	}
-	snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
-	if err != nil {
-		return fmt.Errorf("load stack snapshot: %w", err)
-	}
 
-	snippetUUID, exists, err := resolveSnippetUUID(snap, name, res.Token)
+	proposed, err := uuid.NewV4()
 	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("resource %s %q does not exist in stack %s", res.Token, name, stack.Ref())
+		return fmt.Errorf("generate snippet uuid: %w", err)
 	}
 
 	result, err := pc.runStatefulUpdate(ctx, cmd.Flags(), StatefulUpdateRequest{
 		Snippet: resource.Snippet{
-			UUID: snippetUUID,
+			UUID: proposed.String(),
 			Name: name,
 			Type: res.Token,
 		},
@@ -317,10 +299,13 @@ func (pc *packageCommand) runStatefulSnippetDelete(
 		Sink:        pc.diagFwd,
 	})
 	if err != nil {
+		if errors.Is(err, engine.ErrSnippetNotFound) {
+			return fmt.Errorf("resource %s %q does not exist in stack %s", res.Token, name, stack.Ref())
+		}
 		return err
 	}
 	if result != nil && !pc.dryrun {
-		fmt.Fprintf(cmd.OutOrStdout(), "deleted %s (snippet %s)\n", name, result.SnippetUUID)
+		fmt.Fprintf(cmd.OutOrStdout(), "deleted %s\n", name)
 	}
 	return nil
 }
@@ -337,31 +322,8 @@ func addStatefulSnippetUpdateFlags(
 	addInputFlags(cmd, "input", inputs)
 }
 
-// resolveSnippetUUID looks up an existing snippet in snap matching (name, resourceToken) and
-// returns its UUID for reuse (with existed=true); otherwise it mints a fresh UUIDv4 (existed=false).
-// Callers use existed to enforce operation-specific invariants: stateful `create` errors when a
-// snippet already exists, `upsert` doesn't care, and stateful `delete` errors when it doesn't.
-//
-// Snippet identity within a snapshot is (Name, Type): a second snippet with the same pair would
-// register the same resource URN and race with the first, so any resolver that reuses an existing
-// entry is preserving that invariant.
-func resolveSnippetUUID(snap *deploy.Snapshot, name, resourceToken string) (string, bool, error) {
-	if snap != nil {
-		for _, existing := range snap.Snippets {
-			if existing.Name == name && existing.Type == resourceToken {
-				return existing.UUID, true, nil
-			}
-		}
-	}
-	fresh, err := uuid.NewV4()
-	if err != nil {
-		return "", false, fmt.Errorf("generate snippet uuid: %w", err)
-	}
-	return fresh.String(), false, nil
-}
-
 // DefaultRunStatefulUpdate is the production implementation of the runStatefulUpdate hook. The
-// caller (typically the upsert command) has already loaded the stack and picked the snippet's
+// caller (typically the upsert command) has already loaded the stack and proposed the snippet's
 // UUID; this function loads config + secrets and calls the backend preview/update entrypoint with
 // an UpdateOperation whose engine options carry the snippet and target it.
 func DefaultRunStatefulUpdate(
@@ -375,7 +337,7 @@ func DefaultRunStatefulUpdate(
 		ShowSecrets: req.ShowSecrets,
 	}
 
-	ssml := cmdStack.SecretsManagerLoader{FallbackToState: true}
+	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, req.Sink, ssml, req.Stack, req.Proj, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("get stack configuration: %w", err)
@@ -387,18 +349,13 @@ func DefaultRunStatefulUpdate(
 	}
 	cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
-	snippetUUIDVal, err := uuid.FromString(req.Snippet.UUID)
-	if err != nil {
-		return nil, fmt.Errorf("snippet uuid: %w", err)
-	}
-	var snippet *resource.Snippet
-	if !req.Delete {
-		snippet = &req.Snippet
-	}
-
 	engineOpts := engine.UpdateOptions{
-		Snippets:       map[uuid.UUID]*resource.Snippet{snippetUUIDVal: snippet},
-		TargetSnippets: []string{snippetUUIDVal.String()},
+		Snippets: []engine.SnippetUpdate{{
+			Snippet:      req.Snippet,
+			Delete:       req.Delete,
+			RequireFresh: req.RequireFresh,
+		}},
+		TargetSnippets: []string{req.Snippet.UUID},
 		ShowSecrets:    req.ShowSecrets,
 	}
 
@@ -422,7 +379,7 @@ func DefaultRunStatefulUpdate(
 		return nil, err
 	}
 
-	return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+	return &StatefulUpdateResult{}, nil
 }
 
 // packageDescriptorFromProto lifts the codegen-RPC schema request into the resource-layer

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -17,12 +17,12 @@ package do
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/gofrs/uuid"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,7 +114,7 @@ func TestDoCmdResourceUpsertConstructsSnippet(t *testing.T) {
 	) (*StatefulUpdateResult, error) {
 		called = true
 		got = req
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
@@ -144,17 +144,19 @@ size = 2
 	require.NotNil(t, got.Stack, "runStatefulUpdate should receive the loaded stack")
 	assert.False(t, got.DryRun)
 	assert.True(t, got.Yes)
+	assert.False(t, got.RequireFresh, "upsert accepts existing snippets")
 
-	assert.Contains(t, stdout.String(), got.Snippet.UUID)
+	assert.Contains(t, stdout.String(), "upserted myres")
 	_ = stderr
 }
 
-// TestDoCmdResourceUpsertReusesExistingSnippet asserts that upsert against a stack whose snapshot
-// already has a snippet with the same (Name, Type) reuses that snippet's UUID (so the engine
-// replaces the snippet in place rather than adding a duplicate).
+// TestDoCmdResourceUpsertProposesFreshUUID asserts that upsert does not load the stack snapshot to
+// resolve the snippet's UUID: even when the snapshot already has a snippet with the same
+// (Name, Type), the CLI proposes a fresh UUID and leaves identity resolution (adopting the
+// existing snippet's UUID) to the engine, which has the snapshot in hand anyway.
 //
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
-func TestDoCmdResourceUpsertReusesExistingSnippet(t *testing.T) {
+func TestDoCmdResourceUpsertProposesFreshUUID(t *testing.T) {
 	existing := resource.Snippet{
 		UUID: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
 		Name: "myres", Type: "azure:index:myResource",
@@ -167,7 +169,7 @@ func TestDoCmdResourceUpsertReusesExistingSnippet(t *testing.T) {
 	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
 	) (*StatefulUpdateResult, error) {
 		got = req
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -184,7 +186,8 @@ func TestDoCmdResourceUpsertReusesExistingSnippet(t *testing.T) {
 	})
 	require.NoError(t, cmd.Execute())
 
-	assert.Equal(t, existing.UUID, got.Snippet.UUID, "existing snippet UUID should be reused")
+	require.NotEmpty(t, got.Snippet.UUID)
+	assert.NotEqual(t, existing.UUID, got.Snippet.UUID, "the CLI should propose a fresh UUID")
 	assert.Equal(t, `name = "new"`, got.Snippet.Code, "code should be replaced with the new file contents")
 	_ = stdout
 	_ = stderr
@@ -259,16 +262,20 @@ func TestDoCmdResourceUpsertEndToEnd(t *testing.T) {
 	var finalSnap *deploy.Snapshot
 	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
 	) (*StatefulUpdateResult, error) {
-		snap := baseSnap
-		snap.Snippets = []resource.Snippet{req.Snippet}
+		p.Options.Snippets = []engine.SnippetUpdate{{
+			Snippet:      req.Snippet,
+			Delete:       req.Delete,
+			RequireFresh: req.RequireFresh,
+		}}
+		p.Options.TargetSnippets = []string{req.Snippet.UUID}
 		var err error
 		finalSnap, err = lt.TestOp(engine.Update).RunStep(
-			p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1",
+			p.GetProject(), p.GetTarget(t, baseSnap), p.Options, false, p.BackendClient, nil, "1",
 		)
 		if err != nil {
 			return nil, err
 		}
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 
 	mws, mlm := installMockUpsertBackend(t, &deploy.Snapshot{})
@@ -441,7 +448,7 @@ func TestDoCmdResourceStatefulCreateConstructsSnippet(t *testing.T) {
 	) (*StatefulUpdateResult, error) {
 		called = true
 		got = req
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -463,13 +470,14 @@ func TestDoCmdResourceStatefulCreateConstructsSnippet(t *testing.T) {
 	assert.Equal(t, "azure:index:myResource", got.Snippet.Type)
 	assert.Contains(t, got.Snippet.Code, `name = "example"`)
 	require.NotEmpty(t, got.Snippet.UUID)
+	assert.True(t, got.RequireFresh, "create should require a fresh snippet")
 	assert.Contains(t, stdout.String(), "created myres")
 	_ = stderr
 }
 
 // TestDoCmdResourceStatefulCreateRejectsExisting checks the invariant that distinguishes create
-// from upsert: if a snippet with the same (Name, Type) already lives in the snapshot, create
-// refuses rather than replacing it in place.
+// from upsert: the engine reports ErrSnippetExists for a RequireFresh update matching an existing
+// snippet, and the CLI translates that into an error naming the stack and suggesting `upsert`.
 //
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
 func TestDoCmdResourceStatefulCreateRejectsExisting(t *testing.T) {
@@ -481,10 +489,10 @@ func TestDoCmdResourceStatefulCreateRejectsExisting(t *testing.T) {
 	}
 	mws, mlm := installMockUpsertBackend(t, &deploy.Snapshot{Snippets: []resource.Snippet{existing}})
 
-	stub := func(_ context.Context, _ *pflag.FlagSet, _ StatefulUpdateRequest,
+	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
 	) (*StatefulUpdateResult, error) {
-		require.Fail(t, "runStatefulUpdate should not be called when the snippet already exists")
-		return nil, nil
+		require.True(t, req.RequireFresh, "create should require a fresh snippet")
+		return nil, fmt.Errorf("snippet %q (%s) %w", req.Snippet.Name, req.Snippet.Type, engine.ErrSnippetExists)
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -500,15 +508,15 @@ func TestDoCmdResourceStatefulCreateRejectsExisting(t *testing.T) {
 		"--input", "pcl", "--input-file", inputFile,
 	})
 	err := cmd.Execute()
-	require.ErrorContains(t, err, "already exists")
+	require.ErrorContains(t, err, "already exists in stack myorg/proj/dev")
 	require.ErrorContains(t, err, "upsert")
 	_ = stdout
 	_ = stderr
 }
 
-// TestDoCmdResourceStatefulDeleteConstructsSnippetDelete checks that stateful `delete` resolves
-// the existing snippet by (Name, Type), targets that snippet UUID, and marks the request as a
-// snippet deletion.
+// TestDoCmdResourceStatefulDeleteConstructsSnippetDelete checks that stateful `delete` proposes a
+// fresh UUID for the engine to resolve by (Name, Type), targets that snippet, and marks the
+// request as a snippet deletion.
 //
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
 func TestDoCmdResourceStatefulDeleteConstructsSnippetDelete(t *testing.T) {
@@ -526,7 +534,7 @@ func TestDoCmdResourceStatefulDeleteConstructsSnippetDelete(t *testing.T) {
 	) (*StatefulUpdateResult, error) {
 		called = true
 		got = req
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -541,25 +549,26 @@ func TestDoCmdResourceStatefulDeleteConstructsSnippetDelete(t *testing.T) {
 
 	require.True(t, called, "runStatefulUpdate should have been invoked")
 	assert.True(t, got.Delete)
-	assert.Equal(t, existing.UUID, got.Snippet.UUID)
+	require.NotEmpty(t, got.Snippet.UUID)
+	assert.NotEqual(t, existing.UUID, got.Snippet.UUID, "the CLI should propose a fresh UUID")
 	assert.Equal(t, "myres", got.Snippet.Name)
 	assert.Equal(t, "azure:index:myResource", got.Snippet.Type)
 	assert.Contains(t, stdout.String(), "deleted myres")
-	assert.Contains(t, stdout.String(), existing.UUID)
 	_ = stderr
 }
 
-// TestDoCmdResourceStatefulDeleteRejectsMissing checks that delete refuses to run a backend update
-// when the named snippet does not exist in the stack snapshot.
+// TestDoCmdResourceStatefulDeleteRejectsMissing checks that the engine's ErrSnippetNotFound for a
+// delete naming a snippet absent from the snapshot is translated into an error naming the
+// resource and stack.
 //
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
 func TestDoCmdResourceStatefulDeleteRejectsMissing(t *testing.T) {
 	mws, mlm := installMockUpsertBackend(t, &deploy.Snapshot{})
 
-	stub := func(_ context.Context, _ *pflag.FlagSet, _ StatefulUpdateRequest,
+	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
 	) (*StatefulUpdateResult, error) {
-		require.Fail(t, "runStatefulUpdate should not be called when the snippet is missing")
-		return nil, nil
+		require.True(t, req.Delete)
+		return nil, fmt.Errorf("snippet %q (%s) %w", req.Snippet.Name, req.Snippet.Type, engine.ErrSnippetNotFound)
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -571,7 +580,7 @@ func TestDoCmdResourceStatefulDeleteRejectsMissing(t *testing.T) {
 
 	cmd.SetArgs([]string{"azure:index:myResource", "delete", "myres", "--yes"})
 	err := cmd.Execute()
-	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "does not exist in stack myorg/proj/dev")
 	require.ErrorContains(t, err, "myres")
 	_ = stdout
 	_ = stderr
@@ -601,7 +610,7 @@ func TestDoCmdResourceUpsertMergesInputFlags(t *testing.T) {
 	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
 	) (*StatefulUpdateResult, error) {
 		got = req
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -635,7 +644,7 @@ func TestDoCmdResourceUpsertAllowsInputFlagsWithoutFile(t *testing.T) {
 	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
 	) (*StatefulUpdateResult, error) {
 		got = req
-		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+		return &StatefulUpdateResult{}, nil
 	}
 	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
 		return &testProvider{spec: doResourceSpec(false)}, nil
@@ -720,7 +729,7 @@ func TestDefaultRunStatefulUpdateDryRunUsesPreview(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.True(t, previewCalled, "dry-run upsert should call PreviewStack")
-	require.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", result.SnippetUUID)
+	require.NotNil(t, result)
 }
 
 //nolint:paralleltest // Uses t.Chdir
@@ -784,11 +793,11 @@ func TestDefaultRunStatefulUpdateYesAutoApprovesUpdate(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.True(t, updateCalled, "non-dry-run upsert should call UpdateStack")
-	require.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", result.SnippetUUID)
+	require.NotNil(t, result)
 }
 
 //nolint:paralleltest // Uses t.Chdir
-func TestDefaultRunStatefulUpdateDeletePassesNilSnippet(t *testing.T) {
+func TestDefaultRunStatefulUpdateDeletePassesDeleteUpdate(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(root+"/Pulumi.yaml", []byte("name: proj\nruntime: yaml\n"), 0o600))
 	t.Chdir(root)
@@ -805,8 +814,9 @@ func TestDefaultRunStatefulUpdateDeletePassesNilSnippet(t *testing.T) {
 			require.Len(t, op.Opts.Engine.TargetSnippets, 1)
 			assert.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", op.Opts.Engine.TargetSnippets[0])
 			require.Len(t, op.Opts.Engine.Snippets, 1)
-			snippetID := uuid.Must(uuid.FromString("3fa85f64-5717-4562-b3fc-2c963f66afa6"))
-			assert.Nil(t, op.Opts.Engine.Snippets[snippetID])
+			assert.True(t, op.Opts.Engine.Snippets[0].Delete)
+			assert.Equal(t, "myres", op.Opts.Engine.Snippets[0].Snippet.Name)
+			assert.Equal(t, "azure:index:myResource", op.Opts.Engine.Snippets[0].Snippet.Type)
 			return nil, nil
 		},
 	}
@@ -843,5 +853,5 @@ func TestDefaultRunStatefulUpdateDeletePassesNilSnippet(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.True(t, updateCalled, "stateful delete should call UpdateStack")
-	require.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", result.SnippetUUID)
+	require.NotNil(t, result)
 }

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -49,3 +49,8 @@ func AsDecryptError(err error) (*DecryptError, bool) {
 	ok := errors.As(err, &de)
 	return de, ok
 }
+
+var (
+	ErrSnippetExists   = errors.New("already exists in snapshot")
+	ErrSnippetNotFound = errors.New("does not exist in snapshot")
+)

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -1667,13 +1667,14 @@ func TestPclSnippetAddUpdateDeleteViaOption(t *testing.T) {
 	}
 
 	snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
-	p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
-		snippetID: {
+	p.Options.Snippets = []SnippetUpdate{{
+		Snippet: resource.Snippet{
+			UUID: snippetID.String(),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
 		},
-	}
+	}}
 	snap, err := lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "add")
 	require.NoError(t, err)
@@ -1684,13 +1685,15 @@ func TestPclSnippetAddUpdateDeleteViaOption(t *testing.T) {
 	require.Empty(t, updated)
 	require.Empty(t, deleted)
 
-	p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
-		snippetID: {
+	otherID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+	p.Options.Snippets = []SnippetUpdate{{
+		Snippet: resource.Snippet{
+			UUID: otherID.String(),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = false`,
 		},
-	}
+	}}
 	snap, err = lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "update")
 	require.NoError(t, err)
@@ -1701,7 +1704,10 @@ func TestPclSnippetAddUpdateDeleteViaOption(t *testing.T) {
 	require.Len(t, updated, 1, "snippet update should update the resource")
 	require.Empty(t, deleted)
 
-	p.Options.Snippets = map[uuid.UUID]*resource.Snippet{snippetID: nil}
+	p.Options.Snippets = []SnippetUpdate{{
+		Snippet: resource.Snippet{Name: "test-resource", Type: "pkgA:index:res"},
+		Delete:  true,
+	}}
 	snap, err = lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "delete")
 	require.NoError(t, err)
@@ -1729,36 +1735,171 @@ func TestPclSnippetOptionValidation(t *testing.T) {
 		}
 	}
 
-	t.Run("mismatched UUID", func(t *testing.T) {
+	t.Run("missing UUID", func(t *testing.T) {
 		t.Parallel()
 
 		p := newPlan(t)
-		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
-		otherID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
-		p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
-			snippetID: {
-				UUID: otherID.String(),
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
 				Name: "test-resource", Type: "pkgA:index:res",
 				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 				Code:       `propA = true`,
 			},
-		}
+		}}
 
 		_, err := lt.TestOp(Update).RunStep(
-			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "mismatched")
-		require.ErrorContains(t, err, fmt.Sprintf("snippet %q has mismatched uuid %q", snippetID, otherID))
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "missing-uuid")
+		require.ErrorContains(t, err, `snippet "test-resource" (pkgA:index:res) has invalid uuid ""`)
 	})
 
 	t.Run("delete missing", func(t *testing.T) {
 		t.Parallel()
 
 		p := newPlan(t)
-		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
-		p.Options.Snippets = map[uuid.UUID]*resource.Snippet{snippetID: nil}
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{Name: "test-resource", Type: "pkgA:index:res"},
+			Delete:  true,
+		}}
 
 		_, err := lt.TestOp(Update).RunStep(
 			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "delete-missing")
-		require.ErrorContains(t, err, fmt.Sprintf("cannot delete snippet %q: no such snippet in snapshot", snippetID))
+		require.ErrorContains(t, err, `snippet "test-resource" (pkgA:index:res) does not exist in snapshot`)
+		require.ErrorIs(t, err, ErrSnippetNotFound)
+	})
+
+	t.Run("require fresh rejects existing", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
+				UUID: snippetID.String(),
+				Name: "test-resource", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = true`,
+			},
+		}}
+		snap, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "fresh-add")
+		require.NoError(t, err)
+
+		otherID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
+				UUID: otherID.String(),
+				Name: "test-resource", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = false`,
+			},
+			RequireFresh: true,
+		}}
+		_, err = lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "fresh-conflict")
+		require.ErrorContains(t, err, `snippet "test-resource" (pkgA:index:res) already exists in snapshot`)
+		require.ErrorIs(t, err, ErrSnippetExists)
+	})
+
+	t.Run("proposal colliding with another snippet's uuid", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		firstID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		secondID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = []SnippetUpdate{
+			{
+				Snippet: resource.Snippet{
+					UUID: firstID.String(),
+					Name: "first", Type: "pkgA:index:res",
+					Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+					Code:       `propA = true`,
+				},
+			},
+			{
+				Snippet: resource.Snippet{
+					UUID: secondID.String(),
+					Name: "second", Type: "pkgA:index:res",
+					Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+					Code:       `propA = true`,
+				},
+			},
+		}
+		snap, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "add-two")
+		require.NoError(t, err)
+		require.Len(t, snap.Snippets, 2)
+
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
+				UUID: firstID.String(),
+				Name: "second", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = false`,
+			},
+		}}
+		_, err = lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "hijack")
+		require.ErrorContains(t, err,
+			fmt.Sprintf(`snippet "second" (pkgA:index:res) reuses uuid %q of another snippet`, firstID))
+	})
+
+	t.Run("delete frees uuid for reuse in the same batch", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
+				UUID: snippetID.String(),
+				Name: "test-resource", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = true`,
+			},
+		}}
+		snap, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "seed")
+		require.NoError(t, err)
+
+		p.Options.Snippets = []SnippetUpdate{
+			{
+				Snippet: resource.Snippet{Name: "test-resource", Type: "pkgA:index:res"},
+				Delete:  true,
+			},
+			{
+				Snippet: resource.Snippet{
+					UUID: snippetID.String(),
+					Name: "replacement", Type: "pkgA:index:res",
+					Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+					Code:       `propA = true`,
+				},
+			},
+		}
+		snap, err = lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "delete-and-reuse")
+		require.NoError(t, err)
+		require.Len(t, snap.Snippets, 1)
+		require.Equal(t, "replacement", snap.Snippets[0].Name)
+		require.Equal(t, snippetID.String(), snap.Snippets[0].UUID)
+	})
+
+	t.Run("non-canonical uuid is normalized", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
+				UUID: "{" + snippetID.String() + "}",
+				Name: "test-resource", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = true`,
+			},
+		}}
+		snap, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "braced")
+		require.NoError(t, err)
+		require.Len(t, snap.Snippets, 1)
+		require.Equal(t, snippetID.String(), snap.Snippets[0].UUID)
 	})
 
 	t.Run("invalid snippet is not persisted", func(t *testing.T) {
@@ -1766,13 +1907,14 @@ func TestPclSnippetOptionValidation(t *testing.T) {
 
 		p := newPlan(t)
 		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
-		p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
-			snippetID: {
+		p.Options.Snippets = []SnippetUpdate{{
+			Snippet: resource.Snippet{
+				UUID: snippetID.String(),
 				Name: "test-resource", Type: "pkgA:index:res",
 				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 				Code:       ``,
 			},
-		}
+		}}
 
 		snap, err := lt.TestOp(Update).RunStep(
 			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "invalid")

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"maps"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -436,15 +437,29 @@ type UpdateOptions struct {
 	// the provider registry when they are actually requested.
 	SkipPluginPreInstall bool
 
-	// Snippets updates the PCL snippets stored in the stack snapshot as part of this deployment. Keys are snippet
-	// UUIDs. A new UUID adds a snippet, an existing UUID replaces that snippet when the value is non-nil, and an
-	// existing UUID with a nil value deletes that snippet.
-	Snippets map[uuid.UUID]*resource.Snippet
+	// Snippets updates the PCL snippets stored in the stack snapshot as part of this deployment.
+	// Snippets are identified by (Name, Type): an update matching an existing snippet replaces (or,
+	// with Delete set, removes) that snippet in place, adopting its UUID; otherwise the update adds
+	// a new snippet under the UUID proposed in Snippet.UUID. TargetSnippets entries naming a
+	// proposed UUID are rewritten to the adopted UUID during resolution.
+	Snippets []SnippetUpdate
 }
 
-func applySnippetUpdates(base []resource.Snippet, updates map[uuid.UUID]*resource.Snippet) ([]resource.Snippet, error) {
+type SnippetUpdate struct {
+	Snippet      resource.Snippet
+	Delete       bool
+	RequireFresh bool
+}
+
+func snippetUUIDReuseError(name, typ string, id uuid.UUID) error {
+	return fmt.Errorf("snippet %q (%s) reuses uuid %q of another snippet", name, typ, id)
+}
+
+func applySnippetUpdates(
+	base []resource.Snippet, updates []SnippetUpdate,
+) ([]resource.Snippet, map[string]string, error) {
 	if len(updates) == 0 {
-		return base, nil
+		return base, nil, nil
 	}
 
 	byUUID := make(map[uuid.UUID]int, len(base))
@@ -452,57 +467,86 @@ func applySnippetUpdates(base []resource.Snippet, updates map[uuid.UUID]*resourc
 	for i, snippet := range base {
 		id, err := uuid.FromString(snippet.UUID)
 		if err != nil {
-			return nil, fmt.Errorf("snippet at index %d has invalid uuid %q", i, snippet.UUID)
+			return nil, nil, fmt.Errorf("snippet at index %d has invalid uuid %q", i, snippet.UUID)
 		}
 		if other, ok := byUUID[id]; ok {
-			return nil, fmt.Errorf("duplicate snippet uuid %q at indexes %d and %d", snippet.UUID, other, i)
+			return nil, nil, fmt.Errorf("duplicate snippet uuid %q at indexes %d and %d", snippet.UUID, other, i)
 		}
 		byUUID[id] = len(result)
 		result = append(result, snippet)
 	}
 
-	keys := make([]uuid.UUID, 0, len(updates))
-	for id := range updates {
-		if id == uuid.Nil {
-			return nil, errors.New("snippet update contains nil uuid")
-		}
-		keys = append(keys, id)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].String() < keys[j].String()
-	})
-
-	for _, id := range keys {
-		snippet := updates[id]
-		existing, exists := byUUID[id]
-		if snippet == nil {
-			if !exists {
-				return nil, fmt.Errorf("cannot delete snippet %q: no such snippet in snapshot", id)
-			}
-			result = append(result[:existing], result[existing+1:]...)
-			delete(byUUID, id)
-			for i := existing; i < len(result); i++ {
-				parsed, err := uuid.FromString(result[i].UUID)
-				contract.AssertNoErrorf(err, "validated snippet UUID changed")
-				byUUID[parsed] = i
-			}
-			continue
+	resolved := make(map[string]string, len(updates))
+	proposedSeen := make(map[uuid.UUID]bool, len(updates))
+	for i, update := range updates {
+		name, typ := update.Snippet.Name, update.Snippet.Type
+		if name == "" || typ == "" {
+			return nil, nil, fmt.Errorf("snippet update at index %d is missing a name or type", i)
 		}
 
-		updated := *snippet
-		if updated.UUID != "" && updated.UUID != id.String() {
-			return nil, fmt.Errorf("snippet %q has mismatched uuid %q", id, updated.UUID)
+		proposal := uuid.Nil
+		if update.Snippet.UUID != "" {
+			id, err := uuid.FromString(update.Snippet.UUID)
+			if err != nil || id == uuid.Nil {
+				return nil, nil, fmt.Errorf("snippet %q (%s) has invalid uuid %q", name, typ, update.Snippet.UUID)
+			}
+			if proposedSeen[id] {
+				return nil, nil, fmt.Errorf("snippet %q (%s) reuses proposed uuid %q of another update", name, typ, id)
+			}
+			proposedSeen[id] = true
+			proposal = id
 		}
-		updated.UUID = id.String()
-		if exists {
+
+		existing := slices.IndexFunc(result, func(s resource.Snippet) bool {
+			return s.Name == name && s.Type == typ
+		})
+
+		switch {
+		case update.Delete:
+			if existing < 0 {
+				return nil, nil, fmt.Errorf("snippet %q (%s) %w", name, typ, ErrSnippetNotFound)
+			}
+			victim := result[existing]
+			if proposal != uuid.Nil {
+				if _, used := byUUID[proposal]; used && proposal.String() != victim.UUID {
+					return nil, nil, snippetUUIDReuseError(name, typ, proposal)
+				}
+				resolved[update.Snippet.UUID] = victim.UUID
+			}
+			victimID, err := uuid.FromString(victim.UUID)
+			contract.AssertNoErrorf(err, "validated snippet uuid %q", victim.UUID)
+			delete(byUUID, victimID)
+			result = slices.Delete(result, existing, existing+1)
+		case existing >= 0:
+			if update.RequireFresh {
+				return nil, nil, fmt.Errorf("snippet %q (%s) %w", name, typ, ErrSnippetExists)
+			}
+			adopted := result[existing].UUID
+			if proposal != uuid.Nil {
+				if _, used := byUUID[proposal]; used && proposal.String() != adopted {
+					return nil, nil, snippetUUIDReuseError(name, typ, proposal)
+				}
+				resolved[update.Snippet.UUID] = adopted
+			}
+			updated := update.Snippet
+			updated.UUID = adopted
 			result[existing] = updated
-		} else {
-			byUUID[id] = len(result)
+		default:
+			if proposal == uuid.Nil {
+				return nil, nil, fmt.Errorf("snippet %q (%s) has invalid uuid %q", name, typ, update.Snippet.UUID)
+			}
+			if _, used := byUUID[proposal]; used {
+				return nil, nil, snippetUUIDReuseError(name, typ, proposal)
+			}
+			updated := update.Snippet
+			updated.UUID = proposal.String()
+			resolved[update.Snippet.UUID] = updated.UUID
+			byUUID[proposal] = len(result)
 			result = append(result, updated)
 		}
 	}
 
-	return result, nil
+	return result, resolved, nil
 }
 
 func targetWithSnippets(target *deploy.Target, snippets []resource.Snippet) *deploy.Target {
@@ -544,12 +588,21 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	if u.Target != nil && u.Target.Snapshot != nil {
 		baseSnippets = u.Target.Snapshot.Snippets
 	}
-	effectiveSnippets, err := applySnippetUpdates(baseSnippets, opts.Snippets)
+	effectiveSnippets, resolvedSnippets, err := applySnippetUpdates(baseSnippets, opts.Snippets)
 	if err != nil {
 		return nil, nil, err
 	}
 	if len(opts.Snippets) > 0 {
 		u.Target = targetWithSnippets(u.Target, effectiveSnippets)
+		if len(opts.TargetSnippets) > 0 {
+			targets := slices.Clone(opts.TargetSnippets)
+			for i, t := range targets {
+				if final, ok := resolvedSnippets[t]; ok {
+					targets[i] = final
+				}
+			}
+			opts.TargetSnippets = targets
+		}
 	}
 
 	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "update", ctx.ParentSpan)


### PR DESCRIPTION
In `pulumi do`, we currently fetch the snapshot to resolve the UUID of a snippet, and then fetch the snapshot again in the engine.  This has 2 issues:
1) it's racy. We don't hold the lock, so the snippet can disappear in
   between fetching the snapshot first and then actually getting it
   under lock inside the operation.
2) getting the snapshot can take a while (1s locally for a snapshot
   with 4000 resources), so it affects performance.

Instead, do the UUID resolution directly in the engine, where we already fetch the snapshot anyway.
restrictions to your ability to contribute to this project.

The downside is that we can't display the snippet UUID anymore. I haven't seen that used anywhere, but I might well be missing something.