### PR TITLE
fix(cli/stack): report program errors in `stack history events --summary`

### DIFF
--- a/changelog/pending/20260729--cli--history-events-summary-program-errors.yaml
+++ b/changelog/pending/20260729--cli--history-events-summary-program-errors.yaml
@@ -1,4 +1,4 @@
 component: cli
 kind: fix
-body: '`pulumi stack history events --summary` now reports the program errors a language host writes to stderr, so a preview that failed before reaching a resource operation no longer summarizes with an empty `diagnostics` list'
+body: Make '`pulumi stack history events --summary` report the program errors  from the language host
 time: 2026-07-29T00:00:00+00:00

--- a/changelog/pending/20260729--cli--history-events-summary-program-errors.yaml
+++ b/changelog/pending/20260729--cli--history-events-summary-program-errors.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: '`pulumi stack history events --summary` now reports the program errors a language host writes to stderr, so a preview that failed before reaching a resource operation no longer summarizes with an empty `diagnostics` list'
+time: 2026-07-29T00:00:00+00:00

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	pkgdisplay "github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -78,6 +79,7 @@ func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSu
 	var startTs, endTs int
 	var summaryEvent *apitype.SummaryEvent
 	anyFailed := false
+	anyError := false
 
 	markFailed := func(m apitype.StepEventMetadata) {
 		for i := len(s.Resources) - 1; i >= 0; i-- {
@@ -115,9 +117,15 @@ func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSu
 			markFailed(ev.ResOpFailedEvent.Metadata)
 		case ev.DiagnosticEvent != nil:
 			d := ev.DiagnosticEvent
-			if d.Severity != "error" || d.Ephemeral {
+			// A failing program reports through the language host's stderr, which
+			// arrives as "info#err" rather than "error" — for a preview that never
+			// reached a resource operation it is the only record of what went wrong.
+			// It doesn't imply failure on its own (a program can write to stderr and
+			// succeed), so only "error" contributes to the result below.
+			if d.Ephemeral || (d.Severity != string(diag.Error) && d.Severity != string(diag.Infoerr)) {
 				continue
 			}
+			anyError = anyError || d.Severity == string(diag.Error)
 			s.Diagnostics = append(s.Diagnostics, diagnosticSummary{
 				Severity: d.Severity,
 				URN:      d.URN,
@@ -136,7 +144,7 @@ func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSu
 	switch {
 	case summaryEvent != nil && summaryEvent.Result != "":
 		s.Result = summaryEvent.Result
-	case anyFailed || len(s.Diagnostics) > 0:
+	case anyFailed || anyError:
 		s.Result = apitype.OperationResultFailed
 	case summaryEvent != nil:
 		s.Result = apitype.OperationResultSucceeded

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary_test.go
@@ -205,6 +205,49 @@ func TestBuildUpdateSummary_ResultFallbacks(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultSucceeded, s.Result)
+
+	// Program stderr alone doesn't imply failure: it is reported, but a summary
+	// event with no result still reads as succeeded.
+	s, err = buildUpdateSummary(eventSeq(
+		apitype.EngineEvent{
+			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "npm notice", Severity: "info#err"},
+		},
+		apitype.EngineEvent{SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1}},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, apitype.OperationResultSucceeded, s.Result)
+	require.Len(t, s.Diagnostics, 1)
+}
+
+// A program error never reaches a resource operation, so the failed preview it
+// produces carries no "error" diagnostic and no ResOpFailed — its stderr output
+// is the only record of what went wrong.
+func TestBuildUpdateSummary_ReportsProgramErrors(t *testing.T) {
+	t.Parallel()
+
+	s, err := buildUpdateSummary(eventSeq(
+		apitype.EngineEvent{
+			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "warming up", Severity: "info"},
+		},
+		apitype.EngineEvent{
+			DiagnosticEvent: &apitype.DiagnosticEvent{
+				Message:  "Error: length: Cannot assign type 'string' to type 'integer'\n",
+				Severity: "info#err",
+			},
+		},
+		apitype.EngineEvent{
+			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "transient", Severity: "info#err", Ephemeral: true},
+		},
+		apitype.EngineEvent{
+			SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1, Result: apitype.OperationResultFailed},
+		},
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, apitype.OperationResultFailed, s.Result)
+	require.Len(t, s.Diagnostics, 1)
+	assert.Equal(t, "info#err", s.Diagnostics[0].Severity)
+	assert.Equal(t, "Error: length: Cannot assign type 'string' to type 'integer'", s.Diagnostics[0].Message)
 }
 
 func TestBuildUpdateSummary_DurationFallsBackToTimestamps(t *testing.T) {


### PR DESCRIPTION
Follow-up to #23960 (`--summary`, requested in #23965).

`buildUpdateSummary` collects a diagnostic only when its severity is exactly `error`. A program error (what a language host writes to stderr when the program itself fails) is tagged `info#err`, not `error`. Those are dropped.

That matters most for a failed preview, which is the case `--summary` was added to serve: the program never reached a resource operation, so there is no `ResOpFailed` event and no `error` diagnostic. The summary reports the failure but not one word about its cause:

```
$ pulumi stack history events <preview-id> --summary --output json
{"result":"failed","duration":1000000000,"summary":{"create":1},"resources":[...]}
```

The events are there, they just don't make it past the filter:

```
$ pulumi stack history events <preview-id> --all --event-type 3 --output json
...
{"message":"Error: random:index/randomPassword:RandomPassword is not assignable from {length: string}\n","severity":"info#err"}
{"message":"  on Pulumi.yaml line 7:\n","severity":"info#err"}
{"message":"  length: Cannot assign type 'string' to type 'integer'\n","severity":"info#err"}
```

So the flag whose reason for existing is a cheap first pass over a failed operation still requires the full event dump to answer "why did it fail".

## Change

Collect `info#err` alongside `error`. Each entry keeps its own severity, so a consumer that only wants hard errors can still filter.

Stderr output does not imply failure on its own. A program can write to stderr and succeed, so the result inference now keys on `error` severity rather than "any diagnostic was collected". A stream with `info#err` output and a summary event carrying no result still reads as `succeeded`, same as before.

Provider errors are unaffected: they carry `error` severity and already worked.

## Tests

- `TestBuildUpdateSummary_ReportsProgramErrors` — a failed preview whose only evidence is `info#err`; asserts the message survives and that the ephemeral one is still dropped.
- `TestBuildUpdateSummary_ResultFallbacks` gains a case pinning that `info#err` alone doesn't flip the result to failed.

Both fail on `master`.
