### PR TITLE
fix parallel `pulumi install` resulting in provider missing

### DIFF
--- a/changelog/pending/cli-bug-parallel-install-race.yaml
+++ b/changelog/pending/cli-bug-parallel-install-race.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: fix
+body: Fix parallel `pulumi install` processes sharing a `PULUMI_HOME` intermittently
+  failing with a missing provider executable error
+time: 2026-07-27T00:00:00.000000+00:00

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -203,7 +203,7 @@ func (w Workspace) DownloadPlugin(
 			"Unpacking provider "+pluginSpec.Name, diagutils.GetGlobalColorization())
 	}
 	cleanup, err := pluginstorage.UnpackContents(
-		ctx, pluginSpec, pluginstorage.TarPlugin(unpackStream), true, /* reinstall */
+		ctx, pluginSpec, pluginstorage.TarPlugin(unpackStream), false, /* reinstall */
 	)
 	if err != nil {
 		return "", nil, err

--- a/pkg/pluginstorage/download.go
+++ b/pkg/pluginstorage/download.go
@@ -104,8 +104,12 @@ func UnpackContents(
 		}
 
 		// Either the partial file exists--meaning a previous attempt at installing the plugin failed--or we're
-		// deliberately reinstalling the plugin. Delete finalDir so we can try installing again. There's no need to
-		// delete the partial file since we'd just be recreating it again below anyway.
+		// deliberately reinstalling the plugin. Delete finalDir so we can try installing again. Create the partial
+		// file before deleting so concurrent processes never observe the directory mid-deletion as a completed
+		// install.
+		if err := os.WriteFile(partialFilePath, nil, 0o600); err != nil {
+			return nil, err
+		}
 		if err := os.RemoveAll(finalDir); err != nil {
 			return nil, err
 		}

--- a/pkg/pluginstorage/download_test.go
+++ b/pkg/pluginstorage/download_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginstorage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func testPluginSpec(t *testing.T) workspace.PluginDescriptor {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	version := semver.MustParse("1.0.0")
+	return workspace.PluginDescriptor{
+		Name:    "test",
+		Kind:    apitype.ResourcePlugin,
+		Version: &version,
+	}
+}
+
+func testPluginContent(t *testing.T, contents string) Content {
+	src := t.TempDir()
+	// The plugin binary must be executable.
+	require.NoError(t, os.WriteFile(filepath.Join(src, "pulumi-resource-test"), []byte(contents), 0o700)) //nolint:gosec
+	return DirPlugin(src)
+}
+
+func binaryContents(t *testing.T, spec workspace.PluginDescriptor) string {
+	dir, err := spec.DirPath()
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(dir, "pulumi-resource-test"))
+	require.NoError(t, err)
+	return string(contents)
+}
+
+//nolint:paralleltest // t.Setenv is incompatible with t.Parallel
+func TestUnpackContentsFreshInstall(t *testing.T) {
+	spec := testPluginSpec(t)
+
+	cleanup, err := UnpackContents(t.Context(), spec, testPluginContent(t, "new"), false)
+	require.NoError(t, err)
+	cleanup(true)
+
+	assert.Equal(t, "new", binaryContents(t, spec))
+	assert.True(t, workspace.HasPlugin(spec))
+}
+
+//nolint:paralleltest // t.Setenv is incompatible with t.Parallel
+func TestUnpackContentsKeepsCompleteInstall(t *testing.T) {
+	spec := testPluginSpec(t)
+
+	cleanup, err := UnpackContents(t.Context(), spec, testPluginContent(t, "original"), false)
+	require.NoError(t, err)
+	cleanup(true)
+
+	cleanup, err = UnpackContents(t.Context(), spec, testPluginContent(t, "new"), false)
+	require.NoError(t, err)
+	cleanup(true)
+
+	assert.Equal(t, "original", binaryContents(t, spec))
+	assert.True(t, workspace.HasPlugin(spec))
+}
+
+//nolint:paralleltest // t.Setenv is incompatible with t.Parallel
+func TestUnpackContentsReinstallOverwrites(t *testing.T) {
+	spec := testPluginSpec(t)
+
+	cleanup, err := UnpackContents(t.Context(), spec, testPluginContent(t, "original"), false)
+	require.NoError(t, err)
+	cleanup(true)
+
+	cleanup, err = UnpackContents(t.Context(), spec, testPluginContent(t, "new"), true)
+	require.NoError(t, err)
+	cleanup(true)
+
+	assert.Equal(t, "new", binaryContents(t, spec))
+	assert.True(t, workspace.HasPlugin(spec))
+}
+
+//nolint:paralleltest // t.Setenv is incompatible with t.Parallel
+func TestUnpackContentsRecoversFailedInstall(t *testing.T) {
+	spec := testPluginSpec(t)
+
+	cleanup, err := UnpackContents(t.Context(), spec, testPluginContent(t, "broken"), false)
+	require.NoError(t, err)
+	cleanup(false)
+
+	assert.False(t, workspace.HasPlugin(spec))
+
+	cleanup, err = UnpackContents(t.Context(), spec, testPluginContent(t, "new"), false)
+	require.NoError(t, err)
+	cleanup(true)
+
+	assert.Equal(t, "new", binaryContents(t, spec))
+	assert.True(t, workspace.HasPlugin(spec))
+}


### PR DESCRIPTION
In [#23330](<https://github.com/pulumi/pulumi/issues/23330>) we started using `InstallPluginSet` instead of `EnsurePluginsAreInstalled` for installing missing plugins.  These two functions have a small but significant semantic difference.  The newer function always sets "reinstall" to true, while the old one set it to false.  This means we now re-install providers even when they are already successfully installed.

This is both unnecessary, and triggers an issue when multiple `pulumi install` processes are running in parallel. Namely an install process can delete an already installed provider, which a different process expects to exist already. This causes the issues seen in pulumi/pulumi#24059, but can also affect users if they are running `pulumi install` in parallel.

There's no need to always re-install the plugin in this case. We already have a marker for partial downloads that the download process respects, so we can just rely on that.

Fixes pulumi/pulumi#24059