### PR TITLE
Lower Node.js property-only applies to output projections

### DIFF
--- a/changelog/pending/programgen-nodejs-fix-20260729-120000.yaml
+++ b/changelog/pending/programgen-nodejs-fix-20260729-120000.yaml
@@ -1,0 +1,4 @@
+component: programgen/nodejs
+kind: fix
+body: Avoid redundant applies when projecting properties from Node.js outputs
+time: 2026-07-29T12:00:00+02:00

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -15,11 +15,35 @@
 package nodejs
 
 import (
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var outputMemberNames = codegen.NewStringSet(
+	"allResources",
+	"apply",
+	"constructor",
+	"deploymentOnlyModule",
+	"doNotCapture",
+	"get",
+	"hasOwnProperty",
+	"isKnown",
+	"isPrototypeOf",
+	"isSecret",
+	"promise",
+	"propertyIsEnumerable",
+	"resources",
+	"then",
+	"toJSON",
+	"toLocaleString",
+	"toString",
+	"valueOf",
 )
 
 func isOutputType(t model.Type) bool {
@@ -55,20 +79,66 @@ func isPromiseType(t model.Type) bool {
 	return false
 }
 
-func isParameterReference(parameters codegen.Set, x model.Expression) bool {
+func isDirectParameterReference(parameters codegen.Set, x model.Expression) bool {
 	scopeTraversal, ok := x.(*model.ScopeTraversalExpression)
-	if !ok {
+	if !ok || len(scopeTraversal.Parts) != 1 {
 		return false
 	}
 
 	return parameters.Has(scopeTraversal.Parts[0])
 }
 
-// canLiftTraversal returns true if this traversal can be lifted. Any traversal that does not traverse
-// possibly-undefined values can be lifted.
+func parameterRelativeTraversal(parameters codegen.Set, x model.Expression) (
+	hcl.Traversal, []model.Traversable, bool,
+) {
+	switch x := x.(type) {
+	case *model.ScopeTraversalExpression:
+		if !parameters.Has(x.Parts[0]) {
+			return nil, nil, false
+		}
+		return x.Traversal.SimpleSplit().Rel, x.Parts, true
+	case *model.RelativeTraversalExpression:
+		if !isDirectParameterReference(parameters, x.Source) {
+			return nil, nil, false
+		}
+		return x.Traversal, x.Parts, true
+	default:
+		return nil, nil, false
+	}
+}
+
+func canLiftOutputTraversal(traversal hcl.Traversal) bool {
+	for _, traverser := range traversal {
+		var name string
+		switch traverser := traverser.(type) {
+		case hcl.TraverseAttr:
+			name = traverser.Name
+		case hcl.TraverseIndex:
+			if traverser.Key.Type() != cty.String {
+				continue
+			}
+			name = traverser.Key.AsString()
+		default:
+			continue
+		}
+
+		// The Output proxy resolves real Output and Object members before lifting properties.
+		if strings.HasPrefix(name, "__") || outputMemberNames.Has(name) {
+			return false
+		}
+	}
+	return true
+}
+
+// canLiftTraversal returns true if this traversal can be lifted. Any traversal that does not traverse through
+// possibly-undefined values can be lifted. The result itself may be undefined.
 func (g *generator) canLiftTraversal(parts []model.Traversable) bool {
-	for _, p := range parts {
-		t := model.GetTraversableType(p)
+	if len(parts) < 2 {
+		return false
+	}
+	// Only check nonterminal parts: the final part is the result and may itself be undefined.
+	for _, part := range parts[:len(parts)-1] {
+		t := model.GetTraversableType(part)
 		if model.IsOptionalType(t) || isPromiseType(t) {
 			return false
 		}
@@ -100,33 +170,41 @@ func (g *generator) parseProxyApply(parameters codegen.Set, args []model.Express
 	case *model.IndexExpression:
 		t := arg.Type()
 		skipType := model.IsOptionalType(t) || isPromiseType(t) || isOutputType(t)
-		if !isParameterReference(parameters, then.Collection) || skipType {
+		if !isDirectParameterReference(parameters, then.Collection) || skipType {
 			return nil, false
 		}
-		then.Collection = arg
-	case *model.ScopeTraversalExpression:
-		if !isParameterReference(parameters, then) || isPromiseType(arg.Type()) {
+		newIndex := &model.IndexExpression{
+			Collection: arg,
+			Key:        then.Key,
+		}
+		if diags := newIndex.Typecheck(false); diags.HasErrors() {
 			return nil, false
 		}
-		if !g.canLiftTraversal(then.Parts) {
+		return newIndex, true
+	case *model.ScopeTraversalExpression, *model.RelativeTraversalExpression:
+		traversal, parts, ok := parameterRelativeTraversal(parameters, then)
+		if !ok || isPromiseType(arg.Type()) {
 			return nil, false
 		}
-
-		switch arg := arg.(type) {
-		case *model.RelativeTraversalExpression:
-			arg.Traversal = append(arg.Traversal, then.Traversal[1:]...)
-			arg.Parts = append(arg.Parts, then.Parts...)
-		case *model.ScopeTraversalExpression:
-			arg.Traversal = append(arg.Traversal, then.Traversal[1:]...)
-			arg.Parts = append(arg.Parts, then.Parts...)
-		default:
+		// A direct parameter reference is the identity projection. Preserve its argument so interpolation lowering can
+		// use it without introducing an explicit apply.
+		if len(traversal) == 0 {
+			return arg, true
+		}
+		if !g.canLiftTraversal(parts) || !canLiftOutputTraversal(traversal) {
 			return nil, false
 		}
+		newTraversal := &model.RelativeTraversalExpression{
+			Source:    arg,
+			Traversal: traversal,
+		}
+		if diags := newTraversal.Typecheck(false); diags.HasErrors() {
+			return nil, false
+		}
+		return newTraversal, true
 	default:
 		return nil, false
 	}
-
-	return arg, true
 }
 
 func callbackParameterReferences(expr model.Expression, parameters codegen.Set) []*model.Variable {

--- a/pkg/codegen/nodejs/gen_program_lower_test.go
+++ b/pkg/codegen/nodejs/gen_program_lower_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProxyApplyWithCallExpression(t *testing.T) {
+	t.Parallel()
+
+	resultType := model.NewObjectType(map[string]model.Type{
+		"result": model.NewOptionalType(model.StringType),
+	})
+	call := &model.FunctionCallExpression{
+		Name: "call",
+		Signature: model.StaticFunctionSignature{
+			ReturnType: model.NewOutputType(resultType),
+		},
+	}
+	parameter := &model.Variable{Name: "result", VariableType: resultType}
+	body := &model.RelativeTraversalExpression{
+		Source: model.VariableReference(parameter),
+		Traversal: hcl.Traversal{
+			hcl.TraverseAttr{Name: "result"},
+		},
+	}
+	require.Empty(t, body.Typecheck(false))
+
+	parameters := codegen.Set{}
+	parameters.Add(parameter)
+	projection, ok := (&generator{}).parseProxyApply(parameters, []model.Expression{call}, body)
+	require.True(t, ok)
+
+	traversal, ok := projection.(*model.RelativeTraversalExpression)
+	require.True(t, ok)
+	assert.Same(t, call, traversal.Source)
+	require.Len(t, traversal.Traversal, 1)
+	attr, ok := traversal.Traversal[0].(hcl.TraverseAttr)
+	require.True(t, ok)
+	assert.Equal(t, "result", attr.Name)
+	assert.True(t, traversal.Type().Equals(model.NewOutputType(model.NewOptionalType(model.StringType))))
+}
+
+func TestParseProxyApplyWithOutputMemberName(t *testing.T) {
+	t.Parallel()
+
+	resultType := model.NewObjectType(map[string]model.Type{
+		"apply": model.StringType,
+	})
+	call := &model.FunctionCallExpression{
+		Name: "call",
+		Signature: model.StaticFunctionSignature{
+			ReturnType: model.NewOutputType(resultType),
+		},
+	}
+	parameter := &model.Variable{Name: "result", VariableType: resultType}
+	body := &model.RelativeTraversalExpression{
+		Source: model.VariableReference(parameter),
+		Traversal: hcl.Traversal{
+			hcl.TraverseAttr{Name: "apply"},
+		},
+	}
+	require.Empty(t, body.Typecheck(false))
+
+	parameters := codegen.Set{}
+	parameters.Add(parameter)
+	_, ok := (&generator{}).parseProxyApply(parameters, []model.Expression{call}, body)
+	assert.False(t, ok)
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-proxy-index/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-proxy-index/index.ts
@@ -16,7 +16,7 @@ export default async () => {
     return {
         l: l[0],
         m: m.key,
-        c: c.apply(c => c.property),
+        c: c.property,
         o: o.property,
         a: a.apply(a => a.property),
     };

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-component-call-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-component-call-simple/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
 
 const component1 = new component.ComponentCallable("component1", {value: "bar"});
-export const from_identity = component1.identity().apply(call => call.result);
+export const from_identity = component1.identity().result;
 export const from_prefixed = component1.prefixed(({
     prefix: "foo-",
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-component-property-deps/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-component-property-deps/index.ts
@@ -24,4 +24,4 @@ export const propertyDepsFromCall = component1.refs(({
         one: custom1,
         two: custom2,
     },
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-elide-index/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-elide-index/index.ts
@@ -5,4 +5,4 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 const res = new simple.Resource("res", {value: true});
 export const inv = simple_invoke.myInvokeOutput({
     value: "test",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-extension-parameterized-resource/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-extension-parameterized-resource/index.ts
@@ -7,4 +7,4 @@ export const parameterValue = greeting.parameterValue;
 export const parameterValueFromComponent = greetingComp.parameterValue;
 export const invokeGreeting = myext.greetOutput({
     name: "Pulumi",
-}).apply(invoke => invoke.greeting);
+}).greeting;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-index-mod/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-index-mod/index.ts
@@ -3,13 +3,13 @@ import * as index_mod from "@pulumi/index-mod";
 
 const res1 = new index_mod.indexmine.Resource("res1", {text: index_mod.indexmine.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out1 = res1.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 const res2 = new index_mod.indexmine.nested.Resource("res2", {text: index_mod.indexmine.nested.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out2 = res2.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-dependencies/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-dependencies/index.ts
@@ -8,7 +8,7 @@ const first = new simple.Resource("first", {value: false});
 const second = new simple.Resource("second", {value: simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: first.value,
-}).apply(invoke => invoke.secret)});
+}).secret});
 const third = new simple_invoke.StringResource("third", {text: "third"});
 // third.text is known during preview, but third does not exist yet. SDKs must
 // infer the dependency on third from the invoke's arguments and skip the

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-multi-argument/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-multi-argument/index.ts
@@ -1,5 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as multi_argument_invoke from "@pulumi/multi-argument-invoke";
 
-export const both = multi_argument_invoke.multiArgumentInvokeOutput("hello", "world").apply(invoke => invoke.result);
-export const onlyRequired = multi_argument_invoke.multiArgumentInvokeOutput("hello").apply(invoke => invoke.result);
+export const both = multi_argument_invoke.multiArgumentInvokeOutput("hello", "world").result;
+export const onlyRequired = multi_argument_invoke.multiArgumentInvokeOutput("hello").result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-output-only/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-output-only/index.ts
@@ -3,7 +3,7 @@ import * as output_only_invoke from "@pulumi/output-only-invoke";
 
 export const hello = output_only_invoke.myInvokeOutput({
     value: "hello",
-}).apply(invoke => invoke.result);
+}).result;
 export const goodbye = output_only_invoke.myInvokeOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-secrets/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-secrets/index.ts
@@ -6,12 +6,12 @@ const res = new simple.Resource("res", {value: true});
 export const nonSecret = simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: false,
-}).apply(invoke => invoke.response);
+}).response;
 export const firstSecret = simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: res.value,
-}).apply(invoke => invoke.response);
+}).response;
 export const secondSecret = simple_invoke.secretInvokeOutput({
     value: pulumi.secret("goodbye"),
     secretResponse: false,
-}).apply(invoke => invoke.response);
+}).response;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-simple/index.ts
@@ -3,7 +3,7 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 
 export const hello = simple_invoke.myInvokeOutput({
     value: "hello",
-}).apply(invoke => invoke.result);
+}).result;
 export const goodbye = simple_invoke.myInvokeOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-variants/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-variants/index.ts
@@ -4,5 +4,5 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 const res = new simple_invoke.StringResource("res", {text: "hello"});
 export const outputInput = simple_invoke.myInvokeOutput({
     value: res.text,
-}).apply(invoke => invoke.result);
-export const unit = simple_invoke.unitOutput({}).apply(invoke => invoke.result);
+}).result;
+export const unit = simple_invoke.unitOutput({}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-module-format/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-module-format/index.ts
@@ -6,49 +6,49 @@ import * as module_format from "@pulumi/module-format";
 // First use the fully specified token to invoke and create a resource.
 const res1 = new module_format.mod.Resource("res1", {text: module_format.mod.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out1 = res1.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res2 = new module_format.mod.Resource("res2", {text: module_format.mod.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out2 = res2.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // First use the fully specified token to invoke and create a resource.
 const res3 = new module_format.mod.nested.Resource("res3", {text: module_format.mod.nested.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out3 = res3.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res4 = new module_format.mod.nested.Resource("res4", {text: module_format.mod.nested.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out4 = res4.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // First use the fully specified token to invoke and create a resource in the index module.
 const res5 = new module_format.Resource("res5", {text: module_format.concatWorldOutput({
     value: "bonjour",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out5 = res5.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res6 = new module_format.Resource("res6", {text: module_format.concatWorldOutput({
     value: "youkoso",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out6 = res6.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // Next use the short, 2 component, form because this is the index module
 const res7 = new module_format.Resource("res7", {text: module_format.concatWorldOutput({
     value: "guten tag",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out7 = res7.call(({
     input: "xxx",
-})).apply(call => call.output);
+})).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-parameterized-invoke/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-parameterized-invoke/index.ts
@@ -3,4 +3,4 @@ import * as subpackage from "@pulumi/subpackage";
 
 export const parameterValue = subpackage.doHelloWorldOutput({
     input: "goodbye",
-}).apply(invoke => invoke.output);
+}).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-primitive-ref-optional/index.ts
@@ -25,12 +25,12 @@ const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
 const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
     string: setRes.optionalData.apply(optionalData => optionalData?.string),
 }});
-export const setBoolean = setRes.data.apply(data => data.boolean);
-export const setFloat = setRes.data.apply(data => data.float);
-export const setInteger = setRes.data.apply(data => data.integer);
-export const setString = setRes.data.apply(data => data.string);
-export const setNumberArray = setRes.data.apply(data => data.numberArray);
-export const setBooleanMap = setRes.data.apply(data => data.booleanMap);
+export const setBoolean = setRes.data.boolean;
+export const setFloat = setRes.data.float;
+export const setInteger = setRes.data.integer;
+export const setString = setRes.data.string;
+export const setNumberArray = setRes.data.numberArray;
+export const setBooleanMap = setRes.data.booleanMap;
 export const unsetBoolean = unsetRes.data.apply(data => data.boolean == null ? "null" : "not null");
 export const unsetFloat = unsetRes.data.apply(data => data.float == null ? "null" : "not null");
 export const unsetInteger = unsetRes.data.apply(data => data.integer == null ? "null" : "not null");

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-provider-call-explicit/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-provider-call-explicit/index.ts
@@ -5,8 +5,8 @@ const explicitProv = new call.Provider("explicitProv", {value: "explicitProvValu
 const explicitRes = new call.Custom("explicitRes", {value: "explicitValue"}, {
     provider: explicitProv,
 });
-export const explicitProviderValue = explicitRes.providerValue().apply(call => call.result);
-export const explicitProvFromIdentity = explicitProv.identity().apply(call => call.result);
+export const explicitProviderValue = explicitRes.providerValue().result;
+export const explicitProvFromIdentity = explicitProv.identity().result;
 export const explicitProvFromPrefixed = explicitProv.prefixed(({
     prefix: "call-prefix-",
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-provider-call/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-provider-call/index.ts
@@ -2,4 +2,4 @@ import * as pulumi from "@pulumi/pulumi";
 import * as call from "@pulumi/call";
 
 const defaultRes = new call.Custom("defaultRes", {value: "defaultValue"});
-export const defaultProviderValue = defaultRes.providerValue().apply(call => call.result);
+export const defaultProviderValue = defaultRes.providerValue().result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-provider-grpc-config-secret/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-provider-grpc-config-secret/index.ts
@@ -5,38 +5,38 @@ import * as config_grpc from "@pulumi/config-grpc";
 const config_grpc_provider = new config_grpc.Provider("config_grpc_provider", {
     string1: config_grpc.toSecretOutput({
         string1: "SECRET",
-    }).apply(invoke => invoke.string1),
+    }).string1,
     int1: config_grpc.toSecretOutput({
         int1: 1234567890,
-    }).apply(invoke => invoke.int1),
+    }).int1,
     num1: config_grpc.toSecretOutput({
         num1: 123456.789,
-    }).apply(invoke => invoke.num1),
+    }).num1,
     bool1: config_grpc.toSecretOutput({
         bool1: true,
-    }).apply(invoke => invoke.bool1),
+    }).bool1,
     listString1: config_grpc.toSecretOutput({
         listString1: [
             "SECRET",
             "SECRET2",
         ],
-    }).apply(invoke => invoke.listString1),
+    }).listString1,
     listString2: [
         "VALUE",
         config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     ],
     mapString2: {
         key1: "value1",
         key2: config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     },
     objString2: {
         x: config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     },
 });
 const config = new config_grpc.ConfigFetcher("config", {}, {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-invoke-dynamic-function/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-invoke-dynamic-function/index.ts
@@ -8,4 +8,4 @@ export const dynamic = any_type_function.dynListToDynOutput({
         localValue,
         {},
     ],
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-snake-names/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-snake-names/index.ts
@@ -14,4 +14,4 @@ const third = new snake_names.cool_module.Another_resource("third", {the_input: 
     nested: [{
         value: "fuzz",
     }],
-}).apply(invoke => invoke.nested_output[0].key.value)});
+}).nested_output[0].key.value});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-range-bool-ref/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-range-bool-ref/index.ts
@@ -7,4 +7,4 @@ let boolResource: nestedobject.Target | undefined;
 if (createBool) {
     boolResource = new nestedobject.Target("boolResource", {name: "bool-resource"});
 }
-const boolTarget = new nestedobject.Target("boolTarget", {name: boolResource!.name.apply(name => `${name}+`)});
+const boolTarget = new nestedobject.Target("boolTarget", {name: pulumi.interpolate`${boolResource!.name}+`});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-proxy-index/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-proxy-index/index.ts
@@ -16,7 +16,7 @@ export = async () => {
     return {
         l: l[0],
         m: m.key,
-        c: c.apply(c => c.property),
+        c: c.property,
         o: o.property,
         a: a.apply(a => a.property),
     };

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-component-call-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-component-call-simple/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
 
 const component1 = new component.ComponentCallable("component1", {value: "bar"});
-export const from_identity = component1.identity().apply(call => call.result);
+export const from_identity = component1.identity().result;
 export const from_prefixed = component1.prefixed(({
     prefix: "foo-",
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-component-property-deps/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-component-property-deps/index.ts
@@ -24,4 +24,4 @@ export const propertyDepsFromCall = component1.refs(({
         one: custom1,
         two: custom2,
     },
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-docs/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-docs/index.ts
@@ -9,6 +9,6 @@ const enumRes = new _enum.Res("enumRes", {
 const res = new docs.Resource("res", {
     "in": docs.funOutput({
         "in": false,
-    }).apply(invoke => invoke.out),
+    }).out,
     externalEnum: _enum.StringEnum.StringOne,
 });

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-elide-index/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-elide-index/index.ts
@@ -5,4 +5,4 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 const res = new simple.Resource("res", {value: true});
 export const inv = simple_invoke.myInvokeOutput({
     value: "test",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-extension-parameterized-resource/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-extension-parameterized-resource/index.ts
@@ -7,4 +7,4 @@ export const parameterValue = greeting.parameterValue;
 export const parameterValueFromComponent = greetingComp.parameterValue;
 export const invokeGreeting = myext.greetOutput({
     name: "Pulumi",
-}).apply(invoke => invoke.greeting);
+}).greeting;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-index-mod/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-index-mod/index.ts
@@ -3,13 +3,13 @@ import * as index_mod from "@pulumi/index-mod";
 
 const res1 = new index_mod.indexmine.Resource("res1", {text: index_mod.indexmine.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out1 = res1.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 const res2 = new index_mod.indexmine.nested.Resource("res2", {text: index_mod.indexmine.nested.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out2 = res2.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-dependencies/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-dependencies/index.ts
@@ -8,7 +8,7 @@ const first = new simple.Resource("first", {value: false});
 const second = new simple.Resource("second", {value: simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: first.value,
-}).apply(invoke => invoke.secret)});
+}).secret});
 const third = new simple_invoke.StringResource("third", {text: "third"});
 // third.text is known during preview, but third does not exist yet. SDKs must
 // infer the dependency on third from the invoke's arguments and skip the

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-multi-argument/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-multi-argument/index.ts
@@ -1,5 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as multi_argument_invoke from "@pulumi/multi-argument-invoke";
 
-export const both = multi_argument_invoke.multiArgumentInvokeOutput("hello", "world").apply(invoke => invoke.result);
-export const onlyRequired = multi_argument_invoke.multiArgumentInvokeOutput("hello").apply(invoke => invoke.result);
+export const both = multi_argument_invoke.multiArgumentInvokeOutput("hello", "world").result;
+export const onlyRequired = multi_argument_invoke.multiArgumentInvokeOutput("hello").result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-output-only/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-output-only/index.ts
@@ -3,7 +3,7 @@ import * as output_only_invoke from "@pulumi/output-only-invoke";
 
 export const hello = output_only_invoke.myInvokeOutput({
     value: "hello",
-}).apply(invoke => invoke.result);
+}).result;
 export const goodbye = output_only_invoke.myInvokeOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-secrets/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-secrets/index.ts
@@ -6,12 +6,12 @@ const res = new simple.Resource("res", {value: true});
 export const nonSecret = simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: false,
-}).apply(invoke => invoke.response);
+}).response;
 export const firstSecret = simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: res.value,
-}).apply(invoke => invoke.response);
+}).response;
 export const secondSecret = simple_invoke.secretInvokeOutput({
     value: pulumi.secret("goodbye"),
     secretResponse: false,
-}).apply(invoke => invoke.response);
+}).response;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-simple/index.ts
@@ -3,7 +3,7 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 
 export const hello = simple_invoke.myInvokeOutput({
     value: "hello",
-}).apply(invoke => invoke.result);
+}).result;
 export const goodbye = simple_invoke.myInvokeOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-variants/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-variants/index.ts
@@ -4,5 +4,5 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 const res = new simple_invoke.StringResource("res", {text: "hello"});
 export const outputInput = simple_invoke.myInvokeOutput({
     value: res.text,
-}).apply(invoke => invoke.result);
-export const unit = simple_invoke.unitOutput({}).apply(invoke => invoke.result);
+}).result;
+export const unit = simple_invoke.unitOutput({}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-module-format/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-module-format/index.ts
@@ -6,49 +6,49 @@ import * as module_format from "@pulumi/module-format";
 // First use the fully specified token to invoke and create a resource.
 const res1 = new module_format.mod.Resource("res1", {text: module_format.mod.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out1 = res1.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res2 = new module_format.mod.Resource("res2", {text: module_format.mod.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out2 = res2.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // First use the fully specified token to invoke and create a resource.
 const res3 = new module_format.mod.nested.Resource("res3", {text: module_format.mod.nested.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out3 = res3.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res4 = new module_format.mod.nested.Resource("res4", {text: module_format.mod.nested.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out4 = res4.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // First use the fully specified token to invoke and create a resource in the index module.
 const res5 = new module_format.Resource("res5", {text: module_format.concatWorldOutput({
     value: "bonjour",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out5 = res5.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res6 = new module_format.Resource("res6", {text: module_format.concatWorldOutput({
     value: "youkoso",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out6 = res6.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // Next use the short, 2 component, form because this is the index module
 const res7 = new module_format.Resource("res7", {text: module_format.concatWorldOutput({
     value: "guten tag",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out7 = res7.call(({
     input: "xxx",
-})).apply(call => call.output);
+})).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-parameterized-invoke/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-parameterized-invoke/index.ts
@@ -3,4 +3,4 @@ import * as subpackage from "@pulumi/subpackage";
 
 export const parameterValue = subpackage.doHelloWorldOutput({
     input: "goodbye",
-}).apply(invoke => invoke.output);
+}).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-primitive-ref-optional/index.ts
@@ -25,12 +25,12 @@ const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
 const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
     string: setRes.optionalData.apply(optionalData => optionalData?.string),
 }});
-export const setBoolean = setRes.data.apply(data => data.boolean);
-export const setFloat = setRes.data.apply(data => data.float);
-export const setInteger = setRes.data.apply(data => data.integer);
-export const setString = setRes.data.apply(data => data.string);
-export const setNumberArray = setRes.data.apply(data => data.numberArray);
-export const setBooleanMap = setRes.data.apply(data => data.booleanMap);
+export const setBoolean = setRes.data.boolean;
+export const setFloat = setRes.data.float;
+export const setInteger = setRes.data.integer;
+export const setString = setRes.data.string;
+export const setNumberArray = setRes.data.numberArray;
+export const setBooleanMap = setRes.data.booleanMap;
 export const unsetBoolean = unsetRes.data.apply(data => data.boolean == null ? "null" : "not null");
 export const unsetFloat = unsetRes.data.apply(data => data.float == null ? "null" : "not null");
 export const unsetInteger = unsetRes.data.apply(data => data.integer == null ? "null" : "not null");

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-provider-call-explicit/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-provider-call-explicit/index.ts
@@ -5,8 +5,8 @@ const explicitProv = new call.Provider("explicitProv", {value: "explicitProvValu
 const explicitRes = new call.Custom("explicitRes", {value: "explicitValue"}, {
     provider: explicitProv,
 });
-export const explicitProviderValue = explicitRes.providerValue().apply(call => call.result);
-export const explicitProvFromIdentity = explicitProv.identity().apply(call => call.result);
+export const explicitProviderValue = explicitRes.providerValue().result;
+export const explicitProvFromIdentity = explicitProv.identity().result;
 export const explicitProvFromPrefixed = explicitProv.prefixed(({
     prefix: "call-prefix-",
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-provider-call/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-provider-call/index.ts
@@ -2,4 +2,4 @@ import * as pulumi from "@pulumi/pulumi";
 import * as call from "@pulumi/call";
 
 const defaultRes = new call.Custom("defaultRes", {value: "defaultValue"});
-export const defaultProviderValue = defaultRes.providerValue().apply(call => call.result);
+export const defaultProviderValue = defaultRes.providerValue().result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-provider-grpc-config-secret/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-provider-grpc-config-secret/index.ts
@@ -5,38 +5,38 @@ import * as config_grpc from "@pulumi/config-grpc";
 const config_grpc_provider = new config_grpc.Provider("config_grpc_provider", {
     string1: config_grpc.toSecretOutput({
         string1: "SECRET",
-    }).apply(invoke => invoke.string1),
+    }).string1,
     int1: config_grpc.toSecretOutput({
         int1: 1234567890,
-    }).apply(invoke => invoke.int1),
+    }).int1,
     num1: config_grpc.toSecretOutput({
         num1: 123456.789,
-    }).apply(invoke => invoke.num1),
+    }).num1,
     bool1: config_grpc.toSecretOutput({
         bool1: true,
-    }).apply(invoke => invoke.bool1),
+    }).bool1,
     listString1: config_grpc.toSecretOutput({
         listString1: [
             "SECRET",
             "SECRET2",
         ],
-    }).apply(invoke => invoke.listString1),
+    }).listString1,
     listString2: [
         "VALUE",
         config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     ],
     mapString2: {
         key1: "value1",
         key2: config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     },
     objString2: {
         x: config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     },
 });
 const config = new config_grpc.ConfigFetcher("config", {}, {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-invoke-dynamic-function/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-invoke-dynamic-function/index.ts
@@ -8,4 +8,4 @@ export const dynamic = any_type_function.dynListToDynOutput({
         localValue,
         {},
     ],
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-snake-names/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-snake-names/index.ts
@@ -14,4 +14,4 @@ const third = new snake_names.cool_module.Another_resource("third", {the_input: 
     nested: [{
         value: "fuzz",
     }],
-}).apply(invoke => invoke.nested_output[0].key.value)});
+}).nested_output[0].key.value});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-range-bool-ref/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-range-bool-ref/index.ts
@@ -7,4 +7,4 @@ let boolResource: nestedobject.Target | undefined;
 if (createBool) {
     boolResource = new nestedobject.Target("boolResource", {name: "bool-resource"});
 }
-const boolTarget = new nestedobject.Target("boolTarget", {name: boolResource!.name.apply(name => `${name}+`)});
+const boolTarget = new nestedobject.Target("boolTarget", {name: pulumi.interpolate`${boolResource!.name}+`});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-proxy-index/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-proxy-index/index.ts
@@ -16,7 +16,7 @@ export = async () => {
     return {
         l: l[0],
         m: m.key,
-        c: c.apply(c => c.property),
+        c: c.property,
         o: o.property,
         a: a.apply(a => a.property),
     };

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-component-call-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-component-call-simple/index.ts
@@ -2,7 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as component from "@pulumi/component";
 
 const component1 = new component.ComponentCallable("component1", {value: "bar"});
-export const from_identity = component1.identity().apply(call => call.result);
+export const from_identity = component1.identity().result;
 export const from_prefixed = component1.prefixed(({
     prefix: "foo-",
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-component-property-deps/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-component-property-deps/index.ts
@@ -24,4 +24,4 @@ export const propertyDepsFromCall = component1.refs(({
         one: custom1,
         two: custom2,
     },
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-docs/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-docs/index.ts
@@ -9,6 +9,6 @@ const enumRes = new _enum.Res("enumRes", {
 const res = new docs.Resource("res", {
     "in": docs.funOutput({
         "in": false,
-    }).apply(invoke => invoke.out),
+    }).out,
     externalEnum: _enum.StringEnum.StringOne,
 });

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-elide-index/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-elide-index/index.ts
@@ -5,4 +5,4 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 const res = new simple.Resource("res", {value: true});
 export const inv = simple_invoke.myInvokeOutput({
     value: "test",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-extension-parameterized-resource/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-extension-parameterized-resource/index.ts
@@ -7,4 +7,4 @@ export const parameterValue = greeting.parameterValue;
 export const parameterValueFromComponent = greetingComp.parameterValue;
 export const invokeGreeting = myext.greetOutput({
     name: "Pulumi",
-}).apply(invoke => invoke.greeting);
+}).greeting;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-index-mod/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-index-mod/index.ts
@@ -3,13 +3,13 @@ import * as index_mod from "@pulumi/index-mod";
 
 const res1 = new index_mod.indexmine.Resource("res1", {text: index_mod.indexmine.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out1 = res1.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 const res2 = new index_mod.indexmine.nested.Resource("res2", {text: index_mod.indexmine.nested.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out2 = res2.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-dependencies/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-dependencies/index.ts
@@ -8,7 +8,7 @@ const first = new simple.Resource("first", {value: false});
 const second = new simple.Resource("second", {value: simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: first.value,
-}).apply(invoke => invoke.secret)});
+}).secret});
 const third = new simple_invoke.StringResource("third", {text: "third"});
 // third.text is known during preview, but third does not exist yet. SDKs must
 // infer the dependency on third from the invoke's arguments and skip the

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-multi-argument/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-multi-argument/index.ts
@@ -1,5 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as multi_argument_invoke from "@pulumi/multi-argument-invoke";
 
-export const both = multi_argument_invoke.multiArgumentInvokeOutput("hello", "world").apply(invoke => invoke.result);
-export const onlyRequired = multi_argument_invoke.multiArgumentInvokeOutput("hello").apply(invoke => invoke.result);
+export const both = multi_argument_invoke.multiArgumentInvokeOutput("hello", "world").result;
+export const onlyRequired = multi_argument_invoke.multiArgumentInvokeOutput("hello").result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-output-only/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-output-only/index.ts
@@ -3,7 +3,7 @@ import * as output_only_invoke from "@pulumi/output-only-invoke";
 
 export const hello = output_only_invoke.myInvokeOutput({
     value: "hello",
-}).apply(invoke => invoke.result);
+}).result;
 export const goodbye = output_only_invoke.myInvokeOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-secrets/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-secrets/index.ts
@@ -6,12 +6,12 @@ const res = new simple.Resource("res", {value: true});
 export const nonSecret = simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: false,
-}).apply(invoke => invoke.response);
+}).response;
 export const firstSecret = simple_invoke.secretInvokeOutput({
     value: "hello",
     secretResponse: res.value,
-}).apply(invoke => invoke.response);
+}).response;
 export const secondSecret = simple_invoke.secretInvokeOutput({
     value: pulumi.secret("goodbye"),
     secretResponse: false,
-}).apply(invoke => invoke.response);
+}).response;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-simple/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-simple/index.ts
@@ -3,7 +3,7 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 
 export const hello = simple_invoke.myInvokeOutput({
     value: "hello",
-}).apply(invoke => invoke.result);
+}).result;
 export const goodbye = simple_invoke.myInvokeOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-variants/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-variants/index.ts
@@ -4,5 +4,5 @@ import * as simple_invoke from "@pulumi/simple-invoke";
 const res = new simple_invoke.StringResource("res", {text: "hello"});
 export const outputInput = simple_invoke.myInvokeOutput({
     value: res.text,
-}).apply(invoke => invoke.result);
-export const unit = simple_invoke.unitOutput({}).apply(invoke => invoke.result);
+}).result;
+export const unit = simple_invoke.unitOutput({}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-module-format/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-module-format/index.ts
@@ -6,49 +6,49 @@ import * as module_format from "@pulumi/module-format";
 // First use the fully specified token to invoke and create a resource.
 const res1 = new module_format.mod.Resource("res1", {text: module_format.mod.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out1 = res1.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res2 = new module_format.mod.Resource("res2", {text: module_format.mod.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out2 = res2.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // First use the fully specified token to invoke and create a resource.
 const res3 = new module_format.mod.nested.Resource("res3", {text: module_format.mod.nested.concatWorldOutput({
     value: "hello",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out3 = res3.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res4 = new module_format.mod.nested.Resource("res4", {text: module_format.mod.nested.concatWorldOutput({
     value: "goodbye",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out4 = res4.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // First use the fully specified token to invoke and create a resource in the index module.
 const res5 = new module_format.Resource("res5", {text: module_format.concatWorldOutput({
     value: "bonjour",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out5 = res5.call(({
     input: "x",
-})).apply(call => call.output);
+})).output;
 // Next use just the module name as defined by the module format
 const res6 = new module_format.Resource("res6", {text: module_format.concatWorldOutput({
     value: "youkoso",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out6 = res6.call(({
     input: "xx",
-})).apply(call => call.output);
+})).output;
 // Next use the short, 2 component, form because this is the index module
 const res7 = new module_format.Resource("res7", {text: module_format.concatWorldOutput({
     value: "guten tag",
-}).apply(invoke => invoke.result)});
+}).result});
 export const out7 = res7.call(({
     input: "xxx",
-})).apply(call => call.output);
+})).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-parameterized-invoke/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-parameterized-invoke/index.ts
@@ -3,4 +3,4 @@ import * as subpackage from "@pulumi/subpackage";
 
 export const parameterValue = subpackage.doHelloWorldOutput({
     input: "goodbye",
-}).apply(invoke => invoke.output);
+}).output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-primitive-ref-optional/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-primitive-ref-optional/index.ts
@@ -25,12 +25,12 @@ const unsetRes = new optional_primitive_ref.Resource("unsetRes", {data: {}});
 const fromNestedOptional = new optional_primitive_ref.Resource("fromNestedOptional", {data: {
     string: setRes.optionalData.apply(optionalData => optionalData?.string),
 }});
-export const setBoolean = setRes.data.apply(data => data.boolean);
-export const setFloat = setRes.data.apply(data => data.float);
-export const setInteger = setRes.data.apply(data => data.integer);
-export const setString = setRes.data.apply(data => data.string);
-export const setNumberArray = setRes.data.apply(data => data.numberArray);
-export const setBooleanMap = setRes.data.apply(data => data.booleanMap);
+export const setBoolean = setRes.data.boolean;
+export const setFloat = setRes.data.float;
+export const setInteger = setRes.data.integer;
+export const setString = setRes.data.string;
+export const setNumberArray = setRes.data.numberArray;
+export const setBooleanMap = setRes.data.booleanMap;
 export const unsetBoolean = unsetRes.data.apply(data => data.boolean == null ? "null" : "not null");
 export const unsetFloat = unsetRes.data.apply(data => data.float == null ? "null" : "not null");
 export const unsetInteger = unsetRes.data.apply(data => data.integer == null ? "null" : "not null");

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-provider-call-explicit/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-provider-call-explicit/index.ts
@@ -5,8 +5,8 @@ const explicitProv = new call.Provider("explicitProv", {value: "explicitProvValu
 const explicitRes = new call.Custom("explicitRes", {value: "explicitValue"}, {
     provider: explicitProv,
 });
-export const explicitProviderValue = explicitRes.providerValue().apply(call => call.result);
-export const explicitProvFromIdentity = explicitProv.identity().apply(call => call.result);
+export const explicitProviderValue = explicitRes.providerValue().result;
+export const explicitProvFromIdentity = explicitProv.identity().result;
 export const explicitProvFromPrefixed = explicitProv.prefixed(({
     prefix: "call-prefix-",
-})).apply(call => call.result);
+})).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-provider-call/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-provider-call/index.ts
@@ -2,4 +2,4 @@ import * as pulumi from "@pulumi/pulumi";
 import * as call from "@pulumi/call";
 
 const defaultRes = new call.Custom("defaultRes", {value: "defaultValue"});
-export const defaultProviderValue = defaultRes.providerValue().apply(call => call.result);
+export const defaultProviderValue = defaultRes.providerValue().result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-provider-grpc-config-secret/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-provider-grpc-config-secret/index.ts
@@ -5,38 +5,38 @@ import * as config_grpc from "@pulumi/config-grpc";
 const config_grpc_provider = new config_grpc.Provider("config_grpc_provider", {
     string1: config_grpc.toSecretOutput({
         string1: "SECRET",
-    }).apply(invoke => invoke.string1),
+    }).string1,
     int1: config_grpc.toSecretOutput({
         int1: 1234567890,
-    }).apply(invoke => invoke.int1),
+    }).int1,
     num1: config_grpc.toSecretOutput({
         num1: 123456.789,
-    }).apply(invoke => invoke.num1),
+    }).num1,
     bool1: config_grpc.toSecretOutput({
         bool1: true,
-    }).apply(invoke => invoke.bool1),
+    }).bool1,
     listString1: config_grpc.toSecretOutput({
         listString1: [
             "SECRET",
             "SECRET2",
         ],
-    }).apply(invoke => invoke.listString1),
+    }).listString1,
     listString2: [
         "VALUE",
         config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     ],
     mapString2: {
         key1: "value1",
         key2: config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     },
     objString2: {
         x: config_grpc.toSecretOutput({
             string1: "SECRET",
-        }).apply(invoke => invoke.string1),
+        }).string1,
     },
 });
 const config = new config_grpc.ConfigFetcher("config", {}, {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-invoke-dynamic-function/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-invoke-dynamic-function/index.ts
@@ -8,4 +8,4 @@ export const dynamic = any_type_function.dynListToDynOutput({
         localValue,
         {},
     ],
-}).apply(invoke => invoke.result);
+}).result;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-snake-names/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-snake-names/index.ts
@@ -14,4 +14,4 @@ const third = new snake_names.cool_module.Another_resource("third", {the_input: 
     nested: [{
         value: "fuzz",
     }],
-}).apply(invoke => invoke.nested_output[0].key.value)});
+}).nested_output[0].key.value});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-range-bool-ref/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-range-bool-ref/index.ts
@@ -7,4 +7,4 @@ let boolResource: nestedobject.Target | undefined;
 if (createBool) {
     boolResource = new nestedobject.Target("boolResource", {name: "bool-resource"});
 }
-const boolTarget = new nestedobject.Target("boolTarget", {name: boolResource!.name.apply(name => `${name}+`)});
+const boolTarget = new nestedobject.Target("boolTarget", {name: pulumi.interpolate`${boolResource!.name}+`});

--- a/tests/testdata/codegen/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
+++ b/tests/testdata/codegen/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
@@ -42,7 +42,7 @@ export = async () => {
                 input: currentVpc.ipv6CidrBlock,
                 newbits: 8,
                 netnum: Number(publicSubnetIpv6Prefixes[range]),
-            }).apply(invoke => invoke.result) : null,
+            }).result : null,
             ipv6Native: enableIpv6 && publicSubnetIpv6Native,
             vpcId: currentVpc.id,
         }));


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/24112

Expand Node.js's existing `lowerProxyApplies` pass so property-only applies are lowered when their source is any output-producing expression.

Node.js programgen now emits:

```typescript
const res = new indexMod.Resource("res", {
  text: indexMod.concatWorldOutput({ value: "hello" }).result,
});
export const out = res.call({ input: "x" }).output;
```

instead of property-only callbacks such as:

```typescript
const res = new indexMod.Resource("res", {
    indexMod.concatWorldOutput({ value: "hello" }).apply(invoke => invoke.result),
});
export const out = res.call({ input: "x" }).apply(call => call.output)
```
