### PR TITLE
[fix] Carry `-C` into the `pulumi stack rm` hint printed by destroy

### DIFF
--- a/changelog/pending/20260729--cli--destroy-stack-rm-hint-cwd.yaml
+++ b/changelog/pending/20260729--cli--destroy-stack-rm-hint-cwd.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Include `-C <dir>` in the `pulumi stack rm` command suggested after `pulumi destroy`
+    so the hint is runnable when the global `--cwd` flag was used

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 
@@ -381,7 +382,7 @@ func NewDestroyCmd() *cobra.Command {
 				if !jsonDisplay && output != "json" && !remove && !previewOnly {
 					fmt.Fprintf(out, "The resources in the stack have been deleted, but the history and configuration "+
 						"associated with the stack are still maintained. \nIf you want to remove the stack "+
-						"completely, run `pulumi stack rm %s`.\n", s.Ref())
+						"completely, run `%s`.\n", stackRemoveHint(s.Ref().String(), rootCwdFlag(cmd)))
 				} else if remove {
 					_, err = backend.RemoveStack(ctx, s, false /*force*/, false /*removeBackups*/)
 					if err != nil {
@@ -604,4 +605,26 @@ func getProtectedExcludes(resources []*pkgresource.State) ([]string, error) {
 	}
 
 	return urns, nil
+}
+
+func rootCwdFlag(cmd *cobra.Command) string {
+	flag := cmd.Root().PersistentFlags().Lookup("cwd")
+	if flag == nil {
+		return ""
+	}
+	return flag.Value.String()
+}
+
+func stackRemoveHint(stackRef, cwd string) string {
+	if cwd == "" {
+		return "pulumi stack rm " + stackRef
+	}
+	return fmt.Sprintf("pulumi -C %s stack rm %s", shellArg(cwd), stackRef)
+}
+
+func shellArg(s string) string {
+	if s != "" && !strings.ContainsAny(s, " \t\n\"'\\$`&|;<>()*?[]#~=%") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/pkg/cmd/pulumi/operations/destroy_test.go
+++ b/pkg/cmd/pulumi/operations/destroy_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackRemoveHint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		stackRef string
+		cwd      string
+		expected string
+	}{
+		{
+			name:     "no cwd flag",
+			stackRef: "dev",
+			expected: "pulumi stack rm dev",
+		},
+		{
+			name:     "no cwd flag, qualified ref",
+			stackRef: "acmecorp/website/dev",
+			expected: "pulumi stack rm acmecorp/website/dev",
+		},
+		{
+			name:     "relative cwd",
+			stackRef: "dev",
+			cwd:      ".e2e/dev",
+			expected: "pulumi -C .e2e/dev stack rm dev",
+		},
+		{
+			name:     "absolute cwd",
+			stackRef: "dev",
+			cwd:      "/home/user/infra",
+			expected: "pulumi -C /home/user/infra stack rm dev",
+		},
+		{
+			name:     "cwd with a space is quoted",
+			stackRef: "dev",
+			cwd:      "my infra",
+			expected: "pulumi -C 'my infra' stack rm dev",
+		},
+		{
+			name:     "cwd with a quote is escaped",
+			stackRef: "dev",
+			cwd:      "it's/infra",
+			expected: `pulumi -C 'it'\''s/infra' stack rm dev`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, stackRemoveHint(tt.stackRef, tt.cwd))
+		})
+	}
+}
+
+func TestRootCwdFlag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset", func(t *testing.T) {
+		t.Parallel()
+		root := &cobra.Command{Use: "pulumi"}
+		root.PersistentFlags().StringP("cwd", "C", "", "")
+		child := &cobra.Command{Use: "destroy"}
+		root.AddCommand(child)
+
+		assert.Equal(t, "", rootCwdFlag(child))
+	})
+
+	t.Run("set on root, read from child", func(t *testing.T) {
+		t.Parallel()
+		root := &cobra.Command{Use: "pulumi"}
+		root.PersistentFlags().StringP("cwd", "C", "", "")
+		child := &cobra.Command{Use: "destroy"}
+		root.AddCommand(child)
+		require.NoError(t, root.PersistentFlags().Set("cwd", ".e2e/dev"))
+
+		assert.Equal(t, ".e2e/dev", rootCwdFlag(child))
+	})
+
+	t.Run("no cwd flag registered", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", rootCwdFlag(&cobra.Command{Use: "destroy"}))
+	})
+}


### PR DESCRIPTION
## Summary

After a successful `pulumi destroy`, we suggest `pulumi stack rm <stack>` so the user can drop the stack's history and configuration too. That suggestion is not always runnable.

Stack references are stringified relative to the current project — `cloudBackendReference.String()` elides the org and project when they match the current project, leaving just the bare stack name. A bare name only resolves from inside the project directory, but nothing in the hint says so. So when the destroy is run from elsewhere using the global `-C`/`--cwd` flag, the printed command is valid only in a directory the user was never in:

```
$ pulumi -C .e2e/my-stack destroy
...
The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained.
If you want to remove the stack completely, run `pulumi stack rm my-stack`.

$ pulumi stack rm my-stack
error: no current project found, pass the fully qualified stack name (org/project/stack)
```

The suggestion is copy-pasteable by construction, so the failure is silent until the user pastes it and has to work out that the elision assumed a directory the command no longer runs in.

This carries `-C <dir>` into the suggested command when the flag was used:

```
If you want to remove the stack completely, run `pulumi -C .e2e/my-stack stack rm my-stack`.
```

Output is byte-identical when `-C` is absent, which is the overwhelmingly common case.

**Alternative considered:** print `s.Ref().FullyQualifiedName()` instead, which resolves from any directory. Rejected because it makes the common in-project hint noisier (`pulumi stack rm org/project/stack`) to fix a case that only arises with `-C`, and users who want that form already have `-Q`/`--fully-qualify-stack-names`.

**Not addressed here:** `stack_migrate.go` prints `pulumi stack rm %s --yes --force` twice with the same elided reference. Happy to fold those in if you'd like them fixed in the same PR.

No linked issue — reported by a user hitting it against v3.255.0.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`destroy_test.go` is new and covers both helpers: `stackRemoveHint` across no-flag, relative, absolute and space/quote-containing paths, and `rootCwdFlag` for unset, set-on-root-read-from-child, and no-flag-registered (a command built outside the root tree).

The hint is printed with `fmt.Fprintf` inside `NewDestroyCmd`, not through the display renderers, so there is no golden-test surface to extend. If you'd prefer this asserted end-to-end over a real destroy rather than at the helper level, point me at the harness you want it in.

## Validation
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

What was actually run, rather than the whole matrix:

- `bin/custom-gcl run --config .golangci.yml` over `./cmd/pulumi/operations/...` — 0 issues (`perfsprint` caught a single-arg `fmt.Sprintf` on the first pass; fixed)
- `gofumpt -l -extra` on both changed files — clean
- `go vet ./cmd/pulumi/operations/` — clean
- `go test -count=1 ./cmd/pulumi/operations/` — pass
- `changie batch auto --dry-run` — renders the entry

No SDK, proto, or `go.mod` changes, so those checks have nothing to act on.

## Changelog
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

`changelog/pending/20260729--cli--destroy-stack-rm-hint-cwd.yaml`, `component: cli`, `kind: fix`. I'll add the PR number to `custom.PR` once this has one.

## Risk

Low. The change is confined to one user-facing string in `pulumi destroy` — no state, engine, protocol, or event surface is touched, and no exported API is added or changed.

It does touch the public CLI *output*, which is the point: anything scraping this line for a bare stack name would now see the `-C` form, but only in runs that already passed `-C`. `rootCwdFlag` reads the flag through `cmd.Root().PersistentFlags().Lookup("cwd")` and returns `""` when the lookup misses, so a `destroy` command constructed outside the root tree degrades to today's exact output rather than panicking.
