### PR TITLE
uv: allow overriding UV_PROJECT_ENVIRONMENT

### DIFF
--- a/changelog/pending/sdk-python-improvement-20260727-111915.yaml
+++ b/changelog/pending/sdk-python-improvement-20260727-111915.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: improvement
+body: Allow `UV_PROJECT_ENVIRONMENT` to override the virtualenv path if uv is used
+time: 2026-07-27T11:19:15.36565495+02:00

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -64,10 +64,11 @@ func newUv(root, virtualenv string) (*uv, error) {
 	if virtualenv == "" {
 		// If virtualenv is not set, look for the nearest uv.lock or pyproject.toml to
 		// determine where to place the virtualenv.
+		projectDir := root
 		uvLockDir, err := searchup(root, "uv.lock")
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				return nil, fmt.Errorf("error while looking for pyproject.toml in %s: %w", root, err)
+				return nil, fmt.Errorf("error while looking for uv.lock in %s: %w", root, err)
 			}
 			// No uv.lock, do we have a pyproject.toml?
 			pyprojectTomlDir, err := searchup(root, "pyproject.toml")
@@ -76,14 +77,21 @@ func newUv(root, virtualenv string) (*uv, error) {
 					return nil, fmt.Errorf("error while looking for pyproject.toml in %s: %w", root, err)
 				}
 				// We have no uv.lock and no pyproject.toml, place the virtualenv in the project root.
-				virtualenv = filepath.Join(root, defaultVirtualEnv)
 			} else {
 				// We have a pyproject.toml, place the virtualenv next to it.
-				virtualenv = filepath.Join(pyprojectTomlDir, defaultVirtualEnv)
+				projectDir = pyprojectTomlDir
 			}
 		} else {
 			// We have a uv.lock, place the virtualenv next to it.
-			virtualenv = filepath.Join(uvLockDir, defaultVirtualEnv)
+			projectDir = uvLockDir
+		}
+		if env := os.Getenv("UV_PROJECT_ENVIRONMENT"); env != "" {
+			virtualenv = env
+			if !filepath.IsAbs(virtualenv) {
+				virtualenv = filepath.Join(projectDir, virtualenv)
+			}
+		} else {
+			virtualenv = filepath.Join(projectDir, defaultVirtualEnv)
 		}
 	}
 	if !filepath.IsAbs(virtualenv) {

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -83,6 +83,50 @@ func TestUvVirtualenvPath(t *testing.T) {
 	})
 }
 
+func TestUvVirtualenvPathUvProjectEnvironment(t *testing.T) {
+	t.Run("absolute path", func(t *testing.T) {
+		root := t.TempDir()
+		venv := filepath.Join(t.TempDir(), "custom-env")
+		t.Setenv("UV_PROJECT_ENVIRONMENT", venv)
+
+		uv, err := newUv(root, "")
+		require.NoError(t, err)
+		require.Equal(t, venv, uv.virtualenvPath, "virtualenv is taken from UV_PROJECT_ENVIRONMENT")
+	})
+
+	t.Run("relative path resolves against the project directory", func(t *testing.T) {
+		root := t.TempDir()
+		pulumiRoot := filepath.Join(root, "subfolder")
+		require.NoError(t, os.Mkdir(pulumiRoot, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "uv.lock"), []byte{}, 0o600))
+		t.Setenv("UV_PROJECT_ENVIRONMENT", "custom-env")
+
+		uv, err := newUv(pulumiRoot, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(root, "custom-env"), uv.virtualenvPath,
+			"relative UV_PROJECT_ENVIRONMENT is resolved next to uv.lock")
+	})
+
+	t.Run("virtualenv option takes precedence", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("UV_PROJECT_ENVIRONMENT", filepath.Join(t.TempDir(), "custom-env"))
+
+		uv, err := newUv(root, "banana")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(root, "banana"), uv.virtualenvPath,
+			"the virtualenv runtime option wins over UV_PROJECT_ENVIRONMENT")
+	})
+
+	t.Run("empty value is ignored", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("UV_PROJECT_ENVIRONMENT", "")
+
+		uv, err := newUv(root, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(root, ".venv"), uv.virtualenvPath, "virtualenv is in the project root")
+	})
+}
+
 func TestUvVersion(t *testing.T) {
 	t.Parallel()
 
@@ -153,6 +197,35 @@ func TestUvCommandSyncsEnvironmentCustomVenv(t *testing.T) {
 	require.DirExists(t, filepath.Join(root, "my_venv"))
 
 	// `wheel`, the project's dependency, should be installed
+	cmd, err = uv.ModuleCommand(t.Context(), "wheel", "version")
+	require.NoError(t, err)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(out), "wheel"), "unexpected output: %s", out)
+}
+
+func TestUvCommandSyncsEnvironmentUvProjectEnvironment(t *testing.T) {
+	root := t.TempDir()
+	pyproject, err := os.ReadFile(filepath.Join("testdata", "project", "pyproject.toml"))
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(root, "pyproject.toml"), pyproject, 0o600)
+	require.NoError(t, err)
+
+	venv := filepath.Join(t.TempDir(), "custom-env")
+	t.Setenv("UV_PROJECT_ENVIRONMENT", venv)
+
+	uv, err := newUv(root, "")
+	require.NoError(t, err)
+
+	cmd, err := uv.Command(t.Context(), "-c", "print('hello')")
+	require.NoError(t, err)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, "hello", strings.TrimSpace(string(out)))
+
+	require.DirExists(t, venv)
+	require.NoDirExists(t, filepath.Join(root, ".venv"))
+
 	cmd, err = uv.ModuleCommand(t.Context(), "wheel", "version")
 	require.NoError(t, err)
 	out, err = cmd.CombinedOutput()


### PR DESCRIPTION
`UV_PROJECT_ENVIRONMENT` can be used in `uv` to override the virtual env path. Since this seems to be a standard in uv, let's allow our users to do the same.  Note that this doesn't override a manually set virtualenv path in `Pulumi.yaml`.

Fixes #22911 
