### PR TITLE
increase timeout for TestDebuggerAttachBun

### DIFF
--- a/tests/integration/integration_bun_test.go
+++ b/tests/integration/integration_bun_test.go
@@ -15,12 +15,9 @@
 package ints
 
 import (
-	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -49,55 +46,22 @@ func TestDebuggerAttachBun(t *testing.T) {
 	e.RunCommand("pulumi", "stack", "select", "debugger-test")
 
 	eventLog := filepath.Join(e.RootPath, "debugger.log")
-	cmd := e.SetupCommandIn(e.Context(), e.CWD, "pulumi", "preview", "--attach-debugger", "--event-log", eventLog)
-	var previewStdout, previewStderr bytes.Buffer
-	cmd.Stdout = &previewStdout
-	cmd.Stderr = &previewStderr
-	e.Logf("Running command %v %v", cmd.Path, strings.Join(cmd.Args[1:], " "))
-	require.NoError(t, cmd.Start())
-
+	var previewStdout, previewStderr string
 	var previewErr error
 	previewDone := make(chan struct{})
 	go func() {
 		defer close(previewDone)
-		previewErr = cmd.Wait()
+		previewStdout, previewStderr, previewErr = e.GetCommandResults("pulumi", "preview", "--attach-debugger",
+			"--event-log", eventLog)
 	}()
 
-	previewDiagnostics := func() string {
-		var sb strings.Builder
-		select {
-		case <-previewDone:
-			fmt.Fprintf(&sb, "pulumi preview exited early: %v\n", previewErr)
-		default:
-			if err := cmd.Process.Signal(syscall.SIGQUIT); err != nil {
-				fmt.Fprintf(&sb, "pulumi preview is still running; sending SIGQUIT to dump goroutine stacks failed: %v\n", err)
-			} else {
-				select {
-				case <-previewDone:
-					fmt.Fprintf(&sb, "pulumi preview was still running; goroutine stacks from SIGQUIT are in stderr below\n")
-				case <-time.After(15 * time.Second):
-					fmt.Fprintf(&sb, "pulumi preview was still running and did not exit within 15s of SIGQUIT\n")
-				}
-			}
-		}
-		select {
-		case <-previewDone:
-			fmt.Fprintf(&sb, "stdout:\n%s\nstderr:\n%s\n", previewStdout.String(), previewStderr.String())
-		default:
-		}
-		if contents, err := os.ReadFile(eventLog); err != nil {
-			fmt.Fprintf(&sb, "reading event log: %v", err)
-		} else {
-			fmt.Fprintf(&sb, "event log contents:\n%s", contents)
-		}
-		return sb.String()
-	}
-
 	// Wait for the debugging event
+	deadline := time.Now().Add(2 * time.Minute)
 	wait := 20 * time.Millisecond
 	var debugEvent *apitype.StartDebuggingEvent
+	exited := false
 outer:
-	for range 50 {
+	for {
 		events, err := readUpdateEventLog(eventLog)
 		require.NoError(t, err)
 		for _, event := range events {
@@ -106,13 +70,27 @@ outer:
 				break outer
 			}
 		}
-		time.Sleep(wait)
-		if wait < 500*time.Millisecond {
-			wait *= 2
+		if exited || time.Now().After(deadline) {
+			break
+		}
+		select {
+		case <-previewDone:
+			exited = true
+		case <-time.After(wait):
+			if wait < 500*time.Millisecond {
+				wait *= 2
+			}
 		}
 	}
 	if debugEvent == nil {
-		require.NotNilf(t, debugEvent, "no StartDebuggingEvent appeared in the event log; %s", previewDiagnostics())
+		detail := "pulumi preview is still running"
+		select {
+		case <-previewDone:
+			detail = fmt.Sprintf("pulumi preview exited early: %v\nstdout:\n%s\nstderr:\n%s",
+				previewErr, previewStdout, previewStderr)
+		default:
+		}
+		require.NotNilf(t, debugEvent, "no StartDebuggingEvent appeared in the event log; %s", detail)
 	}
 
 	wsURL, ok := debugEvent.Config["url"].(string)
@@ -145,10 +123,11 @@ outer:
 	select {
 	case <-previewDone:
 		require.NoError(t, previewErr, "pulumi preview failed:\nstdout:\n%s\nstderr:\n%s",
-			previewStdout.String(), previewStderr.String())
+			previewStdout, previewStderr)
 	case <-time.After(60 * time.Second):
+		events, _ := readUpdateEventLog(eventLog)
 		require.FailNowf(t, "timed out waiting for program to complete after detaching the debugger",
-			"bun likely never resumed execution.\ndebugger responses received:\n%s\n%s",
-			strings.Join(received, "\n"), previewDiagnostics())
+			"bun likely never resumed execution.\ndebugger responses received:\n%s\n"+
+				"event log contained %d events", strings.Join(received, "\n"), len(events))
 	}
 }


### PR DESCRIPTION
Looks like this test just had a timeout that's too short and is not actually hanging.  Increase the timeout to 2 mins to hopefully stop it from flaking.

Also remove the now hopefully unnecessary debug machinery which we added temporarily.

Fixes #24124