### PR TITLE
Add `Environment.RunTestCommand` that doesn't hang

### DIFF
--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -151,6 +151,21 @@ var YarnInstallMutex sync.Mutex
 
 // RunCommand runs the command expecting a zero exit code, returning stdout and stderr.
 func (e *Environment) RunCommand(cmd string, args ...string) (string, string) {
+	e.Helper()
+	return e.runCommand(e.Context(), cmd, args...)
+}
+
+// RunTestCommand is like [*Environment.RunTestCommand], but it kills the command if the test fails.
+func (e *Environment) RunTestCommand(cmd string, args ...string) (string, string) {
+	e.Helper()
+	ctx, cancelWithCause := context.WithCancelCause(e.Context())
+	cancel := cancelOnFail(e, cancelWithCause)
+	defer cancel()
+	return e.runCommand(ctx, cmd, args...)
+}
+
+func (e *Environment) runCommand(ctx context.Context, cmd string, args ...string) (string, string) {
+	e.Helper()
 	// We don't want to time out on yarn installs.
 	if cmd == "yarn" {
 		YarnInstallMutex.Lock()
@@ -158,7 +173,7 @@ func (e *Environment) RunCommand(cmd string, args ...string) (string, string) {
 	}
 
 	e.Helper()
-	stdout, stderr, err := e.GetCommandResults(cmd, args...)
+	stdout, stderr, err := e.getCommandResults(ctx, cmd, args...)
 	if err != nil {
 		e.Logf("Run Error: %v", err)
 		e.Logf("STDOUT: %v", stdout)
@@ -225,15 +240,28 @@ func (e *Environment) LocalURL() string {
 // GetCommandResults runs the given command and args in the Environments CWD, returning
 // STDOUT, STDERR, and the result of os/exec.Command{}.Run.
 func (e *Environment) GetCommandResults(command string, args ...string) (string, string, error) {
-	return e.GetCommandResultsIn(e.CWD, command, args...)
+	e.Helper()
+	return e.getCommandResults(e.Context(), command, args...)
+}
+
+func (e *Environment) getCommandResults(ctx context.Context, command string, args ...string) (string, string, error) {
+	e.Helper()
+	return e.getCommandResultsIn(ctx, e.CWD, command, args...)
 }
 
 // GetCommandResultsIn runs the given command and args in the given directory, returning
 // STDOUT, STDERR, and the result of os/exec.Command{}.Run.
 func (e *Environment) GetCommandResultsIn(dir string, command string, args ...string) (string, string, error) {
 	e.Helper()
+	return e.getCommandResultsIn(e.Context(), dir, command, args...)
+}
 
-	cmd := e.SetupCommandIn(e.Context(), dir, command, args...)
+func (e *Environment) getCommandResultsIn(
+	ctx context.Context, dir string, command string, args ...string,
+) (string, string, error) {
+	e.Helper()
+
+	cmd := e.SetupCommandIn(ctx, dir, command, args...)
 	e.Logf("Running command %v %v", cmd.Path, strings.Join(args, " "))
 
 	// Buffer STDOUT and STDERR so we can return them later.

--- a/sdk/go/common/testing/util.go
+++ b/sdk/go/common/testing/util.go
@@ -15,10 +15,13 @@
 package testing
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -36,4 +39,31 @@ func LogIfVerbose(t *testing.T, name, message string) {
 		return
 	}
 	t.Logf("%s: %s", name, message)
+}
+
+var errTestHasFailed = errors.New("test has failed")
+
+func cancelOnFail(t interface {
+	Failed() bool
+}, cancel context.CancelCauseFunc,
+) context.CancelFunc {
+	done := make(chan struct{})
+
+	go func() {
+		ticker := time.Tick(time.Second / 10)
+
+		for {
+			select {
+			case <-ticker:
+				if t.Failed() {
+					cancel(errTestHasFailed)
+					return
+				}
+			case <-done:
+				cancel(nil)
+			}
+		}
+	}()
+
+	return func() { close(done) }
 }


### PR DESCRIPTION
Add a command to `testing.Environment` that is automatically stopped when the test fails. This makes it harder to hang a test with a command, and impossible if you set a fail on timeout:

```go
func setTimeout(t *testing.T, duration time.Duration) {
	go func() {
		select {
		case <-time.After(duration):
			t.Logf("Timed out after %s", duration)
			t.Fail()
		case <-t.Context().Done():
			return
		}
	}()
}
```

This logic is not applied to the existing `Environment.RunCommand` because it prevents `Environment.RunCommand` from being used for test cleanup, and it is already used that way in the wild.

The goal here is to make it harder to write integration tests that can hang. (https://github.com/pulumi/pulumi-dotnet/pull/1027)