### PR TITLE
Suggest `pulumi neo --debug-update`/`--debug-preview` in the diagnostics link

### DIFF
--- a/changelog/pending/20260727--cli-display--suggest-targeted-neo-debug-command-in-diagnostics-link.yaml
+++ b/changelog/pending/20260727--cli-display--suggest-targeted-neo-debug-command-in-diagnostics-link.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: The Neo diagnostics link now suggests `pulumi neo --debug-update` or `pulumi neo --debug-preview` to investigate the failed operation
 time: 2026-07-27T00:00:00+00:00
 custom:
-  PR: ""
+  PR: "24075"

--- a/changelog/pending/20260727--cli-display--suggest-targeted-neo-debug-command-in-diagnostics-link.yaml
+++ b/changelog/pending/20260727--cli-display--suggest-targeted-neo-debug-command-in-diagnostics-link.yaml
@@ -1,0 +1,6 @@
+component: cli/display
+kind: improvement
+body: The Neo diagnostics link now suggests `pulumi neo --debug-update` or `pulumi neo --debug-preview` to investigate the failed operation
+time: 2026-07-27T00:00:00+00:00
+custom:
+  PR: ""

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -852,7 +852,8 @@ func (display *ProgressDisplay) printDiagnostics() {
 			colors.SpecCreateReplacement + "[Pulumi Neo]" + colors.Reset + " Would you like help with these diagnostics?")
 		display.println("    " +
 			colors.Underline + colors.Blue + ExplainFailureLink(display.permalink) + colors.Reset)
-		display.println("    " + "Or run `pulumi neo` for an interactive agent in your terminal.")
+		display.println("    " + "Or run `" + neoDebugCommand(display.isPreview) +
+			"` for an interactive agent in your terminal.")
 		display.println("")
 	}
 }


### PR DESCRIPTION
When a failed update/preview prints the plain Neo diagnostics link (Neo enabled in the org but summaries not shown), the terminal hint now suggests the targeted debug command — `pulumi neo --debug-update` for a failed update or `pulumi neo --debug-preview` for a failed preview — instead of a bare `pulumi neo`, matching the Neo Diagnostics summary variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J7z2PWi5M6rbXgEggwH9E