### PR TITLE
Remove locks from Construct/Call in python servers

### DIFF
--- a/changelog/pending/sdk-python-fix-20260727-134717.yaml
+++ b/changelog/pending/sdk-python-fix-20260727-134717.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: fix
+body: Allow Construct and Call methods to run concurrently in provider servers
+time: 2026-07-27T13:47:17.383419+01:00

--- a/sdk/python/lib/pulumi/provider/experimental/server.py
+++ b/sdk/python/lib/pulumi/provider/experimental/server.py
@@ -85,7 +85,6 @@ class ProviderServicer(ResourceProviderServicer):
     _args: list[str]
     _provider: provider.Provider
     _engine_address: str
-    _lock: asyncio.Lock
 
     def __init__(
         self,
@@ -99,7 +98,6 @@ class ProviderServicer(ResourceProviderServicer):
         self._version = version
         self._provider = provider
         self._engine_address = engine_address
-        self._lock = asyncio.Lock()
 
     async def GetPluginInfo(self, request, context) -> proto.PluginInfo:
         return proto.PluginInfo(version=self._version)
@@ -142,9 +140,6 @@ class ProviderServicer(ResourceProviderServicer):
     async def Construct(
         self, request: proto.ConstructRequest, context
     ) -> proto.ConstructResponse:
-        # Calls to `Construct` and `Call` are serialized because they currently modify globals. When we are able to
-        # avoid modifying globals, we can remove the locking.
-        await self._lock.acquire()
         try:
             return await self._construct(request, context)
         except Exception as e:  # noqa
@@ -169,8 +164,6 @@ class ProviderServicer(ResourceProviderServicer):
                     stack = traceback.extract_tb(e.__traceback__)[:]
                 pretty_stack = "".join(traceback.format_list(stack))
                 raise Exception(f"{str(e)}:\n{pretty_stack}")
-        finally:
-            self._lock.release()
 
     async def _construct(
         self, request: proto.ConstructRequest, context
@@ -290,9 +283,6 @@ class ProviderServicer(ResourceProviderServicer):
         )
 
     async def Call(self, request: proto.CallRequest, context):
-        # Calls to `Construct` and `Call` are serialized because they currently modify globals. When we are able to
-        # avoid modifying globals, we can remove the locking.
-        await self._lock.acquire()
         try:
             return await self._call(request, context)
         except InputPropertiesError as e:
@@ -307,8 +297,6 @@ class ProviderServicer(ResourceProviderServicer):
             await context.abort_with_status(status)
             # We already aborted at this point
             raise
-        finally:
-            self._lock.release()
 
     async def _call(self, request: proto.CallRequest, context):
         assert isinstance(request, proto.CallRequest), (

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -85,7 +85,6 @@ class ProviderServicer(ResourceProviderServicer):
     engine_address: str
     provider: Provider
     args: list[str]
-    lock: asyncio.Lock
 
     def create_grpc_invalid_properties_status(
         self, message: str, errors: Optional[list[InputPropertyErrorDetails]]
@@ -121,9 +120,6 @@ class ProviderServicer(ResourceProviderServicer):
     async def Construct(
         self, request: proto.ConstructRequest, context
     ) -> proto.ConstructResponse:
-        # Calls to `Construct` and `Call` are serialized because they currently modify globals. When we are able to
-        # avoid modifying globals, we can remove the locking.
-        await self.lock.acquire()
         try:
             return await self._construct(request, context)
         except Exception as e:  # noqa
@@ -150,8 +146,6 @@ class ProviderServicer(ResourceProviderServicer):
                     stack = traceback.extract_tb(e.__traceback__)[:]
                 pretty_stack = "".join(traceback.format_list(stack))
                 raise Exception(f"{str(e)}:\n{pretty_stack}")
-        finally:
-            self.lock.release()
 
     async def _construct(
         self, request: proto.ConstructRequest, context
@@ -349,9 +343,6 @@ class ProviderServicer(ResourceProviderServicer):
         return proto.ConstructResponse(urn=urn, state=state, stateDependencies=deps)
 
     async def Call(self, request: proto.CallRequest, context):
-        # Calls to `Construct` and `Call` are serialized because they currently modify globals. When we are able to
-        # avoid modifying globals, we can remove the locking.
-        await self.lock.acquire()
         try:
             return await self._call(request, context)
         except InputPropertiesError as e:
@@ -366,8 +357,6 @@ class ProviderServicer(ResourceProviderServicer):
             await context.abort_with_status(status)
             # We already aborted at this point
             raise
-        finally:
-            self.lock.release()
 
     async def _call(self, request: proto.CallRequest, context):
         assert isinstance(request, proto.CallRequest), (
@@ -510,7 +499,6 @@ class ProviderServicer(ResourceProviderServicer):
         self.provider = provider
         self.args = args
         self.engine_address = engine_address
-        self.lock = asyncio.Lock()
 
 
 def main(provider: Provider, args: list[str]) -> None:  # args not in use?

--- a/sdk/python/lib/test/provider/experimental/test_server.py
+++ b/sdk/python/lib/test/provider/experimental/test_server.py
@@ -1,0 +1,86 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Optional
+
+import pytest
+
+from pulumi.provider.experimental import provider
+from pulumi.provider.experimental.property_value import PropertyValue
+from pulumi.provider.experimental.server import ProviderServicer
+from pulumi.runtime import config, proto, settings
+from test.grpc_stubs import provider_servicer_stub
+
+
+class ConcurrentConstructCallProvider(provider.Provider):
+    def __init__(self):
+        super().__init__()
+        self.construct_waiting = asyncio.Event()
+        self.call_ran = asyncio.Event()
+        self.construct_stack_after_call: Optional[str] = None
+        self.construct_config_after_call: Optional[str] = None
+
+    async def construct(
+        self, request: provider.ConstructRequest
+    ) -> provider.ConstructResponse:
+        assert settings.get_stack() == "construct-stack"
+        assert config.get_config("test:key") == "construct-config"
+
+        self.construct_waiting.set()
+        await self.call_ran.wait()
+        self.construct_stack_after_call = settings.get_stack()
+        self.construct_config_after_call = config.get_config("test:key")
+
+        return provider.ConstructResponse(
+            urn=f"urn:pulumi:{request.name}::{request.resource_type}::test-resource",
+            state={"result": PropertyValue("construct")},
+            state_dependencies={},
+        )
+
+    async def call(self, request: provider.CallRequest) -> provider.CallResponse:
+        assert settings.get_stack() == "call-stack"
+        assert config.get_config("test:key") == "call-config"
+        self.call_ran.set()
+        return provider.CallResponse({"result": PropertyValue("call")})
+
+
+@pytest.mark.asyncio
+async def test_construct_and_call_can_run_concurrently():
+    test_provider = ConcurrentConstructCallProvider()
+    servicer = ProviderServicer([], "1.0.0", test_provider, "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        construct_request = proto.ConstructRequest(
+            name="construct",
+            type="test:index:Component",
+            stack="construct-stack",
+            config={"test:key": "construct-config"},
+        )
+        construct_task = asyncio.ensure_future(stub.Construct(construct_request))
+
+        await asyncio.wait_for(test_provider.construct_waiting.wait(), timeout=2)
+
+        call_request = proto.CallRequest(
+            tok="test:index:call",
+            stack="call-stack",
+            config={"test:key": "call-config"},
+        )
+        call_response = await asyncio.wait_for(stub.Call(call_request), timeout=2)
+        construct_response = await asyncio.wait_for(construct_task, timeout=2)
+
+        assert getattr(call_response, "return")["result"] == "call"
+        assert construct_response.urn.endswith("::test-resource")
+        assert test_provider.construct_stack_after_call == "construct-stack"
+        assert test_provider.construct_config_after_call == "construct-config"

--- a/sdk/python/lib/test/provider/test_server.py
+++ b/sdk/python/lib/test/provider/test_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import functools
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 
@@ -25,7 +26,7 @@ from pulumi.errors import (
 )
 from pulumi.provider.server import ComponentInitError
 import pulumi.output
-from pulumi.provider import ConstructResult
+from pulumi.provider import CallResult, ConstructResult
 from pulumi.provider.provider import Provider
 import pytest
 
@@ -36,6 +37,7 @@ from pulumi.runtime import Mocks, ResourceModule, proto, rpc
 from pulumi.runtime.proto.provider_pb2 import ConstructRequest
 from pulumi.runtime.proto import status_pb2, errors_pb2
 from pulumi.runtime.settings import Settings, configure
+from pulumi.runtime import config, settings
 from semver import VersionInfo as Version
 from ..grpc_stubs import provider_servicer_stub
 
@@ -661,6 +663,40 @@ class MockProvider(Provider):
         )
 
 
+class ConcurrentConstructCallProvider(Provider):
+    def __init__(self):
+        super().__init__("1.0.0")
+        self.construct_waiting = asyncio.Event()
+        self.call_ran = asyncio.Event()
+        self.construct_stack_after_call: Optional[str] = None
+        self.construct_config_after_call: Optional[str] = None
+
+    def construct(
+        self,
+        name: str,
+        resource_type: str,
+        inputs: Inputs,
+        options: Optional[ResourceOptions] = None,
+    ) -> ConstructResult:
+        assert settings.get_stack() == "construct-stack"
+        assert config.get_config("test:key") == "construct-config"
+
+        async def urn() -> str:
+            self.construct_waiting.set()
+            await self.call_ran.wait()
+            self.construct_stack_after_call = settings.get_stack()
+            self.construct_config_after_call = config.get_config("test:key")
+            return f"urn:pulumi:{name}::{resource_type}::test-resource"
+
+        return ConstructResult(urn=urn(), state={"result": "construct"})
+
+    def call(self, token: str, args: Inputs) -> CallResult:
+        assert settings.get_stack() == "call-stack"
+        assert config.get_config("test:key") == "call-config"
+        self.call_ran.set()
+        return CallResult({"result": "call"})
+
+
 @pytest.mark.asyncio
 async def test_construct_success():
     provider = MockProvider()
@@ -672,6 +708,36 @@ async def test_construct_success():
 
         assert response.urn.startswith("urn:pulumi:")
         assert "test-resource" in response.urn
+
+
+@pytest.mark.asyncio
+async def test_construct_and_call_can_run_concurrently():
+    provider = ConcurrentConstructCallProvider()
+    servicer = ProviderServicer(provider, [], "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        construct_request = proto.ConstructRequest(
+            name="construct",
+            type="test:index:Component",
+            stack="construct-stack",
+            config={"test:key": "construct-config"},
+        )
+        construct_task = asyncio.ensure_future(stub.Construct(construct_request))
+
+        await asyncio.wait_for(provider.construct_waiting.wait(), timeout=2)
+
+        call_request = proto.CallRequest(
+            tok="test:index:call",
+            stack="call-stack",
+            config={"test:key": "call-config"},
+        )
+        call_response = await asyncio.wait_for(stub.Call(call_request), timeout=2)
+        construct_response = await asyncio.wait_for(construct_task, timeout=2)
+
+        assert getattr(call_response, "return")["result"] == "call"
+        assert construct_response.urn.endswith("::test-resource")
+        assert provider.construct_stack_after_call == "construct-stack"
+        assert provider.construct_config_after_call == "construct-config"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allow python provider server Call and Construct methods to run concurrently.