### PR TITLE
Fix plugin leaks in analyzer startup

### DIFF
--- a/changelog/pending/engine-fix-20260728-plugin-leak.yaml
+++ b/changelog/pending/engine-fix-20260728-plugin-leak.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Fix a plugin process leak in `NewPolicyAnalyzer` when `ConfigureStack` fails after the plugin has booted
+time: 2026-07-28T16:00:00.000000+02:00

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -328,6 +328,7 @@ func (host *defaultHost) PolicyAnalyzer(
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
+				contract.IgnoreError(plug.Close())
 				return nil, infoerr
 			}
 
@@ -372,6 +373,7 @@ func (host *defaultHost) Provider(
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
+				contract.IgnoreError(plug.Close())
 				return nil, infoerr
 			}
 
@@ -469,6 +471,7 @@ func (host *defaultHost) LanguageRuntime(ctx *plugin.Context, runtime string,
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
+				contract.IgnoreError(plug.Close())
 				return nil, infoerr
 			}
 

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -328,7 +328,7 @@ func (host *defaultHost) PolicyAnalyzer(
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
-				contract.IgnoreError(plug.Close())
+				contract.IgnoreClose(plug)
 				return nil, infoerr
 			}
 
@@ -373,7 +373,7 @@ func (host *defaultHost) Provider(
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
-				contract.IgnoreError(plug.Close())
+				contract.IgnoreClose(plug)
 				return nil, infoerr
 			}
 
@@ -471,7 +471,7 @@ func (host *defaultHost) LanguageRuntime(ctx *plugin.Context, runtime string,
 		if err == nil && plug != nil {
 			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
-				contract.IgnoreError(plug.Close())
+				contract.IgnoreClose(plug)
 				return nil, infoerr
 			}
 

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -255,6 +255,9 @@ func NewPolicyAnalyzer(
 				logging.V(7).Infof("StackConfigure: not supported by '%v'", name)
 			} else {
 				logging.V(7).Infof("StackConfigure: failed: err=%v", status)
+				if closeErr := plug.Close(); closeErr != nil {
+					logging.V(7).Infof("StackConfigure: failed to close plugin: err=%v", closeErr)
+				}
 				return nil, rpcerror.Convert(err)
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/24102

Fixes a plugin leak in NewPolicyAnalyzer where if ConfigureStack failed the plugin process was leaked.
Also fixes some leaks in the host code where after calling `GetPluginInfo` if that failed we leaked the plugin.