### PR TITLE
fix flaky TestReturnsNextPortIfNotAvailable

### DIFF
--- a/sdk/go/pulumi-internal/netutil/netutil_test.go
+++ b/sdk/go/pulumi-internal/netutil/netutil_test.go
@@ -54,7 +54,9 @@ func TestReturnsNextPortIfNotAvailable(t *testing.T) {
 	// Open a listener on the port to make it unavailable.
 	// Ignore the error.  If the port is already open that's also fine.
 	l, _ := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	defer l.Close()
+	if l != nil {
+		defer l.Close()
+	}
 	availablePort, err := FindNextAvailablePort(port)
 	require.NoError(t, err)
 	require.Equal(t, port+1, availablePort)

--- a/sdk/go/pulumi-internal/netutil/netutil_test.go
+++ b/sdk/go/pulumi-internal/netutil/netutil_test.go
@@ -15,7 +15,6 @@
 package netutil
 
 import (
-	"fmt"
 	"net"
 	"testing"
 
@@ -46,18 +45,14 @@ func TestReturnsErrorIfPortNumberTooHigh(t *testing.T) {
 func TestReturnsNextPortIfNotAvailable(t *testing.T) {
 	t.Parallel()
 
-	// "random" port for testing
-	port := 58943
-	if !isPortAvailable(port + 1) {
-		t.Skip("port 58944 is not available")
-	}
-	// Open a listener on the port to make it unavailable.
-	// Ignore the error.  If the port is already open that's also fine.
-	l, _ := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if l != nil {
-		defer l.Close()
-	}
+	// Open a listener on a port to make it unavailable.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	port := l.Addr().(*net.TCPAddr).Port
 	availablePort, err := FindNextAvailablePort(port)
 	require.NoError(t, err)
-	require.Equal(t, port+1, availablePort)
+	require.Greater(t, availablePort, port)
+	require.True(t, isPortAvailable(availablePort))
 }


### PR DESCRIPTION
This test currently panics if the prot we're trying to open is already taken.  In that case `net.Listen` can return `nil`, and the test crashes on `l.Close()`.

There is still a very small possible race condition, in case the port is originally unavailable, and becomes unavailable after we try listening to it, but before we try to find the next available port. That's probably not worth worrying about though.
