### PR TITLE
Support --provider flag in stateful operations

### DIFF
--- a/changelog/pending/cli-do-improvement-20260730-151808.yaml
+++ b/changelog/pending/cli-do-improvement-20260730-151808.yaml
@@ -1,4 +1,4 @@
 component: cli/do
 kind: improvement
-body: Adds support for the `--provider` argument for stateful operations
+body: Add support for the `--provider` argument for stateful operations
 time: 2026-07-30T15:18:08.804503+01:00

--- a/changelog/pending/cli-do-improvement-20260730-151808.yaml
+++ b/changelog/pending/cli-do-improvement-20260730-151808.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: improvement
+body: Adds support for the `--provider` argument for stateful operations
+time: 2026-07-30T15:18:08.804503+01:00

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -236,7 +236,7 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 	// the user typed on the command line. If no file was provided, the flags become the snippet
 	// body by themselves.
 	inputFlags := collectInputFlags(cmd, "input", args.res.InputProperties)
-	code, _, resourceNames, err := parseFile(
+	code, resourceFilename, resourceNames, err := parseFile(
 		ctx, args.inputFile, "input", args.inputFormat, args.res.Token,
 		pc.converter, pc.loaderTarget, pc.packageDescriptor, inputFlags, resourceInfos,
 	)
@@ -259,6 +259,28 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 		return fmt.Errorf("resource %s %q already exists in stack %s; use `upsert` to replace it",
 			args.res.Token, args.name, stack.Ref())
 	}
+	// Handle bare --provider: reference the given provider URN from the resource snippet and
+	// inject an options { provider = provider } block into its PCL.
+	if pc.providerURN != "" {
+		// Pick an identifier for the injected provider reference that doesn't collide with a
+		// user-supplied resource reference of the same name.
+		providerRefName := "provider"
+		for i := 2; ; i++ {
+			if _, taken := references[providerRefName]; !taken {
+				break
+			}
+			providerRefName = fmt.Sprintf("provider%d", i)
+		}
+		if references == nil {
+			references = map[string]string{}
+		}
+		references[providerRefName] = pc.providerURN
+		code, err = injectProviderOptionInPCL(code, resourceFilename, providerRefName)
+		if err != nil {
+			return fmt.Errorf("inject provider option: %w", err)
+		}
+	}
+
 	snippet := resource.Snippet{
 		UUID:       snippetUUID,
 		Name:       args.name,

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -186,6 +186,52 @@ size = 2
 	_ = stderr
 }
 
+// TestDoCmdResourceUpsertBareProviderReference verifies that supplying --provider (without any
+// provider overrides) makes the resource snippet reference the given provider URN via its
+// References map and injects an options { provider = provider } block into its code, without
+// producing an inline provider snippet.
+//
+//nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
+func TestDoCmdResourceUpsertBareProviderReference(t *testing.T) {
+	// Existing provider resource in the snapshot for the URN we point at with --provider.
+	providerURN := "urn:pulumi:dev::proj::pulumi:providers:azure::existing"
+	mws, mlm := installMockUpsertBackend(t, &deploy.Snapshot{
+		Resources: []*pkgresource.State{{
+			URN:    resource.URN(providerURN),
+			Type:   tokens.Type("pulumi:providers:azure"),
+			Inputs: resource.PropertyMap{"region": resource.NewProperty("us-east-1")},
+		}},
+	})
+
+	var got StatefulUpdateRequest
+	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
+	) (*StatefulUpdateResult, error) {
+		got = req
+		return &StatefulUpdateResult{SnippetUUID: req.Snippet.UUID}, nil
+	}
+	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
+		return &testProvider{spec: doResourceSpec(false)}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, stub)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	inputFile := writeHCLFile(t, "upsert.pcl", `name = "example"`+"\n")
+	cmd.SetArgs([]string{
+		"azure:index:myResource", "upsert", "myres", "--yes",
+		"--provider", providerURN,
+		"--input", "pcl", "--input-file", inputFile,
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, providerURN, got.Snippet.References["provider"])
+	assert.Contains(t, got.Snippet.Code, "options {")
+	assert.Contains(t, got.Snippet.Code, "provider = provider")
+	_ = stdout
+	_ = stderr
+}
+
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
 func TestDoCmdResourceUpsertConstructsSnippetWithReferences(t *testing.T) {
 	referencedURN := resource.URN("urn:pulumi:dev::proj::azure:index:myResource::source")
@@ -727,8 +773,6 @@ func TestDoCmdResourceStatefulCreateConstructsSnippetWithReferences(t *testing.T
 	require.NoError(t, cmd.Execute())
 
 	assert.Equal(t, map[string]string{"source": string(referencedURN)}, got.Snippet.References)
-	_ = stdout
-	_ = stderr
 }
 
 func TestReadResourceReferences(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -572,6 +572,45 @@ func mergeAttributeLiteralsIntoPCL(
 	return out, nil
 }
 
+// injectProviderOptionInPCL rewrites a resource snippet's PCL to reference the (external) provider
+// snippet's URN via the given identifier (declared by the snippet's References map). If the
+// source already has a top-level `options` block, `provider = <name>` is added inside it (unless
+// a provider attribute is already present); otherwise a fresh `options { provider = <name> }`
+// block is appended.
+func injectProviderOptionInPCL(source []byte, filename, name string) ([]byte, error) {
+	if len(source) > 0 && source[len(source)-1] != '\n' {
+		source = append(append([]byte{}, source...), '\n')
+	}
+	file, diags := hclwrite.ParseConfig(source, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	body := file.Body()
+	overlay, diags := hclwrite.ParseConfig(
+		fmt.Appendf(nil, "provider = %s\n", name), "<options.provider>", hcl.Pos{Line: 1, Column: 1},
+	)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	providerAttr := overlay.Body().GetAttribute("provider")
+	if providerAttr == nil {
+		return nil, errors.New("failed to construct provider option tokens")
+	}
+	providerTokens := providerAttr.Expr().BuildTokens(nil)
+	for _, block := range body.Blocks() {
+		if block.Type() != "options" {
+			continue
+		}
+		if block.Body().GetAttribute("provider") == nil {
+			block.Body().SetAttributeRaw("provider", providerTokens)
+		}
+		return file.Bytes(), nil
+	}
+	newBlock := body.AppendNewBlock("options", nil)
+	newBlock.Body().SetAttributeRaw("provider", providerTokens)
+	return file.Bytes(), nil
+}
+
 func pclLiteral(flag inputFlagValue) (string, error) {
 	switch flag.typ {
 	case schema.StringType:

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -1258,3 +1258,35 @@ options {
 		})
 	}
 }
+
+func TestInjectProviderOptionInPCL(t *testing.T) {
+	t.Parallel()
+
+	// No existing options block: a fresh one is appended.
+	got, err := injectProviderOptionInPCL([]byte(`name = "example"`+"\n"), "res.pcl", "provider")
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `name = "example"`)
+	assert.Contains(t, string(got), "options {")
+	assert.Contains(t, string(got), "provider = provider")
+
+	// Existing options block without provider: provider is added inside it.
+	got, err = injectProviderOptionInPCL([]byte(`name = "example"
+options {
+  protect = true
+}
+`), "res.pcl", "provider")
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "protect  = true")
+	assert.Contains(t, string(got), "provider = provider")
+
+	// Existing options block with provider already set: idempotent.
+	src := `name = "example"
+options {
+  provider = other
+}
+`
+	got, err = injectProviderOptionInPCL([]byte(src), "res.pcl", "provider")
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "provider = other")
+	assert.NotContains(t, string(got), "provider = provider")
+}


### PR DESCRIPTION
This adds support for the `--provider` option for stateful operations.