### PR TITLE
otel traces: allow traces over https://

### DIFF
--- a/changelog/pending/cli-improvement-20260727-122020.yaml
+++ b/changelog/pending/cli-improvement-20260727-122020.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Allow otel traces to be sent over https
+time: 2026-07-27T12:20:20.003939991+02:00

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -465,7 +465,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		"Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file")
 	cmd.PersistentFlags().StringVar(&otelTracesFlag, "otel-traces", "",
 		"Export OpenTelemetry traces to the specified endpoint. "+
-			"Use file:// for local JSON files, grpc:// for remote collectors")
+			"Use file:// for local JSON files, grpc:// or https:// for remote collectors")
 	cmd.PersistentFlags().StringVar(&profiling, "profiling", "",
 		"Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively")
 	cmd.PersistentFlags().IntVar(&memProfileRate, "memprofilerate", 0,

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -282,6 +282,8 @@ type ProgramTestOptions struct {
 	//   - file:///path/to/traces.json  — writes OTLP JSON to a local file
 	//   - grpc://host:port             — sends via insecure gRPC
 	//   - grpcs://host:port            — sends via TLS-secured gRPC
+	//   - http://host:port             — sends via insecure OTLP HTTP
+	//   - https://host:port            — sends via TLS-secured OTLP HTTP
 	//
 	// Template `{command}` syntax will be expanded to the current
 	// command name such as `pulumi-up`. This is useful for file-based

--- a/sdk/go/auto/automation/opt/options.go
+++ b/sdk/go/auto/automation/opt/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	Logtostderr bool
 	// Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
 	Memprofilerate int
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
 	Profiling string

--- a/sdk/go/auto/automation/optcancel/options.go
+++ b/sdk/go/auto/automation/optcancel/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	Logtostderr bool
 	// Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
 	Memprofilerate int
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
 	Profiling string

--- a/sdk/go/auto/automation/optimport/options.go
+++ b/sdk/go/auto/automation/optimport/options.go
@@ -62,7 +62,7 @@ type Options struct {
 	Memprofilerate int
 	// Optional message to associate with the update operation
 	Message string
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// The path to the file that will contain the generated resource declarations
 	Out string

--- a/sdk/go/auto/automation/optnew/options.go
+++ b/sdk/go/auto/automation/optnew/options.go
@@ -64,7 +64,7 @@ type Options struct {
 	Name string
 	// Use locally cached templates without making any network requests
 	Offline bool
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
 	Profiling string

--- a/sdk/go/auto/automation/optorg/options.go
+++ b/sdk/go/auto/automation/optorg/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	Logtostderr bool
 	// Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
 	Memprofilerate int
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
 	Profiling string

--- a/sdk/go/auto/automation/optorggetdefault/options.go
+++ b/sdk/go/auto/automation/optorggetdefault/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	Logtostderr bool
 	// Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
 	Memprofilerate int
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
 	Profiling string

--- a/sdk/go/auto/automation/optorgsearch/options.go
+++ b/sdk/go/auto/automation/optorgsearch/options.go
@@ -46,7 +46,7 @@ type Options struct {
 	Memprofilerate int
 	// Name of the organization to search. Defaults to the current user's default organization.
 	Org string
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Output format. Supported values are: default, json, yaml and csv
 	Output string

--- a/sdk/go/auto/automation/optorgsearchai/options.go
+++ b/sdk/go/auto/automation/optorgsearchai/options.go
@@ -46,7 +46,7 @@ type Options struct {
 	Memprofilerate int
 	// Organization name to search within
 	Org string
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Output format. Supported values are: default, json, yaml and csv
 	Output string

--- a/sdk/go/auto/automation/optorgsetdefault/options.go
+++ b/sdk/go/auto/automation/optorgsetdefault/options.go
@@ -42,7 +42,7 @@ type Options struct {
 	Logtostderr bool
 	// Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
 	Memprofilerate int
-	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+	// Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
 	OtelTraces string
 	// Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
 	Profiling string

--- a/sdk/go/common/util/otelreceiver/exporter.go
+++ b/sdk/go/common/util/otelreceiver/exporter.go
@@ -51,11 +51,17 @@ type SpanExporter interface {
 //   - file:// - writes OTLP JSON to a local file
 //   - grpc:// - sends OTLP via insecure gRPC (local collectors)
 //   - grpcs:// - sends OTLP via TLS-secured gRPC with optional header auth
+//   - http:// - sends OTLP via plain HTTP (local collectors)
+//   - https:// - sends OTLP via TLS-secured HTTP with optional header auth
 //
-// grpc:// and grpcs:// support passing arbitrary gRPC metadata headers as
-// URL query parameters:
+// The remote schemes support passing arbitrary metadata headers as URL query
+// parameters:
 //
 //	grpcs://api.honeycomb.io:443?x-honeycomb-team=YOUR_API_KEY
+//	https://api.honeycomb.io?x-honeycomb-team=YOUR_API_KEY
+//
+// For http:// and https:// endpoints the OTLP default path /v1/traces is
+// appended when no path is given.
 func NewExporter(endpoint string) (SpanExporter, error) {
 	if endpoint == "" {
 		return nil, errors.New("endpoint is required")
@@ -94,6 +100,19 @@ func NewExporter(endpoint string) (SpanExporter, error) {
 			tls:     true,
 			headers: headersFromQuery(u.Query()),
 		})
+
+	case "http", "https":
+		if u.Host == "" {
+			return nil, fmt.Errorf("host is required for %s:// endpoint", u.Scheme)
+		}
+		target := url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path}
+		if target.Path == "" || target.Path == "/" {
+			target.Path = "/v1/traces"
+		}
+		return newHTTPExporterWithOptions(httpExporterOptions{
+			url:     target.String(),
+			headers: headersFromQuery(u.Query()),
+		}), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported endpoint scheme: %s", u.Scheme)

--- a/sdk/go/common/util/otelreceiver/exporter_test.go
+++ b/sdk/go/common/util/otelreceiver/exporter_test.go
@@ -91,7 +91,7 @@ func TestNewExporterSchemes(t *testing.T) {
 
 	t.Run("unsupported scheme returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewExporter("https://example.com")
+		_, err := NewExporter("ftp://example.com")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported endpoint scheme")
 	})
@@ -137,6 +137,61 @@ func TestNewExporterSchemes(t *testing.T) {
 		grpcExp, ok := exp.(*GRPCExporter)
 		require.True(t, ok, "expected *GRPCExporter")
 		require.Equal(t, []string{"testkey"}, grpcExp.headers["x-api-key"])
+		require.NoError(t, exp.Shutdown(t.Context()))
+	})
+
+	t.Run("http:// scheme requires a host", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewExporter("http://")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "host is required")
+	})
+
+	t.Run("https:// scheme requires a host", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewExporter("https://")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "host is required")
+	})
+
+	t.Run("https:// defaults to the OTLP traces path", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("https://api.example.com")
+		require.NoError(t, err)
+		httpExp, ok := exp.(*HTTPExporter)
+		require.True(t, ok, "expected *HTTPExporter")
+		require.Equal(t, "https://api.example.com/v1/traces", httpExp.url)
+		require.NoError(t, exp.Shutdown(t.Context()))
+	})
+
+	t.Run("https:// preserves an explicit path", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("https://api.example.com:4318/custom/traces")
+		require.NoError(t, err)
+		httpExp, ok := exp.(*HTTPExporter)
+		require.True(t, ok, "expected *HTTPExporter")
+		require.Equal(t, "https://api.example.com:4318/custom/traces", httpExp.url)
+		require.NoError(t, exp.Shutdown(t.Context()))
+	})
+
+	t.Run("https:// exporter carries headers", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("https://api.example.com?x-api-key=testkey")
+		require.NoError(t, err)
+		httpExp, ok := exp.(*HTTPExporter)
+		require.True(t, ok, "expected *HTTPExporter")
+		require.Equal(t, "testkey", httpExp.headers["x-api-key"])
+		require.Equal(t, "https://api.example.com/v1/traces", httpExp.url)
+		require.NoError(t, exp.Shutdown(t.Context()))
+	})
+
+	t.Run("http:// creates exporter", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("http://localhost:4318")
+		require.NoError(t, err)
+		httpExp, ok := exp.(*HTTPExporter)
+		require.True(t, ok, "expected *HTTPExporter")
+		require.Equal(t, "http://localhost:4318/v1/traces", httpExp.url)
 		require.NoError(t, exp.Shutdown(t.Context()))
 	})
 }

--- a/sdk/go/common/util/otelreceiver/http_exporter.go
+++ b/sdk/go/common/util/otelreceiver/http_exporter.go
@@ -1,0 +1,84 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelreceiver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+type HTTPExporter struct {
+	client  *http.Client
+	url     string
+	headers map[string]string
+}
+
+type httpExporterOptions struct {
+	url     string
+	headers map[string]string
+}
+
+func newHTTPExporterWithOptions(opts httpExporterOptions) *HTTPExporter {
+	return &HTTPExporter{
+		client:  &http.Client{Timeout: 30 * time.Second},
+		url:     opts.url,
+		headers: opts.headers,
+	}
+}
+
+func (e *HTTPExporter) ExportSpans(ctx context.Context, spans []*tracepb.ResourceSpans) error {
+	if len(spans) == 0 {
+		return nil
+	}
+
+	body, err := proto.Marshal(&coltracepb.ExportTraceServiceRequest{ResourceSpans: spans})
+	if err != nil {
+		return fmt.Errorf("failed to marshal spans: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create export request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	for k, v := range e.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to export spans: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("failed to export spans: %s: %s", resp.Status, msg)
+	}
+	return nil
+}
+
+func (e *HTTPExporter) Shutdown(ctx context.Context) error {
+	e.client.CloseIdleConnections()
+	return nil
+}

--- a/sdk/go/common/util/otelreceiver/http_exporter_test.go
+++ b/sdk/go/common/util/otelreceiver/http_exporter_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otelreceiver
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func testSpans() []*tracepb.ResourceSpans {
+	return []*tracepb.ResourceSpans{
+		{
+			ScopeSpans: []*tracepb.ScopeSpans{
+				{
+					Spans: []*tracepb.Span{
+						{
+							Name:    "test-span",
+							TraceId: []byte("0123456789abcdef"),
+							SpanId:  []byte("01234567"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestHTTPExporterExportSpans(t *testing.T) {
+	t.Parallel()
+
+	type received struct {
+		method      string
+		path        string
+		contentType string
+		apiKey      string
+		body        []byte
+	}
+	requests := make(chan received, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requests <- received{
+			method:      r.Method,
+			path:        r.URL.Path,
+			contentType: r.Header.Get("Content-Type"),
+			apiKey:      r.Header.Get("X-Api-Key"),
+			body:        body,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	exp, err := NewExporter(server.URL + "?x-api-key=testkey")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, exp.Shutdown(t.Context()))
+	}()
+
+	require.NoError(t, exp.ExportSpans(t.Context(), testSpans()))
+
+	req := <-requests
+	require.Equal(t, http.MethodPost, req.method)
+	require.Equal(t, "/v1/traces", req.path)
+	require.Equal(t, "application/x-protobuf", req.contentType)
+	require.Equal(t, "testkey", req.apiKey)
+
+	var exportReq coltracepb.ExportTraceServiceRequest
+	require.NoError(t, proto.Unmarshal(req.body, &exportReq))
+	require.Len(t, exportReq.ResourceSpans, 1)
+	require.Equal(t, "test-span", exportReq.ResourceSpans[0].ScopeSpans[0].Spans[0].Name)
+}
+
+func TestHTTPExporterEmptySpans(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("no request expected for empty spans")
+	}))
+	defer server.Close()
+
+	exp, err := NewExporter(server.URL)
+	require.NoError(t, err)
+	require.NoError(t, exp.ExportSpans(t.Context(), nil))
+	require.NoError(t, exp.Shutdown(t.Context()))
+}
+
+func TestHTTPExporterServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid api key", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	exp, err := NewExporter(server.URL)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, exp.Shutdown(t.Context()))
+	}()
+
+	err = exp.ExportSpans(t.Context(), testSpans())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "401")
+	require.Contains(t, err.Error(), "invalid api key")
+}

--- a/sdk/nodejs/automation/interface/index.ts
+++ b/sdk/nodejs/automation/interface/index.ts
@@ -793,7 +793,7 @@ export interface PulumiCancelOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -821,7 +821,7 @@ export interface PulumiImportOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -895,7 +895,7 @@ export interface PulumiNewOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -953,7 +953,7 @@ export interface PulumiOrgOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -979,7 +979,7 @@ export interface PulumiOrgGetDefaultOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -1005,7 +1005,7 @@ export interface PulumiOrgSearchOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -1046,7 +1046,7 @@ export interface PulumiOrgSearchAiOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;
@@ -1082,7 +1082,7 @@ export interface PulumiOrgSetDefaultOptions extends BaseOptions {
     logtostderr?: boolean;
     /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
     memprofilerate?: number;
-    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors */
     otelTraces?: string;
     /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
     profiling?: string;

--- a/sdk/python/lib/pulumi/automation/interface/__init__.py
+++ b/sdk/python/lib/pulumi/automation/interface/__init__.py
@@ -69,7 +69,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -174,7 +174,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -342,7 +342,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -467,7 +467,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -547,7 +547,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -643,7 +643,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -737,7 +737,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.
@@ -813,7 +813,7 @@ class API:
         :param logflow: Flow log settings to child processes (like plugins)
         :param logtostderr: Log to stderr instead of to files
         :param memprofilerate: Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate
-        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors
+        :param otel_traces: Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// or https:// for remote collectors
         :param profiling: Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
         :param tracing: Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file
         :param tracing_header: Include the tracing header with the given contents.


### PR DESCRIPTION
We currently only support traces going over the file:// or grpc:// protocol. Allow traces to go over https:// as well.

Fixes #23376 