### PR TITLE
Mark generated proto files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
 pkg/engine/lifecycletest/testdata/** linguist-generated=true
+
+# Generated protobuf/gRPC stubs (see proto/generate.sh).
+sdk/proto/go/** linguist-generated=true
+sdk/nodejs/proto/** linguist-generated=true
+sdk/python/lib/pulumi/runtime/proto/** linguist-generated=true
+# The __init__.py files are hand-maintained; generate.sh restores them from git.
+sdk/python/lib/pulumi/runtime/proto/**/__init__.py linguist-generated=false


### PR DESCRIPTION
GitHub's linguist detects generated Go protobuf stubs by content, but the
Python .pyi stubs and the Node.js _pb.js/_grpc_pb.d.ts outputs were shown
in full in PR diffs. Mark all three generated proto output directories as
linguist-generated, excepting the hand-maintained __init__.py files that
proto/generate.sh restores from git after each regeneration.