### PR TITLE
Resolve, download & install required package specs on `pulumi new`

### DIFF
--- a/changelog/pending/20260730--cli-new--install-required-packages.yaml
+++ b/changelog/pending/20260730--cli-new--install-required-packages.yaml
@@ -1,0 +1,5 @@
+component: cli/new
+kind: fix
+body: Resolve and install packages required by the program during `pulumi new`, as
+  `pulumi install` does
+time: 2026-07-30T11:00:00+02:00

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -26,12 +26,9 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageinstallation"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageresolution"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageworkspace"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
-	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -192,37 +189,13 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			}
 
 			if !noPlugins {
-				// Compute the set of plugins the current project needs.
-				packages, specs, err := lang.GetRequiredPackages(ctx, programInfo)
-				if err != nil {
-					return err
-				}
-
-				projPath, err := workspace.DetectProjectPathFrom(root)
-				if err != nil {
-					return fmt.Errorf("locating Pulumi.yaml: %w", err)
-				}
-
-				ws := packageworkspace.New(pluginstorage.Instance, pkgWorkspace.Instance,
-					pctx, cmd.OutOrStderr(), cmd.ErrOrStderr(), nil,
-					packageworkspace.Options{
-						UseLanguageVersionTools: useLanguageVersionTools,
-					})
-
 				// Pass the continuation from InstallPackagesFromProject so the packages it
 				// already installed and linked are not reinstalled or regenerated here.
-				_, err = packageinstallation.InstallPluginSet(ctx, packages, specs, proj, filepath.Dir(projPath),
-					packageinstallation.Options{
-						Concurrency: parallel,
-						PriorState:  continuation,
-						Options: packageresolution.Options{
-							ResolveVersionWithLocalWorkspace:           true,
-							ResolveWithRegistry:                        !env.DisableRegistryResolve.Value(),
-							AllowNonInvertableLocalWorkspaceResolution: true,
-						},
-					}, registry, ws)
+				err := newcmd.InstallRequiredPackages(ctx, pctx, proj, root, main,
+					continuation, parallel, useLanguageVersionTools, registry,
+					cmd.OutOrStderr(), cmd.ErrOrStderr())
 				if err != nil {
-					return fmt.Errorf("installing packages: %w", err)
+					return err
 				}
 			}
 

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageinstallation"
@@ -64,6 +65,50 @@ func InstallDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 		return fmt.Errorf("installing dependencies failed: %w\nRun `pulumi install` to complete the installation.", err)
 	}
 
+	return nil
+}
+
+// InstallRequiredPackages asks the language runtime which packages the program requires,
+// resolves them, and then installs them.
+func InstallRequiredPackages(
+	ctx context.Context, pctx *plugin.Context, proj *workspace.Project, root, main string,
+	prior packageinstallation.State, parallelism int, useLanguageVersionTools bool,
+	reg registry.Registry, stdout, stderr io.Writer,
+) error {
+	lang, err := pctx.Host.LanguageRuntime(pctx, proj.Runtime.Name())
+	if err != nil {
+		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
+	}
+
+	programInfo := plugin.NewProgramInfo(pctx.Root, pctx.Pwd, main, proj.Runtime.Options())
+	packages, specs, err := lang.GetRequiredPackages(ctx, programInfo)
+	if err != nil {
+		return err
+	}
+
+	projPath, err := workspace.DetectProjectPathFrom(root)
+	if err != nil {
+		return fmt.Errorf("locating Pulumi.yaml: %w", err)
+	}
+
+	ws := packageworkspace.New(pluginstorage.Instance, pkgWorkspace.Instance, pctx, stdout, stderr, nil,
+		packageworkspace.Options{
+			UseLanguageVersionTools: useLanguageVersionTools,
+		})
+
+	_, err = packageinstallation.InstallPluginSet(ctx, packages, specs, proj, filepath.Dir(projPath),
+		packageinstallation.Options{
+			Concurrency: parallelism,
+			PriorState:  prior,
+			Options: packageresolution.Options{
+				ResolveVersionWithLocalWorkspace:           true,
+				ResolveWithRegistry:                        !env.DisableRegistryResolve.Value(),
+				AllowNonInvertableLocalWorkspaceResolution: true,
+			},
+		}, reg, ws)
+	if err != nil {
+		return fmt.Errorf("installing packages: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -505,11 +505,16 @@ func runNew(ctx context.Context, args newArgs) error {
 		registry := cmdCmd.NewDefaultRegistry(
 			ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global(),
 		)
-		if _, err := InstallPackagesFromProject(ctx, proj, root,
-			registry, -1, false, args.stderr, args.stderr, env.Global()); err != nil {
+		continuation, err := InstallPackagesFromProject(ctx, proj, root,
+			registry, -1, false, args.stderr, args.stderr, env.Global())
+		if err != nil {
 			return err
 		}
 		if err := InstallDependencies(pluginCtx, &proj.Runtime, entryPoint); err != nil {
+			return err
+		}
+		if err := InstallRequiredPackages(ctx, pluginCtx, proj, root, entryPoint,
+			continuation, -1, false, registry, args.stderr, args.stderr); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -15,16 +15,21 @@
 package newcmd
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"iter"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1450,11 +1455,13 @@ func TestNewCmdYesRejectsInvalidExplicitName(t *testing.T) {
 }
 
 // requiredPackagesRecorder is an in-process language runtime, attached via
-// PULUMI_DEBUG_LANGUAGES, that records the GetRequiredPackages call it receives.
+// PULUMI_DEBUG_LANGUAGES, that records the GetRequiredPackages call it receives and
+// reports a single required package.
 type requiredPackagesRecorder struct {
 	pulumirpc.UnimplementedLanguageRuntimeServer
 
 	programDirectory atomic.Value
+	requiredPackage  *pulumirpc.PackageDependency
 }
 
 func (s *requiredPackagesRecorder) Handshake(
@@ -1477,15 +1484,61 @@ func (s *requiredPackagesRecorder) GetRequiredPackages(
 	_ context.Context, req *pulumirpc.GetRequiredPackagesRequest,
 ) (*pulumirpc.GetRequiredPackagesResponse, error) {
 	s.programDirectory.Store(req.Info.ProgramDirectory)
-	return &pulumirpc.GetRequiredPackagesResponse{}, nil
+	return &pulumirpc.GetRequiredPackagesResponse{
+		Packages: []*pulumirpc.PackageDependency{s.requiredPackage},
+	}, nil
+}
+
+func pluginBinaryName(name string) string {
+	binary := "pulumi-resource-" + name
+	if goruntime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	return binary
+}
+
+// fakePluginServer serves a plugin tarball containing a stub pulumi-resource-<name>
+// binary, in the layout the plugin download machinery expects.
+func fakePluginServer(t *testing.T, name string) *httptest.Server {
+	t.Helper()
+
+	var tarball bytes.Buffer
+	gzw := gzip.NewWriter(&tarball)
+	tw := tar.NewWriter(gzw)
+	binary := []byte("#!/bin/sh\nexit 0\n")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: pluginBinaryName(name),
+		Mode: 0o755,
+		Size: int64(len(binary)),
+	}))
+	_, err := tw.Write(binary)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(tarball.Bytes())
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	return server
 }
 
 // TestNewInstallsRequiredPackages ensures that `pulumi new` resolves & installs required packages.
 func TestNewInstallsRequiredPackages(t *testing.T) {
 	useTempFilestateBackend(t)
-	t.Setenv("PULUMI_HOME", t.TempDir())
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
 
-	lang := &requiredPackagesRecorder{}
+	pluginServer := fakePluginServer(t, "testpkg")
+	lang := &requiredPackagesRecorder{
+		requiredPackage: &pulumirpc.PackageDependency{
+			Name:    "testpkg",
+			Kind:    "resource",
+			Version: "1.2.3",
+			Server:  pluginServer.URL,
+		},
+	}
 	cancel := make(chan bool)
 	t.Cleanup(func() { close(cancel) })
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
@@ -1515,6 +1568,8 @@ func TestNewInstallsRequiredPackages(t *testing.T) {
 	require.NoError(t, runNew(t.Context(), args))
 
 	assert.Equal(t, tempdir, lang.programDirectory.Load())
+	assert.FileExists(t,
+		filepath.Join(pulumiHome, "plugins", "resource-testpkg-v1.2.3", pluginBinaryName("testpkg")))
 }
 
 //nolint:paralleltest

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -43,9 +44,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 //nolint:paralleltest // changes directory for process
@@ -1442,6 +1447,74 @@ func TestNewCmdYesRejectsInvalidExplicitName(t *testing.T) {
 	require.ErrorContains(t, err, "'my project' is not a valid project name")
 	_, statErr := os.Stat(filepath.Join(dir, "Pulumi.yaml"))
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+// requiredPackagesRecorder is an in-process language runtime, attached via
+// PULUMI_DEBUG_LANGUAGES, that records the GetRequiredPackages call it receives.
+type requiredPackagesRecorder struct {
+	pulumirpc.UnimplementedLanguageRuntimeServer
+
+	programDirectory atomic.Value
+}
+
+func (s *requiredPackagesRecorder) Handshake(
+	context.Context, *pulumirpc.LanguageHandshakeRequest,
+) (*pulumirpc.LanguageHandshakeResponse, error) {
+	return &pulumirpc.LanguageHandshakeResponse{}, nil
+}
+
+func (s *requiredPackagesRecorder) GetPluginInfo(context.Context, *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
+	return &pulumirpc.PluginInfo{Version: "1.0.0"}, nil
+}
+
+func (s *requiredPackagesRecorder) InstallDependencies(
+	*pulumirpc.InstallDependenciesRequest, pulumirpc.LanguageRuntime_InstallDependenciesServer,
+) error {
+	return nil
+}
+
+func (s *requiredPackagesRecorder) GetRequiredPackages(
+	_ context.Context, req *pulumirpc.GetRequiredPackagesRequest,
+) (*pulumirpc.GetRequiredPackagesResponse, error) {
+	s.programDirectory.Store(req.Info.ProgramDirectory)
+	return &pulumirpc.GetRequiredPackagesResponse{}, nil
+}
+
+// TestNewInstallsRequiredPackages ensures that `pulumi new` resolves & installs required packages.
+func TestNewInstallsRequiredPackages(t *testing.T) {
+	useTempFilestateBackend(t)
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	lang := &requiredPackagesRecorder{}
+	cancel := make(chan bool)
+	t.Cleanup(func() { close(cancel) })
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterLanguageRuntimeServer(srv, lang)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	t.Setenv("PULUMI_DEBUG_LANGUAGES", fmt.Sprintf("testlang:%d", handle.Port))
+
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+	template := writeLocalTemplate(t, t.TempDir(), "testlang-template",
+		"name: ${PROJECT}\ndescription: ${DESCRIPTION}\nruntime: testlang\n")
+
+	args := newArgs{
+		interactive:       false,
+		yes:               true,
+		prompt:            ui.PromptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: template,
+		languageTemplate:  languageTemplateMock,
+	}
+	require.NoError(t, runNew(t.Context(), args))
+
+	assert.Equal(t, tempdir, lang.programDirectory.Load())
 }
 
 //nolint:paralleltest


### PR DESCRIPTION
This brings the behavior of `pulumi new` inline with the behavior of `pulumi install`, maintaining the goal that `pulumi new <template> && pulumi up` works. Before this PR, `pulumi new` didn't gather & resolve pacakges from the language host, breaking HCL tempaltes.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/465
