### PR TITLE
[POC] esc: default environments

### DIFF
--- a/changelog/pending/20260729--cli-env--esc-default-environments.yaml
+++ b/changelog/pending/20260729--cli-env--esc-default-environments.yaml
@@ -1,0 +1,6 @@
+component: cli/env
+kind: feat
+body: Infer a default environment for esc commands from the nearest .esc.yaml file
+  or the selected Pulumi stack, show it with `esc env default`, and annotate it in
+  `esc env ls`
+time: 2026-07-29T00:00:00+00:00

--- a/changelog/pending/20260729--cli-env--esc-default-environments.yaml
+++ b/changelog/pending/20260729--cli-env--esc-default-environments.yaml
@@ -4,3 +4,5 @@ body: Infer a default environment for esc commands from the nearest .esc.yaml fi
   or the selected Pulumi stack, show it with `esc env default`, and annotate it in
   `esc env ls`
 time: 2026-07-29T00:00:00+00:00
+custom:
+  PR: "24114"

--- a/pkg/cmd/esc/cli/cli_test.go
+++ b/pkg/cmd/esc/cli/cli_test.go
@@ -143,13 +143,25 @@ func (env testEnviron) Vars() []string {
 }
 
 // mockWorkspace returns a pulumi workspace Context that serves the given stored credentials,
-// used to drive ESC's credential reads in tests.
-func mockWorkspace(creds workspace.Credentials) pkgWorkspace.Context {
-	return &pkgWorkspace.MockContext{
+// used to drive ESC's credential reads in tests. If selectedStack is non-empty, the context also
+// serves a workspace whose selected stack is selectedStack; otherwise New reports that there is no
+// project, which the default environment resolver treats as "no selected stack".
+func mockWorkspace(creds workspace.Credentials, selectedStack string) pkgWorkspace.Context {
+	ctx := &pkgWorkspace.MockContext{
 		GetStoredCredentialsF: func() (workspace.Credentials, error) {
 			return creds, nil
 		},
 	}
+	if selectedStack != "" {
+		ctx.NewF = func(string) (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{
+				SettingsF: func() *pkgWorkspace.Settings {
+					return &pkgWorkspace.Settings{Stack: selectedStack}
+				},
+			}, nil
+		}
+	}
+	return ctx
 }
 
 type testProvider struct{}
@@ -1593,6 +1605,9 @@ type testExec struct {
 	fs       testFS
 	environ  map[string]string
 	commands map[string]string
+	cwd      string
+
+	selectedStack string
 
 	parentPath string
 	login      *testLoginManager
@@ -1645,11 +1660,12 @@ func (c *testExec) runScript(script string, cmd *exec.Cmd) error {
 					Stderr:     hc.Stderr,
 					Colors:     colors.Never,
 					Login:      c.login,
-					ws:         mockWorkspace(c.creds),
+					ws:         mockWorkspace(c.creds, c.selectedStack),
 					fs:         c.fs,
 					environ:    environ,
 					exec:       c,
 					pager:      testPager(0),
+					wd:         testWD(valueOrDefault(c.cwd, ".")),
 					newClient: func(_, backendURL, accessToken string, insecure bool) client.Client {
 						return c.client
 					},
@@ -1734,6 +1750,19 @@ type cliTestcaseProcess struct {
 	FS       map[string]string `yaml:"fs,omitempty"`
 	Environ  map[string]string `yaml:"environ,omitempty"`
 	Commands map[string]string `yaml:"commands,omitempty"`
+	Cwd      string            `yaml:"cwd,omitempty"`
+}
+
+// cliTestcasePulumi describes the state of the Pulumi CLI's workspace for a testcase.
+type cliTestcasePulumi struct {
+	SelectedStack string `yaml:"selected-stack,omitempty"`
+}
+
+// testWD is a working directory implementation backed by a fixed path.
+type testWD string
+
+func (wd testWD) Getwd() (string, error) {
+	return string(wd), nil
 }
 
 type cliTestcaseRetract struct {
@@ -1881,6 +1910,7 @@ type cliTestcaseYAML struct {
 	Error string `yaml:"error,omitempty"`
 
 	Process *cliTestcaseProcess `yaml:"process,omitempty"`
+	Pulumi  *cliTestcasePulumi  `yaml:"pulumi,omitempty"`
 
 	Environments map[string]yaml.Node `yaml:"environments,omitempty"`
 }
@@ -1927,6 +1957,11 @@ func loadTestcase(path string) (*cliTestcaseYAML, *cliTestcase, error) {
 
 		exec.environ = testcase.Process.Environ
 		exec.commands = testcase.Process.Commands
+		exec.cwd = testcase.Process.Cwd
+	}
+
+	if testcase.Pulumi != nil {
+		exec.selectedStack = testcase.Pulumi.SelectedStack
 	}
 
 	environments := map[string]*testEnvironment{}

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -49,6 +49,45 @@ type envCommand struct {
 	esc *escCommand
 
 	envNameFlag string
+
+	// Memoized result of resolveDefaultEnvironment.
+	defaultEnvOnce bool
+	defaultEnv     *defaultEnvironment
+	defaultEnvErr  error
+}
+
+// errAnonymousDefault is returned when a command that requires a named environment picks up a
+// default environment that is an anonymous list of imports.
+var errAnonymousDefault = errors.New(
+	"the default environment is an anonymous list of imports; this command requires a named environment. " +
+		"Pass an environment explicitly")
+
+// envTarget identifies the environment a command operates on: either a named environment or the
+// anonymous import list implied by a default.
+type envTarget struct {
+	ref  environmentRef
+	anon *defaultEnvironment
+}
+
+// isAnonymous returns true if the target is an anonymous import list rather than a named environment.
+func (t envTarget) isAnonymous() bool {
+	return t.anon != nil
+}
+
+// orgName returns the organization the target is evaluated in.
+func (t envTarget) orgName() string {
+	if t.anon != nil {
+		return t.anon.orgName
+	}
+	return t.ref.orgName
+}
+
+// name returns a display name for the target.
+func (t envTarget) name() string {
+	if t.anon != nil {
+		return "default"
+	}
+	return t.ref.envName
 }
 
 func newEnvCmd(esc *escCommand) *cobra.Command {
@@ -78,6 +117,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 
 	cmd.AddCommand(newEnvInitCmd(env))
 	cmd.AddCommand(newEnvCloneCmd(env))
+	cmd.AddCommand(newEnvDefaultCmd(env))
 	cmd.AddCommand(newEnvEditCmd(env))
 	cmd.AddCommand(newEnvGetCmd(env))
 	cmd.AddCommand(newEnvDiffCmd(env))

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -369,6 +369,50 @@ func (cmd *envCommand) getExistingEnvRefWithRelative(
 	return ref, nil
 }
 
+// getEnvTargetForOpenGet resolves the target of a command that accepts an optional environment
+// followed by an optional property path (i.e. `open` and `get`). It returns the target and the
+// remaining arguments.
+//
+// Disambiguation follows the default environment rules: an argument that contains a '/' is always
+// an environment reference, while a bare argument is a property path when a default environment is
+// configured and an environment name otherwise.
+func (cmd *envCommand) getEnvTargetForOpenGet(
+	ctx context.Context,
+	args []string,
+) (envTarget, []string, error) {
+	// An explicit --env is always the environment, and never consumes a positional argument.
+	if cmd.envNameFlag != "" {
+		ref, err := cmd.getExistingEnvRefWithRelative(ctx, cmd.envNameFlag, nil)
+		return envTarget{ref: ref}, args, err
+	}
+
+	// An explicit environment reference is always the environment.
+	if len(args) >= 2 || (len(args) == 1 && strings.Contains(args[0], "/")) {
+		ref, args, err := cmd.getExistingEnvRef(ctx, args)
+		return envTarget{ref: ref}, args, err
+	}
+
+	def, err := cmd.resolveDefaultEnvironment(ctx)
+	if err != nil {
+		return envTarget{}, nil, err
+	}
+
+	if len(args) == 1 {
+		if def == nil {
+			// No default: the bare argument names an environment, as it always has.
+			ref, args, err := cmd.getExistingEnvRef(ctx, args)
+			return envTarget{ref: ref}, args, err
+		}
+		// A default is configured: the bare argument is a property path.
+		return def.target(), args, nil
+	}
+
+	if def == nil {
+		return envTarget{}, nil, errors.New("no environment name specified")
+	}
+	return def.target(), nil, nil
+}
+
 func sortEnvironmentDiagnostics(diags []client.EnvironmentDiagnostic) {
 	sort.Slice(diags, func(i, j int) bool {
 		di, dj := diags[i], diags[j]

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -306,13 +306,27 @@ func (cmd *envCommand) getNewEnvRef(
 
 // Get an environment reference for an existing environment
 // If the given path is ambiguous, we need to make additional API calls to disambiguate
+//
+// If no environment is given, the default environment for the working directory is used. Commands
+// that route through this function require a named environment, so an anonymous default (a list of
+// imports) is rejected.
 func (cmd *envCommand) getExistingEnvRef(
 	ctx context.Context,
 	args []string,
 ) (environmentRef, []string, error) {
 	if cmd.envNameFlag == "" {
 		if len(args) == 0 {
-			return environmentRef{}, nil, errors.New("no environment name specified")
+			def, err := cmd.resolveDefaultEnvironment(ctx)
+			if err != nil {
+				return environmentRef{}, nil, err
+			}
+			if def == nil {
+				return environmentRef{}, nil, errors.New("no environment name specified")
+			}
+			if def.ref == nil {
+				return environmentRef{}, nil, errAnonymousDefault
+			}
+			return *def.ref, nil, nil
 		}
 		cmd.envNameFlag, args = args[0], args[1:]
 	}

--- a/pkg/cmd/esc/cli/env_default.go
+++ b/pkg/cmd/esc/cli/env_default.go
@@ -1,0 +1,74 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newEnvDefaultCmd(env *envCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "default",
+		Args:  cobra.NoArgs,
+		Short: "Show the default environment.",
+		Long: "Show the default environment\n" +
+			"\n" +
+			"This command prints the default environment for the working directory and the source\n" +
+			"it was inferred from.\n" +
+			"\n" +
+			"The default environment is taken from the nearest .esc.yaml file in the working\n" +
+			"directory or one of its parents. A .esc.yaml file declares an environment either as\n" +
+			"a single reference:\n" +
+			"\n" +
+			"    environment: my-org/my-project/my-env\n" +
+			"\n" +
+			"or as an anonymous list of imports opened in a named organization:\n" +
+			"\n" +
+			"    environment:\n" +
+			"      organization: my-org\n" +
+			"      imports:\n" +
+			"        - my-project/base\n" +
+			"        - my-project/staging\n" +
+			"\n" +
+			"If there is no .esc.yaml file, the environments imported by the currently-selected\n" +
+			"Pulumi stack are used instead. Note that this only works for stacks whose\n" +
+			"configuration is stored in a Pulumi.<stack>.yaml file; stacks whose configuration is\n" +
+			"stored in the Pulumi Cloud do not resolve to a default environment.\n",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			def, err := env.resolveDefaultEnvironment(ctx)
+			if err != nil {
+				return err
+			}
+			if def == nil {
+				return errors.New("no default environment")
+			}
+
+			fmt.Fprint(env.esc.stdout, def.description())
+			fmt.Fprintf(env.esc.stdout, "source: %v\n", def.source)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/esc/cli/env_default_resolution.go
+++ b/pkg/cmd/esc/cli/env_default_resolution.go
@@ -1,0 +1,278 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// escConfigFile is the name of the file that declares a default environment for a directory tree.
+const escConfigFile = ".esc.yaml"
+
+// defaultEnvironment describes an environment inferred from the working directory. It is either a
+// single named environment (ref != nil) or an anonymous list of imports opened in orgName.
+type defaultEnvironment struct {
+	// ref is the referenced environment, if the default names a single environment.
+	ref *environmentRef
+
+	// orgName is the organization the anonymous import list is opened in. Only set if ref is nil.
+	orgName string
+	// imports is the anonymous list of imports. Only set if ref is nil.
+	imports []string
+
+	// source describes where the default came from: a path to a .esc.yaml file or "stack <name>".
+	source string
+}
+
+// definition returns the YAML definition for an anonymous import list default.
+func (d *defaultEnvironment) definition() []byte {
+	def, err := yaml.Marshal(map[string]any{"imports": d.imports})
+	if err != nil {
+		// yaml.Marshal of a map of strings cannot fail.
+		return nil
+	}
+	return def
+}
+
+// target returns the default environment as a command target.
+func (d *defaultEnvironment) target() envTarget {
+	if d.ref != nil {
+		return envTarget{ref: *d.ref}
+	}
+	return envTarget{anon: d}
+}
+
+// description renders the default environment in .esc.yaml syntax.
+func (d *defaultEnvironment) description() string {
+	if d.ref != nil {
+		return fmt.Sprintf("environment: %v\n", d.ref.String())
+	}
+
+	s := "environment:\n"
+	if d.orgName != "" {
+		s += fmt.Sprintf("  organization: %v\n", d.orgName)
+	}
+	s += "  imports:\n"
+	for _, imp := range d.imports {
+		s += fmt.Sprintf("    - %v\n", imp)
+	}
+	return s
+}
+
+// resolveDefaultEnvironment infers the default environment for the current working directory. It
+// returns (nil, nil) if no default is configured. Errors are only returned for malformed files:
+// the absence of a .esc.yaml, a Pulumi project, a selected stack, or stack config is never an
+// error.
+func (cmd *envCommand) resolveDefaultEnvironment(ctx context.Context) (*defaultEnvironment, error) {
+	if cmd.defaultEnvOnce {
+		return cmd.defaultEnv, cmd.defaultEnvErr
+	}
+	cmd.defaultEnvOnce = true
+	cmd.defaultEnv, cmd.defaultEnvErr = cmd.inferDefaultEnvironment(ctx)
+	return cmd.defaultEnv, cmd.defaultEnvErr
+}
+
+func (cmd *envCommand) inferDefaultEnvironment(ctx context.Context) (*defaultEnvironment, error) {
+	cwd, err := cmd.esc.wd.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getting working directory: %w", err)
+	}
+
+	// The nearest .esc.yaml wins, if there is one.
+	if path, contents, ok := cmd.findNearestFile(cwd, escConfigFile); ok {
+		def, err := cmd.parseESCConfigFile(ctx, path, contents)
+		if err != nil || def != nil {
+			return def, err
+		}
+		// A .esc.yaml without an `environment` key is inert: fall through to the stack source.
+	}
+
+	return cmd.resolveStackDefaultEnvironment(cwd)
+}
+
+// findNearestFile searches dir and each of its parents for a file with one of the given names,
+// returning the path and contents of the first one it finds.
+func (cmd *envCommand) findNearestFile(dir string, names ...string) (string, []byte, bool) {
+	for {
+		for _, name := range names {
+			path := filepath.Join(dir, name)
+			if contents, ok := cmd.readFile(path); ok {
+				return path, contents, true
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil, false
+		}
+		dir = parent
+	}
+}
+
+// readFile reads a file through the injectable filesystem. Paths are normalized to forward slashes
+// because io/fs (and therefore the test harness's MapFS) only understands slash-separated paths;
+// os.ReadFile accepts them on every supported platform.
+func (cmd *envCommand) readFile(path string) ([]byte, bool) {
+	contents, err := cmd.esc.fs.ReadFile(filepath.ToSlash(path))
+	if err != nil {
+		return nil, false
+	}
+	return contents, true
+}
+
+// escConfigEnvironment is the object form of a .esc.yaml `environment` field.
+type escConfigEnvironment struct {
+	Organization string   `yaml:"organization,omitempty"`
+	Imports      []string `yaml:"imports,omitempty"`
+}
+
+// parseESCConfigFile parses a .esc.yaml file. It returns (nil, nil) if the file does not declare
+// an environment.
+func (cmd *envCommand) parseESCConfigFile(
+	ctx context.Context,
+	path string,
+	contents []byte,
+) (*defaultEnvironment, error) {
+	invalid := func(err error) error {
+		return fmt.Errorf("invalid %v: %w", path, err)
+	}
+
+	var config struct {
+		Environment yaml.Node `yaml:"environment"`
+	}
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		return nil, invalid(err)
+	}
+
+	node := config.Environment
+	switch {
+	case node.Kind == 0 || node.Tag == "!!null":
+		// No environment declared.
+		return nil, nil
+	case node.Kind == yaml.ScalarNode && node.Tag == "!!str":
+		ref, err := cmd.getExistingEnvRefWithRelative(ctx, node.Value, nil)
+		if err != nil {
+			return nil, err
+		}
+		return &defaultEnvironment{ref: &ref, source: path}, nil
+	case node.Kind == yaml.MappingNode:
+		var env escConfigEnvironment
+		if err := node.Decode(&env); err != nil {
+			return nil, invalid(err)
+		}
+		if len(env.Imports) == 0 {
+			return nil, invalid(errors.New("the 'environment' object must specify at least one import"))
+		}
+		orgName := env.Organization
+		if orgName == "" {
+			orgName = cmd.esc.account.DefaultOrg
+		}
+		return &defaultEnvironment{orgName: orgName, imports: env.Imports, source: path}, nil
+	default:
+		return nil, invalid(errors.New("the 'environment' field must be an environment reference or an " +
+			"object with 'organization' and 'imports' fields"))
+	}
+}
+
+// resolveStackDefaultEnvironment infers a default environment from the currently-selected Pulumi
+// stack. This is best effort: no project, no selected stack, no stack config, or no environment
+// imports all resolve to no default. Malformed project or stack files are errors.
+//
+// Note that stacks whose configuration is stored in the Pulumi Cloud (rather than in a
+// Pulumi.<stack>.yaml file) do not resolve to a default: reading their linked environment would
+// require Pulumi Cloud stack APIs that the ESC client does not expose.
+func (cmd *envCommand) resolveStackDefaultEnvironment(cwd string) (*defaultEnvironment, error) {
+	projectPath, projectBytes, ok := cmd.findNearestFile(cwd, "Pulumi.yaml", "Pulumi.yml")
+	if !ok {
+		return nil, nil
+	}
+
+	project, err := workspace.LoadProjectBytes(projectBytes, projectPath, encoding.YAML)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %v: %w", projectPath, err)
+	}
+
+	projectDir := filepath.Dir(projectPath)
+
+	// Ask the Pulumi workspace which stack is selected. A workspace that cannot be loaded (most
+	// commonly because there is no project state on disk yet) means there is no selected stack,
+	// which is not an error.
+	w, err := cmd.esc.ws.New(projectDir)
+	if err != nil {
+		return nil, nil
+	}
+	stackName := w.Settings().Stack
+	if stackName == "" {
+		return nil, nil
+	}
+
+	stackPath, stackBytes, ok := cmd.findStackConfigFile(projectDir, stackName)
+	if !ok {
+		return nil, nil
+	}
+
+	stack, err := workspace.LoadProjectStackBytes(nil, project, stackBytes, stackPath, encoding.YAML)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %v: %w", stackPath, err)
+	}
+	if stack.Environment == nil {
+		return nil, nil
+	}
+
+	imports := stackEnvironmentImports(stack.Environment)
+	if len(imports) == 0 {
+		return nil, nil
+	}
+
+	return &defaultEnvironment{
+		orgName: cmd.esc.account.DefaultOrg,
+		imports: imports,
+		source:  "stack " + stackName,
+	}, nil
+}
+
+// findStackConfigFile returns the Pulumi.<stack>.yaml file for the given stack, if it exists. Note
+// that unlike .esc.yaml and Pulumi.yaml, stack config lives next to the project file rather than
+// anywhere up the directory tree.
+func (cmd *envCommand) findStackConfigFile(projectDir, stackName string) (string, []byte, bool) {
+	for _, ext := range []string{".yaml", ".yml"} {
+		path := filepath.Join(projectDir, "Pulumi."+stackName+ext)
+		if contents, ok := cmd.readFile(path); ok {
+			return path, contents, true
+		}
+	}
+	return "", nil, false
+}
+
+// stackEnvironmentImports returns the environments imported by a stack's `environment` block.
+//
+// Environment.Imports appends a "yaml" sentinel when the block also contains inline values.
+// Projecting those inline values is out of scope, so we drop the sentinel and build the default
+// from the real imports only.
+func stackEnvironmentImports(env *workspace.Environment) []string {
+	imports := env.Imports()
+	if n := len(imports); n != 0 && imports[n-1] == "yaml" {
+		imports = imports[:n-1]
+	}
+	return imports
+}

--- a/pkg/cmd/esc/cli/env_default_resolution.go
+++ b/pkg/cmd/esc/cli/env_default_resolution.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -68,15 +69,16 @@ func (d *defaultEnvironment) description() string {
 		return fmt.Sprintf("environment: %v\n", d.ref.String())
 	}
 
-	s := "environment:\n"
+	var s strings.Builder
+	s.WriteString("environment:\n")
 	if d.orgName != "" {
-		s += fmt.Sprintf("  organization: %v\n", d.orgName)
+		fmt.Fprintf(&s, "  organization: %v\n", d.orgName)
 	}
-	s += "  imports:\n"
+	s.WriteString("  imports:\n")
 	for _, imp := range d.imports {
-		s += fmt.Sprintf("    - %v\n", imp)
+		fmt.Fprintf(&s, "    - %v\n", imp)
 	}
-	return s
+	return s.String()
 }
 
 // resolveDefaultEnvironment infers the default environment for the current working directory. It

--- a/pkg/cmd/esc/cli/env_diff.go
+++ b/pkg/cmd/esc/cli/env_diff.go
@@ -103,7 +103,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			baseData, err := diff.getEnvironment(ctx, baseRef, path, showSecrets)
+			baseData, err := diff.getEnvironment(ctx, envTarget{ref: baseRef}, path, showSecrets)
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 				baseData = &envGetTemplateData{}
 			}
 
-			compareData, err := diff.getEnvironment(ctx, compareRef, path, showSecrets)
+			compareData, err := diff.getEnvironment(ctx, envTarget{ref: compareRef}, path, showSecrets)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/esc/cli/env_edit.go
+++ b/pkg/cmd/esc/cli/env_edit.go
@@ -46,7 +46,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 	edit := &envEditCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:     "edit [<org-name>/][<project-name>/]<environment-name>",
+		Use:     "edit [[<org-name>/][<project-name>/]<environment-name>]",
 		Aliases: []string{"update", "modify"},
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Edit an environment definition",
@@ -57,7 +57,12 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 			"variable. If VISUAL is not set, EDITOR is used. These values are interpreted as\n" +
 			"commands to which the name of the temporary file used for the environment is appended.\n" +
 			"If no editor is specified via the --editor flag or environment variables, edit\n" +
-			"defaults to `vi`.\n",
+			"defaults to `vi`.\n" +
+			"\n" +
+			"If no environment is given, the default environment for the working directory is\n" +
+			"used. Because this command requires a named environment, a default that is an\n" +
+			"anonymous list of imports is rejected. Run `env default` to see the default\n" +
+			"environment in effect.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/pkg/cmd/esc/cli/env_get.go
+++ b/pkg/cmd/esc/cli/env_get.go
@@ -52,14 +52,24 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 	get := &envGetCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "get [<org-name>/][<project-name>/]<environment-name>[@<version>] <path>",
-		Args:  cobra.RangeArgs(1, 2),
+		Use:   "get [[<org-name>/][<project-name>/]<environment-name>[@<version>]] [path]",
+		Args:  cobra.MaximumNArgs(2),
 		Short: "Get a value within an environment.",
 		Long: "Get a value within an environment\n" +
 			"\n" +
 			"This command fetches the current definition for the named environment and gets a\n" +
 			"value within it. The path to the value to set is a Pulumi property path. The value\n" +
-			"is printed to stdout as YAML.\n",
+			"is printed to stdout as YAML.\n" +
+			"\n" +
+			"If no environment is given, the default environment for the working directory is\n" +
+			"used. The default environment is taken from the nearest .esc.yaml file in the\n" +
+			"working directory or one of its parents, or, failing that, from the environments\n" +
+			"imported by the currently-selected Pulumi stack. Run `env default` to see the\n" +
+			"default environment in effect.\n" +
+			"\n" +
+			"When a default environment is configured, a single argument that does not contain a\n" +
+			"'/' is treated as a property path rather than an environment name. An argument that\n" +
+			"contains a '/' is always treated as an environment reference.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -67,7 +77,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getExistingEnvRef(ctx, args)
+			target, args, err := env.getEnvTargetForOpenGet(ctx, args)
 			if err != nil {
 				return err
 			}
@@ -88,22 +98,22 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 			case "":
 				// OK
 			case "detailed", "json", "string":
-				return get.showValue(ctx, ref, path, value, showSecrets)
+				return get.showValue(ctx, target, path, value, showSecrets)
 			case "dotenv":
 				if len(path) != 0 {
 					return fmt.Errorf("output format '%s' may not be used with a property path", value)
 				}
-				return get.showValue(ctx, ref, path, value, showSecrets)
+				return get.showValue(ctx, target, path, value, showSecrets)
 			case "shell":
 				if len(path) != 0 {
 					return fmt.Errorf("output format '%s' may not be used with a property path", value)
 				}
-				return get.showValue(ctx, ref, path, value, showSecrets)
+				return get.showValue(ctx, target, path, value, showSecrets)
 			default:
 				return fmt.Errorf("unknown output format %q", value)
 			}
 
-			data, err := get.getEnvironment(ctx, ref, path, showSecrets)
+			data, err := get.getEnvironment(ctx, target, path, showSecrets)
 			if err != nil {
 				return err
 			}
@@ -162,14 +172,18 @@ func marshalYAML(v any) (string, error) {
 	return b.String(), nil
 }
 
-func (get *envGetCommand) writeValue(
+// definition returns the definition of the target environment. For a named environment this is the
+// stored definition; for an anonymous default it is the synthesized `{imports: [...]}` document.
+func (get *envGetCommand) definition(
 	ctx context.Context,
-	out io.Writer,
-	ref environmentRef,
-	path resource.PropertyPath,
-	format string,
+	target envTarget,
 	showSecrets bool,
-) error {
+) ([]byte, error) {
+	if target.isAnonymous() {
+		return target.anon.definition(), nil
+	}
+
+	ref := target.ref
 	def, _, _, err := get.env.esc.client.GetEnvironment(
 		ctx,
 		ref.orgName,
@@ -179,11 +193,26 @@ func (get *envGetCommand) writeValue(
 		showSecrets,
 	)
 	if err != nil {
-		return fmt.Errorf("getting environment definition: %w", err)
+		return nil, fmt.Errorf("getting environment definition: %w", err)
+	}
+	return def, nil
+}
+
+func (get *envGetCommand) writeValue(
+	ctx context.Context,
+	out io.Writer,
+	target envTarget,
+	path resource.PropertyPath,
+	format string,
+	showSecrets bool,
+) error {
+	def, err := get.definition(ctx, target, showSecrets)
+	if err != nil {
+		return err
 	}
 	env, _, err := get.env.esc.client.CheckYAMLEnvironment(
 		ctx,
-		ref.orgName,
+		target.orgName(),
 		def,
 		client.CheckYAMLOption{ShowSecrets: showSecrets},
 	)
@@ -195,12 +224,12 @@ func (get *envGetCommand) writeValue(
 
 func (get *envGetCommand) showValue(
 	ctx context.Context,
-	ref environmentRef,
+	target envTarget,
 	path resource.PropertyPath,
 	format string,
 	showSecrets bool,
 ) error {
-	return get.writeValue(ctx, get.env.esc.stdout, ref, path, format, showSecrets)
+	return get.writeValue(ctx, get.env.esc.stdout, target, path, format, showSecrets)
 }
 
 func diff(oldName, old, newName, new string) string {
@@ -228,11 +257,11 @@ func (get *envGetCommand) diffValue(
 	showSecrets bool,
 ) error {
 	var base strings.Builder
-	if err := get.writeValue(ctx, &base, baseRef, path, format, showSecrets); err != nil {
+	if err := get.writeValue(ctx, &base, envTarget{ref: baseRef}, path, format, showSecrets); err != nil {
 		return err
 	}
 	var compare strings.Builder
-	if err := get.writeValue(ctx, &compare, compareRef, path, format, showSecrets); err != nil {
+	if err := get.writeValue(ctx, &compare, envTarget{ref: compareRef}, path, format, showSecrets); err != nil {
 		return err
 	}
 
@@ -250,25 +279,18 @@ func (get *envGetCommand) diffValue(
 
 func (get *envGetCommand) getEnvironment(
 	ctx context.Context,
-	ref environmentRef,
+	target envTarget,
 	path resource.PropertyPath,
 	showSecrets bool,
 ) (*envGetTemplateData, error) {
-	def, _, _, err := get.env.esc.client.GetEnvironment(
-		ctx,
-		ref.orgName,
-		ref.projectName,
-		ref.envName,
-		ref.version,
-		showSecrets,
-	)
+	def, err := get.definition(ctx, target, showSecrets)
 	if err != nil {
-		return nil, fmt.Errorf("getting environment definition: %w", err)
+		return nil, err
 	}
 	if len(path) == 0 {
-		return get.getEntireEnvironment(ctx, ref.orgName, def, showSecrets)
+		return get.getEntireEnvironment(ctx, target.orgName(), def, showSecrets)
 	}
-	return get.getEnvironmentMember(ctx, ref.orgName, ref.envName, def, path, showSecrets)
+	return get.getEnvironmentMember(ctx, target.orgName(), target.name(), def, path, showSecrets)
 }
 
 func (get *envGetCommand) getEntireEnvironment(

--- a/pkg/cmd/esc/cli/env_ls.go
+++ b/pkg/cmd/esc/cli/env_ls.go
@@ -37,7 +37,12 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 		Short:   "List environments.",
 		Long: "List environments\n" +
 			"\n" +
-			"This command lists environments. All environments you have access to will be listed.\n",
+			"This command lists environments. All environments you have access to will be listed.\n" +
+			"\n" +
+			"If the default environment for the working directory is a single named environment,\n" +
+			"it is annotated with a '(default)' suffix. In JSON output the default is reported in\n" +
+			"a top-level 'default' field instead. Run `env default` to see the default environment\n" +
+			"in effect.\n",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
@@ -68,6 +73,21 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 				return ei.Organization < ej.Organization
 			})
 
+			// If the working directory has a default environment that names a single
+			// environment, annotate it in the listing.
+			def, err := env.resolveDefaultEnvironment(ctx)
+			if err != nil {
+				return err
+			}
+			var defaultID string
+			if def != nil && def.ref != nil {
+				defaultID = envIdentifier(client.OrgEnvironment{
+					Organization: def.ref.orgName,
+					Project:      def.ref.projectName,
+					Name:         def.ref.envName,
+				})
+			}
+
 			if format == outputJSON {
 				ids := make([]string, 0, len(allEnvs))
 				for _, e := range allEnvs {
@@ -75,11 +95,18 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 				}
 				return writeJSON(env.esc.stdout, struct {
 					Environments []string `json:"environments"`
-				}{ids})
+					Default      string   `json:"default,omitempty"`
+				}{ids, defaultID})
 			}
 
 			for _, e := range allEnvs {
-				fmt.Fprintln(env.esc.stdout, envIdentifier(e))
+				id := envIdentifier(e)
+				// listEnvironments blanks out the org for the caller's own environments, so
+				// compare against both the blanked and fully-qualified forms.
+				if defaultID != "" && (id == defaultID || fmt.Sprintf("%s/%s", env.esc.account.Username, id) == defaultID) {
+					id += " (default)"
+				}
+				fmt.Fprintln(env.esc.stdout, id)
 			}
 
 			return nil

--- a/pkg/cmd/esc/cli/env_open.go
+++ b/pkg/cmd/esc/cli/env_open.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -36,13 +37,23 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	var draft string
 
 	cmd := &cobra.Command{
-		Use:   "open [<org-name>/][<project-name>/]<environment-name>[@<version>] [property path]",
+		Use:   "open [[<org-name>/][<project-name>/]<environment-name>[@<version>]] [property path]",
 		Args:  cobra.MaximumNArgs(2),
 		Short: "Open the environment with the given name.",
 		Long: "Open the environment with the given name and return the result\n" +
 			"\n" +
 			"This command opens the environment with the given name. The result is written to\n" +
-			"stdout as JSON. If a property path is specified, only retrieves that property.\n",
+			"stdout as JSON. If a property path is specified, only retrieves that property.\n" +
+			"\n" +
+			"If no environment is given, the default environment for the working directory is\n" +
+			"opened. The default environment is taken from the nearest .esc.yaml file in the\n" +
+			"working directory or one of its parents, or, failing that, from the environments\n" +
+			"imported by the currently-selected Pulumi stack. Run `env default` to see the\n" +
+			"default environment in effect.\n" +
+			"\n" +
+			"When a default environment is configured, a single argument that does not contain a\n" +
+			"'/' is treated as a property path rather than an environment name. An argument that\n" +
+			"contains a '/' is always treated as an environment reference.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -50,7 +61,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := envcmd.getExistingEnvRef(ctx, args)
+			target, args, err := envcmd.getEnvTargetForOpenGet(ctx, args)
 			if err != nil {
 				return err
 			}
@@ -75,7 +86,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
+			env, diags, err := envcmd.openTarget(ctx, target, duration, draft)
 			if err != nil {
 				return err
 			}
@@ -247,5 +258,34 @@ func (env *envCommand) openEnvironment(
 		return nil, diags, err
 	}
 	open, err := env.esc.client.GetOpenEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, envID)
+	return open, nil, err
+}
+
+// openTarget opens the given target, which may be either a named environment or the anonymous list
+// of imports implied by a default environment.
+func (env *envCommand) openTarget(
+	ctx context.Context,
+	target envTarget,
+	duration time.Duration,
+	changeRequestID string,
+) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
+	if !target.isAnonymous() {
+		return env.openEnvironment(ctx, target.ref, duration, changeRequestID)
+	}
+
+	// Drafts are a property of a stored environment, so there is nothing to open a draft of.
+	if changeRequestID != "" {
+		return nil, nil, errors.New("--draft requires a named environment")
+	}
+
+	orgName := target.anon.orgName
+	envID, diags, err := env.esc.client.OpenYAMLEnvironment(ctx, orgName, target.anon.definition(), duration)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(diags) != 0 {
+		return nil, diags, nil
+	}
+	open, err := env.esc.client.GetAnonymousOpenEnvironment(ctx, orgName, envID)
 	return open, nil, err
 }

--- a/pkg/cmd/esc/cli/env_run.go
+++ b/pkg/cmd/esc/cli/env_run.go
@@ -110,7 +110,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 	shell := valueOrDefault(filepath.Base(envcmd.esc.environ.Get("SHELL")), "sh")
 
 	cmd := &cobra.Command{
-		Use:   "run [<org-name>/][<project-name>/]<environment-name> [flags] [--] [command]",
+		Use:   "run [[<org-name>/][<project-name>/]<environment-name>] [flags] [--] [command]",
 		Args:  cobra.ArbitraryArgs,
 		Short: "Open the environment with the given name and run a command.",
 		Long: fmt.Sprintf("Open the environment with the given name and run a command\n"+
@@ -131,7 +131,18 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			"It is not strictly required that you pass `--`. The `--` indicates that any\n"+
 			"arguments that follow it should be treated as positional arguments instead of flags.\n"+
 			"It is only required if the arguments to the command you would like to run include\n"+
-			"flags of the form `--flag` or `-f`.\n", shell),
+			"flags of the form `--flag` or `-f`.\n"+
+			"\n"+
+			"The environment name may be omitted, in which case the default environment for the\n"+
+			"working directory is used. Because the first argument is otherwise interpreted as an\n"+
+			"environment name, the command must be preceded by `--`:\n"+
+			"\n"+
+			"    run -- %[1]s -c '\"echo $MY_ENV_VAR\"'\n"+
+			"\n"+
+			"The default environment is taken from the nearest .esc.yaml file in the working\n"+
+			"directory or one of its parents, or, failing that, from the environments imported by\n"+
+			"the currently-selected Pulumi stack. Run `env default` to see the default environment\n"+
+			"in effect.\n", shell),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -139,13 +150,27 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			// If -- was used but there's no arguments, it means no environment was specified before the command
+			// If -- was used but there's no arguments before it, no environment was specified
+			// before the command: fall back to the default environment for the working directory.
+			var target envTarget
 			if cmd.ArgsLenAtDash() == 0 {
-				return errors.New("no environment specified")
-			}
-			ref, args, err := envcmd.getExistingEnvRef(ctx, args)
-			if err != nil {
-				return err
+				if envcmd.envNameFlag != "" {
+					return errors.New("no environment specified")
+				}
+				def, err := envcmd.resolveDefaultEnvironment(ctx)
+				if err != nil {
+					return err
+				}
+				if def == nil {
+					return errors.New("no environment specified")
+				}
+				target = def.target()
+			} else {
+				ref, rest, err := envcmd.getExistingEnvRef(ctx, args)
+				if err != nil {
+					return err
+				}
+				target, args = envTarget{ref: ref}, rest
 			}
 
 			if len(args) == 0 {
@@ -157,7 +182,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 			args = args[1:]
 
-			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
+			env, diags, err := envcmd.openTarget(ctx, target, duration, draft)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/esc/cli/env_set.go
+++ b/pkg/cmd/esc/cli/env_set.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -40,14 +41,19 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "set [<org-name>/][<project-name>/]<environment-name> <path> <value>",
-		Args:  cobra.RangeArgs(1, 3),
+		Use:   "set [[<org-name>/][<project-name>/]<environment-name>] <path> <value>",
+		Args:  cobra.MaximumNArgs(3),
 		Short: "Set a value within an environment.",
 		Long: "Set a value within an environment\n" +
 			"\n" +
 			"This command fetches the current definition for the named environment and modifies a\n" +
 			"value within it. The path to the value to set is a Pulumi property path. The value\n" +
-			"is interpreted as YAML.\n",
+			"is interpreted as YAML.\n" +
+			"\n" +
+			"If no environment is given, the default environment for the working directory is\n" +
+			"used. Because this command requires a named environment, a default that is an\n" +
+			"anonymous list of imports is rejected. Run `env default` to see the default\n" +
+			"environment in effect.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -55,7 +61,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getExistingEnvRef(ctx, args)
+			ref, args, err := env.getEnvRefForSet(ctx, args, file != "")
 			if err != nil {
 				return err
 			}
@@ -234,6 +240,42 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 	cmd.Flag("draft").NoOptDefVal = "new"
 
 	return cmd
+}
+
+// getEnvRefForSet resolves the environment for `env set`, which accepts an optional environment
+// followed by a path and a value (or, with --file, just a path).
+//
+// Disambiguation follows the same rules as `open` and `get`: an argument that contains a '/' is
+// always an environment reference, and a bare leading argument names an environment only when no
+// default environment is configured. A full-form invocation (all positionals present) always names
+// an environment.
+func (cmd *envCommand) getEnvRefForSet(
+	ctx context.Context,
+	args []string,
+	hasFile bool,
+) (environmentRef, []string, error) {
+	if cmd.envNameFlag != "" {
+		ref, err := cmd.getExistingEnvRefWithRelative(ctx, cmd.envNameFlag, nil)
+		return ref, args, err
+	}
+
+	fullForm := len(args) >= 3 || (hasFile && len(args) >= 2)
+	if fullForm || (len(args) != 0 && strings.Contains(args[0], "/")) {
+		return cmd.getExistingEnvRef(ctx, args)
+	}
+
+	def, err := cmd.resolveDefaultEnvironment(ctx)
+	if err != nil {
+		return environmentRef{}, nil, err
+	}
+	if def == nil {
+		// No default: the first argument names an environment, as it always has.
+		return cmd.getExistingEnvRef(ctx, args)
+	}
+	if def.ref == nil {
+		return environmentRef{}, nil, errAnonymousDefault
+	}
+	return *def.ref, args, nil
 }
 
 // keyPattern is the regular expression a configuration key must match before we check (and error) if we think

--- a/pkg/cmd/esc/cli/env_version.go
+++ b/pkg/cmd/esc/cli/env_version.go
@@ -31,12 +31,17 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "version [<org-name>/][<project-name>/]<environment-name>@<version>",
-		Args:  cobra.ExactArgs(1),
+		Use:   "version [[<org-name>/][<project-name>/]<environment-name>]@<version>",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Manage versions",
 		Long: "Manage versions\n" +
 			"\n" +
 			"This command describes the referenced environment version.\n" +
+			"\n" +
+			"If no environment is given, the default environment for the working directory is\n" +
+			"used. Because this command requires a named environment, a default that is an\n" +
+			"anonymous list of imports is rejected. Run `env default` to see the default\n" +
+			"environment in effect.\n" +
 			"\n" +
 			"Subcommands exist for viewing revision history and managing" +
 			"tagged versions.",

--- a/pkg/cmd/esc/cli/esc.go
+++ b/pkg/cmd/esc/cli/esc.go
@@ -51,6 +51,7 @@ type Options struct {
 	exec    cmdExec
 	pager   pager
 	ws      pkgWorkspace.Context
+	wd      workingDir
 
 	newClient func(userAgent, backendURL, accessToken string, insecure bool) client.Client
 }
@@ -61,6 +62,7 @@ type escCommand struct {
 	exec    cmdExec
 	pager   pager
 	ws      pkgWorkspace.Context
+	wd      workingDir
 
 	stdin  io.Reader
 	stdout io.Writer
@@ -85,6 +87,7 @@ func newESC(opts *Options) *escCommand {
 		environ:   valueOrDefault(opts.environ, newEnviron()),
 		exec:      valueOrDefault(opts.exec, newCmdExec()),
 		pager:     valueOrDefault(opts.pager, newPager()),
+		wd:        valueOrDefault(opts.wd, newWorkingDir()),
 		stdin:     valueOrDefault(opts.Stdin, io.Reader(os.Stdin)),
 		stdout:    valueOrDefault(opts.Stdout, io.Writer(os.Stdout)), //nolint:forbidigo,lll // default writer for the ESC CLI root command
 		stderr:    valueOrDefault(opts.Stderr, io.Writer(os.Stderr)), //nolint:forbidigo,lll // default writer for the ESC CLI root command

--- a/pkg/cmd/esc/cli/login_test.go
+++ b/pkg/cmd/esc/cli/login_test.go
@@ -70,7 +70,7 @@ func (noCredsLoginManager) LoginWithOIDCToken(
 
 func TestNoCreds(t *testing.T) { //nolint:paralleltest,lll // non-thread-safe shared state
 	esc := &escCommand{
-		ws:    mockWorkspace(pulumi_workspace.Credentials{}),
+		ws:    mockWorkspace(pulumi_workspace.Credentials{}, ""),
 		login: noCredsLoginManager(0),
 	}
 	err := esc.getCachedClient(t.Context())
@@ -128,7 +128,7 @@ func TestCurrentAccountButInvalidToken(t *testing.T) { //nolint:paralleltest,lll
 					Username:    "bobm",
 				},
 			},
-		}),
+		}, ""),
 		login: invalidatedCredsLoginManager(0),
 	}
 	err := esc.getCachedClient(t.Context())
@@ -251,7 +251,7 @@ func TestInvalidSelfHostedBackend(t *testing.T) { //nolint:paralleltest,lll // n
 		Accounts: map[string]pulumi_workspace.Account{
 			"http://pulumi.com": {},
 		},
-	})}
+	}, "")}
 	err := esc.getCachedClient(t.Context())
 	assert.ErrorContains(t, err, "not a valid self-hosted backend")
 
@@ -266,7 +266,7 @@ func TestFilestateBackend(t *testing.T) { //nolint:paralleltest,lll // non-threa
 		Accounts: map[string]pulumi_workspace.Account{
 			"gs://foo": {},
 		},
-	})}
+	}, "")}
 	err := esc.getCachedClient(t.Context())
 	assert.ErrorContains(t, err, "does not support Pulumi ESC")
 	assert.ErrorContains(t, err, "log into the Pulumi Cloud backend")
@@ -297,7 +297,7 @@ func TestEnvVarOverridesAccounts(t *testing.T) {
 	esc := &escCommand{
 		command: "esc",
 		login:   &testLoginManager{creds: creds},
-		ws:      mockWorkspace(creds),
+		ws:      mockWorkspace(creds, ""),
 		newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
 			return client.New(userAgent, backendURL, accessToken, insecure)
 		},
@@ -347,7 +347,7 @@ func TestDefaultOrgConfiguration(t *testing.T) { //nolint:paralleltest,lll // no
 		esc := &escCommand{
 			command: "esc",
 			login:   &testLoginManager{creds: creds},
-			ws:      mockWorkspace(creds),
+			ws:      mockWorkspace(creds, ""),
 			newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
 				return &testClient
 			},
@@ -375,7 +375,7 @@ func TestDefaultOrgConfiguration(t *testing.T) { //nolint:paralleltest,lll // no
 		esc := &escCommand{
 			command: "esc",
 			login:   &testLoginManager{creds: creds},
-			ws:      mockWorkspace(creds),
+			ws:      mockWorkspace(creds, ""),
 			newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
 				return &testClient
 			},
@@ -400,7 +400,7 @@ func TestDefaultOrgConfiguration(t *testing.T) { //nolint:paralleltest,lll // no
 		esc := &escCommand{
 			command: "esc",
 			login:   &testLoginManager{creds: creds},
-			ws:      mockWorkspace(creds),
+			ws:      mockWorkspace(creds, ""),
 			newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
 				return &testClient
 			},

--- a/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-object.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-object.yaml
@@ -1,0 +1,28 @@
+run: esc env default
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        organization: test-org
+        imports:
+          - project-a/base
+          - project-a/staging
+environments:
+  test-org/project-a/base:
+    values:
+      foo: bar
+  test-org/project-a/staging:
+    values:
+      baz: qux
+
+---
+> esc env default
+environment:
+  organization: test-org
+  imports:
+    - project-a/base
+    - project-a/staging
+source: .esc.yaml
+
+---
+> esc env default

--- a/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-over-stack.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-over-stack.yaml
@@ -1,0 +1,29 @@
+run: esc env default
+process:
+  fs:
+    work/.esc.yaml: |
+      environment: test-user/default/test
+    work/Pulumi.dev.yaml: |
+      environment:
+        - default/other
+    work/Pulumi.yaml: |
+      name: my-project
+      runtime: nodejs
+  cwd: work
+pulumi:
+  selected-stack: dev
+environments:
+  test-user/default/other:
+    values:
+      foo: baz
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env default
+environment: test-user/default/test
+source: work/.esc.yaml
+
+---
+> esc env default

--- a/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-parent-walk.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-parent-walk.yaml
@@ -1,0 +1,18 @@
+run: esc env default
+process:
+  fs:
+    work/.esc.yaml: |
+      environment: test-user/default/test
+  cwd: work/app/sub
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env default
+environment: test-user/default/test
+source: work/.esc.yaml
+
+---
+> esc env default

--- a/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-string.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-esc-yaml-string.yaml
@@ -1,0 +1,17 @@
+run: esc env default
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env default
+environment: test-user/default/test
+source: .esc.yaml
+
+---
+> esc env default

--- a/pkg/cmd/esc/cli/testdata/env-default-malformed-esc-yaml.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-malformed-esc-yaml.yaml
@@ -1,0 +1,13 @@
+run: esc env default
+error: exit status 1
+process:
+  fs:
+    .esc.yaml: |
+      environment: [
+
+---
+> esc env default
+
+---
+> esc env default
+Error: invalid .esc.yaml: yaml: line 1: did not find expected node content

--- a/pkg/cmd/esc/cli/testdata/env-default-malformed-pulumi-yaml.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-malformed-pulumi-yaml.yaml
@@ -1,0 +1,14 @@
+run: esc env default
+error: exit status 1
+process:
+  fs:
+    Pulumi.yaml: |
+      name: my-project
+      runtime: [
+
+---
+> esc env default
+
+---
+> esc env default
+Error: invalid Pulumi.yaml: could not unmarshal 'Pulumi.yaml': invalid YAML file: yaml: line 2: did not find expected node content

--- a/pkg/cmd/esc/cli/testdata/env-default-malformed-stack-yaml.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-malformed-stack-yaml.yaml
@@ -1,0 +1,18 @@
+run: esc env default
+error: exit status 1
+process:
+  fs:
+    Pulumi.dev.yaml: |
+      environment: [
+    Pulumi.yaml: |
+      name: my-project
+      runtime: nodejs
+pulumi:
+  selected-stack: dev
+
+---
+> esc env default
+
+---
+> esc env default
+Error: invalid Pulumi.dev.yaml: invalid YAML file: yaml: line 1: did not find expected node content

--- a/pkg/cmd/esc/cli/testdata/env-default-none.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-none.yaml
@@ -1,0 +1,13 @@
+run: esc env default
+error: exit status 1
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env default
+
+---
+> esc env default
+Error: no default environment

--- a/pkg/cmd/esc/cli/testdata/env-default-stack-inline-values.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-stack-inline-values.yaml
@@ -1,0 +1,29 @@
+run: esc env default
+process:
+  fs:
+    Pulumi.dev.yaml: |
+      environment:
+        imports:
+          - default/base
+        values:
+          size: t3.micro
+    Pulumi.yaml: |
+      name: my-project
+      runtime: nodejs
+pulumi:
+  selected-stack: dev
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+
+---
+> esc env default
+environment:
+  organization: test-user
+  imports:
+    - default/base
+source: stack dev
+
+---
+> esc env default

--- a/pkg/cmd/esc/cli/testdata/env-default-stack-no-imports.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-stack-no-imports.yaml
@@ -1,0 +1,23 @@
+run: esc env default
+error: exit status 1
+process:
+  fs:
+    Pulumi.dev.yaml: |
+      config:
+        my-project:size: t3.micro
+    Pulumi.yaml: |
+      name: my-project
+      runtime: nodejs
+pulumi:
+  selected-stack: dev
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+
+---
+> esc env default
+
+---
+> esc env default
+Error: no default environment

--- a/pkg/cmd/esc/cli/testdata/env-default-stack-no-selected-stack.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-stack-no-selected-stack.yaml
@@ -1,0 +1,21 @@
+run: esc env default
+error: exit status 1
+process:
+  fs:
+    Pulumi.dev.yaml: |
+      environment:
+        - default/base
+    Pulumi.yaml: |
+      name: my-project
+      runtime: nodejs
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+
+---
+> esc env default
+
+---
+> esc env default
+Error: no default environment

--- a/pkg/cmd/esc/cli/testdata/env-default-stack.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-default-stack.yaml
@@ -1,0 +1,32 @@
+run: esc env default
+process:
+  fs:
+    work/Pulumi.dev.yaml: |
+      environment:
+        - default/base
+        - default/staging
+    work/Pulumi.yaml: |
+      name: my-project
+      runtime: nodejs
+  cwd: work/app
+pulumi:
+  selected-stack: dev
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+  test-user/default/staging:
+    values:
+      baz: qux
+
+---
+> esc env default
+environment:
+  organization: test-user
+  imports:
+    - default/base
+    - default/staging
+source: stack dev
+
+---
+> esc env default

--- a/pkg/cmd/esc/cli/testdata/env-edit-default-imports-rejected.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-default-imports-rejected.yaml
@@ -1,0 +1,22 @@
+run: esc env edit -f new.yaml
+error: exit status 1
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/base
+    new.yaml: |
+      values:
+        foo: updated
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+
+---
+> esc env edit -f new.yaml
+
+---
+> esc env edit -f new.yaml
+Error: the default environment is an anonymous list of imports; this command requires a named environment. Pass an environment explicitly

--- a/pkg/cmd/esc/cli/testdata/env-edit-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-edit-default.yaml
@@ -1,0 +1,26 @@
+run: |
+  esc env edit -f new.yaml
+  esc env get --value json
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+    new.yaml: |
+      values:
+        foo: updated
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env edit -f new.yaml
+Environment updated. (revision 3)
+> esc env get --value json
+{
+  "foo": "updated"
+}
+
+---
+> esc env edit -f new.yaml
+> esc env get --value json

--- a/pkg/cmd/esc/cli/testdata/env-get-default-imports.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-get-default-imports.yaml
@@ -1,0 +1,55 @@
+run: |
+  esc env get
+  esc env get foo
+  esc env get --value json
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/base
+          - default/staging
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+  test-user/default/staging:
+    values:
+      baz: qux
+
+---
+> esc env get
+# Value
+```json
+{
+  "baz": "qux",
+  "foo": "bar"
+}
+```
+# Definition
+```yaml
+imports:
+  - default/base
+  - default/staging
+
+```
+
+> esc env get foo
+# Value
+```json
+"bar"
+```
+
+# Defined at
+- default/base:2:10
+
+> esc env get --value json
+{
+  "baz": "qux",
+  "foo": "bar"
+}
+
+---
+> esc env get
+> esc env get foo
+> esc env get --value json

--- a/pkg/cmd/esc/cli/testdata/env-get-default-single.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-get-default-single.yaml
@@ -1,0 +1,51 @@
+run: |
+  esc env get
+  esc env get foo
+  esc env get --value json
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env get
+# Value
+```json
+{
+  "foo": "bar"
+}
+```
+# Definition
+```yaml
+values:
+  foo: bar
+
+```
+
+> esc env get foo
+# Value
+```json
+"bar"
+```
+# Definition
+```yaml
+bar
+
+```
+
+# Defined at
+- test:2:10
+
+> esc env get --value json
+{
+  "foo": "bar"
+}
+
+---
+> esc env get
+> esc env get foo
+> esc env get --value json

--- a/pkg/cmd/esc/cli/testdata/env-get-disambiguation-no-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-get-disambiguation-no-default.yaml
@@ -1,0 +1,32 @@
+run: |
+  esc env get --value json || echo -n ""
+  esc env get test --value json
+  esc env get default/other --value json
+  esc env get default/other foo --value json
+environments:
+  test-user/default/other:
+    values:
+      foo: other-bar
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env get --value json
+> esc env get test --value json
+{
+  "foo": "bar"
+}
+> esc env get default/other --value json
+{
+  "foo": "other-bar"
+}
+> esc env get default/other foo --value json
+"other-bar"
+
+---
+> esc env get --value json
+Error: no environment name specified
+> esc env get test --value json
+> esc env get default/other --value json
+> esc env get default/other foo --value json

--- a/pkg/cmd/esc/cli/testdata/env-get-disambiguation.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-get-disambiguation.yaml
@@ -1,0 +1,36 @@
+run: |
+  esc env get --value json
+  esc env get foo --value json
+  esc env get default/other --value json
+  esc env get default/other foo --value json
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+environments:
+  test-user/default/other:
+    values:
+      foo: other-bar
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env get --value json
+{
+  "foo": "bar"
+}
+> esc env get foo --value json
+"bar"
+> esc env get default/other --value json
+{
+  "foo": "other-bar"
+}
+> esc env get default/other foo --value json
+"other-bar"
+
+---
+> esc env get --value json
+> esc env get foo --value json
+> esc env get default/other --value json
+> esc env get default/other foo --value json

--- a/pkg/cmd/esc/cli/testdata/env-ls-default-imports.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-ls-default-imports.yaml
@@ -1,0 +1,31 @@
+run: |
+  esc env ls
+  esc env ls --output json
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/env
+environments:
+  test-org/default/env: true
+  test-user/default/env: true
+  test-user/default/env-2: true
+
+---
+> esc env ls
+default/env
+default/env-2
+test-org/default/env
+> esc env ls --output json
+{
+  "environments": [
+    "default/env",
+    "default/env-2",
+    "test-org/default/env"
+  ]
+}
+
+---
+> esc env ls
+> esc env ls --output json

--- a/pkg/cmd/esc/cli/testdata/env-ls-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-ls-default.yaml
@@ -1,0 +1,30 @@
+run: |
+  esc env ls
+  esc env ls --output json
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/env
+environments:
+  test-org/default/env: true
+  test-user/default/env: true
+  test-user/default/env-2: true
+
+---
+> esc env ls
+default/env (default)
+default/env-2
+test-org/default/env
+> esc env ls --output json
+{
+  "environments": [
+    "default/env",
+    "default/env-2",
+    "test-org/default/env"
+  ],
+  "default": "test-user/default/env"
+}
+
+---
+> esc env ls
+> esc env ls --output json

--- a/pkg/cmd/esc/cli/testdata/env-open-default-imports.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-open-default-imports.yaml
@@ -1,0 +1,34 @@
+run: |
+  esc env open
+  esc env open foo
+  esc env open --draft=00000000-0000-0000-0000-000000000000 || echo -n ""
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/base
+          - default/staging
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+  test-user/default/staging:
+    values:
+      baz: qux
+
+---
+> esc env open
+{
+  "baz": "qux",
+  "foo": "bar"
+}
+> esc env open foo
+"bar"
+> esc env open --draft=00000000-0000-0000-0000-000000000000
+
+---
+> esc env open
+> esc env open foo
+> esc env open --draft=00000000-0000-0000-0000-000000000000
+Error: --draft requires a named environment

--- a/pkg/cmd/esc/cli/testdata/env-open-default-single.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-open-default-single.yaml
@@ -1,0 +1,28 @@
+run: |
+  esc env open
+  esc env open foo
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      nested:
+        baz: qux
+
+---
+> esc env open
+{
+  "foo": "bar",
+  "nested": {
+    "baz": "qux"
+  }
+}
+> esc env open foo
+"bar"
+
+---
+> esc env open
+> esc env open foo

--- a/pkg/cmd/esc/cli/testdata/env-open-disambiguation-no-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-open-disambiguation-no-default.yaml
@@ -1,0 +1,32 @@
+run: |
+  esc env open || echo -n ""
+  esc env open test
+  esc env open default/other
+  esc env open default/other foo
+environments:
+  test-user/default/other:
+    values:
+      foo: other-bar
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env open
+> esc env open test
+{
+  "foo": "bar"
+}
+> esc env open default/other
+{
+  "foo": "other-bar"
+}
+> esc env open default/other foo
+"other-bar"
+
+---
+> esc env open
+Error: no environment name specified
+> esc env open test
+> esc env open default/other
+> esc env open default/other foo

--- a/pkg/cmd/esc/cli/testdata/env-open-disambiguation.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-open-disambiguation.yaml
@@ -1,0 +1,36 @@
+run: |
+  esc env open
+  esc env open foo
+  esc env open default/other
+  esc env open default/other foo
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+environments:
+  test-user/default/other:
+    values:
+      foo: other-bar
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env open
+{
+  "foo": "bar"
+}
+> esc env open foo
+"bar"
+> esc env open default/other
+{
+  "foo": "other-bar"
+}
+> esc env open default/other foo
+"other-bar"
+
+---
+> esc env open
+> esc env open foo
+> esc env open default/other
+> esc env open default/other foo

--- a/pkg/cmd/esc/cli/testdata/env-open-no-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-open-no-default.yaml
@@ -1,0 +1,13 @@
+run: esc env open
+error: exit status 1
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env open
+
+---
+> esc env open
+Error: no environment name specified

--- a/pkg/cmd/esc/cli/testdata/env-run-default-imports.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-run-default-imports.yaml
@@ -1,0 +1,23 @@
+run: |
+  esc env run -- dump-env
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/base
+  commands:
+    dump-env: |
+      echo "foo: $FOO"
+environments:
+  test-user/default/base:
+    values:
+      environmentVariables:
+        FOO: bar
+
+---
+> esc env run -- dump-env
+foo: bar
+
+---
+> esc env run -- dump-env

--- a/pkg/cmd/esc/cli/testdata/env-run-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-run-default.yaml
@@ -1,0 +1,37 @@
+run: |
+  esc env run -- dump-env
+  esc env run default/other -- dump-env
+  esc env run default/other dump-env
+  esc env run --env default/other -- dump-env || echo -n ""
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+  commands:
+    dump-env: |
+      echo "foo: $FOO"
+environments:
+  test-user/default/other:
+    values:
+      environmentVariables:
+        FOO: other-bar
+  test-user/default/test:
+    values:
+      environmentVariables:
+        FOO: bar
+
+---
+> esc env run -- dump-env
+foo: bar
+> esc env run default/other -- dump-env
+foo: other-bar
+> esc env run default/other dump-env
+foo: other-bar
+> esc env run --env default/other -- dump-env
+
+---
+> esc env run -- dump-env
+> esc env run default/other -- dump-env
+> esc env run default/other dump-env
+> esc env run --env default/other -- dump-env
+Error: no environment specified

--- a/pkg/cmd/esc/cli/testdata/env-set-default-imports-rejected.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-set-default-imports-rejected.yaml
@@ -1,0 +1,19 @@
+run: esc env set foo baz
+error: exit status 1
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/base
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+
+---
+> esc env set foo baz
+
+---
+> esc env set foo baz
+Error: the default environment is an anonymous list of imports; this command requires a named environment. Pass an environment explicitly

--- a/pkg/cmd/esc/cli/testdata/env-set-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-set-default.yaml
@@ -1,0 +1,34 @@
+run: |
+  esc env set foo baz
+  esc env get --value json
+  esc env set default/other foo qux
+  esc env get default/other --value json
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+environments:
+  test-user/default/other:
+    values:
+      foo: other-bar
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env set foo baz
+> esc env get --value json
+{
+  "foo": "baz"
+}
+> esc env set default/other foo qux
+> esc env get default/other --value json
+{
+  "foo": "qux"
+}
+
+---
+> esc env set foo baz
+> esc env get --value json
+> esc env set default/other foo qux
+> esc env get default/other --value json

--- a/pkg/cmd/esc/cli/testdata/env-set-file.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-set-file.yaml
@@ -95,7 +95,7 @@ file
 > esc env set default/test -f=test.file
 Error: expected a path
 > esc env set -f=test.file
-Error: accepts between 1 and 3 arg(s), received 0
+Error: no environment name specified
 > esc env set default/test -f=binary foo
 Error: file content must be valid UTF-8
 > esc env set -f=- default/test foo

--- a/pkg/cmd/esc/cli/testdata/env-version-default-imports-rejected.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-version-default-imports-rejected.yaml
@@ -1,0 +1,19 @@
+run: esc env version --utc
+error: exit status 1
+process:
+  fs:
+    .esc.yaml: |
+      environment:
+        imports:
+          - default/base
+environments:
+  test-user/default/base:
+    values:
+      foo: bar
+
+---
+> esc env version --utc
+
+---
+> esc env version --utc
+Error: the default environment is an anonymous list of imports; this command requires a named environment. Pass an environment explicitly

--- a/pkg/cmd/esc/cli/testdata/env-version-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-version-default.yaml
@@ -1,0 +1,21 @@
+run: |
+  esc env version --utc
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test@2
+environments:
+  test-user/default/test:
+    revisions:
+      - yaml:
+          values:
+            foo: bar
+
+---
+> esc env version --utc
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
+
+---
+> esc env version --utc

--- a/pkg/cmd/esc/cli/testdata/esc-open-run-default.yaml
+++ b/pkg/cmd/esc/cli/testdata/esc-open-run-default.yaml
@@ -1,0 +1,35 @@
+run: |
+  esc open
+  esc open foo
+  esc run -- dump-env
+process:
+  fs:
+    .esc.yaml: |
+      environment: test-user/default/test
+  commands:
+    dump-env: |
+      echo "foo: $FOO"
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+      environmentVariables:
+        FOO: ${foo}
+
+---
+> esc open
+{
+  "environmentVariables": {
+    "FOO": "bar"
+  },
+  "foo": "bar"
+}
+> esc open foo
+"bar"
+> esc run -- dump-env
+foo: bar
+
+---
+> esc open
+> esc open foo
+> esc run -- dump-env

--- a/pkg/cmd/esc/cli/workdir.go
+++ b/pkg/cmd/esc/cli/workdir.go
@@ -1,0 +1,33 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import "os"
+
+// workingDir abstracts access to the process's working directory so that directory-relative
+// lookups (e.g. the search for the nearest .esc.yaml) can be unit tested.
+type workingDir interface {
+	Getwd() (string, error)
+}
+
+type defaultWorkingDir int
+
+func newWorkingDir() workingDir {
+	return defaultWorkingDir(0)
+}
+
+func (defaultWorkingDir) Getwd() (string, error) {
+	return os.Getwd()
+}


### PR DESCRIPTION
Implements the Notion proposal [ESC Default Environments](https://app.notion.com/p/ESC-Default-Environments-3a7fdbdf1cce8154b2bdd0f7f2046507) as written.

## Scope

- This is a **proof of concept for UX validation**, not production-ready. The goal is to give a
  human reviewer something to build and drive by hand to feel the proposed behavior, not to ship a
  hardened feature.
- The **Trust section of the proposal is deliberately not implemented**. There is no trust record,
  no `$PULUMI_HOME/esc/trust`, no prompt flow, and no `--accept`/`--revoke`. Every discovered
  `.esc.yaml` is treated as trusted.
- The proposal's **six unresolved inline comments were deliberately not addressed** (reusing
  `Pulumi.yaml` instead of a new file, preferring a single named environment over an import list,
  printing the env on stderr, trust-record details, etc.). They are review discussion, not
  requirements for this pass.

## What changed and why

Default environments let `esc` commands infer an environment from the working directory instead of
requiring an explicit name every time — especially useful inside a Pulumi project with a selected
stack.

- **`pkg/cmd/esc/cli/env_default_resolution.go`** (new): the resolution engine.
  - The nearest `.esc.yaml` walking up from the working directory wins. Its `environment` field is
    either a string ref (`org/project/env[@version]`, resolved through
    `getExistingEnvRefWithRelative` so it gets the same ambiguous-ref disambiguation as an explicit
    arg) or an `{organization, imports}` object (an anonymous import list; `organization` falls back
    to the account's default org).
  - Otherwise, falls back to the currently-selected Pulumi stack's `Pulumi.<stack>.yaml`
    `environment` imports (the `"yaml"` sentinel `workspace.Environment.Imports()` appends for
    inline config values is stripped). The selected stack is read via the first-party
    `pkgWorkspace.Context` (`esc.ws`), not a hand-rolled workspace-settings reader.
  - No `.esc.yaml`, no project, no selected stack, no stack config, or no imports all resolve to
    "no default" (`nil, nil`). Malformed `.esc.yaml`, `Pulumi.yaml`, or `Pulumi.<stack>.yaml` are
    errors.
  - Stacks whose config lives in the Pulumi Cloud (service-config stacks) resolve to no default —
    the ESC client has no stack-config APIs, and pulling in `pkg/backend` would breach the
    `pkg/cmd/esc` confinement rule. Documented in `esc env default --help`.
- **`pkg/cmd/esc/cli/env_default.go`** (new): `esc env default` prints the inferred default in
  `.esc.yaml` syntax plus a `source:` line, and errors with "no default environment" when there is
  nothing to show. No trust flags of any kind.
- **`env.go`**: `getExistingEnvRef` falls back to the default (rejecting an anonymous import-list
  default with a new `errAnonymousDefault`) when no environment is given. `getEnvTargetForOpenGet`
  implements the `[env] [path]` disambiguation for `open`/`get`: an explicit `--env` never consumes
  a positional arg; an arg containing `/` is always a ref; a bare arg is a property path when a
  default is configured and an environment name otherwise.
- **`env_open.go` / `env_get.go`**: route through `getEnvTargetForOpenGet`. Anonymous defaults open
  via `OpenYAMLEnvironment`; `get` synthesizes an `{imports: [...]}` doc and checks it via
  `CheckYAMLEnvironment`. `--draft` on an anonymous default is rejected ("--draft requires a named
  environment") since drafts are a property of a stored environment. `env get`'s `Args` validator is
  relaxed to accept zero positional args.
- **`env_run.go`**: `run -- cmd` (`ArgsLenAtDash() == 0`) runs `cmd` in the default (named or
  anonymous); `run <env> -- cmd` / `run <env> cmd` are unchanged; no default and no env still errors
  "no environment specified".
- **`env_set.go` / `env_edit.go` / `env_version.go`** (and, for free, everything else routed through
  `getExistingEnvRef`): use the default when it's a single named environment; reject an anonymous
  default with a clear error telling the user to pass an environment explicitly.
- **`env_ls.go`**: annotates a single-named-environment default with a `(default)` suffix in text
  output (matching even when `env ls` blanks the org for the caller's own username); `--output json`
  gains an additive top-level `"default"` field, with the existing `environments` array untouched.
  An anonymous-import-list default produces no annotation in either format.
- **`workdir.go`** (new): a `Getwd`-backed `workingDir` injectable (there were previously zero
  `Getwd` call sites in this CLI), following the same `valueOrDefault(opts.X, newX())` pattern as
  `exec`/`pager`/`environ`.
- **Test harness** (`cli_test.go`): a `process.cwd` testcase key backed by the new `wd` injectable,
  and a `pulumi: selected-stack:` testcase key that configures `MockContext.NewF` to return a
  `MockW` whose `Settings()` carries the given stack name. No changes outside `pkg/cmd/esc/` were
  needed — `MockContext`/`MockW` already existed.
- **`changelog/pending/20260729--cli-env--esc-default-environments.yaml`**: `cli/env` / `feat` entry.

The diff is confined to `pkg/cmd/esc/` plus the changelog entry — no changes to
`pkg/cmd/pulumi/`, the deployment engine, protobufs, `pkg/workspace`, or the SDK, and no
trust-related code anywhere.

### Divergence from the reference POC

A reviewer-approved implementation of this same proposal exists as an unpushed branch in the
now-archived `pulumi/esc` repo, and its design (the `defaultEnvironment`/`envTarget` types, the
`getEnvTargetForOpenGet` disambiguation, `errAnonymousDefault`, and the ~31-scenario
`env-default-*` test matrix) is carried over here nearly verbatim. The one deliberate divergence:
the archived repo's selected-stack lookup hand-reimplemented the Pulumi CLI's
workspace-settings file layout (`sha1(path)`-named JSON under `$PULUMI_HOME/workspaces`) because
that standalone repo couldn't depend on `pulumi/pulumi`. Here, the selected stack is read through
the first-party `esc.ws` (`pkgWorkspace.Context`) that this CLI already imports — no hand-rolled
settings parsing.

## How this was tested

- `cd pkg && go test -count=1 ./cmd/esc/...` — passes (all packages: `cli`, `cli/client`,
  `analysis`).
- All 104 pre-existing `pkg/cmd/esc/cli/testdata` snapshots pass unmodified, except one line of one
  snapshot (`env-set-file.yaml`) whose error text changed from a cobra arg-count error
  (`accepts between 1 and 3 arg(s), received 0`) to `no environment name specified`, an unavoidable
  side effect of relaxing `env set`'s `Args` validator to allow the zero-positional-arg default
  path — the same change the reviewer-approved reference implementation made for the same reason.
- New snapshot coverage (`pkg/cmd/esc/cli/testdata/env-default-*.yaml`,
  `env-{open,get,set,edit,version,ls,run}-default*.yaml`, `esc-open-run-default.yaml`) covers: each
  resolution source, `.esc.yaml`-over-stack precedence, the parent-directory walk, every no-default
  case (no `.esc.yaml`/no project/no selected stack/no stack config/no imports), every malformed-file
  error (`.esc.yaml`, `Pulumi.yaml`, `Pulumi.<stack>.yaml`), the inline-stack-values "yaml" sentinel
  stripping, `open`/`get`/`run` disambiguation with and without a default, the anonymous-default
  rejection on `set`/`edit`/`version`, and `ls`'s `(default)` annotation (including the
  imports-default no-annotation case) in both text and JSON output.
- `mise exec -- ./bin/custom-gcl run --config .golangci.yml ./cmd/esc/...` — `0 issues`.
- `gofmt -l cmd/esc/cli/` — clean.

## Walkthrough for a human reviewer

```sh
cd pkg && mise exec -- go build -o /tmp/esc ./cmd/esc
export PATH=/tmp:$PATH   # so `esc` on PATH is the built binary
esc login                # or whatever backend you normally use

mkdir -p /tmp/esc-default-poc/sub && cd /tmp/esc-default-poc

# 1. A .esc.yaml naming a single environment.
cat > .esc.yaml <<'EOF'
environment: <your-org>/default/<some-existing-env>
EOF

esc env default          # shows the inferred default + `source: .esc.yaml`
esc env open              # opens it with no explicit name
esc env get somePropertyPath
esc env ls                 # note the `(default)` suffix on that one environment
esc env ls --output json   # note the additive top-level "default" field

cd sub                     # parent-directory walk: still resolves from ../.esc.yaml
esc env default
cd ..

# 2. Switch to an anonymous import-list default.
cat > .esc.yaml <<'EOF'
environment:
  organization: <your-org>
  imports:
    - default/<env-a>
    - default/<env-b>
EOF

esc env default            # prints the import list + source
esc env open                # opens the anonymous list
esc env get                  # synthesizes {imports: [...]} and checks it
esc env set foo bar          # rejected: "the default environment is an anonymous list of
                              #  imports; this command requires a named environment..."
esc env ls                   # no (default) annotation for an import-list default

# 3. Remove .esc.yaml and fall back to a Pulumi stack.
rm .esc.yaml
pulumi new nodejs -y -f       # or `pulumi login --local` + `pulumi stack init dev`
pulumi stack select dev
# Edit Pulumi.dev.yaml to add:
#   environment:
#     - default/<some-existing-env>
esc env default                # source: stack dev
esc env open
esc env run -- env | grep <something-from-that-env>

# 4. Explicit refs and --env keep working exactly as before, regardless of any default in place.
esc env open <your-org>/default/<some-other-env>
esc env get --env <your-org>/default/<some-other-env> somePath
```

## What to look at

- `pkg/cmd/esc/cli/env_default_resolution.go` — the resolution engine; this is the core of the
  change and the highest-value read.
- `pkg/cmd/esc/cli/env.go`'s `getEnvTargetForOpenGet` — the `[env] [path]` disambiguation rules;
  worth tracing through the `env-{open,get}-disambiguation*.yaml` snapshots alongside it.
- The service-config-stacks-resolve-to-no-default call, and the `--draft`-vs-anonymous-default
  rejection in `env_open.go` — both are judgment calls this monorepo forced that the archived
  reference didn't have to make; flagged in code comments and in `env default --help`.
- `env_ls.go`'s default-annotation matching against the org-blanked-for-own-username case.

There is no GitHub issue for this ad-hoc UX-validation POC.
