### PR TITLE
do: treat resources that empty outputs and no ID as not found

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -270,7 +270,7 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 				if err != nil {
 					return nil, err
 				}
-				if response.Outputs == nil {
+				if readNotFound(response) {
 					return nil, fmt.Errorf("resource %q was not found", args[0])
 				}
 				if response.ID != "" {
@@ -314,7 +314,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			if err != nil {
 				return err
 			}
-			if read.Outputs == nil {
+			if readNotFound(read) {
 				return fmt.Errorf("resource %q was not found", args[0])
 			}
 			// AllowMissingProperties because a patch typically only specifies the fields being changed; the binder
@@ -431,7 +431,7 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			if err != nil {
 				return err
 			}
-			if response.Outputs == nil {
+			if readNotFound(response) {
 				return fmt.Errorf("resource %q was not found", args[0])
 			}
 			id := response.ID
@@ -591,6 +591,10 @@ func (pc *packageCommand) checkResourceInputs(
 		return nil, fmt.Errorf("%s", b.String())
 	}
 	return checked.Properties, nil
+}
+
+func readNotFound(read plugin.ReadResponse) bool {
+	return read.Outputs == nil || read.ID == ""
 }
 
 func resultOutputs(id resource.ID, outputs resource.PropertyMap, res *schema.Resource) resource.PropertyMap {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -522,18 +522,6 @@ enabled = true
 func TestDoCmdResourceMissingResourceNotFound(t *testing.T) {
 	t.Parallel()
 
-	notFoundResponses := map[string]plugin.ReadResponse{
-		"nil outputs": {},
-		"empty outputs": {ReadResult: plugin.ReadResult{
-			Inputs:  resource.PropertyMap{},
-			Outputs: resource.PropertyMap{},
-		}},
-		"blank id": {ReadResult: plugin.ReadResult{
-			Inputs:  resource.PropertyMap{"name": resource.NewProperty("stale")},
-			Outputs: resource.PropertyMap{"name": resource.NewProperty("stale")},
-		}},
-	}
-
 	t.Run("delete empty outputs with id", func(t *testing.T) {
 		t.Parallel()
 		var deleted bool
@@ -558,6 +546,18 @@ func TestDoCmdResourceMissingResourceNotFound(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 		assert.True(t, deleted)
 	})
+
+	notFoundResponses := map[string]plugin.ReadResponse{
+		"nil outputs": {},
+		"empty outputs": {ReadResult: plugin.ReadResult{
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{},
+		}},
+		"blank id": {ReadResult: plugin.ReadResult{
+			Inputs:  resource.PropertyMap{"name": resource.NewProperty("stale")},
+			Outputs: resource.PropertyMap{"name": resource.NewProperty("stale")},
+		}},
+	}
 
 	for shape, response := range notFoundResponses {
 		t.Run("delete "+shape, func(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -519,6 +519,106 @@ enabled = true
 	})
 }
 
+func TestDoCmdResourceMissingResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	notFoundResponses := map[string]plugin.ReadResponse{
+		"nil outputs": {},
+		"empty outputs": {ReadResult: plugin.ReadResult{
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{},
+		}},
+		"blank id": {ReadResult: plugin.ReadResult{
+			Inputs:  resource.PropertyMap{"name": resource.NewProperty("stale")},
+			Outputs: resource.PropertyMap{"name": resource.NewProperty("stale")},
+		}},
+	}
+
+	t.Run("delete empty outputs with id", func(t *testing.T) {
+		t.Parallel()
+		var deleted bool
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{},
+						Outputs: resource.PropertyMap{},
+					}}, nil
+				},
+				DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					assert.Equal(t, resource.ID("res-1"), req.ID)
+					deleted = true
+					return plugin.DeleteResponse{}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+		require.NoError(t, cmd.Execute())
+		assert.True(t, deleted)
+	})
+
+	for shape, response := range notFoundResponses {
+		t.Run("delete "+shape, func(t *testing.T) {
+			t.Parallel()
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						return response, nil
+					},
+					DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+						require.Fail(t, "Delete should not be called for a missing resource")
+						return plugin.DeleteResponse{}, nil
+					},
+				},
+			})
+			cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-gone", "--yes"})
+			err := cmd.Execute()
+			assert.ErrorContains(t, err, `resource "res-gone" was not found`)
+		})
+
+		t.Run("read "+shape, func(t *testing.T) {
+			t.Parallel()
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						return response, nil
+					},
+				},
+			})
+			cmd.SetArgs([]string{"azure:index:myResource", "read", "res-gone"})
+			err := cmd.Execute()
+			assert.ErrorContains(t, err, `resource "res-gone" was not found`)
+		})
+
+		t.Run("patch "+shape, func(t *testing.T) {
+			t.Parallel()
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						return response, nil
+					},
+					UpdateF: func(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+						require.Fail(t, "Update should not be called for a missing resource")
+						return plugin.UpdateResponse{}, nil
+					},
+				},
+			})
+			inputFile := writeHCLFile(t, "patch.pcl", `enabled = true`)
+			cmd.SetArgs([]string{
+				"--stateless", "azure:index:myResource", "patch", "res-gone", "--yes",
+				"--input", "pcl", "--input-file", inputFile,
+			})
+			err := cmd.Execute()
+			assert.ErrorContains(t, err, `resource "res-gone" was not found`)
+		})
+	}
+}
+
 func TestDoCmdResourceList(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -158,7 +158,7 @@ func (pc *packageCommand) newStatelessResourceUpsertCommand(res *schema.Resource
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
 			}
-			if read.Outputs == nil {
+			if readNotFound(read) {
 				return pc.runStatelessCreate(cmd, res, yes, func() (resource.PropertyMap, error) {
 					return inputs, nil
 				})

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -613,6 +613,49 @@ size = 2
 		assert.Equal(t, []string{"read", "check", "create"}, calls)
 		assert.JSONEq(t, `{"id":"res-2","name":"new","size":2}`, stdout.String())
 	})
+
+	t.Run("creates a missing resource read back as emptied state", func(t *testing.T) {
+		t.Parallel()
+		var calls []string
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					calls = append(calls, "read")
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						Inputs:  resource.PropertyMap{},
+						Outputs: resource.PropertyMap{},
+					}}, nil
+				},
+				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					calls = append(calls, "check")
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					calls = append(calls, "create")
+					return plugin.CreateResponse{
+						ID: "res-2",
+						Properties: resource.PropertyMap{
+							"name": resource.NewProperty("new"),
+						},
+					}, nil
+				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					require.Fail(t, "Update should not be called for a missing resource")
+					return plugin.UpdateResponse{}, nil
+				},
+			},
+		})
+
+		inputFile := writeHCLFile(t, "upsert.pcl", `name = "new"`)
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "upsert", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile, "--output", "json",
+		})
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, []string{"read", "check", "create"}, calls)
+		assert.JSONEq(t, `{"id":"res-2","name":"new"}`, stdout.String())
+	})
 }
 
 // TestDoCmdResourceStatefulCreateConstructsSnippet mirrors the upsert-constructs-snippet test but


### PR DESCRIPTION
The terraform bridge marshals empty outputs on read to an empty property map, rather than a `nil` property map. When doing a read in `pulumi do`, we currently only take a nil `Outputs` as missing resource, but that is not quite correct with what the terraform bridge is doing.

Instead also check if the ID is empty and the Outputs don't contain anything, so we can detect those resources as not found, instead of continuing on our merry way and confusing the user.

Fixes part of #23916 