### PR TITLE
read project only after checking for remote args

### DIFF
--- a/changelog/pending/cli-fix-20260730-144823.yaml
+++ b/changelog/pending/cli-fix-20260730-144823.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Make --remote not require a Pulumi.yaml file to be present
+time: 2026-07-30T14:48:23.377094232+02:00

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -362,17 +362,6 @@ func NewPreviewCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
-				return err
-			}
-
-			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
-				return err
-			}
-
-			meta := metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
-
 			if err := validateAttachDebuggerFlag(attachDebugger); err != nil {
 				return err
 			}
@@ -441,6 +430,17 @@ func NewPreviewCmd() *cobra.Command {
 
 				return deployment.RunDeployment(ctx, ws, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
+
+			proj, root, err := readProjectForUpdate(ws, client)
+			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+				return err
+			}
+
+			meta := metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, displayOpts)
 			if err != nil {

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -59,6 +59,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // buildImportFile takes an event stream from the engine and builds an import file from it for every create.
@@ -362,6 +363,23 @@ func NewPreviewCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 
+			var proj *workspace.Project
+			var root string
+			var meta *promise.Promise[map[string]string]
+			if !remoteArgs.Remote {
+				var err error
+				proj, root, err = readProjectForUpdate(ws, client)
+				if err != nil {
+					return err
+				}
+
+				if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+					return err
+				}
+
+				meta = metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
+			}
+
 			if err := validateAttachDebuggerFlag(attachDebugger); err != nil {
 				return err
 			}
@@ -430,17 +448,6 @@ func NewPreviewCmd() *cobra.Command {
 
 				return deployment.RunDeployment(ctx, ws, cmd, displayOpts, apitype.Preview, stackName, url, remoteArgs)
 			}
-
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
-				return err
-			}
-
-			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
-				return err
-			}
-
-			meta := metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, displayOpts)
 			if err != nil {

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -114,15 +114,6 @@ func NewRefreshCmd() *cobra.Command {
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
 
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
-				return err
-			}
-
-			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
-				return err
-			}
-
 			// Remote implies we're skipping previews.
 			if remoteArgs.Remote {
 				skipPreview = true
@@ -198,6 +189,15 @@ func NewRefreshCmd() *cobra.Command {
 				}
 
 				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
+			}
+
+			proj, root, err := readProjectForUpdate(ws, client)
+			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+				return err
 			}
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func NewRefreshCmd() *cobra.Command {
@@ -113,6 +114,20 @@ func NewRefreshCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			ws := pkgWorkspace.Instance
+
+			var proj *workspace.Project
+			var root string
+			if !remoteArgs.Remote {
+				var err error
+				proj, root, err = readProjectForUpdate(ws, client)
+				if err != nil {
+					return err
+				}
+
+				if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+					return err
+				}
+			}
 
 			// Remote implies we're skipping previews.
 			if remoteArgs.Remote {
@@ -189,15 +204,6 @@ func NewRefreshCmd() *cobra.Command {
 				}
 
 				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Refresh, stackName, url, remoteArgs)
-			}
-
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
-				return err
-			}
-
-			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
-				return err
 			}
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -605,17 +605,6 @@ func NewUpCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
-				return err
-			}
-
-			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
-				return err
-			}
-
-			meta := metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
-
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 			// Remote implies we're skipping previews.
@@ -702,6 +691,17 @@ func NewUpCmd() *cobra.Command {
 
 				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
+
+			proj, root, err := readProjectForUpdate(ws, client)
+			if err != nil {
+				return err
+			}
+
+			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+				return err
+			}
+
+			meta := metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)
 			if err != nil {

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -605,6 +605,20 @@ func NewUpCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 
+			var meta *promise.Promise[map[string]string]
+			if !remoteArgs.Remote {
+				proj, root, err := readProjectForUpdate(ws, client)
+				if err != nil {
+					return err
+				}
+
+				if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
+					return err
+				}
+
+				meta = metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
+			}
+
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 			// Remote implies we're skipping previews.
@@ -691,17 +705,6 @@ func NewUpCmd() *cobra.Command {
 
 				return deployment.RunDeployment(ctx, ws, cmd, opts.Display, apitype.Update, stackName, url, remoteArgs)
 			}
-
-			proj, root, err := readProjectForUpdate(ws, client)
-			if err != nil {
-				return err
-			}
-
-			if err := plugin.ValidatePulumiVersionRange(proj.RequiredPulumiVersion, version.Version); err != nil {
-				return err
-			}
-
-			meta := metadata.GetLanguageRuntimeMetadata(ctx, root, proj)
 
 			isDIYBackend, err := cmdBackend.IsDIYBackend(ws, opts.Display)
 			if err != nil {

--- a/tests/remote/remote_test.go
+++ b/tests/remote/remote_test.go
@@ -91,8 +91,6 @@ func TestInvalidRemoteFlags(t *testing.T) {
 				e := ptesting.NewEnvironment(t)
 				defer e.DeleteIfNotFailed()
 
-				e.WriteTestFile("Pulumi.yaml", "runtime: yaml\nname: test")
-
 				// Remote flags currently require PULUMI_EXPERIMENTAL.
 				e.Env = append(e.Env, "PULUMI_EXPERIMENTAL=true")
 


### PR DESCRIPTION
For `--remote` operations, we shouldn't need a `Pulumi.yaml` file available locally. We do however currently read the project before we check for `remoteArgs.Remote` in preview/refresh/up, even though we don't need the information. This means those commands fail if no `Pulumi.yaml` file exists, even though it's not necessary and none of the information there is.

Just swap the order around to fix this.

Fixes #24050
