### PR TITLE
Better type some Go maps

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1468,7 +1468,15 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 			return string(*destType)
 		}
 	case *model.ObjectType:
-
+		// If this ObjectType was synthesized from a component's config
+		// variable, we know the generated Go struct name — use it (as a
+		// pointer, matching how values are rendered) rather than falling
+		// back to map[string]interface{}.
+		if !isInput {
+			if md, ok := model.GetObjectTypeAnnotation[*ObjectTypeFromConfigMetadata](destType); ok {
+				return "*" + md.TypeName
+			}
+		}
 		if isInput {
 			// check for element type uniformity and return appropriate type if so
 			allSameType := true

--- a/tests/testdata/codegen/components-pp/go/components.go
+++ b/tests/testdata/codegen/components-pp/go/components.go
@@ -41,7 +41,7 @@ func main() {
 				KeyBase64:     "base64 encoded key",
 				WebhookSecret: "very important secret",
 			},
-			Servers: []map[string]interface{}{
+			Servers: []*ServersArgs{
 				&ServersArgs{
 					Name: "First",
 				},


### PR DESCRIPTION
Use type names from config for map value types if available.

This is an effort to get maps better typed in general, but this appears to the smallest initial change.