### PR TITLE
Consult `GetDeploymentInfo` for feature discovery in Python

### DIFF
--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -270,6 +270,25 @@ class MockMonitor:
         has_support = request.id != "outputValues"
         return type("SupportsFeatureResponse", (object,), {"hasSupport": has_support})
 
+    def GetDeploymentInfo(self, request):
+        # Support for "outputValues" is deliberately disabled for the mock monitor so
+        # instances of `Output` don't show up in `MockResourceArgs` inputs.
+        return resource_pb2.DeploymentInfo(
+            supportedFeatures=[
+                resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_REPLACEMENT_TRIGGER,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_DELETED_WITH,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_REPLACE_WITH,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+                resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS,
+            ]
+        )
+
     def RegisterPackage(self, request):
         # Mocks don't _really_ support packages, so we just return a fake package ref.
         return resource_pb2.RegisterPackageResponse(ref="mock-uuid")

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -28,6 +28,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union
 
 import grpc
+from google.protobuf import empty_pb2
 
 from .._utils import contextproperty
 from ..errors import RunError
@@ -509,18 +510,46 @@ async def _monitor_supports_feature(
     )
 
 
+# A frozen map of old feature IDs to the new resource monitor features.
+#
+# This map should never be updated.
+_LEGACY_FEATURE_MAPPING = {
+    "secrets": resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS,
+    "resourceReferences": resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+    "outputValues": resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES,
+    "deletedWith": resource_pb2.RESOURCE_MONITOR_FEATURE_DELETED_WITH,
+    "replaceWith": resource_pb2.RESOURCE_MONITOR_FEATURE_REPLACE_WITH,
+    "aliasSpecs": resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+    "transforms": resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+    "invokeTransforms": resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS,
+    "parameterization": resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION,
+    "resourceHooks": resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+    "errorHooks": resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS,
+}
+
+
 async def _load_monitor_feature_support():
-    # Prime the feature support cache.
-    await asyncio.gather(
-        monitor_supports_feature("secrets"),
-        monitor_supports_feature("resourceReferences"),
-        monitor_supports_feature("outputValues"),
-        monitor_supports_feature("deletedWith"),
-        monitor_supports_feature("replaceWith"),
-        monitor_supports_feature("aliasSpecs"),
-        monitor_supports_feature("transforms"),
-        monitor_supports_feature("invokeTransforms"),
-        monitor_supports_feature("parameterization"),
-        monitor_supports_feature("resourceHooks"),
-        monitor_supports_feature("errorHooks"),
-    )
+    if not SETTINGS.monitor:
+        return
+
+    try:
+        deployment_info = await asyncio.get_running_loop().run_in_executor(
+            None,
+            wrap_with_context(
+                lambda: SETTINGS.monitor.GetDeploymentInfo(empty_pb2.Empty())
+            ),
+        )
+        for feature, value in _LEGACY_FEATURE_MAPPING.items():
+            SETTINGS.feature_support[feature] = (
+                value in deployment_info.supportedFeatures
+            )
+
+    except grpc.RpcError as exn:
+        if exn.code() != grpc.StatusCode.UNIMPLEMENTED:
+            handle_grpc_error(exn)
+        await asyncio.gather(
+            *(
+                monitor_supports_feature(feature)
+                for feature in sorted(_LEGACY_FEATURE_MAPPING)
+            )
+        )

--- a/sdk/python/lib/test/runtime/test_feature_support.py
+++ b/sdk/python/lib/test/runtime/test_feature_support.py
@@ -1,0 +1,130 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import grpc
+import pytest
+
+from pulumi.runtime import settings
+from pulumi.runtime.proto import resource_pb2
+from pulumi.runtime.settings import Settings, _load_monitor_feature_support
+
+
+class _UnimplementedError(grpc.RpcError):
+    def code(self):
+        return grpc.StatusCode.UNIMPLEMENTED
+
+
+class DeploymentInfoMonitor:
+    """A monitor that advertises its features via GetDeploymentInfo."""
+
+    def __init__(self, features):
+        self.features = features
+        self.supports_feature_calls = 0
+
+    def GetDeploymentInfo(self, _req):
+        return resource_pb2.DeploymentInfo(supportedFeatures=self.features)
+
+    def SupportsFeature(self, req):
+        self.supports_feature_calls += 1
+        return resource_pb2.SupportsFeatureResponse(hasSupport=True)
+
+
+class LegacyMonitor:
+    """A monitor that predates GetDeploymentInfo and only answers SupportsFeature."""
+
+    def __init__(self, features):
+        self.features = features
+        self.probed = []
+
+    def GetDeploymentInfo(self, _req):
+        raise _UnimplementedError()
+
+    def SupportsFeature(self, req):
+        self.probed.append(req.id)
+        return resource_pb2.SupportsFeatureResponse(hasSupport=req.id in self.features)
+
+
+def configure_monitor(monitor):
+    s = Settings(project="project", stack="stack")
+    s.monitor = monitor
+    s.feature_support = {}
+    settings.configure(s)
+
+
+@pytest.mark.asyncio
+async def test_loads_features_from_get_deployment_info():
+    monitor = DeploymentInfoMonitor(
+        [
+            resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS,
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+            resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+            resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+            # Features with no legacy string ID never show up in feature_support.
+            resource_pb2.RESOURCE_MONITOR_FEATURE_BYTE_STRING,
+        ]
+    )
+    configure_monitor(monitor)
+
+    await _load_monitor_feature_support()
+
+    assert settings.SETTINGS.feature_support.fget() == {
+        "secrets": True,
+        "resourceReferences": True,
+        "outputValues": False,
+        "deletedWith": False,
+        "replaceWith": False,
+        "aliasSpecs": True,
+        "transforms": True,
+        "invokeTransforms": False,
+        "parameterization": False,
+        "resourceHooks": True,
+        "errorHooks": False,
+    }
+    assert monitor.supports_feature_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_supports_feature_when_unimplemented():
+    monitor = LegacyMonitor({"secrets", "outputValues", "invokeTransforms"})
+    configure_monitor(monitor)
+
+    await _load_monitor_feature_support()
+
+    assert settings.SETTINGS.feature_support.fget() == {
+        "secrets": True,
+        "resourceReferences": False,
+        "outputValues": True,
+        "deletedWith": False,
+        "replaceWith": False,
+        "aliasSpecs": False,
+        "transforms": False,
+        "invokeTransforms": True,
+        "parameterization": False,
+        "resourceHooks": False,
+        "errorHooks": False,
+    }
+    assert sorted(monitor.probed) == [
+        "aliasSpecs",
+        "deletedWith",
+        "errorHooks",
+        "invokeTransforms",
+        "outputValues",
+        "parameterization",
+        "replaceWith",
+        "resourceHooks",
+        "resourceReferences",
+        "secrets",
+        "transforms",
+    ]


### PR DESCRIPTION
This moves the Python SDK to prioritize feature discovery from `GetDeploymentInfo`, only falling back to the old per-feature RPC when `GetDeploymentInfo` is not available.

Like https://github.com/pulumi/pulumi/pull/24088, this PR forces new features to be added to the resource monitor, since the SDK will no longer read features individually from engines that serve `GetDeploymentInfo`. Behavior on old engines is unchanged.