### PR TITLE
deduplicate filters when adding them

### DIFF
--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -157,7 +157,7 @@ func getStackConfigurationFromProjectStack(
 			return backend.StackConfiguration{}, fmt.Errorf("preparing environment: %w", err)
 		}
 		if len(secrets) != 0 {
-			logging.AddGlobalFilter(logging.CreateFilter(secrets, "[secret]"))
+			logging.AddGlobalSecretFilter(secrets, "[secret]")
 		}
 
 		for _, kvp := range environ {

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -436,7 +436,7 @@ func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, err
 		}
 	}
 
-	logging.AddGlobalFilter(logging.CreateFilter(secrets, "[secret]"))
+	logging.AddGlobalSecretFilter(secrets, "[secret]")
 
 	buffer, done := make(chan Event), make(chan bool)
 	go queueEvents(events, buffer, done)

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -780,7 +780,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 					policyOpts.AdditionalEnv = resolved.EnvironmentVariables
 				}
 				if len(resolved.Secrets) > 0 {
-					logging.AddGlobalFilter(logging.CreateFilter(resolved.Secrets, "[secret]"))
+					logging.AddGlobalSecretFilter(resolved.Secrets, "[secret]")
 				}
 			}
 
@@ -884,7 +884,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 						policyOpts.AdditionalEnv = resolved.EnvironmentVariables
 					}
 					if len(resolved.Secrets) > 0 {
-						logging.AddGlobalFilter(logging.CreateFilter(resolved.Secrets, "[secret]"))
+						logging.AddGlobalSecretFilter(resolved.Secrets, "[secret]")
 					}
 				}
 			}

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -43,10 +43,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
-type Filter interface {
-	Filter(s string) string
-}
-
 var (
 	LogToStderr = false // true if logging is being redirected to stderr.
 	Verbose     = 0     // >0 if verbose logging is enabled at a particular level.
@@ -54,8 +50,11 @@ var (
 )
 
 var (
-	rwLock  sync.RWMutex
-	filters []Filter
+	rwLock sync.RWMutex
+
+	secretsSeen     map[string]struct{}
+	secretsPairs    []string
+	secretsReplacer *strings.Replacer
 )
 
 var (
@@ -446,27 +445,7 @@ func (f formattingHandler) WithGroup(name string) slog.Handler {
 	return formattingHandler{inner: f.inner.WithGroup(name)}
 }
 
-type nopFilter struct{}
-
-func (f *nopFilter) Filter(s string) string {
-	return s
-}
-
-type replacerFilter struct {
-	replacer *strings.Replacer
-}
-
-func (f *replacerFilter) Filter(s string) string {
-	return f.replacer.Replace(s)
-}
-
-func AddGlobalFilter(filter Filter) {
-	rwLock.Lock()
-	filters = append(filters, filter)
-	rwLock.Unlock()
-}
-
-func CreateFilter(secrets []string, replacement string) Filter {
+func replacements(secrets []string, replacement string) []string {
 	items := slice.Prealloc[string](len(secrets))
 	for _, secret := range secrets {
 		// For short secrets, don't actually add them to the filter, this is a trade-off we make to prevent
@@ -488,23 +467,41 @@ func CreateFilter(secrets []string, replacement string) Filter {
 			items = append(items, escaped, replacement)
 		}
 	}
-	if len(items) > 0 {
-		return &replacerFilter{replacer: strings.NewReplacer(items...)}
-	}
+	return items
+}
 
-	return &nopFilter{}
+// AddGlobalSecretFilter registers secrets to be replaced by FilterString. Secrets registered
+// here are deduplicated and folded into a single replacer, so FilterString makes one pass over
+// its input no matter how many operations register their secrets.
+func AddGlobalSecretFilter(secrets []string, replacement string) {
+	rwLock.Lock()
+	defer rwLock.Unlock()
+
+	changed := false
+	for _, secret := range secrets {
+		if _, seen := secretsSeen[secret]; seen {
+			continue
+		}
+		if secretsSeen == nil {
+			secretsSeen = map[string]struct{}{}
+		}
+		secretsSeen[secret] = struct{}{}
+		secretsPairs = append(secretsPairs, replacements([]string{secret}, replacement)...)
+		changed = true
+	}
+	if changed && len(secretsPairs) > 0 {
+		secretsReplacer = strings.NewReplacer(secretsPairs...)
+	}
 }
 
 func FilterString(msg string) string {
-	var localFilters []Filter
 	rwLock.RLock()
-	localFilters = filters
+	secretsFilter := secretsReplacer
 	rwLock.RUnlock()
 
-	for _, filter := range localFilters {
-		msg = filter.Filter(msg)
+	if secretsFilter != nil {
+		msg = secretsFilter.Replace(msg)
 	}
-
 	return msg
 }
 

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -98,63 +98,75 @@ func TestInitLoggingSkipsLogFileWithOTel(t *testing.T) { //nolint:paralleltest /
 	assert.Equal(t, prevPath, logFilePath)
 }
 
-func TestFilter(t *testing.T) {
-	t.Parallel()
+//nolint:paralleltest // exercises the process-global secret filter state.
+func TestFilterString(t *testing.T) {
+	rwLock.Lock()
+	prevSeen, prevPairs, prevReplacer := secretsSeen, secretsPairs, secretsReplacer
+	secretsSeen, secretsPairs, secretsReplacer = nil, nil, nil
+	rwLock.Unlock()
+	t.Cleanup(func() {
+		rwLock.Lock()
+		secretsSeen, secretsPairs, secretsReplacer = prevSeen, prevPairs, prevReplacer
+		rwLock.Unlock()
+	})
 
-	filter1 := CreateFilter([]string{"secret1", "secret2"}, "[secret]")
-	msg1 := filter1.Filter(
-		"These are my secrets: secret1, secret2, secret3, secret10")
+	AddGlobalSecretFilter([]string{"secret1", "secret2"}, "[secret]")
 	assert.Equal(t,
 		"These are my secrets: [secret], [secret], secret3, [secret]0",
-		msg1)
+		FilterString("These are my secrets: secret1, secret2, secret3, secret10"))
 
 	// Ensure that special characters don't screw up the search
-	filter2 := CreateFilter([]string{"secret.*", "secre[t]3"}, "[creds]")
-	msg2 := filter2.Filter(
-		"These are my secrets: secret1, secret2, secret3, secret.*, secre[t]3")
+	AddGlobalSecretFilter([]string{"secret.*", "secre[t]3"}, "[creds]")
 	assert.Equal(t,
-		"These are my secrets: secret1, secret2, secret3, [creds], [creds]",
-		msg2)
+		"These are my secrets: secret3, [creds], [creds]",
+		FilterString("These are my secrets: secret3, secret.*, secre[t]3"))
 
 	// Ensure that non-UTF8 characters don't screw up the search
-	filter3 := CreateFilter([]string{"nonutf8\xa7", "secret1"}, "[creds]")
-	msg3 := filter3.Filter(
-		"These are my secrets: secret1, nonutf8\xa7")
+	AddGlobalSecretFilter([]string{"nonutf8\xa7"}, "[creds]")
 	assert.Equal(t,
-		"These are my secrets: [creds], [creds]",
-		msg3)
+		"These are my secrets: [creds]",
+		FilterString("These are my secrets: nonutf8\xa7"))
 
 	// Short secrets of 1-2 characters are not masked
-	filter4 := CreateFilter([]string{"a", "my", "123"}, "[creds]")
-	msg4 := filter4.Filter(
-		"These are my secrets: a, my, 123")
+	AddGlobalSecretFilter([]string{"a", "my", "123"}, "[creds]")
 	assert.Equal(t,
 		"These are my secrets: a, my, [creds]",
-		msg4)
+		FilterString("These are my secrets: a, my, 123"))
 
 	// Ensure that multi-line secrets are masked in output.
-	filter5 := CreateFilter([]string{"multi\nline\nsecret"}, "[secret]")
-	msg5 := filter5.Filter(
-		`These are my secrets: multi\nline\nsecret`)
+	AddGlobalSecretFilter([]string{"multi\nline\nsecret"}, "[secret]")
 	assert.Equal(t,
 		"These are my secrets: [secret]",
-		msg5)
+		FilterString(`These are my secrets: multi\nline\nsecret`))
 
 	// Ensure that secrets with tabs are masked in output.
-	filter6 := CreateFilter([]string{"secretwith\t"}, "[secret]")
-	msg6 := filter6.Filter(
-		`These are my secrets: secretwith\t`)
+	AddGlobalSecretFilter([]string{"secretwith\t"}, "[secret]")
 	assert.Equal(t,
 		"These are my secrets: [secret]",
-		msg6)
+		FilterString(`These are my secrets: secretwith\t`))
 
 	// Boolean strings "true" and "false" are not masked, regardless of case.
-	filter7 := CreateFilter([]string{"true", "false", "True", "FALSE", "realsecret"}, "[secret]")
-	msg7 := filter7.Filter(
-		"value is True and FALSE but realsecret is hidden")
+	AddGlobalSecretFilter([]string{"true", "false", "True", "FALSE", "realsecret"}, "[secret]")
 	assert.Equal(t,
 		"value is True and FALSE but [secret] is hidden",
-		msg7)
+		FilterString("value is True and FALSE but realsecret is hidden"))
+
+	// Secrets serialized to JSON are masked in their escaped form as well.
+	AddGlobalSecretFilter([]string{`quo"te`}, "[secret]")
+	assert.Equal(t,
+		`values: [secret], [secret]`,
+		FilterString(`values: quo"te, quo\"te`))
+
+	// Different replacements can be used for different secrets.
+	AddGlobalSecretFilter([]string{"hunter2"}, "[credential]")
+	assert.Equal(t,
+		"[secret] and [credential]",
+		FilterString("realsecret and hunter2"))
+
+	// Re-registering secrets must not grow the replacement list.
+	before := len(secretsPairs)
+	AddGlobalSecretFilter([]string{"secret1", "realsecret"}, "[secret]")
+	assert.Equal(t, before, len(secretsPairs))
 }
 
 func TestLoggingDoesNotConflictWithGlog(t *testing.T) {

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -392,7 +392,7 @@ func readCredentialsFile(credsFile string) (Credentials, error) {
 		}
 	}
 
-	logging.AddGlobalFilter(logging.CreateFilter(secrets, "[credential]"))
+	logging.AddGlobalSecretFilter(secrets, "[credential]")
 
 	return creds, nil
 }


### PR DESCRIPTION
Our current logging machinery always appends filter to the global filter, and then runs all of the filters on every log line.  That's usually fine for normal engine operations, since each filter is only appended once.

However in conformance tests, the process runs over multiple engine invocation, and thus potentially adds the same filter multiple times. That in combination with running it over large
strings (e.g. `l2-large-string`) can take a considerable amount of time, and e.g. in `pulumi-yaml` leads to timeouts.

There's never any need to add the same filter multiple times, so change the implementation of `AddGlobalFilter` out to deduplicate the filters.

This is only ever used in `pulumi/pulumi` as far as I can tell, so we break the existing implementation here for simplicity.

I'm not sure why this didn't lead to conformance tests in this repo timing out (maybe we have fewer secrets here than in yaml, or just more partitions for running the conformance tests, so the large string test didn't stand out).

Investigation in https://github.com/pulumi/pulumi-yaml/pull/1161.

Fixes https://github.com/pulumi/pulumi-yaml/issues/1158 once we pull this into yaml.