### PR TITLE
improve error message when resource registrations are still pending

### DIFF
--- a/changelog/pending/sdk-nodejs-improvement-20260727-153436.yaml
+++ b/changelog/pending/sdk-nodejs-improvement-20260727-153436.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: improvement
+body: Improve error message when resource registrations are still pending when pulumi exits
+time: 2026-07-27T15:34:36.570336151+02:00

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -14,6 +14,7 @@
 
 import { Resource } from "./resource";
 import * as settings from "./runtime/settings";
+import { getDeferredOutputSources } from "./runtime/state";
 import * as utils from "./utils";
 
 /* eslint-disable no-shadow, @typescript-eslint/no-shadow */
@@ -408,6 +409,7 @@ export function deferredOutput<T>(): [Output<T>, (source: Output<T>) => void] {
             throw new Error("Deferred Output has already been resolved");
         }
         alreadyResolved = true;
+        getDeferredOutputSources().set(output, source);
         source.promise().then(resolveValue, rejectValue);
         source.isKnown.then(resolveIsKnown, rejectIsKnown);
         source.isSecret.then(resolveIsSecret, rejectIsSecret);
@@ -435,6 +437,7 @@ export function deferredOutput<T>(): [Output<T>, (source: Output<T>) => void] {
             rejectDeps = rej;
         }),
     );
+    (<any>output).__pulumiDeferredOutput = true;
 
     return [output, resolve];
 }

--- a/sdk/nodejs/runtime/debuggable.ts
+++ b/sdk/nodejs/runtime/debuggable.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as log from "../log";
+import type { Resource } from "../resource";
 import * as state from "./state";
 
 /**
@@ -28,14 +29,212 @@ export const debugPromiseLeaks: boolean = !!process.env.PULUMI_DEBUG_PROMISE_LEA
  */
 let leakDetectorScheduled: boolean = false;
 
+function pendingRegistrationDescription(reg: state.PendingResourceRegistration): string {
+    return reg.name && reg.type ? `"${reg.name}" [${reg.type}]` : reg.label;
+}
+
+function isDeferredOutput(v: unknown): boolean {
+    return typeof v === "object" && v !== null && (v as any).__pulumiDeferredOutput === true;
+}
+
+function detectedCycleMessage(pending: Map<Resource, state.PendingResourceRegistration>): string | undefined {
+    for (const reg of pending.values()) {
+        for (const ownerReg of pendingOwners(reg.awaitingOutput, pending)) {
+            const kind = waitCycleKind(ownerReg, reg, pending);
+            if (kind !== undefined) {
+                return cycleDescription(reg, ownerReg, kind);
+            }
+        }
+    }
+    return undefined;
+}
+
+function pendingOwners(
+    output: unknown,
+    pending: Map<Resource, state.PendingResourceRegistration>,
+): Set<state.PendingResourceRegistration> {
+    const owners = new Set<state.PendingResourceRegistration>();
+    if (typeof output !== "object" || output === null) {
+        return owners;
+    }
+    const addOwnersOf = (o: object) => {
+        const resources = (o as any).resources;
+        if (typeof resources !== "function") {
+            return;
+        }
+        for (const res of resources.call(o) as Set<Resource>) {
+            const ownerReg = pending.get(res);
+            if (ownerReg !== undefined) {
+                owners.add(ownerReg);
+            }
+        }
+    };
+    addOwnersOf(output);
+    const source = state.getDeferredOutputSources().get(output);
+    if (source !== undefined) {
+        addOwnersOf(source);
+    }
+    return owners;
+}
+
+function waitCycleKind(
+    start: state.PendingResourceRegistration,
+    target: state.PendingResourceRegistration,
+    pending: Map<Resource, state.PendingResourceRegistration>,
+): "ancestry" | "inputs" | undefined {
+    for (let cur: state.PendingResourceRegistration | undefined = start; cur !== undefined; ) {
+        if (cur === target) {
+            return "ancestry";
+        }
+        cur = cur.parent === undefined ? undefined : pending.get(cur.parent);
+    }
+
+    // Not reachable through parents alone: search the full wait-for graph, where a pending
+    // registration waits on its parent's registration and on the owners of the output its
+    // input serialization is currently awaiting.
+    const visited = new Set<state.PendingResourceRegistration>([start]);
+    const queue: state.PendingResourceRegistration[] = [start];
+    while (queue.length > 0) {
+        const cur = queue.shift()!;
+        if (cur === target) {
+            return "inputs";
+        }
+        const successors: state.PendingResourceRegistration[] = [];
+        if (cur.parent !== undefined) {
+            const parentReg = pending.get(cur.parent);
+            if (parentReg !== undefined) {
+                successors.push(parentReg);
+            }
+        }
+        for (const ownerReg of pendingOwners(cur.awaitingOutput, pending)) {
+            successors.push(ownerReg);
+        }
+        for (const next of successors) {
+            if (!visited.has(next)) {
+                visited.add(next);
+                queue.push(next);
+            }
+        }
+    }
+    return undefined;
+}
+
+const registerOutputsRemedy = "Register the value with `registerResourceOutputs` instead of passing it as an input.";
+
+function cycleDescription(
+    reg: state.PendingResourceRegistration,
+    ownerReg: state.PendingResourceRegistration,
+    kind: "ancestry" | "inputs",
+): string {
+    const prop = reg.inputProperty !== undefined ? ` "${reg.inputProperty}"` : "";
+    const component = pendingRegistrationDescription(reg);
+    const other = pendingRegistrationDescription(ownerReg);
+    let resolvedBy: string;
+    if (ownerReg === reg) {
+        resolvedBy =
+            `from one of ${component}'s own outputs. The resource cannot be registered until this ` +
+            "input resolves, and the output cannot resolve until the resource has been registered";
+    } else if (kind === "inputs") {
+        resolvedBy =
+            `by an output of ${other}, and ${other}'s own registration is in turn waiting on ` +
+            `${component} through its inputs or parent`;
+    } else {
+        resolvedBy =
+            `by ${other}, a descendant of ${component}. ${component} cannot be registered until this ` +
+            `input resolves, and ${other} cannot be registered until its ancestor ${component} has been registered`;
+    }
+    return (
+        `input${prop} of resource ${component} is a deferred output that is resolved ${resolvedBy}, ` +
+        `so the deployment would deadlock. ${registerOutputsRemedy}`
+    );
+}
+
+function pendingRegistrationPhaseDescription(
+    reg: state.PendingResourceRegistration,
+    pending: Map<Resource, state.PendingResourceRegistration>,
+): string {
+    switch (reg.phase) {
+        case "dependencies":
+            return "waiting for its dependencies to resolve";
+        case "inputs": {
+            let suffix = "";
+            if (isDeferredOutput(reg.awaitingOutput)) {
+                suffix = state.getDeferredOutputSources().has(reg.awaitingOutput as object)
+                    ? ", a deferred output"
+                    : ", a deferred output that was never resolved";
+            }
+            return reg.inputProperty === undefined
+                ? `waiting for its input properties to resolve${suffix}`
+                : `waiting for the value of its input property "${reg.inputProperty}"${suffix}`;
+        }
+        case "parent": {
+            const parentReg = reg.parent === undefined ? undefined : pending.get(reg.parent);
+            const parent =
+                parentReg !== undefined
+                    ? pendingRegistrationDescription(parentReg)
+                    : reg.parent?.__name !== undefined
+                      ? `"${reg.parent.__name}"`
+                      : "its parent";
+            return `waiting for its parent ${parent} to finish registering`;
+        }
+        case "provider":
+            return "waiting for its provider to finish registering";
+        case "dependency-urns":
+        default:
+            return "waiting for the URNs of its dependencies to resolve";
+    }
+}
+
+function fallbackCycleMessage(pending: Map<Resource, state.PendingResourceRegistration>): string {
+    for (const reg of pending.values()) {
+        if (isDeferredOutput(reg.awaitingOutput)) {
+            return (
+                "A deferred output that is never resolved, or that is resolved by a resource that directly or\n" +
+                "indirectly waits on the registration awaiting it, can never complete. Make sure every deferred\n" +
+                `output is resolved. ${registerOutputsRemedy}`
+            );
+        }
+    }
+    return (
+        "This can happen when a resource's inputs, dependencies, or parent depend on a promise or\n" +
+        "output that never resolves, or when there is a cyclic dependency between resources."
+    );
+}
+
+function pendingRegistrationsMessage(pending: Map<Resource, state.PendingResourceRegistration>): string {
+    const lines = [...pending.values()].map(
+        (reg) => `  * ${pendingRegistrationDescription(reg)} was ${pendingRegistrationPhaseDescription(reg, pending)}`,
+    );
+    let message =
+        "The Pulumi runtime detected that the program exited before the following resource\n" +
+        "registrations could complete:\n" +
+        lines.join("\n") +
+        "\n\n";
+
+    const detectedCycle = detectedCycleMessage(pending);
+    if (detectedCycle !== undefined) {
+        message += detectedCycle;
+    } else {
+        message += fallbackCycleMessage(pending);
+    }
+
+    return (
+        message +
+        "\n\n" +
+        "Re-run your program with the `PULUMI_DEBUG_PROMISE_LEAKS` environment variable set for\n" +
+        "additional debug information about the leaked promises."
+    );
+}
+
 /**
  * @internal
  */
 export function leakedPromises(): [Set<Promise<any>>, string] {
     const localStore = state.getStore();
     const leaked = localStore.leakCandidates;
+    const pendingRegistrations = localStore.pendingResourceRegistrations;
     const promisePlural = leaked.size === 1 ? "promise was" : "promises were";
-    const message =
+    let message =
         leaked.size === 0
             ? ""
             : `The Pulumi runtime detected that ${leaked.size} ${promisePlural} still active\n` +
@@ -49,6 +248,9 @@ export function leakedPromises(): [Set<Promise<any>>, string] {
               "with the `PULUMI_DEBUG_PROMISE_LEAKS`\n" +
               "environment variable. The Pulumi runtime will then print out additional\n" +
               "debug information about the leaked promises.";
+    if (leaked.size > 0 && pendingRegistrations !== undefined && pendingRegistrations.size > 0) {
+        message = pendingRegistrationsMessage(pendingRegistrations);
+    }
 
     if (debugPromiseLeaks) {
         for (const leak of leaked) {
@@ -108,10 +310,7 @@ export function debuggablePromise<T>(p: Promise<T>, ctx: any): Promise<T> {
                     return;
                 }
 
-                // If we haven't opted-in to the debug error message, print a more user-friendly message.
-                if (!debugPromiseLeaks) {
-                    console.error(message);
-                }
+                console.error(message);
 
                 // Fail the deployment if we leaked any promises.
                 process.exitCode = 1;

--- a/sdk/nodejs/runtime/debuggable.ts
+++ b/sdk/nodejs/runtime/debuggable.ts
@@ -218,12 +218,13 @@ function pendingRegistrationsMessage(pending: Map<Resource, state.PendingResourc
         message += fallbackCycleMessage(pending);
     }
 
-    return (
-        message +
-        "\n\n" +
-        "Re-run your program with the `PULUMI_DEBUG_PROMISE_LEAKS` environment variable set for\n" +
-        "additional debug information about the leaked promises."
-    );
+    if (!debugPromiseLeaks) {
+        message +=
+            "\n\n" +
+            "Re-run your program with the `PULUMI_DEBUG_PROMISE_LEAKS` environment variable set for\n" +
+            "additional debug information about the leaked promises.";
+    }
+    return message;
 }
 
 /**

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -40,7 +40,12 @@ import {
 import { debuggablePromise, debugPromiseLeaks } from "./debuggable";
 import { gatherExplicitDependencies, getAllTransitivelyReferencedResourceURNs } from "./dependsOn";
 import { invoke } from "./invoke";
-import { getStore } from "./state";
+import {
+    failPendingRegistration,
+    getPendingResourceRegistrations,
+    getStore,
+    PendingResourceRegistration,
+} from "./state";
 
 import { isGrpcError } from "../errors";
 import {
@@ -313,6 +318,7 @@ export function getResource(
                 });
             })
             .catch((err) => {
+                failPendingRegistration(res, err);
                 done();
                 throw err;
             }),
@@ -450,6 +456,7 @@ export function readResource(
                 });
             })
             .catch((err) => {
+                failPendingRegistration(res, err);
                 done();
                 throw err;
             }),
@@ -821,7 +828,9 @@ export function registerResource(
             })
             .catch((err) => {
                 log.debug(`RegisterResource RPC failed: t=${t}, name=${name}, err=${err}`);
-                // If we fail to prepare the resource, we need to ensure that we still call done to prevent a hang.
+                // If we fail to prepare the resource, we need to ensure that we still call done to prevent a hang,
+                // and fail the resource's outputs so that dependents (e.g. children awaiting our URN) unblock.
+                failPendingRegistration(res, err);
                 done();
                 throw err;
             }),
@@ -949,6 +958,19 @@ export async function prepareResource(
 
     /** IMPORTANT!  We should never await prior to this line, otherwise the Resource will be partly uninitialized. */
 
+    const pendingRegistrations = getPendingResourceRegistrations();
+    const pending: PendingResourceRegistration = { res, parent, label, type, name, phase: "dependencies" };
+    pending.fail = (err) => {
+        resolveURN("", err);
+        if (resolveID !== undefined) {
+            resolveID(undefined, false, err);
+        }
+        for (const key of Object.keys(resolvers)) {
+            resolvers[key](undefined, true, false, [], err);
+        }
+    };
+    pendingRegistrations.set(res, pending);
+
     // Before we can proceed, all our dependencies must be finished.
     const replaceWithDependencies = await gatherExplicitDependencies(opts.replaceWith);
     const explicitDirectDependencies = new Set(await gatherExplicitDependencies(opts.dependsOn));
@@ -958,6 +980,7 @@ export async function prepareResource(
 
     // Serialize out all our props to their final values.  In doing so, we'll also collect all
     // the Resources pointed to by any Dependency objects we encounter, adding them to 'propertyDependencies'.
+    pending.phase = "inputs";
     const [serializedProps, propertyToDirectDependencies] = await serializeResourceProperties(label, props, {
         // To initially scope the use of this new feature, we only keep output values when
         // remote is true (for multi-lang components, i.e. MLCs).
@@ -967,11 +990,15 @@ export async function prepareResource(
         // on 'propertyDependencies' won't create outputs for properties that only
         // contain resource references.
         excludeResourceReferencesFromDependencies: remote,
+        pendingRegistration: pending,
     });
+    pending.inputProperty = undefined;
 
     // Wait for the parent to complete.
     // If no parent was provided, parent to the root resource.
+    pending.phase = "parent";
     const parentURN = parent ? await parent.urn.promise() : undefined;
+    pending.phase = "provider";
 
     let importID: ID | undefined;
     if (custom) {
@@ -1028,6 +1055,7 @@ export async function prepareResource(
 
     // Collect the URNs for explicit/implicit dependencies for the engine so that it can understand
     // the dependency graph and optimize operations accordingly.
+    pending.phase = "dependency-urns";
 
     // The list of all dependencies (implicit or explicit).
     const allDirectDependencies = new Set<Resource>(explicitDirectDependencies);
@@ -1067,6 +1095,8 @@ export async function prepareResource(
     const deletedWithURN = opts?.deletedWith ? await opts.deletedWith.urn.promise() : undefined;
     const replaceWithResources =
         replaceWithDependencies.length > 0 ? Array.from(new Set(replaceWithDependencies)) : undefined;
+
+    pendingRegistrations.delete(res);
 
     return {
         resolveURN: resolveURN,

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -20,7 +20,7 @@ import { ComponentResource, CustomResource, DependencyResource, ProviderResource
 import { debuggablePromise, debugPromiseLeaks, errorString } from "./debuggable";
 import { getAllTransitivelyReferencedResourceURNs } from "./dependsOn";
 import { excessiveDebugOutput, isDryRun } from "./settings";
-import { getStore, getResourcePackages, getResourceModules } from "./state";
+import { getStore, getResourcePackages, getResourceModules, PendingResourceRegistration } from "./state";
 
 import * as gstruct from "google-protobuf/google/protobuf/struct_pb";
 import * as semver from "semver";
@@ -155,6 +155,9 @@ export interface SerializationOptions {
      * this will have no effect.
      */
     excludeResourceReferencesFromDependencies?: boolean;
+
+    /** @internal */
+    pendingRegistration?: PendingResourceRegistration;
 }
 
 /**
@@ -173,6 +176,9 @@ async function serializeFilteredProperties(
     const result: Record<string, any> = {};
     for (const k of Object.keys(props)) {
         if (acceptKey(k)) {
+            if (opts?.pendingRegistration !== undefined) {
+                opts.pendingRegistration.inputProperty = k;
+            }
             // We treat properties with undefined values as if they do not exist.
             const dependentResources = new Set<Resource>();
             let v;
@@ -449,6 +455,10 @@ export async function serializeProperty(
     if (Output.isInstance(prop)) {
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Output<T>`);
+        }
+
+        if (opts?.pendingRegistration !== undefined) {
+            opts.pendingRegistration.awaitingOutput = prop;
         }
 
         // handle serializing both old-style outputs (with sync resources) and new-style outputs

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -210,6 +210,8 @@ export function resetOptions(
     store.supportsParameterization = false;
     store.callbacks = undefined;
     store.packageRefs = new Map<string, Promise<string>>();
+    store.pendingResourceRegistrations = new Map();
+    store.deferredOutputSources = new WeakMap();
 }
 
 export function setMockOptions(

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -19,6 +19,7 @@ import { Stack } from "./stack";
 
 import * as engrpc from "../proto/engine_grpc_pb";
 import * as resrpc from "../proto/resource_grpc_pb";
+import type { Resource } from "../resource";
 import type { ResourceModule, ResourcePackage } from "./rpc";
 
 const nodeEnvKeys = {
@@ -222,6 +223,65 @@ export interface Store {
      * refs.
      */
     packageRefs: Map<string, Promise<string>>;
+
+    pendingResourceRegistrations: Map<Resource, PendingResourceRegistration>;
+
+    deferredOutputSources: WeakMap<object, object>;
+}
+
+/**
+ * @internal
+ */
+export type PendingRegistrationPhase = "dependencies" | "inputs" | "parent" | "provider" | "dependency-urns";
+
+/**
+ * @internal
+ */
+export interface PendingResourceRegistration {
+    res: Resource;
+    parent: Resource | undefined;
+    label: string;
+    type?: string;
+    name?: string;
+    phase: PendingRegistrationPhase;
+    inputProperty?: string;
+    awaitingOutput?: unknown;
+    fail?: (err: Error) => void;
+}
+
+/**
+ * @internal
+ */
+export function getDeferredOutputSources(): WeakMap<object, object> {
+    const store = getStore();
+    if (store.deferredOutputSources === undefined) {
+        // deferredOutputSources may be undefined if the Store was created by an older
+        // copy of the SDK runtime that didn't define this field.
+        store.deferredOutputSources = new WeakMap();
+    }
+    return store.deferredOutputSources;
+}
+
+/**
+ * @internal
+ */
+export function failPendingRegistration(res: Resource, err: Error): void {
+    const pending = getPendingResourceRegistrations();
+    pending.get(res)?.fail?.(err);
+    pending.delete(res);
+}
+
+/**
+ * @internal
+ */
+export function getPendingResourceRegistrations(): Map<Resource, PendingResourceRegistration> {
+    const store = getStore();
+    if (store.pendingResourceRegistrations === undefined) {
+        // pendingResourceRegistrations may be undefined if the Store was created by an older
+        // copy of the SDK runtime that didn't define this field.
+        store.pendingResourceRegistrations = new Map();
+    }
+    return store.pendingResourceRegistrations;
 }
 
 /**
@@ -275,6 +335,8 @@ export class LocalStore implements Store {
     resourcePackages = new Map<string, ResourcePackage[]>();
     resourceModules = new Map<string, ResourceModule[]>();
     packageRefs = new Map<string, Promise<string>>();
+    pendingResourceRegistrations = new Map<Resource, PendingResourceRegistration>();
+    deferredOutputSources = new WeakMap<object, object>();
 }
 
 /**

--- a/sdk/nodejs/tests_with_mocks/mocks.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/mocks.spec.ts
@@ -236,7 +236,11 @@ describe("mocks: remote component with PULUMI_NODEJS_SKIP_COMPONENT_INPUTS", fun
     });
 
     after(() => {
-        process.env.PULUMI_NODEJS_SKIP_COMPONENT_INPUTS = oldSkipComponentInputsEnv;
+        if (oldSkipComponentInputsEnv === undefined) {
+            Reflect.deleteProperty(process.env, "PULUMI_NODEJS_SKIP_COMPONENT_INPUTS");
+        } else {
+            process.env.PULUMI_NODEJS_SKIP_COMPONENT_INPUTS = oldSkipComponentInputsEnv;
+        }
     });
 
     it("sends inputs to RegisterResource", (done) => {

--- a/sdk/nodejs/tests_with_mocks/pendingRegistrations.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/pendingRegistrations.spec.ts
@@ -1,0 +1,164 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as pulumi from "../index";
+import { leakedPromises } from "../runtime/debuggable";
+import { MockResourceArgs, MockResourceResult } from "../runtime";
+import { getPendingResourceRegistrations } from "../runtime/state";
+
+class ReproComponent extends pulumi.ComponentResource {
+    constructor(name: string, props: pulumi.Inputs) {
+        super("my:module:ReproComponent", name, props);
+    }
+}
+
+class MyCustom extends pulumi.CustomResource {
+    invokeArn!: pulumi.Output<string>;
+    constructor(name: string, opts: pulumi.CustomResourceOptions) {
+        super("test:index:MyCustom", name, { invokeArn: undefined }, opts);
+    }
+}
+
+class SelfCyclicCustom extends pulumi.CustomResource {
+    constructor(name: string, value: pulumi.Input<string>) {
+        super("test:index:MyCustom", name, { value }, {});
+    }
+}
+
+class UnresolvedSubclass extends ReproComponent {
+    constructor(name: string) {
+        const [invokeArn] = pulumi.deferredOutput<string>();
+        super(name, { invokeArn });
+        new MyCustom("child", { parent: this });
+    }
+}
+
+class CyclicSubclass extends ReproComponent {
+    constructor(name: string) {
+        const [invokeArn, resolveInvokeArn] = pulumi.deferredOutput<string>();
+        super(name, { invokeArn });
+        const child = new MyCustom("cyclicChild", { parent: this });
+        resolveInvokeArn(child.invokeArn);
+    }
+}
+
+class ApplyCyclicSubclass extends ReproComponent {
+    constructor(name: string) {
+        const [invokeArn, resolveInvokeArn] = pulumi.deferredOutput<string>();
+        super(name, { invokeArn });
+        const child = new MyCustom("applyChild", { parent: this });
+        resolveInvokeArn(child.invokeArn.apply((v) => v));
+    }
+}
+
+async function settle(): Promise<void> {
+    for (let i = 0; i < 20; i++) {
+        await new Promise((resolve) => setImmediate(resolve));
+    }
+}
+
+async function diagnose(build: () => void): Promise<string> {
+    build();
+    await settle();
+    const [leaks, message] = leakedPromises();
+    assert.ok(leaks.size > 0);
+    return message;
+}
+
+describe("pending resource registration diagnostics", () => {
+    let oldSkipComponentInputsEnv: string | undefined;
+
+    before(async () => {
+        oldSkipComponentInputsEnv = process.env.PULUMI_NODEJS_SKIP_COMPONENT_INPUTS;
+        Reflect.deleteProperty(process.env, "PULUMI_NODEJS_SKIP_COMPONENT_INPUTS");
+
+        await pulumi.runtime.setMocks({
+            newResource: (args: MockResourceArgs): MockResourceResult => ({
+                id: `${args.name}_id`,
+                state: { ...args.inputs, invokeArn: "arn:aws:fake" },
+            }),
+            call: (args) => args.inputs,
+        });
+    });
+
+    afterEach(() => {
+        getPendingResourceRegistrations().clear();
+        leakedPromises();
+    });
+
+    after(() => {
+        if (oldSkipComponentInputsEnv !== undefined) {
+            process.env.PULUMI_NODEJS_SKIP_COMPONENT_INPUTS = oldSkipComponentInputsEnv;
+        }
+    });
+
+    it("describes registrations stuck on a component input that never resolves", async () => {
+        const message = await diagnose(() => new UnresolvedSubclass("myResource"));
+        assert.match(
+            message,
+            /"myResource" \[my:module:ReproComponent\] was waiting for the value of its input property "invokeArn", a deferred output that was never resolved/,
+        );
+        assert.match(
+            message,
+            /"child" \[test:index:MyCustom\] was waiting for its parent "myResource" \[my:module:ReproComponent\] to finish registering/,
+        );
+        assert.match(message, /registerResourceOutputs/);
+    });
+
+    it("explains the cycle when a deferred component input is resolved by a child", async () => {
+        const message = await diagnose(() => new CyclicSubclass("cyclicResource"));
+        assert.match(
+            message,
+            /input "invokeArn" of resource "cyclicResource" \[my:module:ReproComponent\] is a deferred output that is resolved by "cyclicChild" \[test:index:MyCustom\], a descendant/,
+        );
+        assert.match(message, /registerResourceOutputs/);
+    });
+
+    it("explains the cycle when a deferred component input is resolved by an output derived from a child", async () => {
+        const message = await diagnose(() => new ApplyCyclicSubclass("applyResource"));
+        assert.match(
+            message,
+            /input "invokeArn" of resource "applyResource" \[my:module:ReproComponent\] is a deferred output that is resolved by "applyChild" \[test:index:MyCustom\]/,
+        );
+    });
+
+    it("explains the cycle when a deferred input is resolved from the resource's own output", async () => {
+        const message = await diagnose(() => {
+            const [value, resolveValue] = pulumi.deferredOutput<string>();
+            const res = new SelfCyclicCustom("selfCyclic", value);
+            resolveValue(res.urn);
+        });
+        assert.match(
+            message,
+            /input "value" of resource "selfCyclic" \[test:index:MyCustom\] is a deferred output that is resolved from one of/,
+        );
+    });
+
+    it("explains the cycle when two components' deferred inputs are resolved from each other's outputs", async () => {
+        const message = await diagnose(() => {
+            const [valueA, resolveA] = pulumi.deferredOutput<string>();
+            const [valueB, resolveB] = pulumi.deferredOutput<string>();
+            const a = new ReproComponent("mutualA", { value: valueA });
+            const b = new ReproComponent("mutualB", { value: valueB });
+            resolveA(b.urn);
+            resolveB(a.urn);
+        });
+        assert.match(
+            message,
+            /is a deferred output that is resolved by an output of "mutual[AB]" \[my:module:ReproComponent\]/,
+        );
+        assert.match(message, /own registration is in turn waiting on/);
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -130,6 +130,7 @@
         "tests/provider/experimental/analyzer.spec.ts",
         "tests/provider/experimental/schema.spec.ts",
         "tests_with_mocks/mocks.spec.ts",
+        "tests_with_mocks/pendingRegistrations.spec.ts",
         "npm/testdata/nested/project/index.ts",
         "types/arborist.d.ts",
         "types/fs-glob.d.ts"


### PR DESCRIPTION
When a pulumi program exits, and resource registrations are still pending, we currently get a rather confusing/vague error message.  We can do better, and track the resource registrations that are in progress, and show the user what's still pending, and possible circular dependencies, that can cause this.

Fixes #23663
