### PR TITLE
Use Go output accessors for property-only applies

### DIFF
--- a/changelog/pending/programgen-go-fix-20260728-171717.yaml
+++ b/changelog/pending/programgen-go-fix-20260728-171717.yaml
@@ -1,0 +1,4 @@
+component: programgen/go
+kind: fix
+body: Avoid redundant applies when projecting properties from generated Go object outputs
+time: 2026-07-28T17:17:17+02:00

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1814,6 +1814,56 @@ func (pkg *pkgContext) fieldName(r *schema.Resource, field *schema.Property) str
 	return res
 }
 
+type outputPropertyAccessorReceiver int
+
+const (
+	// regularOutputReceiver selects accessors generated on TOutput.
+	regularOutputReceiver outputPropertyAccessorReceiver = iota
+	// pointerOutputReceiver selects accessors generated on TPtrOutput.
+	pointerOutputReceiver
+)
+
+// outputPropertyAccessorName returns the generated accessor name for a property on the given output receiver.
+func outputPropertyAccessorName(propertyName string, receiver outputPropertyAccessorReceiver) string {
+	name := Title(propertyName)
+	if receiver == pointerOutputReceiver {
+		switch name {
+		case "IsSecret", "ElementType":
+			name += "Prop"
+		}
+		return name
+	}
+
+	if isReservedResourceField("", name) {
+		name += "_"
+	}
+	switch strings.ToLower(propertyName) {
+	case "elementtype", "issecret":
+		name = "Get" + name
+	}
+	return name
+}
+
+// supportsOutputPropertyAccessors reports whether an object type has generated property accessors on the given receiver.
+func (pkg *pkgContext) supportsOutputPropertyAccessors(
+	objectType *schema.ObjectType,
+	receiver outputPropertyAccessorReceiver,
+) bool {
+	if objectType.IsOverlay || objectType.IsInputShape() {
+		return false
+	}
+
+	details, ok := pkg.typeDetails[objectType]
+	if !ok {
+		return false
+	}
+
+	if receiver == pointerOutputReceiver {
+		return details.ptrOutput && goPackageInfo(pkg.pkg).Generics != GenericsSettingGenericsOnly
+	}
+	return details.output
+}
+
 func (pkg *pkgContext) genPlainType(w io.Writer, name, comment, deprecationMessage string,
 	properties []*schema.Property,
 ) error {
@@ -2071,11 +2121,7 @@ func (pkg *pkgContext) genOutputTypes(w io.Writer, genArgs genOutputTypesArgs) e
 				outputType = pkg.genericOutputType(p.Type)
 			}
 
-			propName := pkg.fieldName(nil, p)
-			switch strings.ToLower(p.Name) {
-			case "elementtype", "issecret":
-				propName = "Get" + propName
-			}
+			propName := outputPropertyAccessorName(p.Name, regularOutputReceiver)
 			fmt.Fprintf(w, "func (o %sOutput) %s() %s {\n", name, propName, outputType)
 			if !genArgs.usingGenericTypes {
 				fmt.Fprintf(w, "\treturn o.ApplyT(func (v %s) %s { return v.%s }).(%s)\n",
@@ -2113,12 +2159,7 @@ func (pkg *pkgContext) genOutputTypes(w io.Writer, genArgs genOutputTypesArgs) e
 				deref = "&"
 			}
 
-			funcName := Title(p.Name)
-			// Avoid conflicts with Output interface for lifted attributes.
-			switch funcName {
-			case "IsSecret", "ElementType":
-				funcName = funcName + "Prop"
-			}
+			funcName := outputPropertyAccessorName(p.Name, pointerOutputReceiver)
 
 			fmt.Fprintf(w, "func (o %sPtrOutput) %s() %s {\n", name, funcName, outputType)
 			fmt.Fprintf(w, "\treturn o.ApplyT(func (v *%s) %s {\n", name, applyType)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1804,6 +1804,10 @@ func (g *generator) genNYI(w io.Writer, reason string, vs ...any) {
 func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 	// Extract the list of outputs and the continuation expression from the `__apply` arguments.
 	applyArgs, then := pcl.ParseApplyCall(expr)
+	if source, accessor, ok := g.outputPropertyProjection(applyArgs, then); ok {
+		g.Fgenf(w, "%.v.%s()", source, accessor)
+		return
+	}
 	isInput := false
 	retType := g.argumentTypeName(then.Signature.ReturnType, isInput)
 	// TODO account for outputs in other namespaces like aws
@@ -1848,6 +1852,87 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 		g.genAnonymousFunctionExpression(w, allApplyThen, typeConvDecls, true)
 		g.Fgenf(w, ")%s", typeAssertion)
 	}
+}
+
+// outputPropertyProjection recognizes applies that only project a single property from an object output and returns the
+// generated Go SDK accessor for that property, if one exists. For example, it replaces
+//
+//	output.ApplyT(func(v T) (U, error) { return v.Property, nil }).(UOutput)
+//
+// with output.Property().
+func (g *generator) outputPropertyProjection(
+	applyArgs []model.Expression,
+	then *model.AnonymousFunctionExpression,
+) (model.Expression, string, bool) {
+	if len(applyArgs) != 1 || len(then.Parameters) != 1 {
+		return nil, "", false
+	}
+	if _, ok := applyArgs[0].Type().(*model.OutputType); !ok {
+		return nil, "", false
+	}
+
+	var rel hcl.Traversal
+	switch body := then.Body.(type) {
+	case *model.ScopeTraversalExpression:
+		if len(body.Parts) != 2 || body.Parts[0] != then.Parameters[0] {
+			return nil, "", false
+		}
+		rel = body.Traversal.SimpleSplit().Rel
+	case *model.RelativeTraversalExpression:
+		// Output-producing invokes use the callback parameter as the source of a relative traversal.
+		source, ok := body.Source.(*model.ScopeTraversalExpression)
+		if !ok || len(source.Parts) != 1 || source.Parts[0] != then.Parameters[0] || len(body.Parts) != 2 {
+			return nil, "", false
+		}
+		rel = body.Traversal
+	default:
+		return nil, "", false
+	}
+	if len(rel) != 1 {
+		return nil, "", false
+	}
+	attr, ok := rel[0].(hcl.TraverseAttr)
+	if !ok {
+		return nil, "", false
+	}
+
+	argType := model.ResolveOutputs(applyArgs[0].Type())
+	optionalObjectOutput := model.IsOptionalType(argType)
+	argType = pcl.UnwrapOption(argType)
+	objectType, ok := argType.(*model.ObjectType)
+	if !ok {
+		return nil, "", false
+	}
+	schemaType, ok := pcl.GetSchemaForType(objectType)
+	if !ok {
+		return nil, "", false
+	}
+	schemaObject, ok := schemaType.(*schema.ObjectType)
+	if !ok {
+		return nil, "", false
+	}
+	if _, ok := schemaObject.Property(attr.Name); !ok {
+		return nil, "", false
+	}
+
+	owner := schemaObject.PackageReference
+	if owner == nil {
+		return nil, "", false
+	}
+	goInfo := goPackageInfo(owner)
+	mod := tokenToPackage(owner, goInfo.ModuleToPackage, schemaObject.Token)
+	pkg, ok := g.contexts[owner.Name()][mod]
+	if !ok {
+		return nil, "", false
+	}
+	receiver := regularOutputReceiver
+	if optionalObjectOutput {
+		receiver = pointerOutputReceiver
+	}
+	if !pkg.supportsOutputPropertyAccessors(schemaObject, receiver) {
+		return nil, "", false
+	}
+	return applyArgs[0], outputPropertyAccessorName(attr.Name, receiver), true
 }
 
 // rewriteThenForAllApply rewrites an apply func after a .All replacing params with []interface{}

--- a/pkg/testing/pulumi-test-language/providers/optional_primitive_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/optional_primitive_ref_provider.go
@@ -26,10 +26,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-// A small provider with a single resource "Resource" that has a single field "Data" which is a type whose
-// inner primitive fields are all optional. The resource's "data" property itself is required (both as input
-// and output). This exercises the codegen path where a program traverses an output object to reach an
-// optional scalar (e.g. `res.data.string` where the inner field is *string).
+// A small provider with a single resource "Resource" whose object properties have optional primitive fields.
+// The resource has both a required "data" property and an optional "optionalData" property so the language
+// tests can exercise traversals through both regular and pointer object outputs.
 type OptionalPrimitiveRefProvider struct {
 	plugin.UnimplementedProvider
 }
@@ -83,13 +82,15 @@ func (p *OptionalPrimitiveRefProvider) GetSchema(
 	}
 	// No "required" array: all inner fields are optional.
 
-	resourceProperties := map[string]schema.PropertySpec{
-		"data": {
-			TypeSpec: schema.TypeSpec{
-				Type: "ref",
-				Ref:  "#/types/optional-primitive-ref:index:Data",
-			},
+	dataProperty := schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{
+			Type: "ref",
+			Ref:  "#/types/optional-primitive-ref:index:Data",
 		},
+	}
+	resourceProperties := map[string]schema.PropertySpec{
+		"data":         dataProperty,
+		"optionalData": dataProperty,
 	}
 	resourceRequired := []string{"data"}
 
@@ -165,75 +166,72 @@ func (p *OptionalPrimitiveRefProvider) Check(
 			Failures: makeCheckFailure("data", "missing value"),
 		}, nil
 	}
-	if !data.IsObject() {
-		return plugin.CheckResponse{
-			Failures: makeCheckFailure("data", "value is not an object"),
-		}, nil
-	}
-	if len(req.News) != 1 {
+	if len(req.News) > 2 {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
 		}, nil
 	}
+	if _, ok := req.News["optionalData"]; len(req.News) == 2 && !ok {
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+		}, nil
+	}
 
-	inner := data.ObjectValue()
-	for key, v := range inner {
-		switch key {
-		case "boolean":
-			if !v.IsBool() {
-				return plugin.CheckResponse{
-					Failures: makeCheckFailure(key, "value is not a boolean"),
-				}, nil
-			}
-		case "float":
-			if !v.IsNumber() {
-				return plugin.CheckResponse{
-					Failures: makeCheckFailure(key, "value is not a number"),
-				}, nil
-			}
-		case "integer":
-			if !v.IsNumber() {
-				return plugin.CheckResponse{
-					Failures: makeCheckFailure(key, "value is not a number"),
-				}, nil
-			}
-		case "string":
-			if !v.IsString() {
-				return plugin.CheckResponse{
-					Failures: makeCheckFailure(key, "value is not a string"),
-				}, nil
-			}
-		case "numberArray":
-			if !v.IsArray() {
-				return plugin.CheckResponse{
-					Failures: makeCheckFailure(key, "value is not an array"),
-				}, nil
-			}
-			for _, e := range v.ArrayValue() {
-				if !e.IsNumber() {
-					return plugin.CheckResponse{
-						Failures: makeCheckFailure(key, "array element is not a number"),
-					}, nil
+	checkData := func(name resource.PropertyKey, value resource.PropertyValue) []plugin.CheckFailure {
+		if !value.IsObject() {
+			return makeCheckFailure(name, "value is not an object")
+		}
+
+		for key, v := range value.ObjectValue() {
+			property := resource.PropertyKey(string(name) + "." + string(key))
+			switch key {
+			case "boolean":
+				if !v.IsBool() {
+					return makeCheckFailure(property, "value is not a boolean")
 				}
-			}
-		case "booleanMap":
-			if !v.IsObject() {
-				return plugin.CheckResponse{
-					Failures: makeCheckFailure(key, "value is not a map"),
-				}, nil
-			}
-			for _, e := range v.ObjectValue() {
-				if !e.IsBool() {
-					return plugin.CheckResponse{
-						Failures: makeCheckFailure(key, "map value is not a boolean"),
-					}, nil
+			case "float":
+				if !v.IsNumber() {
+					return makeCheckFailure(property, "value is not a number")
 				}
+			case "integer":
+				if !v.IsNumber() {
+					return makeCheckFailure(property, "value is not a number")
+				}
+			case "string":
+				if !v.IsString() {
+					return makeCheckFailure(property, "value is not a string")
+				}
+			case "numberArray":
+				if !v.IsArray() {
+					return makeCheckFailure(property, "value is not an array")
+				}
+				for _, e := range v.ArrayValue() {
+					if !e.IsNumber() {
+						return makeCheckFailure(property, "array element is not a number")
+					}
+				}
+			case "booleanMap":
+				if !v.IsObject() {
+					return makeCheckFailure(property, "value is not a map")
+				}
+				for _, e := range v.ObjectValue() {
+					if !e.IsBool() {
+						return makeCheckFailure(property, "map value is not a boolean")
+					}
+				}
+			default:
+				return makeCheckFailure(property, fmt.Sprintf("unexpected property: %s", key))
 			}
-		default:
-			return plugin.CheckResponse{
-				Failures: makeCheckFailure(resource.PropertyKey("data."+string(key)),
-					fmt.Sprintf("unexpected property: %s", key)),
-			}, nil
+		}
+		return nil
+	}
+
+	if failures := checkData("data", data); len(failures) != 0 {
+		return plugin.CheckResponse{Failures: failures}, nil
+	}
+	if optionalData, ok := req.News["optionalData"]; ok {
+		if failures := checkData("optionalData", optionalData); len(failures) != 0 {
+			return plugin.CheckResponse{Failures: failures}, nil
 		}
 	}
 

--- a/pkg/testing/pulumi-test-language/tests/l2_primitive_ref_optional.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_primitive_ref_optional.go
@@ -53,6 +53,9 @@ func init() {
 							"numberArray": []any{-1.0, 0.0, 1.0},
 							"booleanMap":  map[string]any{"t": true, "f": false},
 						}),
+						"optionalData": resource.NewPropertyMapFromMap(map[string]any{
+							"string": "optional parent",
+						}),
 					})
 					assert.Equal(l, setWant, setRes.Inputs, "setRes inputs")
 					assert.Equal(l, setWant, setRes.Outputs, "setRes outputs")
@@ -65,7 +68,7 @@ func init() {
 
 					fromNestedOptionalWant := resource.NewPropertyMapFromMap(map[string]any{
 						"data": resource.NewPropertyMapFromMap(map[string]any{
-							"string": "hello",
+							"string": "optional parent",
 						}),
 					})
 					assert.Equal(l, fromNestedOptionalWant, fromNestedOptional.Inputs, "fromNestedOptional inputs")

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-primitive-ref-optional/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-primitive-ref-optional/main.pp
@@ -10,6 +10,9 @@ resource "setRes" "optional-primitive-ref:index:Resource" {
             "f" = false,
         }
     }
+    optionalData = {
+        string = "optional parent"
+    }
 }
 
 resource "unsetRes" "optional-primitive-ref:index:Resource" {
@@ -18,13 +21,10 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
 
 resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
     data = {
-        string = setRes.data.string
+        string = setRes.optionalData.string
     }
 }
 
-# Traversal through an output object (data) to an optional inner scalar.
-# In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
-# where the inner field type is already a pointer - the SDK generator must not double-pointer it.
 output "setBoolean" {
     value = setRes.data.boolean
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-docs/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-docs/main.go
@@ -18,9 +18,7 @@ func main() {
 		_, err = docs.NewResource(ctx, "res", &docs.ResourceArgs{
 			In: docs.FunOutput(ctx, docs.FunOutputArgs{
 				In: pulumi.Bool(false),
-			}, nil).ApplyT(func(invoke docs.FunResult) (bool, error) {
-				return invoke.Out, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Out(),
 			ExternalEnum: enum.StringEnumStringOne,
 		})
 		if err != nil {

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-elide-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-elide-index/main.go
@@ -16,9 +16,7 @@ func main() {
 		}
 		ctx.Export("inv", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("test"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-extension-parameterized-resource/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-extension-parameterized-resource/main.go
@@ -19,9 +19,7 @@ func main() {
 		ctx.Export("parameterValueFromComponent", greetingComp.ParameterValue)
 		ctx.Export("invokeGreeting", myext.GreetOutput(ctx, myext.GreetOutputArgs{
 			Name: pulumi.String("Pulumi"),
-		}, nil).ApplyT(func(invoke myext.GreetResult) (string, error) {
-			return invoke.Greeting, nil
-		}).(pulumi.StringOutput))
+		}, nil).Greeting())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-index-mod/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-index-mod/main.go
@@ -11,9 +11,7 @@ func main() {
 		res1, err := indexmine.NewResource(ctx, "res1", &indexmine.ResourceArgs{
 			Text: indexmine.ConcatWorldOutput(ctx, indexmine.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke indexmine.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -30,9 +28,7 @@ func main() {
 		res2, err := nested.NewResource(ctx, "res2", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-dependencies/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-dependencies/main.go
@@ -20,9 +20,7 @@ func main() {
 			Value: simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 				Value:          pulumi.String("hello"),
 				SecretResponse: first.Value,
-			}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (bool, error) {
-				return invoke.Secret, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Secret(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-multi-argument/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-multi-argument/main.go
@@ -7,12 +7,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("both", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), pulumi.String("world")).ApplyT(func(invoke multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
-		ctx.Export("onlyRequired", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil).ApplyT(func(invoke multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("both", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), pulumi.String("world")).Result())
+		ctx.Export("onlyRequired", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-options-depends-on/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-options-depends-on/main.go
@@ -19,16 +19,12 @@ func main() {
 			pulumi.Resource(first),
 		}))
 		_, err = simpleinvoke.NewStringResource(ctx, "second", &simpleinvoke.StringResourceArgs{
-			Text: data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-				return data.Result, nil
-			}).(pulumi.StringOutput),
+			Text: data.Result(),
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("hello", data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-			return data.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("hello", data.Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-options/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-options/main.go
@@ -14,9 +14,7 @@ func main() {
 		data := simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
 		}, pulumi.Provider(explicitProvider), pulumi.Parent(explicitProvider), pulumi.Version("10.0.0"), pulumi.PluginDownloadURL("https://example.com/github/example"))
-		ctx.Export("hello", data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-			return data.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("hello", data.Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-output-only/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-output-only/main.go
@@ -9,14 +9,10 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("hello", outputonlyinvoke.MyInvokeOutput(ctx, outputonlyinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
-		}, nil).ApplyT(func(invoke outputonlyinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		ctx.Export("goodbye", outputonlyinvoke.MyInvokeOutput(ctx, outputonlyinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke outputonlyinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-secrets/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-secrets/main.go
@@ -17,21 +17,15 @@ func main() {
 		ctx.Export("nonSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.String("hello"),
 			SecretResponse: pulumi.Bool(false),
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		ctx.Export("firstSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.String("hello"),
 			SecretResponse: res.Value,
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		ctx.Export("secondSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.ToSecret("goodbye").(pulumi.StringOutput),
 			SecretResponse: pulumi.Bool(false),
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-simple/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-simple/main.go
@@ -9,14 +9,10 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("hello", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		ctx.Export("goodbye", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-variants/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-variants/main.go
@@ -15,12 +15,8 @@ func main() {
 		}
 		ctx.Export("outputInput", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: res.Text,
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
-		ctx.Export("unit", simpleinvoke.UnitOutput(ctx, simpleinvoke.UnitOutputArgs{}, nil).ApplyT(func(invoke simpleinvoke.UnitResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
+		ctx.Export("unit", simpleinvoke.UnitOutput(ctx, simpleinvoke.UnitOutputArgs{}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-map-keys-adversarial/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-map-keys-adversarial/main.go
@@ -49,9 +49,7 @@ func main() {
 			},
 		}, nil)
 		ctx.Export("resourceBooleanMap", res.BooleanMap)
-		ctx.Export("invokeBooleanMap", invokeResult.ApplyT(func(invokeResult primitive.InvokeResult) (map[string]bool, error) {
-			return invokeResult.BooleanMap, nil
-		}).(pulumi.BoolMapOutput))
+		ctx.Export("invokeBooleanMap", invokeResult.BooleanMap())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-module-format/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-module-format/main.go
@@ -15,9 +15,7 @@ func main() {
 		res1, err := mod.NewResource(ctx, "res1", &mod.ResourceArgs{
 			Text: mod.ConcatWorldOutput(ctx, mod.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke mod.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -35,9 +33,7 @@ func main() {
 		res2, err := mod.NewResource(ctx, "res2", &mod.ResourceArgs{
 			Text: mod.ConcatWorldOutput(ctx, mod.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke mod.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -55,9 +51,7 @@ func main() {
 		res3, err := nested.NewResource(ctx, "res3", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -75,9 +69,7 @@ func main() {
 		res4, err := nested.NewResource(ctx, "res4", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -95,9 +87,7 @@ func main() {
 		res5, err := moduleformat.NewResource(ctx, "res5", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("bonjour"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -115,9 +105,7 @@ func main() {
 		res6, err := moduleformat.NewResource(ctx, "res6", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("youkoso"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -135,9 +123,7 @@ func main() {
 		res7, err := moduleformat.NewResource(ctx, "res7", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("guten tag"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-parameterized-invoke/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-parameterized-invoke/main.go
@@ -9,9 +9,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("parameterValue", subpackage.DoHelloWorldOutput(ctx, subpackage.DoHelloWorldOutputArgs{
 			Input: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke subpackage.DoHelloWorldResult) (string, error) {
-			return invoke.Output, nil
-		}).(pulumi.StringOutput))
+		}, nil).Output())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-primitive-ref-optional/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-primitive-ref-optional/main.go
@@ -23,6 +23,9 @@ func main() {
 					"f": pulumi.Bool(false),
 				},
 			},
+			OptionalData: &optionalprimitiveref.DataArgs{
+				String: pulumi.String("optional parent"),
+			},
 		})
 		if err != nil {
 			return err
@@ -35,32 +38,18 @@ func main() {
 		}
 		_, err = optionalprimitiveref.NewResource(ctx, "fromNestedOptional", &optionalprimitiveref.ResourceArgs{
 			Data: &optionalprimitiveref.DataArgs{
-				String: setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
-					return data.String, nil
-				}).(pulumi.StringPtrOutput),
+				String: setRes.OptionalData.String(),
 			},
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("setBoolean", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*bool, error) {
-			return data.Boolean, nil
-		}).(pulumi.BoolPtrOutput))
-		ctx.Export("setFloat", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*float64, error) {
-			return data.Float, nil
-		}).(pulumi.Float64PtrOutput))
-		ctx.Export("setInteger", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*int, error) {
-			return data.Integer, nil
-		}).(pulumi.IntPtrOutput))
-		ctx.Export("setString", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
-			return data.String, nil
-		}).(pulumi.StringPtrOutput))
-		ctx.Export("setNumberArray", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) ([]float64, error) {
-			return data.NumberArray, nil
-		}).(pulumi.Float64ArrayOutput))
-		ctx.Export("setBooleanMap", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (map[string]bool, error) {
-			return data.BooleanMap, nil
-		}).(pulumi.BoolMapOutput))
+		ctx.Export("setBoolean", setRes.Data.Boolean())
+		ctx.Export("setFloat", setRes.Data.Float())
+		ctx.Export("setInteger", setRes.Data.Integer())
+		ctx.Export("setString", setRes.Data.String())
+		ctx.Export("setNumberArray", setRes.Data.NumberArray())
+		ctx.Export("setBooleanMap", setRes.Data.BooleanMap())
 		ctx.Export("unsetBoolean", unsetRes.Data.ApplyT(func(data optionalprimitiveref.Data) (string, error) {
 			var tmp0 string
 			if data.Boolean == nil {

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-provider-grpc-config-secret/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-provider-grpc-config-secret/main.go
@@ -11,54 +11,38 @@ func main() {
 		config_grpc_provider, err := configgrpc.NewProvider(ctx, "config_grpc_provider", &configgrpc.ProviderArgs{
 			String1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				String1: pulumi.String("SECRET"),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-				return invoke.String1, nil
-			}).(pulumi.StringOutput),
+			}, nil).String1(),
 			Int1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Int1: pulumi.Int(1234567890),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (int, error) {
-				return invoke.Int1, nil
-			}).(pulumi.IntOutput),
+			}, nil).Int1(),
 			Num1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Num1: pulumi.Float64(123456.789),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (float64, error) {
-				return invoke.Num1, nil
-			}).(pulumi.Float64Output),
+			}, nil).Num1(),
 			Bool1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Bool1: pulumi.Bool(true),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (bool, error) {
-				return invoke.Bool1, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Bool1(),
 			ListString1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				ListString1: pulumi.StringArray{
 					pulumi.String("SECRET"),
 					pulumi.String("SECRET2"),
 				},
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) ([]string, error) {
-				return invoke.ListString1, nil
-			}).(pulumi.StringArrayOutput),
+			}, nil).ListString1(),
 			ListString2: pulumi.StringArray{
 				pulumi.String("VALUE"),
 				configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 			MapString2: pulumi.StringMap{
 				"key1": pulumi.String("value1"),
 				"key2": configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 			ObjString2: &configgrpc.Tstring2Args{
 				X: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 		})
 		if err != nil {

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-proxy-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-proxy-index/main.go
@@ -55,9 +55,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("bool", res.Data.ApplyT(func(data refref.Data) (bool, error) {
-			return data.Boolean, nil
-		}).(pulumi.BoolOutput))
+		ctx.Export("bool", res.Data.Boolean())
 		ctx.Export("array", res.Data.ApplyT(func(data refref.Data) (bool, error) {
 			return data.BoolArray[0], nil
 		}).(pulumi.BoolOutput))

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-invoke-dynamic-function/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-invoke-dynamic-function/main.go
@@ -14,9 +14,7 @@ func main() {
 				pulumi.String(localValue),
 				pulumi.Any(map[string]interface{}{}),
 			},
-		}, nil).ApplyT(func(invoke anytypefunction.DynListToDynResult) (interface{}, error) {
-			return invoke.Result, nil
-		}).(pulumi.AnyOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l3-component-invoke/invokeComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l3-component-invoke/invokeComponent.go
@@ -29,20 +29,14 @@ func NewInvokeComponent(
 	// out, so parenting it must not displace the options bag into an argument slot.
 	greeting := multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil, pulumi.Parent(&componentResource))
 	providerConfig := config.GetConfigOutput(ctx, config.GetConfigOutputArgs{
-		Text: greeting.ApplyT(func(greeting multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return greeting.Result, nil
-		}).(pulumi.StringOutput),
+		Text: greeting.Result(),
 	}, pulumi.Parent(&componentResource))
 	err = ctx.RegisterResourceOutputs(&componentResource, pulumi.Map{
-		"result": providerConfig.ApplyT(func(providerConfig config.GetConfigResult) (string, error) {
-			return providerConfig.Text, nil
-		}).(pulumi.StringOutput),
+		"result": providerConfig.Text(),
 	})
 	if err != nil {
 		return nil, err
 	}
-	componentResource.Result = pulumi.Any(providerConfig.ApplyT(func(providerConfig config.GetConfigResult) (string, error) {
-		return providerConfig.Text, nil
-	}).(pulumi.StringOutput))
+	componentResource.Result = pulumi.Any(providerConfig.Text())
 	return &componentResource, nil
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/pulumiTypes.go
@@ -54,6 +54,47 @@ func (i DataArgs) ToDataOutputWithContext(ctx context.Context) DataOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DataOutput)
 }
 
+func (i DataArgs) ToDataPtrOutput() DataPtrOutput {
+	return i.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (i DataArgs) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DataOutput).ToDataPtrOutputWithContext(ctx)
+}
+
+// DataPtrInput is an input type that accepts DataArgs, DataPtr and DataPtrOutput values.
+// You can construct a concrete instance of `DataPtrInput` via:
+//
+//	        DataArgs{...}
+//
+//	or:
+//
+//	        nil
+type DataPtrInput interface {
+	pulumi.Input
+
+	ToDataPtrOutput() DataPtrOutput
+	ToDataPtrOutputWithContext(context.Context) DataPtrOutput
+}
+
+type dataPtrType DataArgs
+
+func DataPtr(v *DataArgs) DataPtrInput {
+	return (*dataPtrType)(v)
+}
+
+func (*dataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**Data)(nil)).Elem()
+}
+
+func (i *dataPtrType) ToDataPtrOutput() DataPtrOutput {
+	return i.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (i *dataPtrType) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DataPtrOutput)
+}
+
 type DataOutput struct{ *pulumi.OutputState }
 
 func (DataOutput) ElementType() reflect.Type {
@@ -66,6 +107,16 @@ func (o DataOutput) ToDataOutput() DataOutput {
 
 func (o DataOutput) ToDataOutputWithContext(ctx context.Context) DataOutput {
 	return o
+}
+
+func (o DataOutput) ToDataPtrOutput() DataPtrOutput {
+	return o.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (o DataOutput) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Data) *Data {
+		return &v
+	}).(DataPtrOutput)
 }
 
 func (o DataOutput) Boolean() pulumi.BoolPtrOutput {
@@ -92,7 +143,87 @@ func (o DataOutput) String() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Data) *string { return v.String }).(pulumi.StringPtrOutput)
 }
 
+type DataPtrOutput struct{ *pulumi.OutputState }
+
+func (DataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Data)(nil)).Elem()
+}
+
+func (o DataPtrOutput) ToDataPtrOutput() DataPtrOutput {
+	return o
+}
+
+func (o DataPtrOutput) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return o
+}
+
+func (o DataPtrOutput) Elem() DataOutput {
+	return o.ApplyT(func(v *Data) Data {
+		if v != nil {
+			return *v
+		}
+		var ret Data
+		return ret
+	}).(DataOutput)
+}
+
+func (o DataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Data) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o DataPtrOutput) BooleanMap() pulumi.BoolMapOutput {
+	return o.ApplyT(func(v *Data) map[string]bool {
+		if v == nil {
+			return nil
+		}
+		return v.BooleanMap
+	}).(pulumi.BoolMapOutput)
+}
+
+func (o DataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Data) *float64 {
+		if v == nil {
+			return nil
+		}
+		return v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o DataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Data) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o DataPtrOutput) NumberArray() pulumi.Float64ArrayOutput {
+	return o.ApplyT(func(v *Data) []float64 {
+		if v == nil {
+			return nil
+		}
+		return v.NumberArray
+	}).(pulumi.Float64ArrayOutput)
+}
+
+func (o DataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Data) *string {
+		if v == nil {
+			return nil
+		}
+		return v.String
+	}).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DataPtrInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
+	pulumi.RegisterOutputType(DataPtrOutput{})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/resource.go
@@ -15,7 +15,8 @@ import (
 type Resource struct {
 	pulumi.CustomResourceState
 
-	Data DataOutput `pulumi:"data"`
+	Data         DataOutput    `pulumi:"data"`
+	OptionalData DataPtrOutput `pulumi:"optionalData"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -61,12 +62,14 @@ func (ResourceState) ElementType() reflect.Type {
 }
 
 type resourceArgs struct {
-	Data Data `pulumi:"data"`
+	Data         Data  `pulumi:"data"`
+	OptionalData *Data `pulumi:"optionalData"`
 }
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Data DataInput
+	Data         DataInput
+	OptionalData DataPtrInput
 }
 
 func (ResourceArgs) ElementType() reflect.Type {
@@ -158,6 +161,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 
 func (o ResourceOutput) Data() DataOutput {
 	return o.ApplyT(func(v *Resource) DataOutput { return v.Data }).(DataOutput)
+}
+
+func (o ResourceOutput) OptionalData() DataPtrOutput {
+	return o.ApplyT(func(v *Resource) DataPtrOutput { return v.OptionalData }).(DataPtrOutput)
 }
 
 type ResourceArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-docs/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-docs/main.go
@@ -18,9 +18,7 @@ func main() {
 		_, err = docs.NewResource(ctx, "res", &docs.ResourceArgs{
 			In: docs.FunOutput(ctx, docs.FunOutputArgs{
 				In: pulumi.Bool(false),
-			}, nil).ApplyT(func(invoke docs.FunResult) (bool, error) {
-				return invoke.Out, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Out(),
 			ExternalEnum: enum.StringEnumStringOne,
 		})
 		if err != nil {

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-elide-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-elide-index/main.go
@@ -16,9 +16,7 @@ func main() {
 		}
 		ctx.Export("inv", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("test"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/main.go
@@ -19,9 +19,7 @@ func main() {
 		ctx.Export("parameterValueFromComponent", greetingComp.ParameterValue)
 		ctx.Export("invokeGreeting", myext.GreetOutput(ctx, myext.GreetOutputArgs{
 			Name: pulumi.String("Pulumi"),
-		}, nil).ApplyT(func(invoke myext.GreetResult) (string, error) {
-			return invoke.Greeting, nil
-		}).(pulumi.StringOutput))
+		}, nil).Greeting())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-index-mod/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-index-mod/main.go
@@ -11,9 +11,7 @@ func main() {
 		res1, err := indexmine.NewResource(ctx, "res1", &indexmine.ResourceArgs{
 			Text: indexmine.ConcatWorldOutput(ctx, indexmine.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke indexmine.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -30,9 +28,7 @@ func main() {
 		res2, err := nested.NewResource(ctx, "res2", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-dependencies/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-dependencies/main.go
@@ -20,9 +20,7 @@ func main() {
 			Value: simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 				Value:          pulumi.String("hello"),
 				SecretResponse: first.Value,
-			}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (bool, error) {
-				return invoke.Secret, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Secret(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-multi-argument/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-multi-argument/main.go
@@ -7,12 +7,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("both", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), pulumi.String("world")).ApplyT(func(invoke multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
-		ctx.Export("onlyRequired", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil).ApplyT(func(invoke multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("both", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), pulumi.String("world")).Result())
+		ctx.Export("onlyRequired", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-options-depends-on/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-options-depends-on/main.go
@@ -19,16 +19,12 @@ func main() {
 			pulumi.Resource(first),
 		}))
 		_, err = simpleinvoke.NewStringResource(ctx, "second", &simpleinvoke.StringResourceArgs{
-			Text: data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-				return data.Result, nil
-			}).(pulumi.StringOutput),
+			Text: data.Result(),
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("hello", data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-			return data.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("hello", data.Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-options/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-options/main.go
@@ -14,9 +14,7 @@ func main() {
 		data := simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
 		}, pulumi.Provider(explicitProvider), pulumi.Parent(explicitProvider), pulumi.Version("10.0.0"), pulumi.PluginDownloadURL("https://example.com/github/example"))
-		ctx.Export("hello", data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-			return data.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("hello", data.Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-output-only/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-output-only/main.go
@@ -9,14 +9,10 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("hello", outputonlyinvoke.MyInvokeOutput(ctx, outputonlyinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
-		}, nil).ApplyT(func(invoke outputonlyinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		ctx.Export("goodbye", outputonlyinvoke.MyInvokeOutput(ctx, outputonlyinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke outputonlyinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-secrets/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-secrets/main.go
@@ -17,21 +17,15 @@ func main() {
 		ctx.Export("nonSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.String("hello"),
 			SecretResponse: pulumi.Bool(false),
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		ctx.Export("firstSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.String("hello"),
 			SecretResponse: res.Value,
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		ctx.Export("secondSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.ToSecret("goodbye").(pulumi.StringOutput),
 			SecretResponse: pulumi.Bool(false),
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-simple/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-simple/main.go
@@ -9,14 +9,10 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("hello", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		ctx.Export("goodbye", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-variants/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-variants/main.go
@@ -15,12 +15,8 @@ func main() {
 		}
 		ctx.Export("outputInput", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: res.Text,
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
-		ctx.Export("unit", simpleinvoke.UnitOutput(ctx, simpleinvoke.UnitOutputArgs{}, nil).ApplyT(func(invoke simpleinvoke.UnitResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
+		ctx.Export("unit", simpleinvoke.UnitOutput(ctx, simpleinvoke.UnitOutputArgs{}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-map-keys-adversarial/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-map-keys-adversarial/main.go
@@ -49,9 +49,7 @@ func main() {
 			},
 		}, nil)
 		ctx.Export("resourceBooleanMap", res.BooleanMap)
-		ctx.Export("invokeBooleanMap", invokeResult.ApplyT(func(invokeResult primitive.InvokeResult) (map[string]bool, error) {
-			return invokeResult.BooleanMap, nil
-		}).(pulumi.BoolMapOutput))
+		ctx.Export("invokeBooleanMap", invokeResult.BooleanMap())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-module-format/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-module-format/main.go
@@ -15,9 +15,7 @@ func main() {
 		res1, err := mod.NewResource(ctx, "res1", &mod.ResourceArgs{
 			Text: mod.ConcatWorldOutput(ctx, mod.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke mod.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -35,9 +33,7 @@ func main() {
 		res2, err := mod.NewResource(ctx, "res2", &mod.ResourceArgs{
 			Text: mod.ConcatWorldOutput(ctx, mod.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke mod.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -55,9 +51,7 @@ func main() {
 		res3, err := nested.NewResource(ctx, "res3", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -75,9 +69,7 @@ func main() {
 		res4, err := nested.NewResource(ctx, "res4", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -95,9 +87,7 @@ func main() {
 		res5, err := moduleformat.NewResource(ctx, "res5", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("bonjour"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -115,9 +105,7 @@ func main() {
 		res6, err := moduleformat.NewResource(ctx, "res6", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("youkoso"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -135,9 +123,7 @@ func main() {
 		res7, err := moduleformat.NewResource(ctx, "res7", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("guten tag"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-parameterized-invoke/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-parameterized-invoke/main.go
@@ -9,9 +9,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("parameterValue", subpackage.DoHelloWorldOutput(ctx, subpackage.DoHelloWorldOutputArgs{
 			Input: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke subpackage.DoHelloWorldResult) (string, error) {
-			return invoke.Output, nil
-		}).(pulumi.StringOutput))
+		}, nil).Output())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/main.go
@@ -23,6 +23,9 @@ func main() {
 					"f": pulumi.Bool(false),
 				},
 			},
+			OptionalData: &optionalprimitiveref.DataArgs{
+				String: pulumi.String("optional parent"),
+			},
 		})
 		if err != nil {
 			return err
@@ -35,32 +38,18 @@ func main() {
 		}
 		_, err = optionalprimitiveref.NewResource(ctx, "fromNestedOptional", &optionalprimitiveref.ResourceArgs{
 			Data: &optionalprimitiveref.DataArgs{
-				String: setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
-					return data.String, nil
-				}).(pulumi.StringPtrOutput),
+				String: setRes.OptionalData.String(),
 			},
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("setBoolean", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*bool, error) {
-			return data.Boolean, nil
-		}).(pulumi.BoolPtrOutput))
-		ctx.Export("setFloat", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*float64, error) {
-			return data.Float, nil
-		}).(pulumi.Float64PtrOutput))
-		ctx.Export("setInteger", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*int, error) {
-			return data.Integer, nil
-		}).(pulumi.IntPtrOutput))
-		ctx.Export("setString", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
-			return data.String, nil
-		}).(pulumi.StringPtrOutput))
-		ctx.Export("setNumberArray", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) ([]float64, error) {
-			return data.NumberArray, nil
-		}).(pulumi.Float64ArrayOutput))
-		ctx.Export("setBooleanMap", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (map[string]bool, error) {
-			return data.BooleanMap, nil
-		}).(pulumi.BoolMapOutput))
+		ctx.Export("setBoolean", setRes.Data.Boolean())
+		ctx.Export("setFloat", setRes.Data.Float())
+		ctx.Export("setInteger", setRes.Data.Integer())
+		ctx.Export("setString", setRes.Data.String())
+		ctx.Export("setNumberArray", setRes.Data.NumberArray())
+		ctx.Export("setBooleanMap", setRes.Data.BooleanMap())
 		ctx.Export("unsetBoolean", unsetRes.Data.ApplyT(func(data optionalprimitiveref.Data) (string, error) {
 			var tmp0 string
 			if data.Boolean == nil {

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/pulumiTypes.go
@@ -54,6 +54,47 @@ func (i DataArgs) ToDataOutputWithContext(ctx context.Context) DataOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DataOutput)
 }
 
+func (i DataArgs) ToDataPtrOutput() DataPtrOutput {
+	return i.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (i DataArgs) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DataOutput).ToDataPtrOutputWithContext(ctx)
+}
+
+// DataPtrInput is an input type that accepts DataArgs, DataPtr and DataPtrOutput values.
+// You can construct a concrete instance of `DataPtrInput` via:
+//
+//	        DataArgs{...}
+//
+//	or:
+//
+//	        nil
+type DataPtrInput interface {
+	pulumi.Input
+
+	ToDataPtrOutput() DataPtrOutput
+	ToDataPtrOutputWithContext(context.Context) DataPtrOutput
+}
+
+type dataPtrType DataArgs
+
+func DataPtr(v *DataArgs) DataPtrInput {
+	return (*dataPtrType)(v)
+}
+
+func (*dataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**Data)(nil)).Elem()
+}
+
+func (i *dataPtrType) ToDataPtrOutput() DataPtrOutput {
+	return i.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (i *dataPtrType) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DataPtrOutput)
+}
+
 type DataOutput struct{ *pulumi.OutputState }
 
 func (DataOutput) ElementType() reflect.Type {
@@ -66,6 +107,16 @@ func (o DataOutput) ToDataOutput() DataOutput {
 
 func (o DataOutput) ToDataOutputWithContext(ctx context.Context) DataOutput {
 	return o
+}
+
+func (o DataOutput) ToDataPtrOutput() DataPtrOutput {
+	return o.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (o DataOutput) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Data) *Data {
+		return &v
+	}).(DataPtrOutput)
 }
 
 func (o DataOutput) Boolean() pulumi.BoolPtrOutput {
@@ -92,7 +143,87 @@ func (o DataOutput) String() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Data) *string { return v.String }).(pulumi.StringPtrOutput)
 }
 
+type DataPtrOutput struct{ *pulumi.OutputState }
+
+func (DataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Data)(nil)).Elem()
+}
+
+func (o DataPtrOutput) ToDataPtrOutput() DataPtrOutput {
+	return o
+}
+
+func (o DataPtrOutput) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return o
+}
+
+func (o DataPtrOutput) Elem() DataOutput {
+	return o.ApplyT(func(v *Data) Data {
+		if v != nil {
+			return *v
+		}
+		var ret Data
+		return ret
+	}).(DataOutput)
+}
+
+func (o DataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Data) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o DataPtrOutput) BooleanMap() pulumi.BoolMapOutput {
+	return o.ApplyT(func(v *Data) map[string]bool {
+		if v == nil {
+			return nil
+		}
+		return v.BooleanMap
+	}).(pulumi.BoolMapOutput)
+}
+
+func (o DataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Data) *float64 {
+		if v == nil {
+			return nil
+		}
+		return v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o DataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Data) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o DataPtrOutput) NumberArray() pulumi.Float64ArrayOutput {
+	return o.ApplyT(func(v *Data) []float64 {
+		if v == nil {
+			return nil
+		}
+		return v.NumberArray
+	}).(pulumi.Float64ArrayOutput)
+}
+
+func (o DataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Data) *string {
+		if v == nil {
+			return nil
+		}
+		return v.String
+	}).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DataPtrInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
+	pulumi.RegisterOutputType(DataPtrOutput{})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-primitive-ref-optional/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/resource.go
@@ -15,7 +15,8 @@ import (
 type Resource struct {
 	pulumi.CustomResourceState
 
-	Data DataOutput `pulumi:"data"`
+	Data         DataOutput    `pulumi:"data"`
+	OptionalData DataPtrOutput `pulumi:"optionalData"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -61,12 +62,14 @@ func (ResourceState) ElementType() reflect.Type {
 }
 
 type resourceArgs struct {
-	Data Data `pulumi:"data"`
+	Data         Data  `pulumi:"data"`
+	OptionalData *Data `pulumi:"optionalData"`
 }
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Data DataInput
+	Data         DataInput
+	OptionalData DataPtrInput
 }
 
 func (ResourceArgs) ElementType() reflect.Type {
@@ -108,6 +111,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 
 func (o ResourceOutput) Data() DataOutput {
 	return o.ApplyT(func(v *Resource) DataOutput { return v.Data }).(DataOutput)
+}
+
+func (o ResourceOutput) OptionalData() DataPtrOutput {
+	return o.ApplyT(func(v *Resource) DataPtrOutput { return v.OptionalData }).(DataPtrOutput)
 }
 
 func init() {

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-provider-grpc-config-secret/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-provider-grpc-config-secret/main.go
@@ -11,54 +11,38 @@ func main() {
 		config_grpc_provider, err := configgrpc.NewProvider(ctx, "config_grpc_provider", &configgrpc.ProviderArgs{
 			String1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				String1: pulumi.String("SECRET"),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-				return invoke.String1, nil
-			}).(pulumi.StringOutput),
+			}, nil).String1(),
 			Int1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Int1: pulumi.Int(1234567890),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (int, error) {
-				return invoke.Int1, nil
-			}).(pulumi.IntOutput),
+			}, nil).Int1(),
 			Num1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Num1: pulumi.Float64(123456.789),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (float64, error) {
-				return invoke.Num1, nil
-			}).(pulumi.Float64Output),
+			}, nil).Num1(),
 			Bool1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Bool1: pulumi.Bool(true),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (bool, error) {
-				return invoke.Bool1, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Bool1(),
 			ListString1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				ListString1: pulumi.StringArray{
 					pulumi.String("SECRET"),
 					pulumi.String("SECRET2"),
 				},
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) ([]string, error) {
-				return invoke.ListString1, nil
-			}).(pulumi.StringArrayOutput),
+			}, nil).ListString1(),
 			ListString2: pulumi.StringArray{
 				pulumi.String("VALUE"),
 				configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 			MapString2: pulumi.StringMap{
 				"key1": pulumi.String("value1"),
 				"key2": configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 			ObjString2: &configgrpc.Tstring2Args{
 				X: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 		})
 		if err != nil {

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-proxy-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-proxy-index/main.go
@@ -55,9 +55,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("bool", res.Data.ApplyT(func(data refref.Data) (bool, error) {
-			return data.Boolean, nil
-		}).(pulumi.BoolOutput))
+		ctx.Export("bool", res.Data.Boolean())
 		ctx.Export("array", res.Data.ApplyT(func(data refref.Data) (bool, error) {
 			return data.BoolArray[0], nil
 		}).(pulumi.BoolOutput))

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-invoke-dynamic-function/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-invoke-dynamic-function/main.go
@@ -14,9 +14,7 @@ func main() {
 				pulumi.String(localValue),
 				pulumi.Any(map[string]interface{}{}),
 			},
-		}, nil).ApplyT(func(invoke anytypefunction.DynListToDynResult) (interface{}, error) {
-			return invoke.Result, nil
-		}).(pulumi.AnyOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l3-component-invoke/invokeComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l3-component-invoke/invokeComponent.go
@@ -29,20 +29,14 @@ func NewInvokeComponent(
 	// out, so parenting it must not displace the options bag into an argument slot.
 	greeting := multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil, pulumi.Parent(&componentResource))
 	providerConfig := config.GetConfigOutput(ctx, config.GetConfigOutputArgs{
-		Text: greeting.ApplyT(func(greeting multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return greeting.Result, nil
-		}).(pulumi.StringOutput),
+		Text: greeting.Result(),
 	}, pulumi.Parent(&componentResource))
 	err = ctx.RegisterResourceOutputs(&componentResource, pulumi.Map{
-		"result": providerConfig.ApplyT(func(providerConfig config.GetConfigResult) (string, error) {
-			return providerConfig.Text, nil
-		}).(pulumi.StringOutput),
+		"result": providerConfig.Text(),
 	})
 	if err != nil {
 		return nil, err
 	}
-	componentResource.Result = pulumi.Any(providerConfig.ApplyT(func(providerConfig config.GetConfigResult) (string, error) {
-		return providerConfig.Text, nil
-	}).(pulumi.StringOutput))
+	componentResource.Result = pulumi.Any(providerConfig.Text())
 	return &componentResource, nil
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-docs/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-docs/main.go
@@ -18,9 +18,7 @@ func main() {
 		_, err = docs.NewResource(ctx, "res", &docs.ResourceArgs{
 			In: docs.FunOutput(ctx, docs.FunOutputArgs{
 				In: pulumi.Bool(false),
-			}, nil).ApplyT(func(invoke docs.FunResult) (bool, error) {
-				return invoke.Out, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Out(),
 			ExternalEnum: enum.StringEnumStringOne,
 		})
 		if err != nil {

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-elide-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-elide-index/main.go
@@ -16,9 +16,7 @@ func main() {
 		}
 		ctx.Export("inv", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("test"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-extension-parameterized-resource/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-extension-parameterized-resource/main.go
@@ -19,9 +19,7 @@ func main() {
 		ctx.Export("parameterValueFromComponent", greetingComp.ParameterValue)
 		ctx.Export("invokeGreeting", myext.GreetOutput(ctx, myext.GreetOutputArgs{
 			Name: pulumi.String("Pulumi"),
-		}, nil).ApplyT(func(invoke myext.GreetResult) (string, error) {
-			return invoke.Greeting, nil
-		}).(pulumi.StringOutput))
+		}, nil).Greeting())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-index-mod/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-index-mod/main.go
@@ -11,9 +11,7 @@ func main() {
 		res1, err := indexmine.NewResource(ctx, "res1", &indexmine.ResourceArgs{
 			Text: indexmine.ConcatWorldOutput(ctx, indexmine.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke indexmine.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -30,9 +28,7 @@ func main() {
 		res2, err := nested.NewResource(ctx, "res2", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-dependencies/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-dependencies/main.go
@@ -20,9 +20,7 @@ func main() {
 			Value: simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 				Value:          pulumi.String("hello"),
 				SecretResponse: first.Value,
-			}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (bool, error) {
-				return invoke.Secret, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Secret(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-multi-argument/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-multi-argument/main.go
@@ -7,12 +7,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		ctx.Export("both", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), pulumi.String("world")).ApplyT(func(invoke multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
-		ctx.Export("onlyRequired", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil).ApplyT(func(invoke multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("both", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), pulumi.String("world")).Result())
+		ctx.Export("onlyRequired", multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-options-depends-on/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-options-depends-on/main.go
@@ -19,16 +19,12 @@ func main() {
 			pulumi.Resource(first),
 		}))
 		_, err = simpleinvoke.NewStringResource(ctx, "second", &simpleinvoke.StringResourceArgs{
-			Text: data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-				return data.Result, nil
-			}).(pulumi.StringOutput),
+			Text: data.Result(),
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("hello", data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-			return data.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("hello", data.Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-options/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-options/main.go
@@ -14,9 +14,7 @@ func main() {
 		data := simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
 		}, pulumi.Provider(explicitProvider), pulumi.Parent(explicitProvider), pulumi.Version("10.0.0"), pulumi.PluginDownloadURL("https://example.com/github/example"))
-		ctx.Export("hello", data.ApplyT(func(data simpleinvoke.MyInvokeResult) (string, error) {
-			return data.Result, nil
-		}).(pulumi.StringOutput))
+		ctx.Export("hello", data.Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-output-only/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-output-only/main.go
@@ -9,14 +9,10 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("hello", outputonlyinvoke.MyInvokeOutput(ctx, outputonlyinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
-		}, nil).ApplyT(func(invoke outputonlyinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		ctx.Export("goodbye", outputonlyinvoke.MyInvokeOutput(ctx, outputonlyinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke outputonlyinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-secrets/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-secrets/main.go
@@ -17,21 +17,15 @@ func main() {
 		ctx.Export("nonSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.String("hello"),
 			SecretResponse: pulumi.Bool(false),
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		ctx.Export("firstSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.String("hello"),
 			SecretResponse: res.Value,
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		ctx.Export("secondSecret", simpleinvoke.SecretInvokeOutput(ctx, simpleinvoke.SecretInvokeOutputArgs{
 			Value:          pulumi.ToSecret("goodbye").(pulumi.StringOutput),
 			SecretResponse: pulumi.Bool(false),
-		}, nil).ApplyT(func(invoke simpleinvoke.SecretInvokeResult) (string, error) {
-			return invoke.Response, nil
-		}).(pulumi.StringOutput))
+		}, nil).Response())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-simple/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-simple/main.go
@@ -9,14 +9,10 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("hello", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("hello"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		ctx.Export("goodbye", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-variants/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-variants/main.go
@@ -15,12 +15,8 @@ func main() {
 		}
 		ctx.Export("outputInput", simpleinvoke.MyInvokeOutput(ctx, simpleinvoke.MyInvokeOutputArgs{
 			Value: res.Text,
-		}, nil).ApplyT(func(invoke simpleinvoke.MyInvokeResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
-		ctx.Export("unit", simpleinvoke.UnitOutput(ctx, simpleinvoke.UnitOutputArgs{}, nil).ApplyT(func(invoke simpleinvoke.UnitResult) (string, error) {
-			return invoke.Result, nil
-		}).(pulumi.StringOutput))
+		}, nil).Result())
+		ctx.Export("unit", simpleinvoke.UnitOutput(ctx, simpleinvoke.UnitOutputArgs{}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-map-keys-adversarial/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-map-keys-adversarial/main.go
@@ -49,9 +49,7 @@ func main() {
 			},
 		}, nil)
 		ctx.Export("resourceBooleanMap", res.BooleanMap)
-		ctx.Export("invokeBooleanMap", invokeResult.ApplyT(func(invokeResult primitive.InvokeResult) (map[string]bool, error) {
-			return invokeResult.BooleanMap, nil
-		}).(pulumi.BoolMapOutput))
+		ctx.Export("invokeBooleanMap", invokeResult.BooleanMap())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-module-format/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-module-format/main.go
@@ -15,9 +15,7 @@ func main() {
 		res1, err := mod.NewResource(ctx, "res1", &mod.ResourceArgs{
 			Text: mod.ConcatWorldOutput(ctx, mod.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke mod.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -35,9 +33,7 @@ func main() {
 		res2, err := mod.NewResource(ctx, "res2", &mod.ResourceArgs{
 			Text: mod.ConcatWorldOutput(ctx, mod.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke mod.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -55,9 +51,7 @@ func main() {
 		res3, err := nested.NewResource(ctx, "res3", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("hello"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -75,9 +69,7 @@ func main() {
 		res4, err := nested.NewResource(ctx, "res4", &nested.ResourceArgs{
 			Text: nested.ConcatWorldOutput(ctx, nested.ConcatWorldOutputArgs{
 				Value: pulumi.String("goodbye"),
-			}, nil).ApplyT(func(invoke nested.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -95,9 +87,7 @@ func main() {
 		res5, err := moduleformat.NewResource(ctx, "res5", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("bonjour"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -115,9 +105,7 @@ func main() {
 		res6, err := moduleformat.NewResource(ctx, "res6", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("youkoso"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err
@@ -135,9 +123,7 @@ func main() {
 		res7, err := moduleformat.NewResource(ctx, "res7", &moduleformat.ResourceArgs{
 			Text: moduleformat.ConcatWorldOutput(ctx, moduleformat.ConcatWorldOutputArgs{
 				Value: pulumi.String("guten tag"),
-			}, nil).ApplyT(func(invoke moduleformat.ConcatWorldResult) (string, error) {
-				return invoke.Result, nil
-			}).(pulumi.StringOutput),
+			}, nil).Result(),
 		})
 		if err != nil {
 			return err

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-parameterized-invoke/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-parameterized-invoke/main.go
@@ -9,9 +9,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		ctx.Export("parameterValue", subpackage.DoHelloWorldOutput(ctx, subpackage.DoHelloWorldOutputArgs{
 			Input: pulumi.String("goodbye"),
-		}, nil).ApplyT(func(invoke subpackage.DoHelloWorldResult) (string, error) {
-			return invoke.Output, nil
-		}).(pulumi.StringOutput))
+		}, nil).Output())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-primitive-ref-optional/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-primitive-ref-optional/main.go
@@ -23,6 +23,9 @@ func main() {
 					"f": pulumi.Bool(false),
 				},
 			},
+			OptionalData: &optionalprimitiveref.DataArgs{
+				String: pulumi.String("optional parent"),
+			},
 		})
 		if err != nil {
 			return err
@@ -35,32 +38,18 @@ func main() {
 		}
 		_, err = optionalprimitiveref.NewResource(ctx, "fromNestedOptional", &optionalprimitiveref.ResourceArgs{
 			Data: &optionalprimitiveref.DataArgs{
-				String: setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
-					return data.String, nil
-				}).(pulumi.StringPtrOutput),
+				String: setRes.OptionalData.String(),
 			},
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("setBoolean", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*bool, error) {
-			return data.Boolean, nil
-		}).(pulumi.BoolPtrOutput))
-		ctx.Export("setFloat", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*float64, error) {
-			return data.Float, nil
-		}).(pulumi.Float64PtrOutput))
-		ctx.Export("setInteger", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*int, error) {
-			return data.Integer, nil
-		}).(pulumi.IntPtrOutput))
-		ctx.Export("setString", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
-			return data.String, nil
-		}).(pulumi.StringPtrOutput))
-		ctx.Export("setNumberArray", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) ([]float64, error) {
-			return data.NumberArray, nil
-		}).(pulumi.Float64ArrayOutput))
-		ctx.Export("setBooleanMap", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (map[string]bool, error) {
-			return data.BooleanMap, nil
-		}).(pulumi.BoolMapOutput))
+		ctx.Export("setBoolean", setRes.Data.Boolean())
+		ctx.Export("setFloat", setRes.Data.Float())
+		ctx.Export("setInteger", setRes.Data.Integer())
+		ctx.Export("setString", setRes.Data.String())
+		ctx.Export("setNumberArray", setRes.Data.NumberArray())
+		ctx.Export("setBooleanMap", setRes.Data.BooleanMap())
 		ctx.Export("unsetBoolean", unsetRes.Data.ApplyT(func(data optionalprimitiveref.Data) (string, error) {
 			var tmp0 string
 			if data.Boolean == nil {

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-provider-grpc-config-secret/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-provider-grpc-config-secret/main.go
@@ -11,54 +11,38 @@ func main() {
 		config_grpc_provider, err := configgrpc.NewProvider(ctx, "config_grpc_provider", &configgrpc.ProviderArgs{
 			String1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				String1: pulumi.String("SECRET"),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-				return invoke.String1, nil
-			}).(pulumi.StringOutput),
+			}, nil).String1(),
 			Int1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Int1: pulumi.Int(1234567890),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (int, error) {
-				return invoke.Int1, nil
-			}).(pulumi.IntOutput),
+			}, nil).Int1(),
 			Num1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Num1: pulumi.Float64(123456.789),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (float64, error) {
-				return invoke.Num1, nil
-			}).(pulumi.Float64Output),
+			}, nil).Num1(),
 			Bool1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				Bool1: pulumi.Bool(true),
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (bool, error) {
-				return invoke.Bool1, nil
-			}).(pulumi.BoolOutput),
+			}, nil).Bool1(),
 			ListString1: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 				ListString1: pulumi.StringArray{
 					pulumi.String("SECRET"),
 					pulumi.String("SECRET2"),
 				},
-			}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) ([]string, error) {
-				return invoke.ListString1, nil
-			}).(pulumi.StringArrayOutput),
+			}, nil).ListString1(),
 			ListString2: pulumi.StringArray{
 				pulumi.String("VALUE"),
 				configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 			MapString2: pulumi.StringMap{
 				"key1": pulumi.String("value1"),
 				"key2": configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 			ObjString2: &configgrpc.Tstring2Args{
 				X: configgrpc.ToSecretOutput(ctx, configgrpc.ToSecretOutputArgs{
 					String1: pulumi.String("SECRET"),
-				}, nil).ApplyT(func(invoke configgrpc.ToSecretResult) (string, error) {
-					return invoke.String1, nil
-				}).(pulumi.StringOutput),
+				}, nil).String1(),
 			},
 		})
 		if err != nil {

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-proxy-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-proxy-index/main.go
@@ -55,9 +55,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("bool", res.Data.ApplyT(func(data refref.Data) (bool, error) {
-			return data.Boolean, nil
-		}).(pulumi.BoolOutput))
+		ctx.Export("bool", res.Data.Boolean())
 		ctx.Export("array", res.Data.ApplyT(func(data refref.Data) (bool, error) {
 			return data.BoolArray[0], nil
 		}).(pulumi.BoolOutput))

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-invoke-dynamic-function/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-invoke-dynamic-function/main.go
@@ -14,9 +14,7 @@ func main() {
 				pulumi.String(localValue),
 				pulumi.Any(map[string]interface{}{}),
 			},
-		}, nil).ApplyT(func(invoke anytypefunction.DynListToDynResult) (interface{}, error) {
-			return invoke.Result, nil
-		}).(pulumi.AnyOutput))
+		}, nil).Result())
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l3-component-invoke/invokeComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l3-component-invoke/invokeComponent.go
@@ -29,20 +29,14 @@ func NewInvokeComponent(
 	// out, so parenting it must not displace the options bag into an argument slot.
 	greeting := multiargumentinvoke.MultiArgumentInvokeOutput(ctx, pulumi.String("hello"), nil, pulumi.Parent(&componentResource))
 	providerConfig := config.GetConfigOutput(ctx, config.GetConfigOutputArgs{
-		Text: greeting.ApplyT(func(greeting multiargumentinvoke.MultiArgumentInvokeResult) (string, error) {
-			return greeting.Result, nil
-		}).(pulumi.StringOutput),
+		Text: greeting.Result(),
 	}, pulumi.Parent(&componentResource))
 	err = ctx.RegisterResourceOutputs(&componentResource, pulumi.Map{
-		"result": providerConfig.ApplyT(func(providerConfig config.GetConfigResult) (string, error) {
-			return providerConfig.Text, nil
-		}).(pulumi.StringOutput),
+		"result": providerConfig.Text(),
 	})
 	if err != nil {
 		return nil, err
 	}
-	componentResource.Result = pulumi.Any(providerConfig.ApplyT(func(providerConfig config.GetConfigResult) (string, error) {
-		return providerConfig.Text, nil
-	}).(pulumi.StringOutput))
+	componentResource.Result = pulumi.Any(providerConfig.Text())
 	return &componentResource, nil
 }

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/pulumiTypes.go
@@ -54,6 +54,47 @@ func (i DataArgs) ToDataOutputWithContext(ctx context.Context) DataOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DataOutput)
 }
 
+func (i DataArgs) ToDataPtrOutput() DataPtrOutput {
+	return i.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (i DataArgs) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DataOutput).ToDataPtrOutputWithContext(ctx)
+}
+
+// DataPtrInput is an input type that accepts DataArgs, DataPtr and DataPtrOutput values.
+// You can construct a concrete instance of `DataPtrInput` via:
+//
+//	        DataArgs{...}
+//
+//	or:
+//
+//	        nil
+type DataPtrInput interface {
+	pulumi.Input
+
+	ToDataPtrOutput() DataPtrOutput
+	ToDataPtrOutputWithContext(context.Context) DataPtrOutput
+}
+
+type dataPtrType DataArgs
+
+func DataPtr(v *DataArgs) DataPtrInput {
+	return (*dataPtrType)(v)
+}
+
+func (*dataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**Data)(nil)).Elem()
+}
+
+func (i *dataPtrType) ToDataPtrOutput() DataPtrOutput {
+	return i.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (i *dataPtrType) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DataPtrOutput)
+}
+
 type DataOutput struct{ *pulumi.OutputState }
 
 func (DataOutput) ElementType() reflect.Type {
@@ -66,6 +107,16 @@ func (o DataOutput) ToDataOutput() DataOutput {
 
 func (o DataOutput) ToDataOutputWithContext(ctx context.Context) DataOutput {
 	return o
+}
+
+func (o DataOutput) ToDataPtrOutput() DataPtrOutput {
+	return o.ToDataPtrOutputWithContext(context.Background())
+}
+
+func (o DataOutput) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Data) *Data {
+		return &v
+	}).(DataPtrOutput)
 }
 
 func (o DataOutput) Boolean() pulumi.BoolPtrOutput {
@@ -92,7 +143,87 @@ func (o DataOutput) String() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Data) *string { return v.String }).(pulumi.StringPtrOutput)
 }
 
+type DataPtrOutput struct{ *pulumi.OutputState }
+
+func (DataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Data)(nil)).Elem()
+}
+
+func (o DataPtrOutput) ToDataPtrOutput() DataPtrOutput {
+	return o
+}
+
+func (o DataPtrOutput) ToDataPtrOutputWithContext(ctx context.Context) DataPtrOutput {
+	return o
+}
+
+func (o DataPtrOutput) Elem() DataOutput {
+	return o.ApplyT(func(v *Data) Data {
+		if v != nil {
+			return *v
+		}
+		var ret Data
+		return ret
+	}).(DataOutput)
+}
+
+func (o DataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Data) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o DataPtrOutput) BooleanMap() pulumi.BoolMapOutput {
+	return o.ApplyT(func(v *Data) map[string]bool {
+		if v == nil {
+			return nil
+		}
+		return v.BooleanMap
+	}).(pulumi.BoolMapOutput)
+}
+
+func (o DataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Data) *float64 {
+		if v == nil {
+			return nil
+		}
+		return v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o DataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Data) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o DataPtrOutput) NumberArray() pulumi.Float64ArrayOutput {
+	return o.ApplyT(func(v *Data) []float64 {
+		if v == nil {
+			return nil
+		}
+		return v.NumberArray
+	}).(pulumi.Float64ArrayOutput)
+}
+
+func (o DataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Data) *string {
+		if v == nil {
+			return nil
+		}
+		return v.String
+	}).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DataPtrInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
+	pulumi.RegisterOutputType(DataPtrOutput{})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/optional-primitive-ref-40.0.0/optionalprimitiveref/resource.go
@@ -15,7 +15,8 @@ import (
 type Resource struct {
 	pulumi.CustomResourceState
 
-	Data DataOutput `pulumi:"data"`
+	Data         DataOutput    `pulumi:"data"`
+	OptionalData DataPtrOutput `pulumi:"optionalData"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -61,12 +62,14 @@ func (ResourceState) ElementType() reflect.Type {
 }
 
 type resourceArgs struct {
-	Data Data `pulumi:"data"`
+	Data         Data  `pulumi:"data"`
+	OptionalData *Data `pulumi:"optionalData"`
 }
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Data DataInput
+	Data         DataInput
+	OptionalData DataPtrInput
 }
 
 func (ResourceArgs) ElementType() reflect.Type {
@@ -108,6 +111,10 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 
 func (o ResourceOutput) Data() DataOutput {
 	return o.ApplyT(func(v *Resource) DataOutput { return v.Data }).(DataOutput)
+}
+
+func (o ResourceOutput) OptionalData() DataPtrOutput {
+	return o.ApplyT(func(v *Resource) DataPtrOutput { return v.OptionalData }).(DataPtrOutput)
 }
 
 func init() {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-primitive-ref-optional/index.ts
@@ -1,24 +1,29 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as optional_primitive_ref from "@pulumi/optional-primitive-ref";
 
-const setRes = new optional_primitive_ref.Resource("setRes", {data: {
-    boolean: true,
-    float: 3.14,
-    integer: 42,
-    string: "hello",
-    numberArray: [
-        -1,
-        0,
-        1,
-    ],
-    booleanMap: {
-        t: true,
-        f: false,
+const setRes = new optional_primitive_ref.Resource("setRes", {
+    data: {
+        boolean: true,
+        float: 3.14,
+        integer: 42,
+        string: "hello",
+        numberArray: [
+            -1,
+            0,
+            1,
+        ],
+        booleanMap: {
+            t: true,
+            f: false,
+        },
     },
-}});
+    optionalData: {
+        string: "optional parent",
+    },
+});
 const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
 const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
-    string: setRes.data.apply(data => data.string),
+    string: setRes.optionalData.apply(optionalData => optionalData?.string),
 }});
 export const setBoolean = setRes.data.apply(data => data.boolean);
 export const setFloat = setRes.data.apply(data => data.float);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/optional-primitive-ref-40.0.0/resource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/optional-primitive-ref-40.0.0/resource.ts
@@ -34,6 +34,7 @@ export class Resource extends pulumi.CustomResource {
     }
 
     declare public readonly data: pulumi.Output<outputs.Data>;
+    declare public readonly optionalData: pulumi.Output<outputs.Data | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -50,8 +51,10 @@ export class Resource extends pulumi.CustomResource {
                 throw new Error("Missing required property 'data'");
             }
             resourceInputs["data"] = args?.data;
+            resourceInputs["optionalData"] = args?.optionalData;
         } else {
             resourceInputs["data"] = undefined /*out*/;
+            resourceInputs["optionalData"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
@@ -63,4 +66,5 @@ export class Resource extends pulumi.CustomResource {
  */
 export interface ResourceArgs {
     data: pulumi.Input<inputs.DataArgs>;
+    optionalData?: pulumi.Input<inputs.DataArgs | undefined>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-primitive-ref-optional/index.ts
@@ -1,24 +1,29 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as optional_primitive_ref from "@pulumi/optional-primitive-ref";
 
-const setRes = new optional_primitive_ref.Resource("setRes", {data: {
-    boolean: true,
-    float: 3.14,
-    integer: 42,
-    string: "hello",
-    numberArray: [
-        -1,
-        0,
-        1,
-    ],
-    booleanMap: {
-        t: true,
-        f: false,
+const setRes = new optional_primitive_ref.Resource("setRes", {
+    data: {
+        boolean: true,
+        float: 3.14,
+        integer: 42,
+        string: "hello",
+        numberArray: [
+            -1,
+            0,
+            1,
+        ],
+        booleanMap: {
+            t: true,
+            f: false,
+        },
     },
-}});
+    optionalData: {
+        string: "optional parent",
+    },
+});
 const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
 const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
-    string: setRes.data.apply(data => data.string),
+    string: setRes.optionalData.apply(optionalData => optionalData?.string),
 }});
 export const setBoolean = setRes.data.apply(data => data.boolean);
 export const setFloat = setRes.data.apply(data => data.float);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/optional-primitive-ref-40.0.0/resource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/optional-primitive-ref-40.0.0/resource.ts
@@ -34,6 +34,7 @@ export class Resource extends pulumi.CustomResource {
     }
 
     declare public readonly data: pulumi.Output<outputs.Data>;
+    declare public readonly optionalData: pulumi.Output<outputs.Data | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -50,8 +51,10 @@ export class Resource extends pulumi.CustomResource {
                 throw new Error("Missing required property 'data'");
             }
             resourceInputs["data"] = args?.data;
+            resourceInputs["optionalData"] = args?.optionalData;
         } else {
             resourceInputs["data"] = undefined /*out*/;
+            resourceInputs["optionalData"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
@@ -63,4 +66,5 @@ export class Resource extends pulumi.CustomResource {
  */
 export interface ResourceArgs {
     data: pulumi.Input<inputs.DataArgs>;
+    optionalData?: pulumi.Input<inputs.DataArgs | undefined>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-primitive-ref-optional/index.ts
@@ -1,24 +1,29 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as optional_primitive_ref from "@pulumi/optional-primitive-ref";
 
-const setRes = new optional_primitive_ref.Resource("setRes", {data: {
-    boolean: true,
-    float: 3.14,
-    integer: 42,
-    string: "hello",
-    numberArray: [
-        -1,
-        0,
-        1,
-    ],
-    booleanMap: {
-        t: true,
-        f: false,
+const setRes = new optional_primitive_ref.Resource("setRes", {
+    data: {
+        boolean: true,
+        float: 3.14,
+        integer: 42,
+        string: "hello",
+        numberArray: [
+            -1,
+            0,
+            1,
+        ],
+        booleanMap: {
+            t: true,
+            f: false,
+        },
     },
-}});
+    optionalData: {
+        string: "optional parent",
+    },
+});
 const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
 const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
-    string: setRes.data.apply(data => data.string),
+    string: setRes.optionalData.apply(optionalData => optionalData?.string),
 }});
 export const setBoolean = setRes.data.apply(data => data.boolean);
 export const setFloat = setRes.data.apply(data => data.float);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/optional-primitive-ref-40.0.0/resource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/optional-primitive-ref-40.0.0/resource.ts
@@ -34,6 +34,7 @@ export class Resource extends pulumi.CustomResource {
     }
 
     declare public readonly data: pulumi.Output<outputs.Data>;
+    declare public readonly optionalData: pulumi.Output<outputs.Data | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -50,8 +51,10 @@ export class Resource extends pulumi.CustomResource {
                 throw new Error("Missing required property 'data'");
             }
             resourceInputs["data"] = args?.data;
+            resourceInputs["optionalData"] = args?.optionalData;
         } else {
             resourceInputs["data"] = undefined /*out*/;
+            resourceInputs["optionalData"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
@@ -63,4 +66,5 @@ export class Resource extends pulumi.CustomResource {
  */
 export interface ResourceArgs {
     data: pulumi.Input<inputs.DataArgs>;
+    optionalData?: pulumi.Input<inputs.DataArgs | undefined>;
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-primitive-ref-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-primitive-ref-optional/main.pp
@@ -10,6 +10,9 @@ resource "setRes" "optional-primitive-ref:index:Resource" {
             "f" = false,
         }
     }
+    optionalData = {
+        string = "optional parent"
+    }
 }
 
 resource "unsetRes" "optional-primitive-ref:index:Resource" {
@@ -18,13 +21,10 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
 
 resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
     data = {
-        string = setRes.data.string
+        string = setRes.optionalData.string
     }
 }
 
-# Traversal through an output object (data) to an optional inner scalar.
-# In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
-# where the inner field type is already a pointer - the SDK generator must not double-pointer it.
 output "setBoolean" {
     value = setRes.data.boolean
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-primitive-ref-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-primitive-ref-optional/main.pp
@@ -10,6 +10,9 @@ resource "setRes" "optional-primitive-ref:index:Resource" {
             "f" = false,
         }
     }
+    optionalData = {
+        string = "optional parent"
+    }
 }
 
 resource "unsetRes" "optional-primitive-ref:index:Resource" {
@@ -18,13 +21,10 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
 
 resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
     data = {
-        string = setRes.data.string
+        string = setRes.optionalData.string
     }
 }
 
-# Traversal through an output object (data) to an optional inner scalar.
-# In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
-# where the inner field type is already a pointer - the SDK generator must not double-pointer it.
 output "setBoolean" {
     value = setRes.data.boolean
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-primitive-ref-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-primitive-ref-optional/main.pp
@@ -10,6 +10,9 @@ resource "setRes" "optional-primitive-ref:index:Resource" {
             "f" = false,
         }
     }
+    optionalData = {
+        string = "optional parent"
+    }
 }
 
 resource "unsetRes" "optional-primitive-ref:index:Resource" {
@@ -18,13 +21,10 @@ resource "unsetRes" "optional-primitive-ref:index:Resource" {
 
 resource "fromNestedOptional" "optional-primitive-ref:index:Resource" {
     data = {
-        string = setRes.data.string
+        string = setRes.optionalData.string
     }
 }
 
-# Traversal through an output object (data) to an optional inner scalar.
-# In Go this lowers to `setRes.Data.ApplyT(func(d Data) (*T, error) { ... return ?d.Field, nil })`
-# where the inner field type is already a pointer - the SDK generator must not double-pointer it.
 output "setBoolean" {
     value = setRes.data.boolean
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-primitive-ref-optional/__main__.py
@@ -1,24 +1,28 @@
 import pulumi
 import pulumi_optional_primitive_ref as optional_primitive_ref
 
-set_res = optional_primitive_ref.Resource("setRes", data=optional_primitive_ref.DataArgs(
-    boolean=True,
-    float=3.14,
-    integer=42,
-    string="hello",
-    number_array=[
-        float(-1),
-        float(0),
-        float(1),
-    ],
-    boolean_map={
-        "t": True,
-        "f": False,
-    },
-))
+set_res = optional_primitive_ref.Resource("setRes",
+    data=optional_primitive_ref.DataArgs(
+        boolean=True,
+        float=3.14,
+        integer=42,
+        string="hello",
+        number_array=[
+            float(-1),
+            float(0),
+            float(1),
+        ],
+        boolean_map={
+            "t": True,
+            "f": False,
+        },
+    ),
+    optional_data=optional_primitive_ref.DataArgs(
+        string="optional parent",
+    ))
 unset_res = optional_primitive_ref.Resource("unsetRes", data=optional_primitive_ref.DataArgs())
 from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data=optional_primitive_ref.DataArgs(
-    string=set_res.data.string,
+    string=set_res.optional_data.string,
 ))
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
@@ -16,11 +16,14 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 data: pulumi.Input['DataArgs']):
+                 data: pulumi.Input['DataArgs'],
+                 optional_data: pulumi.Input[Optional['DataArgs']] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
         pulumi.set(__self__, "data", data)
+        if optional_data is not None:
+            pulumi.set(__self__, "optional_data", optional_data)
 
     @_builtins.property
     @pulumi.getter
@@ -31,6 +34,15 @@ class ResourceArgs:
     def data(self, value: pulumi.Input['DataArgs']):
         pulumi.set(self, "data", value)
 
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Input[Optional['DataArgs']]:
+        return pulumi.get(self, "optional_data")
+
+    @optional_data.setter
+    def optional_data(self, value: pulumi.Input[Optional['DataArgs']]):
+        pulumi.set(self, "optional_data", value)
+
 
 @pulumi.type_token("optional-primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -39,6 +51,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
+                 optional_data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -71,6 +84,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
+                 optional_data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -83,6 +97,7 @@ class Resource(pulumi.CustomResource):
             if data is None and not opts.urn:
                 raise TypeError("Missing required property 'data'")
             __props__.__dict__["data"] = data
+            __props__.__dict__["optional_data"] = optional_data
         super(Resource, __self__).__init__(
             'optional-primitive-ref:index:Resource',
             resource_name,
@@ -106,10 +121,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["data"] = None
+        __props__.__dict__["optional_data"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
     @pulumi.getter
     def data(self) -> pulumi.Output['outputs.Data']:
         return pulumi.get(self, "data")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Output[Optional['outputs.Data']]:
+        return pulumi.get(self, "optional_data")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-primitive-ref-optional/__main__.py
@@ -1,24 +1,28 @@
 import pulumi
 import pulumi_optional_primitive_ref as optional_primitive_ref
 
-set_res = optional_primitive_ref.Resource("setRes", data=optional_primitive_ref.DataArgs(
-    boolean=True,
-    float=3.14,
-    integer=42,
-    string="hello",
-    number_array=[
-        float(-1),
-        float(0),
-        float(1),
-    ],
-    boolean_map={
-        "t": True,
-        "f": False,
-    },
-))
+set_res = optional_primitive_ref.Resource("setRes",
+    data=optional_primitive_ref.DataArgs(
+        boolean=True,
+        float=3.14,
+        integer=42,
+        string="hello",
+        number_array=[
+            float(-1),
+            float(0),
+            float(1),
+        ],
+        boolean_map={
+            "t": True,
+            "f": False,
+        },
+    ),
+    optional_data=optional_primitive_ref.DataArgs(
+        string="optional parent",
+    ))
 unset_res = optional_primitive_ref.Resource("unsetRes", data=optional_primitive_ref.DataArgs())
 from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data=optional_primitive_ref.DataArgs(
-    string=set_res.data.string,
+    string=set_res.optional_data.string,
 ))
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
@@ -16,11 +16,14 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 data: pulumi.Input['DataArgs']):
+                 data: pulumi.Input['DataArgs'],
+                 optional_data: pulumi.Input[Optional['DataArgs']] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
         pulumi.set(__self__, "data", data)
+        if optional_data is not None:
+            pulumi.set(__self__, "optional_data", optional_data)
 
     @_builtins.property
     @pulumi.getter
@@ -31,6 +34,15 @@ class ResourceArgs:
     def data(self, value: pulumi.Input['DataArgs']):
         pulumi.set(self, "data", value)
 
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Input[Optional['DataArgs']]:
+        return pulumi.get(self, "optional_data")
+
+    @optional_data.setter
+    def optional_data(self, value: pulumi.Input[Optional['DataArgs']]):
+        pulumi.set(self, "optional_data", value)
+
 
 @pulumi.type_token("optional-primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -39,6 +51,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
+                 optional_data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -71,6 +84,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
+                 optional_data: pulumi.Input[Optional[pulumi.InputType['DataArgs']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -83,6 +97,7 @@ class Resource(pulumi.CustomResource):
             if data is None and not opts.urn:
                 raise TypeError("Missing required property 'data'")
             __props__.__dict__["data"] = data
+            __props__.__dict__["optional_data"] = optional_data
         super(Resource, __self__).__init__(
             'optional-primitive-ref:index:Resource',
             resource_name,
@@ -106,10 +121,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["data"] = None
+        __props__.__dict__["optional_data"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
     @pulumi.getter
     def data(self) -> pulumi.Output['outputs.Data']:
         return pulumi.get(self, "data")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Output[Optional['outputs.Data']]:
+        return pulumi.get(self, "optional_data")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-primitive-ref-optional/__main__.py
@@ -1,24 +1,28 @@
 import pulumi
 import pulumi_optional_primitive_ref as optional_primitive_ref
 
-set_res = optional_primitive_ref.Resource("setRes", data={
-    "boolean": True,
-    "float": 3.14,
-    "integer": 42,
-    "string": "hello",
-    "number_array": [
-        float(-1),
-        float(0),
-        float(1),
-    ],
-    "boolean_map": {
-        "t": True,
-        "f": False,
+set_res = optional_primitive_ref.Resource("setRes",
+    data={
+        "boolean": True,
+        "float": 3.14,
+        "integer": 42,
+        "string": "hello",
+        "number_array": [
+            float(-1),
+            float(0),
+            float(1),
+        ],
+        "boolean_map": {
+            "t": True,
+            "f": False,
+        },
     },
-})
+    optional_data={
+        "string": "optional parent",
+    })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
 from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
-    "string": set_res.data.string,
+    "string": set_res.optional_data.string,
 })
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
@@ -21,11 +21,14 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 data: pulumi.Input['DataArgs']):
+                 data: pulumi.Input['DataArgs'],
+                 optional_data: pulumi.Input[Optional['DataArgs']] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
         pulumi.set(__self__, "data", data)
+        if optional_data is not None:
+            pulumi.set(__self__, "optional_data", optional_data)
 
     @_builtins.property
     @pulumi.getter
@@ -36,6 +39,15 @@ class ResourceArgs:
     def data(self, value: pulumi.Input['DataArgs']):
         pulumi.set(self, "data", value)
 
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Input[Optional['DataArgs']]:
+        return pulumi.get(self, "optional_data")
+
+    @optional_data.setter
+    def optional_data(self, value: pulumi.Input[Optional['DataArgs']]):
+        pulumi.set(self, "optional_data", value)
+
 
 @pulumi.type_token("optional-primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -44,6 +56,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -76,6 +89,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -88,6 +102,7 @@ class Resource(pulumi.CustomResource):
             if data is None and not opts.urn:
                 raise TypeError("Missing required property 'data'")
             __props__.__dict__["data"] = data
+            __props__.__dict__["optional_data"] = optional_data
         super(Resource, __self__).__init__(
             'optional-primitive-ref:index:Resource',
             resource_name,
@@ -111,10 +126,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["data"] = None
+        __props__.__dict__["optional_data"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
     @pulumi.getter
     def data(self) -> pulumi.Output['outputs.Data']:
         return pulumi.get(self, "data")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Output[Optional['outputs.Data']]:
+        return pulumi.get(self, "optional_data")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-primitive-ref-optional/__main__.py
@@ -1,24 +1,28 @@
 import pulumi
 import pulumi_optional_primitive_ref as optional_primitive_ref
 
-set_res = optional_primitive_ref.Resource("setRes", data={
-    "boolean": True,
-    "float": 3.14,
-    "integer": 42,
-    "string": "hello",
-    "number_array": [
-        float(-1),
-        float(0),
-        float(1),
-    ],
-    "boolean_map": {
-        "t": True,
-        "f": False,
+set_res = optional_primitive_ref.Resource("setRes",
+    data={
+        "boolean": True,
+        "float": 3.14,
+        "integer": 42,
+        "string": "hello",
+        "number_array": [
+            float(-1),
+            float(0),
+            float(1),
+        ],
+        "boolean_map": {
+            "t": True,
+            "f": False,
+        },
     },
-})
+    optional_data={
+        "string": "optional parent",
+    })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
 from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
-    "string": set_res.data.string,
+    "string": set_res.optional_data.string,
 })
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
@@ -21,11 +21,14 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 data: pulumi.Input['DataArgs']):
+                 data: pulumi.Input['DataArgs'],
+                 optional_data: pulumi.Input[Optional['DataArgs']] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
         pulumi.set(__self__, "data", data)
+        if optional_data is not None:
+            pulumi.set(__self__, "optional_data", optional_data)
 
     @_builtins.property
     @pulumi.getter
@@ -36,6 +39,15 @@ class ResourceArgs:
     def data(self, value: pulumi.Input['DataArgs']):
         pulumi.set(self, "data", value)
 
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Input[Optional['DataArgs']]:
+        return pulumi.get(self, "optional_data")
+
+    @optional_data.setter
+    def optional_data(self, value: pulumi.Input[Optional['DataArgs']]):
+        pulumi.set(self, "optional_data", value)
+
 
 @pulumi.type_token("optional-primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -44,6 +56,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -76,6 +89,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -88,6 +102,7 @@ class Resource(pulumi.CustomResource):
             if data is None and not opts.urn:
                 raise TypeError("Missing required property 'data'")
             __props__.__dict__["data"] = data
+            __props__.__dict__["optional_data"] = optional_data
         super(Resource, __self__).__init__(
             'optional-primitive-ref:index:Resource',
             resource_name,
@@ -111,10 +126,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["data"] = None
+        __props__.__dict__["optional_data"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
     @pulumi.getter
     def data(self) -> pulumi.Output['outputs.Data']:
         return pulumi.get(self, "data")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Output[Optional['outputs.Data']]:
+        return pulumi.get(self, "optional_data")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-primitive-ref-optional/__main__.py
@@ -1,24 +1,28 @@
 import pulumi
 import pulumi_optional_primitive_ref as optional_primitive_ref
 
-set_res = optional_primitive_ref.Resource("setRes", data={
-    "boolean": True,
-    "float": 3.14,
-    "integer": 42,
-    "string": "hello",
-    "number_array": [
-        float(-1),
-        float(0),
-        float(1),
-    ],
-    "boolean_map": {
-        "t": True,
-        "f": False,
+set_res = optional_primitive_ref.Resource("setRes",
+    data={
+        "boolean": True,
+        "float": 3.14,
+        "integer": 42,
+        "string": "hello",
+        "number_array": [
+            float(-1),
+            float(0),
+            float(1),
+        ],
+        "boolean_map": {
+            "t": True,
+            "f": False,
+        },
     },
-})
+    optional_data={
+        "string": "optional parent",
+    })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
 from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
-    "string": set_res.data.string,
+    "string": set_res.optional_data.string,
 })
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
@@ -21,11 +21,14 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 data: pulumi.Input['DataArgs']):
+                 data: pulumi.Input['DataArgs'],
+                 optional_data: pulumi.Input[Optional['DataArgs']] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
         pulumi.set(__self__, "data", data)
+        if optional_data is not None:
+            pulumi.set(__self__, "optional_data", optional_data)
 
     @_builtins.property
     @pulumi.getter
@@ -36,6 +39,15 @@ class ResourceArgs:
     def data(self, value: pulumi.Input['DataArgs']):
         pulumi.set(self, "data", value)
 
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Input[Optional['DataArgs']]:
+        return pulumi.get(self, "optional_data")
+
+    @optional_data.setter
+    def optional_data(self, value: pulumi.Input[Optional['DataArgs']]):
+        pulumi.set(self, "optional_data", value)
+
 
 @pulumi.type_token("optional-primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -44,6 +56,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -76,6 +89,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -88,6 +102,7 @@ class Resource(pulumi.CustomResource):
             if data is None and not opts.urn:
                 raise TypeError("Missing required property 'data'")
             __props__.__dict__["data"] = data
+            __props__.__dict__["optional_data"] = optional_data
         super(Resource, __self__).__init__(
             'optional-primitive-ref:index:Resource',
             resource_name,
@@ -111,10 +126,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["data"] = None
+        __props__.__dict__["optional_data"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
     @pulumi.getter
     def data(self) -> pulumi.Output['outputs.Data']:
         return pulumi.get(self, "data")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Output[Optional['outputs.Data']]:
+        return pulumi.get(self, "optional_data")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-primitive-ref-optional/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-primitive-ref-optional/__main__.py
@@ -1,24 +1,28 @@
 import pulumi
 import pulumi_optional_primitive_ref as optional_primitive_ref
 
-set_res = optional_primitive_ref.Resource("setRes", data={
-    "boolean": True,
-    "float": 3.14,
-    "integer": 42,
-    "string": "hello",
-    "number_array": [
-        float(-1),
-        float(0),
-        float(1),
-    ],
-    "boolean_map": {
-        "t": True,
-        "f": False,
+set_res = optional_primitive_ref.Resource("setRes",
+    data={
+        "boolean": True,
+        "float": 3.14,
+        "integer": 42,
+        "string": "hello",
+        "number_array": [
+            float(-1),
+            float(0),
+            float(1),
+        ],
+        "boolean_map": {
+            "t": True,
+            "f": False,
+        },
     },
-})
+    optional_data={
+        "string": "optional parent",
+    })
 unset_res = optional_primitive_ref.Resource("unsetRes", data={})
 from_nested_optional = optional_primitive_ref.Resource("fromNestedOptional", data={
-    "string": set_res.data.string,
+    "string": set_res.optional_data.string,
 })
 pulumi.export("setBoolean", set_res.data.boolean)
 pulumi.export("setFloat", set_res.data.float)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/resource.py
@@ -21,11 +21,14 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 data: pulumi.Input['DataArgs']):
+                 data: pulumi.Input['DataArgs'],
+                 optional_data: pulumi.Input[Optional['DataArgs']] = None):
         """
         The set of arguments for constructing a Resource resource.
         """
         pulumi.set(__self__, "data", data)
+        if optional_data is not None:
+            pulumi.set(__self__, "optional_data", optional_data)
 
     @_builtins.property
     @pulumi.getter
@@ -36,6 +39,15 @@ class ResourceArgs:
     def data(self, value: pulumi.Input['DataArgs']):
         pulumi.set(self, "data", value)
 
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Input[Optional['DataArgs']]:
+        return pulumi.get(self, "optional_data")
+
+    @optional_data.setter
+    def optional_data(self, value: pulumi.Input[Optional['DataArgs']]):
+        pulumi.set(self, "optional_data", value)
+
 
 @pulumi.type_token("optional-primitive-ref:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -44,6 +56,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -76,6 +89,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
+                 optional_data: pulumi.Input[Optional[Union['DataArgs', 'DataArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -88,6 +102,7 @@ class Resource(pulumi.CustomResource):
             if data is None and not opts.urn:
                 raise TypeError("Missing required property 'data'")
             __props__.__dict__["data"] = data
+            __props__.__dict__["optional_data"] = optional_data
         super(Resource, __self__).__init__(
             'optional-primitive-ref:index:Resource',
             resource_name,
@@ -111,10 +126,16 @@ class Resource(pulumi.CustomResource):
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
         __props__.__dict__["data"] = None
+        __props__.__dict__["optional_data"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
     @pulumi.getter
     def data(self) -> pulumi.Output['outputs.Data']:
         return pulumi.get(self, "data")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalData")
+    def optional_data(self) -> pulumi.Output[Optional['outputs.Data']]:
+        return pulumi.get(self, "optional_data")
 


### PR DESCRIPTION
Follow-up to https://github.com/pulumi/pulumi/pull/24096.

Recognize a single-property apply and use the generated accessor only when the schema-backed output type is known to provide one.

```pcl
output "setString" {
    value = setRes.data.string
}
```

Go programgen now emits:

```go
ctx.Export("setString", setRes.Data.String())
```

instead of:

```go
ctx.Export("setString", setRes.Data.ApplyT(func(data optionalprimitiveref.Data) (*string, error) {
    return data.String, nil
}).(pulumi.StringPtrOutput))
```

Non-trivial callbacks continue to use `ApplyT`.
