### PR TITLE
Consult `GetDeploymentInfo` for feature discovery in TypeScript

### DIFF
--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -244,6 +244,26 @@ export class MockMonitor {
         });
     }
 
+    public getDeploymentInfo(req: any, callback: (err: any, innerResponse: any) => void) {
+        // Support for "outputValues" is deliberately disabled for the mock monitor so
+        // instances of `Output` don't show up in `MockResourceArgs` inputs.
+        const resp = new resproto.DeploymentInfo();
+        resp.setSupportedfeaturesList([
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_SECRETS,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_REPLACEMENT_TRIGGER,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_DELETED_WITH,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_REPLACE_WITH,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+            resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS,
+        ]);
+        callback(null, resp);
+    }
+
     public registerPackage(req: any, callback: (err: any, innerResponse: any) => void) {
         // Mocks don't _really_ support packages, so we just return a fake package ref.
         const resp = new resproto.RegisterPackageResponse();

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -291,55 +291,107 @@ async function monitorSupportsFeature(monitorClient: resrpc.IResourceMonitorClie
 }
 
 /**
+ * Queries the resource monitor for the set of features it supports via
+ * GetDeploymentInfo.
+ *
+ * Resolves to undefined if the monitor does not implement GetDeploymentInfo.
+ *
+ * @internal
+ */
+function getMonitorSupportedFeatures(
+    monitorClient: resrpc.IResourceMonitorClient,
+): Promise<resproto.ResourceMonitorFeature[] | undefined> {
+    return new Promise((resolve, reject) => {
+        monitorClient.getDeploymentInfo(
+            new emptyproto.Empty(),
+            (err: grpc.ServiceError | null, resp: resproto.DeploymentInfo | undefined) => {
+                if (err && err.code === grpc.status.UNIMPLEMENTED) {
+                    return resolve(undefined);
+                }
+
+                if (err) {
+                    return reject(err);
+                }
+
+                if (resp === undefined) {
+                    return reject(new Error("No response from resource monitor"));
+                }
+
+                return resolve(resp.getSupportedfeaturesList());
+            },
+        );
+    });
+}
+
+// A frozen map of old feature IDs to the new resource monitor features.
+//
+// This map should never be updated.
+const legacyFeatureMapping: Record<string, resproto.ResourceMonitorFeature> = {
+    secrets: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_SECRETS,
+    resourceReferences: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+    outputValues: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES,
+    deletedWith: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_DELETED_WITH,
+    replaceWith: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_REPLACE_WITH,
+    aliasSpecs: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+    transforms: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+    invokeTransforms: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS,
+    parameterization: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION,
+    resourceHooks: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+    errorHooks: resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS,
+};
+
+/**
  * Queries the resource monitor for its capabilities and sets the appropriate
- * flags in the store.
+ * flags in the store. Monitor capabilities are advertised as a set via
+ * GetDeploymentInfo. Older monitors don't implement it, in which case we fall
+ * back to probing each feature individually via SupportsFeature.
  *
  * @internal
  **/
 export async function awaitFeatureSupport(): Promise<void> {
     const monitorRef = getMonitor();
-    if (monitorRef !== undefined) {
-        const store = getStore();
-        const [
-            secrets,
-            resourceReferences,
-            outputValues,
-            deletedWith,
-            replaceWith,
-            aliasSpecs,
-            transforms,
-            invokeTransforms,
-            parameterization,
-            resourceHooks,
-            errorHooks,
-        ] = await Promise.all(
-            [
-                "secrets",
-                "resourceReferences",
-                "outputValues",
-                "deletedWith",
-                "replaceWith",
-                "aliasSpecs",
-                "transforms",
-                "invokeTransforms",
-                "parameterization",
-                "resourceHooks",
-                "errorHooks",
-            ].map((feature) => monitorSupportsFeature(monitorRef, feature)),
-        );
-
-        store.supportsSecrets = secrets;
-        store.supportsResourceReferences = resourceReferences;
-        store.supportsOutputValues = outputValues;
-        store.supportsDeletedWith = deletedWith;
-        store.supportsReplaceWith = replaceWith;
-        store.supportsAliasSpecs = aliasSpecs;
-        store.supportsTransforms = transforms;
-        store.supportsInvokeTransforms = invokeTransforms;
-        store.supportsParameterization = parameterization;
-        store.supportsResourceHooks = resourceHooks;
-        store.supportsErrorHooks = errorHooks;
+    if (monitorRef === undefined) {
+        return;
     }
+
+    let features = await getMonitorSupportedFeatures(monitorRef);
+    if (features === undefined) {
+        const probed = await Promise.all(
+            Object.keys(legacyFeatureMapping)
+                .sort()
+                .map(async (id) =>
+                    (await monitorSupportsFeature(monitorRef, id)) ? legacyFeatureMapping[id] : undefined,
+                ),
+        );
+        features = probed.filter((f): f is resproto.ResourceMonitorFeature => f !== undefined);
+    }
+
+    const store = getStore();
+    store.supportsSecrets = features.includes(resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_SECRETS);
+    store.supportsResourceReferences = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+    );
+    store.supportsOutputValues = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES,
+    );
+    store.supportsDeletedWith = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_DELETED_WITH,
+    );
+    store.supportsReplaceWith = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_REPLACE_WITH,
+    );
+    store.supportsAliasSpecs = features.includes(resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS);
+    store.supportsTransforms = features.includes(resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_TRANSFORMS);
+    store.supportsInvokeTransforms = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS,
+    );
+    store.supportsParameterization = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION,
+    );
+    store.supportsResourceHooks = features.includes(
+        resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+    );
+    store.supportsErrorHooks = features.includes(resproto.ResourceMonitorFeature.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS);
 }
 
 /**

--- a/sdk/nodejs/tests/runtime/featureSupport.spec.ts
+++ b/sdk/nodejs/tests/runtime/featureSupport.spec.ts
@@ -1,0 +1,127 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as grpc from "@grpc/grpc-js";
+import * as resproto from "../../proto/resource_pb";
+import { awaitFeatureSupport } from "../../runtime/settings";
+import * as state from "../../runtime/state";
+
+const Feature = resproto.ResourceMonitorFeature;
+
+function storeFeatureFlags() {
+    const store = state.getStore();
+    return {
+        supportsSecrets: store.supportsSecrets,
+        supportsResourceReferences: store.supportsResourceReferences,
+        supportsOutputValues: store.supportsOutputValues,
+        supportsDeletedWith: store.supportsDeletedWith,
+        supportsReplaceWith: store.supportsReplaceWith,
+        supportsAliasSpecs: store.supportsAliasSpecs,
+        supportsTransforms: store.supportsTransforms,
+        supportsInvokeTransforms: store.supportsInvokeTransforms,
+        supportsParameterization: store.supportsParameterization,
+        supportsResourceHooks: store.supportsResourceHooks,
+        supportsErrorHooks: store.supportsErrorHooks,
+    };
+}
+
+describe("runtime/featureSupport", () => {
+    it("loads features from GetDeploymentInfo without probing SupportsFeature", async () => {
+        await state.withLocalStorage(async () => {
+            let supportsFeatureCalls = 0;
+            state.getStore().settings.monitor = {
+                getDeploymentInfo(_req: any, cb: (err: any, resp: any) => void) {
+                    const resp = new resproto.DeploymentInfo();
+                    resp.setSupportedfeaturesList([
+                        Feature.RESOURCE_MONITOR_FEATURE_SECRETS,
+                        Feature.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+                        Feature.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+                        Feature.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+                        Feature.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+                        // Features with no legacy string ID never map to a store flag.
+                        Feature.RESOURCE_MONITOR_FEATURE_BYTE_STRING,
+                    ]);
+                    cb(null, resp);
+                },
+                supportsFeature(_req: any, cb: (err: any, resp: any) => void) {
+                    supportsFeatureCalls++;
+                    cb(null, { getHassupport: () => true });
+                },
+            } as any;
+
+            await awaitFeatureSupport();
+
+            assert.deepStrictEqual(storeFeatureFlags(), {
+                supportsSecrets: true,
+                supportsResourceReferences: true,
+                supportsOutputValues: false,
+                supportsDeletedWith: false,
+                supportsReplaceWith: false,
+                supportsAliasSpecs: true,
+                supportsTransforms: true,
+                supportsInvokeTransforms: false,
+                supportsParameterization: false,
+                supportsResourceHooks: true,
+                supportsErrorHooks: false,
+            });
+            assert.strictEqual(supportsFeatureCalls, 0);
+        });
+    });
+
+    it("falls back to SupportsFeature when GetDeploymentInfo is unimplemented", async () => {
+        await state.withLocalStorage(async () => {
+            const supported = new Set(["secrets", "outputValues", "invokeTransforms"]);
+            const probed: string[] = [];
+            state.getStore().settings.monitor = {
+                getDeploymentInfo(_req: any, cb: (err: any, resp: any) => void) {
+                    cb({ code: grpc.status.UNIMPLEMENTED }, undefined);
+                },
+                supportsFeature(req: any, cb: (err: any, resp: any) => void) {
+                    probed.push(req.getId());
+                    cb(null, { getHassupport: () => supported.has(req.getId()) });
+                },
+            } as any;
+
+            await awaitFeatureSupport();
+
+            assert.deepStrictEqual(storeFeatureFlags(), {
+                supportsSecrets: true,
+                supportsResourceReferences: false,
+                supportsOutputValues: true,
+                supportsDeletedWith: false,
+                supportsReplaceWith: false,
+                supportsAliasSpecs: false,
+                supportsTransforms: false,
+                supportsInvokeTransforms: true,
+                supportsParameterization: false,
+                supportsResourceHooks: false,
+                supportsErrorHooks: false,
+            });
+            assert.deepStrictEqual(probed.sort(), [
+                "aliasSpecs",
+                "deletedWith",
+                "errorHooks",
+                "invokeTransforms",
+                "outputValues",
+                "parameterization",
+                "replaceWith",
+                "resourceHooks",
+                "resourceReferences",
+                "secrets",
+                "transforms",
+            ]);
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -104,6 +104,7 @@
         "tests/runtime/asyncIterableUtil.spec.ts",
         "tests/runtime/codePaths.spec.ts",
         "tests/runtime/dependsOn.spec.ts",
+        "tests/runtime/featureSupport.spec.ts",
         "tests/runtime/findWorkspaceRoot.spec.ts",
         "tests/runtime/manifest.spec.ts",
         "tests/runtime/registerPackage.spec.ts",


### PR DESCRIPTION
This moves the Node SDK to prioritize feature discovery from `GetDeploymentInfo`, only falling back to the old per-feature RPC when `GetDeploymentInfo` is not available.

Like https://github.com/pulumi/pulumi/pull/24088 & https://github.com/pulumi/pulumi/pull/24090, this PR forces new features to be added to the resource monitor, since the SDK will no longer read features individually from engines that serve `GetDeploymentInfo`. Behavior on old engines is unchanged.
