### PR TITLE
Refresh the CLI login welcome message

### DIFF
--- a/changelog/pending/20260729--cli--refresh-login-welcome-message.yaml
+++ b/changelog/pending/20260729--cli--refresh-login-welcome-message.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Refresh the first-login welcome message to link your Pulumi Cloud console and the Pulumi changelog
+time: 2026-07-29T00:00:00+00:00

--- a/changelog/pending/20260729--cli--refresh-login-welcome-message.yaml
+++ b/changelog/pending/20260729--cli--refresh-login-welcome-message.yaml
@@ -2,3 +2,5 @@ component: cli
 kind: improvement
 body: Refresh the first-login welcome message to link your Pulumi Cloud console and the Pulumi changelog
 time: 2026-07-29T00:00:00+00:00
+custom:
+  PR: "24122"

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -922,25 +922,18 @@ func (m defaultLoginManager) LoginWithOIDCToken(
 	return &account, nil
 }
 
-// WelcomeUser prints a Welcome to Pulumi message.
-func WelcomeUser(opts display.Options) {
-	fmt.Printf(`
-
-  %s
-
-  Pulumi helps you create, deploy, and manage infrastructure on any cloud using
-  your favorite language. You can get started today with Pulumi at:
-
-      https://www.pulumi.com/docs/get-started/
-
-  %s Resources you create with Pulumi are given unique names (a randomly
-  generated suffix) by default. To learn more about auto-naming or customizing resource
-  names see https://www.pulumi.com/docs/intro/concepts/resources/#autonaming.
-
-
-`,
-		opts.Color.Colorize(colors.SpecHeadline+"Welcome to Pulumi!"+colors.Reset),
-		opts.Color.Colorize(colors.SpecSubHeadline+"Tip:"+colors.Reset))
+// WelcomeUser prints a Welcome to Pulumi message. consoleURL may be empty, in which case the
+// console line is omitted.
+func WelcomeUser(opts display.Options, consoleURL string) {
+	fmt.Printf("\n\n  %s\n\n", opts.Color.Colorize(colors.SpecHeadline+"Welcome to Pulumi!"+colors.Reset))
+	if consoleURL != "" {
+		fmt.Printf("  Your stacks, state, and deployment history live at %s\n\n",
+			opts.Color.Colorize(colors.BrightBlue+colors.Underline+consoleURL+colors.Reset))
+	}
+	fmt.Printf("  See what's new: %s\n\n",
+		opts.Color.Colorize(colors.BrightBlue+colors.Underline+"https://www.pulumi.com/releases/changelog/"+colors.Reset))
+	fmt.Printf("  %s Create your first project with `pulumi new`.\n\n\n",
+		opts.Color.Colorize(colors.SpecSubHeadline+"New to Pulumi?"+colors.Reset))
 }
 
 func (b *cloudBackend) StackConsoleURL(stackRef backend.StackReference) (string, error) {

--- a/pkg/cmd/pulumi/backend/login_manager.go
+++ b/pkg/cmd/pulumi/backend/login_manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -102,7 +103,9 @@ func (f *lm) Login(
 	opts := display.Options{
 		Color: color,
 	}
-	_, err := lm.Login(ctx, url, insecure, "pulumi", "Pulumi stacks", httpstate.WelcomeUser, setCurrent, opts)
+	consoleURL := client.CloudConsoleURL(httpstate.ValueOrDefaultURL(ws, url))
+	welcome := func(opts display.Options) { httpstate.WelcomeUser(opts, consoleURL) }
+	_, err := lm.Login(ctx, url, insecure, "pulumi", "Pulumi stacks", welcome, setCurrent, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The first-login welcome message has been unchanged since August 2019 (#3145). It pitched getting started to a reader who had just logged in, and taught resource auto-naming before the reader had ever seen a suffixed name. This replaces it with three short lines that work for both new and returning users:

```

  Welcome to Pulumi!

  Your stacks, state, and deployment history live at https://app.pulumi.com

  See what's new: https://www.pulumi.com/releases/changelog/

  New to Pulumi? Create your first project with `pulumi new`.

```