### PR TITLE
Let renovate auto-merge the unbundled language runtime pins

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -135,6 +135,7 @@
       ],
       matchFileNames: [
         'scripts/get-language-providers.sh',
+        'pkg/util/plugin.go',
       ],
       dependencyDashboardApproval: false,
       minimumReleaseAge: '0 days',


### PR DESCRIPTION
## Summary

The custom regex manager for `pkg/util/plugin.go` has tracked the HCL version pin since https://github.com/pulumi/pulumi/pull/23356, but the org preset ([pulumi/renovate-config](https://github.com/pulumi/renovate-config/blob/main/default.json5)) defaults `dependencyDashboardApproval: true`, and the "Auto merge the language runtimes" rule only covers `scripts/get-language-providers.sh`. Renovate therefore never opened a PR for new `pulumi-labs/pulumi-hcl` releases, and every bump so far has been manual (https://github.com/pulumi/pulumi/pull/23679, https://github.com/pulumi/pulumi/pull/23761, https://github.com/pulumi/pulumi/pull/23890, https://github.com/pulumi/pulumi/pull/24006).

This adds `pkg/util/plugin.go` to that rule's `matchFileNames`, so a new HCL release flows through the standard renovate path: renovate opens the bump PR, `pulumi-renovate-approve` approves it, and it auto-merges once CI passes. The rule's `make renovate` post-upgrade task is a no-op for `plugin.go` bumps (`scripts/renovate-changelog.py` only inspects `get-language-providers.sh`).