### PR TITLE
fix ci-dev-release and cron-direct-build workflows

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -55,10 +55,13 @@ jobs:
           cache-dependency-path: pkg/go.sum
           go-version-file: pkg/go.mod
       - uses: ./.github/actions/retry
+        env:
+          MISE_NPM_SHELL_OUT: "true"
         with:
           action: jdx/mise-action@v2
           with: |
             experimental: true
+            cache_key_prefix: mise-npm-shell-out-v0
       - name: Install CLI
         run: SDKS='' make install
       - name: build matrix

--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -14,10 +14,13 @@ jobs:
         with:
           go-version: "1.25"
       - uses: ./.github/actions/retry
+        env:
+          MISE_NPM_SHELL_OUT: "true"
         with:
           action: jdx/mise-action@v2
           with: |
             experimental: true
+            cache_key_prefix: mise-npm-shell-out-v0
       - name: Build
         shell: bash
         run: |


### PR DESCRIPTION
This has the same problem as was fixed in a couple other jobs in #24029.

Fixes https://github.com/pulumi/pulumi/issues/24033
Fixes https://github.com/pulumi/pulumi/issues/24027