### PR TITLE
Fix import file generation

### DIFF
--- a/changelog/pending/cli-import-fix-20260724-163949.yaml
+++ b/changelog/pending/cli-import-fix-20260724-163949.yaml
@@ -1,0 +1,4 @@
+component: cli/import
+kind: fix
+body: Fix import file generation when parent resources share names
+time: 2026-07-24T16:39:49.824025259+01:00

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -88,10 +88,13 @@ func buildImportFile(
 			NameTable: map[string]resource.URN{},
 		}
 
-		// A mapping of names to the index of the resourceSpec in imports.Resources that used it. We have to
-		// fix up names _as we go_ because we're mapping over the event stream, and it would be pretty
-		// inefficient to wait for the whole thing to finish before building the import specs.
-		takenNames := map[string]int{}
+		// A mapping of names to their logical name and type that used it. We have to fix up names _as we go_
+		// because we're mapping over the event stream, and it would be pretty inefficient to wait for the
+		// whole thing to finish before building the import specs.
+		takenNames := map[string]struct {
+			name string
+			typ  tokens.Type
+		}{}
 
 		// We want to prefer using the urns name for the source name, but if it conflicts with other resources
 		// we'll auto suffix it, first with the type, then with rising numbers. This function does that
@@ -119,34 +122,44 @@ func buildImportFile(
 
 			urn := preEvent.Metadata.URN
 			name := urn.Name()
-			if i, has := takenNames[name]; has {
-				// Another resource already has this name, lets check if that was it's original name or if it was a rename
-				importI := imports.Resources[i]
-				if importI.LogicalName != "" {
-					// i was renamed, so we're going to go backwards rename it again and then we can use our name for this resource.
-					newName := uniqueName(importI.LogicalName, importI.Type)
-					imports.Resources[i].Name = newName
-					// Go through all the resources and fix up any parent references to use the new name.
-					for j := range imports.Resources {
-						if imports.Resources[j].Parent == name {
-							imports.Resources[j].Parent = newName
-						}
-					}
-					// Fix up the nametable if needed
+			if old, has := takenNames[name]; has {
+				// Another resource already has this name, lets check if that was it's original name or if it was a rename.
+				if old.name != name {
+					// old was renamed, so we're going to go backwards rename it again and then we can use our name for this resource.
+					newName := uniqueName(old.name, old.typ)
+
+					// Fix up the name table to reflect the rename.
 					if urn, has := imports.NameTable[name]; has {
 						delete(imports.NameTable, name)
 						imports.NameTable[newName] = urn
 					}
+					// Then go through all the resources and fix up any name, parent or provider references to use the new name.
+					for j := range imports.Resources {
+						if imports.Resources[j].Name == name {
+							imports.Resources[j].Name = newName
+						}
+						if imports.Resources[j].Parent == name {
+							imports.Resources[j].Parent = newName
+						}
+						if imports.Resources[j].Provider == name {
+							imports.Resources[j].Provider = newName
+						}
+					}
 					// Fix up takenNames incase this is hit again
-					takenNames[newName] = i
+					takenNames[newName] = takenNames[name]
+					delete(takenNames, name)
 				} else {
-					// i just had the same name as us, lets find a new one
+					// old just had the same name as us, lets find a new one
 					name = uniqueName(name, urn.Type())
 				}
 			}
 
 			// Name is unique at this point
 			fullNameTable[urn] = name
+			takenNames[name] = struct {
+				name string
+				typ  tokens.Type
+			}{urn.Name(), urn.Type()}
 
 			// If this is a provider we need to note we've seen it so we can build the Version and PluginDownloadURL of
 			// any resources that use it.
@@ -257,7 +270,6 @@ func buildImportFile(
 				logicalName = urn.Name()
 			}
 
-			takenNames[name] = len(imports.Resources)
 			imports.Resources = append(imports.Resources, importSpec{
 				Type:              new.Type,
 				Name:              name,

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -613,3 +613,65 @@ func TestBuildImportFile_regress_15068(t *testing.T) {
 	_, err := importFilePromise.Result(t.Context())
 	assert.ErrorContains(t, err, "could not parse provider reference")
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/24056
+// Tests that when multiple existing component resources share the same name,
+// generated import resources still reference the correct distinct parents.
+func TestBuildImportFile_regress_24056(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(t.Context(), events, sdkconfig.NopEncrypter)
+
+	// Pretend the root stack already exists.
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	// Two existing components with the same logical name.
+	parentA := makeStateMetadata(t, "bug", "example:components:ComponentResourceA", false, stateOptions{})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, parentA),
+	})
+
+	parentB := makeStateMetadata(t, "bug", "example:components:ComponentResourceB", false, stateOptions{})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, parentB),
+	})
+
+	// Each created resource has one of the existing components as its parent.
+	childA := makeStateMetadata(t, "child-a", "example:components:ChildA", false, stateOptions{Parent: parentA.URN})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, childA),
+	})
+
+	childB := makeStateMetadata(t, "child-b", "example:components:ChildB", false, stateOptions{Parent: parentB.URN})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, childB),
+	})
+
+	close(events)
+
+	importFile, err := importFilePromise.Result(t.Context())
+	require.NoError(t, err)
+	require.Len(t, importFile.Resources, 2)
+
+	parentsByType := map[tokens.Type]string{}
+	for _, spec := range importFile.Resources {
+		parentsByType[spec.Type] = spec.Parent
+	}
+
+	parentAliasA, ok := parentsByType[childA.Type]
+	require.True(t, ok)
+	require.NotEmpty(t, parentAliasA)
+	parentAliasB, ok := parentsByType[childB.Type]
+	require.True(t, ok)
+	require.NotEmpty(t, parentAliasB)
+
+	// The two distinct parents must not collapse to the same alias.
+	assert.NotEqual(t, parentAliasA, parentAliasB)
+
+	// And each alias must resolve to the correct parent URN in the name table.
+	assert.Equal(t, parentA.URN, importFile.NameTable[parentAliasA])
+	assert.Equal(t, parentB.URN, importFile.NameTable[parentAliasB])
+}

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -359,6 +359,75 @@ func TestBuildImportFile_ExistingProvider(t *testing.T) {
 	assert.Equal(t, expected, importFile.Resources[0])
 }
 
+// TestBuildImportFile_RenamedProviderReference tests that if a provider's generated import-file
+// name is renamed after a resource has already referenced it, the resource's Provider field is
+// updated to the provider's new name.
+func TestBuildImportFile_RenamedProviderReference(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(t.Context(), events, sdkconfig.NopEncrypter)
+
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	// Occupy the provider's logical name so the provider is initially renamed from "prov" to "provPkg".
+	existingState := makeStateMetadata(t, "prov", "other:index:Existing", true, stateOptions{})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, existingState),
+	})
+
+	providerState := makeStateMetadata(t, "prov", "pulumi:providers:pkg", true, stateOptions{
+		Inputs: resource.NewPropertyMapFromMap(map[string]any{
+			"version": "3.2.1",
+		}),
+	})
+	uuid, err := uuid.NewV4()
+	require.NoError(t, err)
+	providerState.ID = resource.ID(uuid.String())
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, providerState),
+	})
+
+	providerRef, err := providers.NewReference(providerState.URN, providerState.ID)
+	require.NoError(t, err)
+	usesProvider := makeStateMetadata(t, "usesProvider", "pkg:mod:typ", true, stateOptions{
+		Provider: &providerRef,
+	})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, usesProvider),
+	})
+
+	// This resource takes the provider's current generated name, forcing the provider alias to
+	// be renamed again from "provPkg" to "provPkg2".
+	conflictingState := makeStateMetadata(t, "provPkg", "other:index:Conflict", true, stateOptions{})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, conflictingState),
+	})
+
+	close(events)
+	importFile, err := importFilePromise.Result(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, importFile.NameTable, 1)
+	assert.Equal(t, providerState.URN, importFile.NameTable["provPkg2"])
+
+	require.Len(t, importFile.Resources, 2)
+	assert.Equal(t, importSpec{
+		ID:       "<PLACEHOLDER>",
+		Type:     "pkg:mod:typ",
+		Name:     "usesProvider",
+		Provider: "provPkg2",
+		Version:  "3.2.1",
+	}, importFile.Resources[0])
+	assert.Equal(t, importSpec{
+		ID:   "<PLACEHOLDER>",
+		Type: "other:index:Conflict",
+		Name: "provPkg",
+	}, importFile.Resources[1])
+}
+
 // TestBuildImportFile_NewProvider tests that we can generate an import file for a resource that uses
 // an explicit provider that is also being created in the same deployment (#15453).
 func TestBuildImportFile_NewProvider(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/24056

When multiple existing resources had the same logical name, child resources could be written with the wrong parent alias in the generated import file.

Name collision tracking was tied to created import resources, and collision repair logic did not fully preserve identity across all references. In particular, duplicate names among existing resources could overwrite alias mappings used later for parent resolution.

This rewrote the name collision logic to be based around old logical names + types, regardless of if it was being imported, or just referenced. While at it we also fixed up the back-renaming logic to fix up `Provider` like it already did for `Parent`.
