### PR TITLE
add more debug output for TestDebuggerAttachBun

### DIFF
--- a/tests/integration/integration_bun_test.go
+++ b/tests/integration/integration_bun_test.go
@@ -15,9 +15,12 @@
 package ints
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -45,21 +48,57 @@ func TestDebuggerAttachBun(t *testing.T) {
 	e.RunCommand("pulumi", "stack", "init", "debugger-test")
 	e.RunCommand("pulumi", "stack", "select", "debugger-test")
 
-	var previewStdout, previewStderr string
+	eventLog := filepath.Join(e.RootPath, "debugger.log")
+	cmd := e.SetupCommandIn(e.Context(), e.CWD, "pulumi", "preview", "--attach-debugger", "--event-log", eventLog)
+	var previewStdout, previewStderr bytes.Buffer
+	cmd.Stdout = &previewStdout
+	cmd.Stderr = &previewStderr
+	e.Logf("Running command %v %v", cmd.Path, strings.Join(cmd.Args[1:], " "))
+	require.NoError(t, cmd.Start())
+
 	var previewErr error
 	previewDone := make(chan struct{})
 	go func() {
 		defer close(previewDone)
-		previewStdout, previewStderr, previewErr = e.GetCommandResults("pulumi", "preview", "--attach-debugger",
-			"--event-log", filepath.Join(e.RootPath, "debugger.log"))
+		previewErr = cmd.Wait()
 	}()
+
+	previewDiagnostics := func() string {
+		var sb strings.Builder
+		select {
+		case <-previewDone:
+			fmt.Fprintf(&sb, "pulumi preview exited early: %v\n", previewErr)
+		default:
+			if err := cmd.Process.Signal(syscall.SIGQUIT); err != nil {
+				fmt.Fprintf(&sb, "pulumi preview is still running; sending SIGQUIT to dump goroutine stacks failed: %v\n", err)
+			} else {
+				select {
+				case <-previewDone:
+					fmt.Fprintf(&sb, "pulumi preview was still running; goroutine stacks from SIGQUIT are in stderr below\n")
+				case <-time.After(15 * time.Second):
+					fmt.Fprintf(&sb, "pulumi preview was still running and did not exit within 15s of SIGQUIT\n")
+				}
+			}
+		}
+		select {
+		case <-previewDone:
+			fmt.Fprintf(&sb, "stdout:\n%s\nstderr:\n%s\n", previewStdout.String(), previewStderr.String())
+		default:
+		}
+		if contents, err := os.ReadFile(eventLog); err != nil {
+			fmt.Fprintf(&sb, "reading event log: %v", err)
+		} else {
+			fmt.Fprintf(&sb, "event log contents:\n%s", contents)
+		}
+		return sb.String()
+	}
 
 	// Wait for the debugging event
 	wait := 20 * time.Millisecond
 	var debugEvent *apitype.StartDebuggingEvent
 outer:
 	for range 50 {
-		events, err := readUpdateEventLog(filepath.Join(e.RootPath, "debugger.log"))
+		events, err := readUpdateEventLog(eventLog)
 		require.NoError(t, err)
 		for _, event := range events {
 			if event.StartDebuggingEvent != nil {
@@ -73,14 +112,7 @@ outer:
 		}
 	}
 	if debugEvent == nil {
-		detail := "pulumi preview is still running"
-		select {
-		case <-previewDone:
-			detail = fmt.Sprintf("pulumi preview exited early: %v\nstdout:\n%s\nstderr:\n%s",
-				previewErr, previewStdout, previewStderr)
-		default:
-		}
-		require.NotNilf(t, debugEvent, "no StartDebuggingEvent appeared in the event log; %s", detail)
+		require.NotNilf(t, debugEvent, "no StartDebuggingEvent appeared in the event log; %s", previewDiagnostics())
 	}
 
 	wsURL, ok := debugEvent.Config["url"].(string)
@@ -113,11 +145,10 @@ outer:
 	select {
 	case <-previewDone:
 		require.NoError(t, previewErr, "pulumi preview failed:\nstdout:\n%s\nstderr:\n%s",
-			previewStdout, previewStderr)
+			previewStdout.String(), previewStderr.String())
 	case <-time.After(60 * time.Second):
-		events, _ := readUpdateEventLog(filepath.Join(e.RootPath, "debugger.log"))
 		require.FailNowf(t, "timed out waiting for program to complete after detaching the debugger",
-			"bun likely never resumed execution.\ndebugger responses received:\n%s\n"+
-				"event log contained %d events", strings.Join(received, "\n"), len(events))
+			"bun likely never resumed execution.\ndebugger responses received:\n%s\n%s",
+			strings.Join(received, "\n"), previewDiagnostics())
 	}
 }


### PR DESCRIPTION
This test keeps flaking despite my latest update, and that hasn't given us enough ideas on how to fix it.

Add more debugging output (in particular send a SIGQUIT before we exit to dump the goroutines), so we can hopefully debug this better in CI (I can't get it to fail for me locally)

