### PR TITLE
Migrate CallResponse to property.Map

### DIFF
--- a/pkg/engine/lifecycletest/components_test.go
+++ b/pkg/engine/lifecycletest/components_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -451,10 +452,10 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 						deps := arg.OutputValue().Dependencies
 
 						return plugin.CallResponse{
-							Return: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewProperty("")),
-							},
+							Return: property.NewMap(map[string]property.Value{
+								"foo": property.New("foo").WithSecret(true),
+								"bar": property.New(property.Computed),
+							}),
 							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
 								"bar": deps,
@@ -601,17 +602,10 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 						deps := arg.OutputValue().Dependencies
 
 						return plugin.CallResponse{
-							Return: resource.PropertyMap{
-								"foo": resource.NewProperty(resource.Output{
-									Element:      resource.NewProperty("foo"),
-									Known:        true,
-									Secret:       true,
-									Dependencies: deps,
-								}),
-								"bar": resource.NewProperty(resource.Output{
-									Dependencies: deps,
-								}),
-							},
+							Return: property.NewMap(map[string]property.Value{
+								"foo": property.New("foo").WithSecret(true).WithDependencies(deps),
+								"bar": property.New(property.Computed).WithDependencies(deps),
+							}),
 							ReturnDependencies: nil, // Left blank on purpose because AcceptsOutputs is true
 						}, nil
 					},
@@ -755,10 +749,10 @@ func TestConstructCallSendDependencies(t *testing.T) {
 						deps := arg.OutputValue().Dependencies
 
 						return plugin.CallResponse{
-							Return: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewProperty("")),
-							},
+							Return: property.NewMap(map[string]property.Value{
+								"foo": property.New("foo").WithSecret(true),
+								"bar": property.New(property.Computed),
+							}),
 							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
 								"bar": deps,
@@ -920,10 +914,10 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 						deps := arg.OutputValue().Dependencies
 
 						return plugin.CallResponse{
-							Return: resource.PropertyMap{
-								"foo": resource.MakeSecret(resource.NewProperty("foo")),
-								"bar": resource.MakeComputed(resource.NewProperty("")),
-							},
+							Return: property.NewMap(map[string]property.Value{
+								"foo": property.New("foo").WithSecret(true),
+								"bar": property.New(property.Computed),
+							}),
 							ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 								"foo": deps,
 								"bar": deps,
@@ -1154,9 +1148,9 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 
 				message := fmt.Sprintf("%s, %s!", name, foo)
 				return plugin.CallResponse{
-					Return: resource.PropertyMap{
-						"message": resource.NewProperty(message),
-					},
+					Return: property.NewMap(map[string]property.Value{
+						"message": property.New(message),
+					}),
 				}, nil
 			}
 
@@ -1731,9 +1725,9 @@ func TestCallSelfProvider(t *testing.T) {
 					_ *deploytest.ResourceMonitor,
 				) (plugin.CallResponse, error) {
 					return plugin.CallResponse{
-						Return: resource.PropertyMap{
-							"state": resource.NewProperty(state),
-						},
+						Return: property.NewMap(map[string]property.Value{
+							"state": property.New(state),
+						}),
 					}, nil
 				},
 			}, nil

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -193,9 +194,9 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 					}, req.Options.ArgDependencies)
 
 					return plugin.CallResponse{
-						Return: resource.PropertyMap{
-							"output": resource.NewProperty("output"),
-						},
+						Return: property.NewMap(map[string]property.Value{
+							"output": property.New("output"),
+						}),
 						ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 							"output": {"urn:pulumi:stack::m::typA::resB"},
 						},
@@ -354,7 +355,8 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 7)
@@ -376,13 +378,15 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 	}), prov.Inputs)
 
 	snap, err = lt.TestOp(Refresh).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 7)
 
 	snap, err = lt.TestOp(Destroy).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 0)
@@ -482,7 +486,8 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 4)
@@ -501,13 +506,15 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 	}), prov.Inputs)
 
 	snap, err = lt.TestOp(Refresh).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 4)
 
 	snap, err = lt.TestOp(Destroy).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 0)
@@ -623,7 +630,8 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up",
+	)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 6)

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -355,8 +355,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up",
-	)
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 7)
@@ -378,15 +377,13 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 	}), prov.Inputs)
 
 	snap, err = lt.TestOp(Refresh).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh",
-	)
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 7)
 
 	snap, err = lt.TestOp(Destroy).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy",
-	)
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 0)
@@ -486,8 +483,7 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up",
-	)
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 4)
@@ -506,15 +502,13 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 	}), prov.Inputs)
 
 	snap, err = lt.TestOp(Refresh).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh",
-	)
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "refresh")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 4)
 
 	snap, err = lt.TestOp(Destroy).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy",
-	)
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "destroy")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 0)
@@ -630,8 +624,7 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up",
-	)
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "up")
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 	require.Len(t, snap.Resources, 6)

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1197,7 +1197,8 @@ func TestStackReferenceRegister(t *testing.T) {
 							payload.URN.Type() == "pulumi:pulumi:StackReference" &&
 							strings.Contains(
 								payload.Message,
-								"The \"pulumi:pulumi:StackReference\" resource type is deprecated.")
+								"The \"pulumi:pulumi:StackReference\" resource type is deprecated.",
+							)
 						found = found || ok
 					}
 				}
@@ -2358,8 +2359,8 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 					}
 
 					return plugin.CallResponse{
-						Return: resource.NewPropertyMapFromMap(map[string]any{
-							"message": ret,
+						Return: property.NewMap(map[string]property.Value{
+							"message": property.New(ret),
 						}),
 					}, nil
 				},
@@ -3208,7 +3209,8 @@ func TestInvalidGetIDReportsUserError(t *testing.T) {
 	project := p.GetProject()
 
 	validate := ExpectDiagMessage(t, regexp.QuoteMeta(
-		"<{%reset%}>Expected an ID for urn:pulumi:test::test::pkgA:m:typA::resA<{%reset%}>"))
+		"<{%reset%}>Expected an ID for urn:pulumi:test::test::pkgA:m:typA::resA<{%reset%}>",
+	))
 
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, validate)
 	require.NoError(t, err)
@@ -3413,14 +3415,16 @@ func TestDefaultParents(t *testing.T) {
 			resource.RootStackType,
 			info.Project+"-"+info.Stack,
 			false,
-			deploytest.ResourceOptions{})
+			deploytest.ResourceOptions{},
+		)
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource(
 			"pkgA:m:typA",
 			"resA",
 			true,
-			deploytest.ResourceOptions{})
+			deploytest.ResourceOptions{},
+		)
 		require.NoError(t, err)
 
 		return nil
@@ -3813,14 +3817,16 @@ func TestTimestampTracking(t *testing.T) {
 			resource.RootStackType,
 			info.Project+"-"+info.Stack,
 			false,
-			deploytest.ResourceOptions{})
+			deploytest.ResourceOptions{},
+		)
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource(
 			"pkgA:m:typA",
 			"resA",
 			true,
-			deploytest.ResourceOptions{})
+			deploytest.ResourceOptions{},
+		)
 		require.NoError(t, err)
 
 		return nil
@@ -4967,7 +4973,8 @@ func TestProgramError(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0",
+	)
 	require.NotNil(t, snap)
 	require.NoError(t, err)
 	require.Len(t, snap.Resources, 3)
@@ -4978,7 +4985,8 @@ func TestProgramError(t *testing.T) {
 	returnError = true
 
 	snap, err = lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1",
+	)
 	require.NotNil(t, snap)
 	require.Error(t, err)
 	require.True(t, result.IsBail(err))
@@ -5017,7 +5025,8 @@ func TestResourceError(t *testing.T) {
 	}
 
 	_, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0",
+	)
 	require.True(t, result.IsBail(err))
 	require.ErrorContains(t, err, "create failed intentionally")
 }

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1197,8 +1197,7 @@ func TestStackReferenceRegister(t *testing.T) {
 							payload.URN.Type() == "pulumi:pulumi:StackReference" &&
 							strings.Contains(
 								payload.Message,
-								"The \"pulumi:pulumi:StackReference\" resource type is deprecated.",
-							)
+								"The \"pulumi:pulumi:StackReference\" resource type is deprecated.")
 						found = found || ok
 					}
 				}
@@ -3209,8 +3208,7 @@ func TestInvalidGetIDReportsUserError(t *testing.T) {
 	project := p.GetProject()
 
 	validate := ExpectDiagMessage(t, regexp.QuoteMeta(
-		"<{%reset%}>Expected an ID for urn:pulumi:test::test::pkgA:m:typA::resA<{%reset%}>",
-	))
+		"<{%reset%}>Expected an ID for urn:pulumi:test::test::pkgA:m:typA::resA<{%reset%}>"))
 
 	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, validate)
 	require.NoError(t, err)
@@ -3415,16 +3413,14 @@ func TestDefaultParents(t *testing.T) {
 			resource.RootStackType,
 			info.Project+"-"+info.Stack,
 			false,
-			deploytest.ResourceOptions{},
-		)
+			deploytest.ResourceOptions{})
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource(
 			"pkgA:m:typA",
 			"resA",
 			true,
-			deploytest.ResourceOptions{},
-		)
+			deploytest.ResourceOptions{})
 		require.NoError(t, err)
 
 		return nil
@@ -3817,16 +3813,14 @@ func TestTimestampTracking(t *testing.T) {
 			resource.RootStackType,
 			info.Project+"-"+info.Stack,
 			false,
-			deploytest.ResourceOptions{},
-		)
+			deploytest.ResourceOptions{})
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource(
 			"pkgA:m:typA",
 			"resA",
 			true,
-			deploytest.ResourceOptions{},
-		)
+			deploytest.ResourceOptions{})
 		require.NoError(t, err)
 
 		return nil
@@ -4973,8 +4967,7 @@ func TestProgramError(t *testing.T) {
 	}
 
 	snap, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0",
-	)
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NotNil(t, snap)
 	require.NoError(t, err)
 	require.Len(t, snap.Resources, 3)
@@ -4985,8 +4978,7 @@ func TestProgramError(t *testing.T) {
 	returnError = true
 
 	snap, err = lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1",
-	)
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
 	require.NotNil(t, snap)
 	require.Error(t, err)
 	require.True(t, result.IsBail(err))
@@ -5025,8 +5017,7 @@ func TestResourceError(t *testing.T) {
 	}
 
 	_, err := lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0",
-	)
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.True(t, result.IsBail(err))
 	require.ErrorContains(t, err, "create failed intentionally")
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1301,7 +1301,8 @@ func (rm *resmon) Call(ctx context.Context, req *pulumirpc.ResourceCallRequest) 
 	if ret.ReturnDependencies == nil {
 		ret.ReturnDependencies = map[resource.PropertyKey][]resource.URN{}
 	}
-	for k, v := range ret.Return {
+	retReturn := resource.ToResourcePropertyMap(ret.Return)
+	for k, v := range retReturn {
 		ret.ReturnDependencies[k] = extendOutputDependencies(ret.ReturnDependencies[k], v)
 	}
 
@@ -1314,7 +1315,7 @@ func (rm *resmon) Call(ctx context.Context, req *pulumirpc.ResourceCallRequest) 
 		returnDependencies[string(name)] = &pulumirpc.CallResponse_ReturnDependencies{Urns: urns}
 	}
 
-	mret, err := plugin.MarshalProperties(ret.Return, plugin.MarshalOptions{
+	mret, err := plugin.MarshalProperties(retReturn, plugin.MarshalOptions{
 		Label:            label,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -3392,9 +3392,9 @@ func TestCall(t *testing.T) {
 			Provider: &deploytest.Provider{
 				CallF: func(context.Context, plugin.CallRequest, *deploytest.ResourceMonitor) (plugin.CallResponse, error) {
 					return plugin.CallResponse{
-						Return: resource.PropertyMap{
-							"result": resource.NewProperty(100.0),
-						},
+						Return: property.NewMap(map[string]property.Value{
+							"result": property.New(100.0),
+						}),
 						ReturnDependencies: map[resource.PropertyKey][]resource.URN{
 							"prop": {
 								"urn:pulumi:stack::project::type::dep1",

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -999,7 +999,7 @@ type CallResult struct {
 	// The returned values, if the call was successful.
 	// In the case of a scalar/non-map result, a single key with any name can be used to return the
 	// value.
-	Return resource.PropertyMap
+	Return property.Map
 	// A map from return value keys to the dependencies of the return value.
 	ReturnDependencies map[resource.PropertyKey][]resource.URN
 	// The failures if any arguments didn't pass verification.

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -2388,7 +2388,10 @@ func (p *provider) Call(_ context.Context, req CallRequest) (CallResponse, error
 	}
 
 	logging.V(7).Infof("%s success (#ret=%d,#failures=%d) success", label, len(ret), len(failures))
-	return CallResult{Return: ret, ReturnDependencies: returnDependencies, Failures: failures}, nil
+	return CallResult{
+		Return:             resource.FromResourcePropertyMap(ret),
+		ReturnDependencies: returnDependencies, Failures: failures,
+	}, nil
 }
 
 // GetPluginInfo returns this plugin's information.

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -1069,7 +1069,7 @@ func (p *providerServer) Call(ctx context.Context, req *pulumirpc.CallRequest) (
 
 	opts := p.marshalOptions("return")
 	opts.KeepOutputValues = req.AcceptsOutputValues
-	rpcResult, err := MarshalProperties(result.Return, opts)
+	rpcResult, err := MarshalProperties(resource.ToResourcePropertyMap(result.Return), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testing/pulumi-test-language/providers/call_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/call_provider.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -393,8 +394,8 @@ func (p *CallProvider) callCustomProviderValue(
 	result := provValue.GetStringValue() + resValue.GetStringValue()
 
 	return plugin.CallResponse{
-		Return: resource.NewPropertyMapFromMap(map[string]any{
-			"result": result,
+		Return: property.NewMap(map[string]property.Value{
+			"result": property.New(result),
 		}),
 	}, nil
 }
@@ -423,8 +424,8 @@ func (p *CallProvider) callProviderIdentity(
 	result := value.GetStringValue()
 
 	return plugin.CallResponse{
-		Return: resource.NewPropertyMapFromMap(map[string]any{
-			"result": result,
+		Return: property.NewMap(map[string]property.Value{
+			"result": property.New(result),
 		}),
 	}, nil
 }
@@ -466,8 +467,8 @@ func (p *CallProvider) callProviderPrefixed(
 	result := prefix.StringValue() + value.GetStringValue()
 
 	return plugin.CallResponse{
-		Return: resource.NewPropertyMapFromMap(map[string]any{
-			"result": result,
+		Return: property.NewMap(map[string]property.Value{
+			"result": property.New(result),
 		}),
 	}, nil
 }

--- a/pkg/testing/pulumi-test-language/providers/component_property_deps_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_property_deps_provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -408,9 +409,9 @@ func (p *ComponentPropertyDepsProvider) Call(
 	}
 
 	return plugin.CallResponse{
-		Return: resource.PropertyMap{
-			"result": p.convertMapToObjectProperty(req.Options.ArgDependencies),
-		},
+		Return: property.NewMap(map[string]property.Value{
+			"result": resource.FromResourcePropertyValue(p.convertMapToObjectProperty(req.Options.ArgDependencies)),
+		}),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_provider.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -637,8 +638,8 @@ func (p *ComponentProvider) callComponentCallableIdentity(
 	result := value.GetStringValue()
 
 	return plugin.CallResponse{
-		Return: resource.NewPropertyMapFromMap(map[string]any{
-			"result": result,
+		Return: property.NewMap(map[string]property.Value{
+			"result": property.New(result),
 		}),
 	}, nil
 }
@@ -680,8 +681,8 @@ func (p *ComponentProvider) callComponentCallablePrefixed(
 	result := prefix.StringValue() + value.GetStringValue()
 
 	return plugin.CallResponse{
-		Return: resource.NewPropertyMapFromMap(map[string]any{
-			"result": result,
+		Return: property.NewMap(map[string]property.Value{
+			"result": property.New(result),
 		}),
 	}, nil
 }

--- a/pkg/testing/pulumi-test-language/providers/configurer_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/configurer_provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -411,18 +412,22 @@ func (p *ConfigurerProvider) Call(
 	case "configurer:index:Configurer/plainValue":
 		// Single-value plain returns use the magic key "res" on the wire.
 		return plugin.CallResponse{
-			Return: resource.PropertyMap{"res": resource.NewProperty(42.0)},
+			Return: property.NewMap(map[string]property.Value{
+				"res": property.New(42.0),
+			}),
 		}, nil
 	case "configurer:index:Configurer/plainProvider":
 		return plugin.CallResponse{
-			Return: resource.PropertyMap{"res": *innerRefValue},
+			Return: property.NewMap(map[string]property.Value{
+				"res": resource.FromResourcePropertyValue(*innerRefValue),
+			}),
 		}, nil
 	case "configurer:index:Configurer/nestedPlainProvider":
 		return plugin.CallResponse{
-			Return: resource.PropertyMap{
-				"provider": *innerRefValue,
-				"value":    resource.NewProperty(42.0),
-			},
+			Return: property.NewMap(map[string]property.Value{
+				"provider": resource.FromResourcePropertyValue(*innerRefValue),
+				"value":    property.New(42.0),
+			}),
 		}, nil
 	}
 	return plugin.CallResponse{}, fmt.Errorf("unknown function %v", req.Tok)

--- a/pkg/testing/pulumi-test-language/providers/index_mod_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/index_mod_provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -340,9 +341,9 @@ func (p *IndexModProvider) Call(
 		text := selfRes.Return.Fields["state"].GetStructValue().Fields["text"]
 
 		return plugin.CallResponse{
-			Return: resource.PropertyMap{
-				"output": resource.NewProperty(float64(len(value.StringValue()) + len(text.GetStringValue()))),
-			},
+			Return: property.NewMap(map[string]property.Value{
+				"output": property.New(float64(len(value.StringValue()) + len(text.GetStringValue()))),
+			}),
 		}, nil
 	}
 

--- a/pkg/testing/pulumi-test-language/providers/module_format_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/module_format_provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -424,9 +425,9 @@ func (p *ModuleFormatProvider) Call(
 		text := selfRes.Return.Fields["state"].GetStructValue().Fields["text"]
 
 		return plugin.CallResponse{
-			Return: resource.PropertyMap{
-				"output": resource.NewProperty(float64(len(value.StringValue()) + len(text.GetStringValue()))),
-			},
+			Return: property.NewMap(map[string]property.Value{
+				"output": property.New(float64(len(value.StringValue()) + len(text.GetStringValue()))),
+			}),
 		}, nil
 	}
 


### PR DESCRIPTION
Continuing the `property.Map` migration in bite sized chunks.