### PR TITLE
Fixes nested optional output conversions

### DIFF
--- a/changelog/pending/sdkgen-go-fix-20260728-154826.yaml
+++ b/changelog/pending/sdkgen-go-fix-20260728-154826.yaml
@@ -1,0 +1,4 @@
+component: sdkgen/go
+kind: fix
+body: Fixes nested optional output conversions
+time: 2026-07-28T15:48:26.664135+02:00

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -422,6 +422,13 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 					// interface type strips those methods and breaks use in
 					// pulumi.AssetOrArchiveArray, etc.
 					g.Fgenf(w, "%.v", from)
+				} else if isFromOutput &&
+					model.IsOptionalType(model.ResolveOutputs(fromType)) &&
+					pcl.UnwrapOption(model.ResolveOutputs(fromType)).Equals(to) {
+					// Optional scalar outputs are represented by pointer outputs in Go. When the
+					// destination is the corresponding optional input, the output already implements
+					// that input interface. Wrapping it in the value constructor would not compile.
+					g.Fgenf(w, "%.v", from)
 				} else {
 					g.Fgenf(w, "%s(%.v)", typeName, from)
 				}

--- a/pkg/testing/pulumi-test-language/tests/l2_primitive_ref_optional.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_primitive_ref_optional.go
@@ -36,12 +36,13 @@ func init() {
 
 					RequireStackResource(l, err, changes)
 
-					// stack + provider + 2 resources
-					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
+					// stack + provider + 3 resources
+					require.Len(l, snap.Resources, 5, "expected 5 resources in snapshot")
 
 					RequireSingleResource(l, snap.Resources, "pulumi:providers:optional-primitive-ref")
 					setRes := RequireSingleNamedResource(l, snap.Resources, "setRes")
 					unsetRes := RequireSingleNamedResource(l, snap.Resources, "unsetRes")
+					fromNestedOptional := RequireSingleNamedResource(l, snap.Resources, "fromNestedOptional")
 
 					setWant := resource.NewPropertyMapFromMap(map[string]any{
 						"data": resource.NewPropertyMapFromMap(map[string]any{
@@ -61,6 +62,14 @@ func init() {
 					})
 					assert.Equal(l, unsetWant, unsetRes.Inputs, "unsetRes inputs")
 					assert.Equal(l, unsetWant, unsetRes.Outputs, "unsetRes outputs")
+
+					fromNestedOptionalWant := resource.NewPropertyMapFromMap(map[string]any{
+						"data": resource.NewPropertyMapFromMap(map[string]any{
+							"string": "hello",
+						}),
+					})
+					assert.Equal(l, fromNestedOptionalWant, fromNestedOptional.Inputs, "fromNestedOptional inputs")
+					assert.Equal(l, fromNestedOptionalWant, fromNestedOptional.Outputs, "fromNestedOptional outputs")
 
 					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
 					outputs := stack.Outputs

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-primitive-ref-optional/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-primitive-ref-optional/main.pp
@@ -16,6 +16,12 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
     data = {}
 }
 
+resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
+    data = {
+        string = setRes.data.string
+    }
+}
+
 # Traversal through an output object (data) to an optional inner scalar.
 # In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
 # where the inner field type is already a pointer - the SDK generator must not double-pointer it.

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-primitive-ref-optional/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-primitive-ref-optional/main.go
@@ -33,6 +33,16 @@ func main() {
 		if err != nil {
 			return err
 		}
+		_, err = optionalprimitiveref.NewResource(ctx, "fromNestedOptional", &optionalprimitiveref.ResourceArgs{
+			Data: &optionalprimitiveref.DataArgs{
+				String: setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
+					return data.String, nil
+				}).(pulumi.StringPtrOutput),
+			},
+		})
+		if err != nil {
+			return err
+		}
 		ctx.Export("setBoolean", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*bool, error) {
 			return data.Boolean, nil
 		}).(pulumi.BoolPtrOutput))

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/main.go
@@ -33,6 +33,16 @@ func main() {
 		if err != nil {
 			return err
 		}
+		_, err = optionalprimitiveref.NewResource(ctx, "fromNestedOptional", &optionalprimitiveref.ResourceArgs{
+			Data: &optionalprimitiveref.DataArgs{
+				String: setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
+					return data.String, nil
+				}).(pulumi.StringPtrOutput),
+			},
+		})
+		if err != nil {
+			return err
+		}
 		ctx.Export("setBoolean", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*bool, error) {
 			return data.Boolean, nil
 		}).(pulumi.BoolPtrOutput))

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-primitive-ref-optional/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-primitive-ref-optional/main.go
@@ -33,6 +33,16 @@ func main() {
 		if err != nil {
 			return err
 		}
+		_, err = optionalprimitiveref.NewResource(ctx, "fromNestedOptional", &optionalprimitiveref.ResourceArgs{
+			Data: &optionalprimitiveref.DataArgs{
+				String: setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
+					return data.String, nil
+				}).(pulumi.StringPtrOutput),
+			},
+		})
+		if err != nil {
+			return err
+		}
 		ctx.Export("setBoolean", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*bool, error) {
 			return data.Boolean, nil
 		}).(pulumi.BoolPtrOutput))

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-primitive-ref-optional/index.ts
@@ -17,6 +17,9 @@ const setRes = new optional_primitive_ref.Resource("setRes", {data: {
     },
 }});
 const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
+const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
+    string: setRes.data.apply(data => data.string),
+}});
 export const setBoolean = setRes.data.apply(data => data.boolean);
 export const setFloat = setRes.data.apply(data => data.float);
 export const setInteger = setRes.data.apply(data => data.integer);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-primitive-ref-optional/index.ts
@@ -17,6 +17,9 @@ const setRes = new optional_primitive_ref.Resource("setRes", {data: {
     },
 }});
 const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
+const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
+    string: setRes.data.apply(data => data.string),
+}});
 export const setBoolean = setRes.data.apply(data => data.boolean);
 export const setFloat = setRes.data.apply(data => data.float);
 export const setInteger = setRes.data.apply(data => data.integer);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-primitive-ref-optional/index.ts
@@ -17,6 +17,9 @@ const setRes = new optional_primitive_ref.Resource("setRes", {data: {
     },
 }});
 const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
+const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
+    string: setRes.data.apply(data => data.string),
+}});
 export const setBoolean = setRes.data.apply(data => data.boolean);
 export const setFloat = setRes.data.apply(data => data.float);
 export const setInteger = setRes.data.apply(data => data.integer);

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-primitive-ref-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-primitive-ref-optional/main.pp
@@ -16,6 +16,12 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
     data = {}
 }
 
+resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
+    data = {
+        string = setRes.data.string
+    }
+}
+
 # Traversal through an output object (data) to an optional inner scalar.
 # In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
 # where the inner field type is already a pointer - the SDK generator must not double-pointer it.

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-primitive-ref-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-primitive-ref-optional/main.pp
@@ -16,6 +16,12 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
     data = {}
 }
 
+resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
+    data = {
+        string = setRes.data.string
+    }
+}
+
 # Traversal through an output object (data) to an optional inner scalar.
 # In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
 # where the inner field type is already a pointer - the SDK generator must not double-pointer it.

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-primitive-ref-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-primitive-ref-optional/main.pp
@@ -16,6 +16,12 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
     data = {}
 }
 
+resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
+    data = {
+        string = setRes.data.string
+    }
+}
+
 # Traversal through an output object (data) to an optional inner scalar.
 # In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
 # where the inner field type is already a pointer - the SDK generator must not double-pointer it.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-primitive-ref-optional/__main__.py
@@ -17,6 +17,9 @@ set_res = optional_primitive_ref.Resource("setRes", data=optional_primitive_ref.
     },
 ))
 unset_res = optional_primitive_ref.Resource("unsetRes", data=optional_primitive_ref.DataArgs())
+from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data=optional_primitive_ref.DataArgs(
+    string=set_res.data.string,
+))
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)
 pulumi.export("setInteger", set_res.data.integer)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-primitive-ref-optional/__main__.py
@@ -17,6 +17,9 @@ set_res = optional_primitive_ref.Resource("setRes", data=optional_primitive_ref.
     },
 ))
 unset_res = optional_primitive_ref.Resource("unsetRes", data=optional_primitive_ref.DataArgs())
+from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data=optional_primitive_ref.DataArgs(
+    string=set_res.data.string,
+))
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)
 pulumi.export("setInteger", set_res.data.integer)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-primitive-ref-optional/__main__.py
@@ -17,6 +17,9 @@ set_res = optional_primitive_ref.Resource("setRes", data={
     },
 })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
+from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
+    "string": set_res.data.string,
+})
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)
 pulumi.export("setInteger", set_res.data.integer)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-primitive-ref-optional/__main__.py
@@ -17,6 +17,9 @@ set_res = optional_primitive_ref.Resource("setRes", data={
     },
 })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
+from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
+    "string": set_res.data.string,
+})
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)
 pulumi.export("setInteger", set_res.data.integer)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-primitive-ref-optional/__main__.py
@@ -17,6 +17,9 @@ set_res = optional_primitive_ref.Resource("setRes", data={
     },
 })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
+from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
+    "string": set_res.data.string,
+})
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)
 pulumi.export("setInteger", set_res.data.integer)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-primitive-ref-optional/__main__.py
@@ -17,6 +17,9 @@ set_res = optional_primitive_ref.Resource("setRes", data={
     },
 })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
+from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
+    "string": set_res.data.string,
+})
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)
 pulumi.export("setInteger", set_res.data.integer)


### PR DESCRIPTION
Follow-up to #23418

Nested property access on an output is first rewritten into an apply. As a result, it does not reach the traversal-specific conversion handling added in #23418. When the nested property is optional and is passed to an optional input. Go programgen instead used the default conversion path and wrapped the resulting pointer output in a scalar constructor.

```
resource "producer" "optional-primitive-ref:index:Resource" {
    data = {
        string = "hello"
    }
}

resource "consumer" "optional-primitive-ref:index:Resource" {
    data = {
        string = producer.data.string
    }
}
```

Previously we generated:

```
String: pulumi.String(
    producer.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
        return data.String, nil
    }).(pulumi.StringPtrOutput),
),
```

Which fails to compile because a pulumi.StringPtrOutput cannot be converted to pulumi.String.

The generated code now passes the pointer output directly:

```
String: producer.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
    return data.String, nil
}).(pulumi.StringPtrOutput),
```
