### PR TITLE
Offer to create a first project after an interactive login

### DIFF
--- a/changelog/pending/20260729--cli--login-first-project-prompt.yaml
+++ b/changelog/pending/20260729--cli--login-first-project-prompt.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: feat
+body: Offer to create a first project after logging in to an account with no stacks
+custom:
+    PR: "24133"

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -254,7 +254,7 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env
 				fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s (%s)\n", be.Name(), be.URL())
 			}
 
-			return nil
+			return offerFirstStep(ctx, be, cwd, cmd.OutOrStdout(), displayOptions, cmdutil.Interactive())
 		},
 	}
 

--- a/pkg/cmd/pulumi/auth/onboarding.go
+++ b/pkg/cmd/pulumi/auth/onboarding.go
@@ -1,0 +1,105 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	survey "github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/browser"
+
+	pkgBackend "github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+const (
+	getStartedURL    = "https://www.pulumi.com/docs/get-started/"
+	newProjectAnswer = "Create a new Pulumi project"
+	guideAnswer      = "View the getting started guide"
+	skipAnswer       = "Skip for now"
+	runNewHint       = "To get started, run `pulumi new` in an empty directory"
+)
+
+// offerFirstStep offers a user with no stacks a path into their first project. A user with no
+// stacks at all is treated as new: the CLI cannot distinguish creating an organization at signup
+// from joining one, because the account details the backend returns carry only organization names.
+//
+// It is called after login has already succeeded, so it reports an error only when the user asked
+// for something and that something failed: a backend that cannot tell us whether the account has
+// stacks is treated as "say nothing" rather than as a failed login.
+func offerFirstStep(
+	ctx context.Context,
+	be pkgBackend.Backend,
+	cwd string,
+	out io.Writer,
+	opts display.Options,
+	interactive bool,
+) error {
+	if !interactive || diy.IsDIYBackendURL(be.URL()) {
+		return nil
+	}
+
+	stacks, _, err := be.ListStackNames(ctx, pkgBackend.ListStackNamesFilter{}, nil)
+	if err != nil || len(stacks) > 0 {
+		return nil
+	}
+
+	if newcmd.ErrorIfNotEmptyDirectory(cwd) != nil {
+		fmt.Fprintf(out, "\n%s\n", runNewHint)
+		return nil
+	}
+
+	return promptFirstStep(ctx, out, opts)
+}
+
+// promptFirstStep asks the user what they would like to do and carries out their choice.
+func promptFirstStep(ctx context.Context, out io.Writer, opts display.Options) error {
+	message := "\nYour organization is empty. What would you like to do?"
+	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
+
+	var answer string
+	err := survey.AskOne(&survey.Select{
+		Message: message,
+		Options: []string{newProjectAnswer, guideAnswer, skipAnswer},
+	}, &answer, ui.SurveyIcons(opts.Color))
+	if err != nil {
+		// An interrupt at an optional prompt means "skip", not "fail the login".
+		return nil
+	}
+
+	switch answer {
+	case newProjectAnswer:
+		newCmd := newcmd.NewNewCmd()
+		newCmd.SetArgs([]string{})
+		// `pulumi new`'s usage text and error reporting belong to `pulumi login`'s caller here.
+		newCmd.SilenceUsage = true
+		newCmd.SilenceErrors = true
+		return newCmd.ExecuteContext(ctx)
+	case guideAnswer:
+		fmt.Fprintf(out, "\n%s\n", getStartedURL)
+		contract.IgnoreError(browser.OpenURL(getStartedURL))
+		return nil
+	default:
+		fmt.Fprintf(out, "\n%s\n", runNewHint)
+		return nil
+	}
+}

--- a/pkg/cmd/pulumi/auth/onboarding.go
+++ b/pkg/cmd/pulumi/auth/onboarding.go
@@ -24,7 +24,6 @@ import (
 
 	pkgBackend "github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -39,13 +38,8 @@ const (
 	runNewHint       = "To get started, run `pulumi new` in an empty directory"
 )
 
-// offerFirstStep offers a user with no stacks a path into their first project. A user with no
-// stacks at all is treated as new: the CLI cannot distinguish creating an organization at signup
-// from joining one, because the account details the backend returns carry only organization names.
-//
-// It is called after login has already succeeded, so it reports an error only when the user asked
-// for something and that something failed: a backend that cannot tell us whether the account has
-// stacks is treated as "say nothing" rather than as a failed login.
+// offerFirstStep offers a user with no stacks a path into their first project. It runs after login
+// has succeeded, so it fails only when the user asked for something and that something failed.
 func offerFirstStep(
 	ctx context.Context,
 	be pkgBackend.Backend,
@@ -54,7 +48,7 @@ func offerFirstStep(
 	opts display.Options,
 	interactive bool,
 ) error {
-	if !interactive || diy.IsDIYBackendURL(be.URL()) {
+	if !interactive {
 		return nil
 	}
 
@@ -63,37 +57,21 @@ func offerFirstStep(
 		return nil
 	}
 
-	if newcmd.ErrorIfNotEmptyDirectory(cwd) != nil {
-		fmt.Fprintf(out, "\n%s\n", runNewHint)
-		return nil
-	}
-
-	return promptFirstStep(ctx, out, opts)
-}
-
-// promptFirstStep asks the user what they would like to do and carries out their choice.
-func promptFirstStep(ctx context.Context, out io.Writer, opts display.Options) error {
-	message := "\nYour organization is empty. What would you like to do?"
+	message := "\nYou don't have any stacks yet. What would you like to do?"
 	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
 
 	var answer string
-	err := survey.AskOne(&survey.Select{
+	if err := survey.AskOne(&survey.Select{
 		Message: message,
 		Options: []string{newProjectAnswer, guideAnswer, skipAnswer},
-	}, &answer, ui.SurveyIcons(opts.Color))
-	if err != nil {
+	}, &answer, ui.SurveyIcons(opts.Color)); err != nil {
 		// An interrupt at an optional prompt means "skip", not "fail the login".
 		return nil
 	}
 
 	switch answer {
 	case newProjectAnswer:
-		newCmd := newcmd.NewNewCmd()
-		newCmd.SetArgs([]string{})
-		// `pulumi new`'s usage text and error reporting belong to `pulumi login`'s caller here.
-		newCmd.SilenceUsage = true
-		newCmd.SilenceErrors = true
-		return newCmd.ExecuteContext(ctx)
+		return runNew(ctx, cwd, opts)
 	case guideAnswer:
 		fmt.Fprintf(out, "\n%s\n", getStartedURL)
 		contract.IgnoreError(browser.OpenURL(getStartedURL))
@@ -102,4 +80,31 @@ func promptFirstStep(ctx context.Context, out io.Writer, opts display.Options) e
 		fmt.Fprintf(out, "\n%s\n", runNewHint)
 		return nil
 	}
+}
+
+// runNew runs `pulumi new` in cwd, asking where to put the project when cwd already has files in
+// it. `pulumi new` rejects a directory that isn't empty, so the answer is validated for us.
+func runNew(ctx context.Context, cwd string, opts display.Options) error {
+	// An empty, non-nil slice: cobra parses os.Args when a command's args are nil.
+	args := []string{}
+	if newcmd.ErrorIfNotEmptyDirectory(cwd) != nil {
+		message := opts.Color.Colorize(colors.SpecPrompt +
+			"Current directory is not empty. Please choose an empty directory:" + colors.Reset)
+
+		var dir string
+		if err := survey.AskOne(&survey.Input{
+			Message: message,
+			Help:    "The directory is created if it does not already exist.",
+		}, &dir, survey.WithValidator(survey.Required), ui.SurveyIcons(opts.Color)); err != nil {
+			return nil
+		}
+		args = []string{"--dir", dir}
+	}
+
+	newCmd := newcmd.NewNewCmd()
+	newCmd.SetArgs(args)
+	// `pulumi new`'s usage text and error reporting belong to `pulumi login`'s caller here.
+	newCmd.SilenceUsage = true
+	newCmd.SilenceErrors = true
+	return newCmd.ExecuteContext(ctx)
 }

--- a/pkg/cmd/pulumi/auth/onboarding.go
+++ b/pkg/cmd/pulumi/auth/onboarding.go
@@ -16,8 +16,12 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/browser"
@@ -27,7 +31,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 const (
@@ -35,7 +38,6 @@ const (
 	newProjectAnswer = "Create a new Pulumi project"
 	guideAnswer      = "View the getting started guide"
 	skipAnswer       = "Skip for now"
-	runNewHint       = "To get started, run `pulumi new` in an empty directory"
 )
 
 // offerFirstStep offers a user with no stacks a path into their first project. It runs after login
@@ -57,8 +59,9 @@ func offerFirstStep(
 		return nil
 	}
 
-	message := "\nYou don't have any stacks yet. What would you like to do?"
-	message = opts.Color.Colorize(colors.SpecPrompt + message + colors.Reset)
+	message := opts.Color.Colorize(
+		colors.SpecPrompt + "\n\rYou don't have any stacks yet. What would you like to do?" + colors.Reset,
+	)
 
 	var answer string
 	if err := survey.AskOne(&survey.Select{
@@ -73,32 +76,43 @@ func offerFirstStep(
 	case newProjectAnswer:
 		return runNew(ctx, cwd, opts)
 	case guideAnswer:
-		fmt.Fprintf(out, "\n%s\n", getStartedURL)
-		contract.IgnoreError(browser.OpenURL(getStartedURL))
+		fmt.Fprintln(out, "\nOpening the getting started guide in your web browser...")
+		if err := browser.OpenURL(getStartedURL); err != nil {
+			fmt.Fprintf(out, "\nWe couldn't launch your web browser for some reason. Please visit:\n\n"+
+				"%s\n\nto get started.\n", getStartedURL)
+		}
 		return nil
 	default:
-		fmt.Fprintf(out, "\n%s\n", runNewHint)
+		fmt.Fprintln(out, "\nTo get started, run `pulumi new` in an empty directory")
 		return nil
 	}
 }
 
 // runNew runs `pulumi new` in cwd, asking where to put the project when cwd already has files in
-// it. `pulumi new` rejects a directory that isn't empty, so the answer is validated for us.
+// it.
 func runNew(ctx context.Context, cwd string, opts display.Options) error {
-	// An empty, non-nil slice: cobra parses os.Args when a command's args are nil.
+	// Cobra parses os.Args when a command's args are nil, so pass an empty slice instead.
 	args := []string{}
+	target := cwd
 	if newcmd.ErrorIfNotEmptyDirectory(cwd) != nil {
 		message := opts.Color.Colorize(colors.SpecPrompt +
-			"Current directory is not empty. Please choose an empty directory:" + colors.Reset)
+			"\rCurrent directory is not empty. Enter or create an empty directory:" + colors.Reset)
 
 		var dir string
 		if err := survey.AskOne(&survey.Input{
 			Message: message,
 			Help:    "The directory is created if it does not already exist.",
-		}, &dir, survey.WithValidator(survey.Required), ui.SurveyIcons(opts.Color)); err != nil {
+			Suggest: suggestDirectories,
+		}, &dir, survey.WithValidator(validateProjectDirectory), ui.SurveyIcons(opts.Color)); err != nil {
 			return nil
 		}
 		args = []string{"--dir", dir}
+		target = dir
+	}
+
+	// `pulumi new --dir` changes the working directory, so resolve the target while we still can.
+	if abs, err := filepath.Abs(target); err == nil {
+		target = abs
 	}
 
 	newCmd := newcmd.NewNewCmd()
@@ -106,5 +120,48 @@ func runNew(ctx context.Context, cwd string, opts display.Options) error {
 	// `pulumi new`'s usage text and error reporting belong to `pulumi login`'s caller here.
 	newCmd.SilenceUsage = true
 	newCmd.SilenceErrors = true
-	return newCmd.ExecuteContext(ctx)
+
+	// `pulumi new` can fail before it writes anything or long after, and returns a bare error
+	// either way. We don't have to tell those apart: target was empty before this ran, so anything
+	// in it now is a half-written project the user should know about.
+	err := newCmd.ExecuteContext(ctx)
+	if err != nil && newcmd.ErrorIfNotEmptyDirectory(target) != nil {
+		return fmt.Errorf("%w\nYour new project in %s is incomplete", err, target)
+	}
+	return err
+}
+
+// suggestDirectories completes a partially typed path against the directories it could name, so
+// the prompt answers <tab> the way a shell would.
+func suggestDirectories(toComplete string) []string {
+	// Glob only fails on a malformed pattern, for which no suggestions is the right answer.
+	matches, _ := filepath.Glob(toComplete + "*")
+
+	dirs := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if info, err := os.Stat(match); err == nil && info.IsDir() {
+			dirs = append(dirs, match)
+		}
+	}
+	return dirs
+}
+
+// validateProjectDirectory rejects what `pulumi new` would reject, so the user can correct it at
+// the prompt.
+func validateProjectDirectory(answer any) error {
+	dir, _ := answer.(string)
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return errors.New("please enter a directory")
+	}
+
+	// A directory that does not exist yet is the common answer; `pulumi new --dir` creates it.
+	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if newcmd.ErrorIfNotEmptyDirectory(dir) != nil {
+		return fmt.Errorf("%s is not empty, please enter an empty or new directory", dir)
+	}
+	return nil
 }

--- a/pkg/cmd/pulumi/auth/onboarding_test.go
+++ b/pkg/cmd/pulumi/auth/onboarding_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pkgBackend "github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOfferFirstStepSaysNothingToAUserWithStacks(t *testing.T) {
+	t.Parallel()
+
+	be := &pkgBackend.MockBackend{
+		URLF: func() string { return "https://api.pulumi.com" },
+		ListStackNamesF: func(
+			context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
+		) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
+			return []pkgBackend.StackReference{&pkgBackend.MockStackReference{}}, nil, nil
+		},
+	}
+
+	out := &strings.Builder{}
+	err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, true)
+	require.NoError(t, err)
+	assert.Empty(t, out.String(), "a returning user's login output must be unchanged")
+}
+
+func TestOfferFirstStepPrintsHintInNonEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0o600))
+
+	be := &pkgBackend.MockBackend{
+		URLF: func() string { return "https://api.pulumi.com" },
+		ListStackNamesF: func(
+			context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
+		) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
+			return nil, nil, nil
+		},
+	}
+
+	out := &strings.Builder{}
+	err := offerFirstStep(t.Context(), be, dir, out, display.Options{}, true)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "To get started, run `pulumi new` in an empty directory")
+}
+
+func TestOfferFirstStepNeverCallsBackendWhenGuardSaysNo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		url         string
+		interactive bool
+	}{
+		{name: "non-interactive", url: "https://api.pulumi.com", interactive: false},
+		{name: "diy backend", url: "file:///tmp/state", interactive: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			be := &pkgBackend.MockBackend{
+				URLF: func() string { return tt.url },
+				ListStackNamesF: func(
+					context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
+				) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
+					t.Fatal("ListStackNames must not be called when the guard says no")
+					return nil, nil, nil
+				},
+			}
+
+			out := &strings.Builder{}
+			err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, tt.interactive)
+			require.NoError(t, err)
+			assert.Empty(t, out.String())
+		})
+	}
+}
+
+func TestOfferFirstStepIgnoresListStacksFailure(t *testing.T) {
+	t.Parallel()
+
+	be := &pkgBackend.MockBackend{
+		URLF: func() string { return "https://api.pulumi.com" },
+		ListStackNamesF: func(
+			context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
+		) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
+			return nil, nil, errors.New("network is unreachable")
+		},
+	}
+
+	out := &strings.Builder{}
+	err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, true)
+	require.NoError(t, err, "a failed emptiness check must not fail a successful login")
+	assert.Empty(t, out.String())
+}

--- a/pkg/cmd/pulumi/auth/onboarding_test.go
+++ b/pkg/cmd/pulumi/auth/onboarding_test.go
@@ -17,8 +17,6 @@ package auth
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -31,74 +29,45 @@ import (
 func TestOfferFirstStepSaysNothingToAUserWithStacks(t *testing.T) {
 	t.Parallel()
 
-	be := &pkgBackend.MockBackend{
-		URLF: func() string { return "https://api.pulumi.com" },
-		ListStackNamesF: func(
-			context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
-		) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
-			return []pkgBackend.StackReference{&pkgBackend.MockStackReference{}}, nil, nil
-		},
-	}
+	// Both backend kinds take the same path: a user with stacks is a returning user either way.
+	for _, url := range []string{"https://api.pulumi.com", "file:///tmp/state"} {
+		t.Run(url, func(t *testing.T) {
+			t.Parallel()
 
-	out := &strings.Builder{}
-	err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, true)
-	require.NoError(t, err)
-	assert.Empty(t, out.String(), "a returning user's login output must be unchanged")
+			be := &pkgBackend.MockBackend{
+				URLF: func() string { return url },
+				ListStackNamesF: func(
+					context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
+				) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
+					return []pkgBackend.StackReference{&pkgBackend.MockStackReference{}}, nil, nil
+				},
+			}
+
+			out := &strings.Builder{}
+			err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, true)
+			require.NoError(t, err)
+			assert.Empty(t, out.String(), "a returning user's login output must be unchanged")
+		})
+	}
 }
 
-func TestOfferFirstStepPrintsHintInNonEmptyDirectory(t *testing.T) {
+func TestOfferFirstStepNeverCallsBackendWhenNotInteractive(t *testing.T) {
 	t.Parallel()
-
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0o600))
 
 	be := &pkgBackend.MockBackend{
 		URLF: func() string { return "https://api.pulumi.com" },
 		ListStackNamesF: func(
 			context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
 		) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
+			t.Fatal("ListStackNames must not be called on a non-interactive login")
 			return nil, nil, nil
 		},
 	}
 
 	out := &strings.Builder{}
-	err := offerFirstStep(t.Context(), be, dir, out, display.Options{}, true)
+	err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, false)
 	require.NoError(t, err)
-	assert.Contains(t, out.String(), "To get started, run `pulumi new` in an empty directory")
-}
-
-func TestOfferFirstStepNeverCallsBackendWhenGuardSaysNo(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		url         string
-		interactive bool
-	}{
-		{name: "non-interactive", url: "https://api.pulumi.com", interactive: false},
-		{name: "diy backend", url: "file:///tmp/state", interactive: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			be := &pkgBackend.MockBackend{
-				URLF: func() string { return tt.url },
-				ListStackNamesF: func(
-					context.Context, pkgBackend.ListStackNamesFilter, pkgBackend.ContinuationToken,
-				) ([]pkgBackend.StackReference, pkgBackend.ContinuationToken, error) {
-					t.Fatal("ListStackNames must not be called when the guard says no")
-					return nil, nil, nil
-				},
-			}
-
-			out := &strings.Builder{}
-			err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, tt.interactive)
-			require.NoError(t, err)
-			assert.Empty(t, out.String())
-		})
-	}
+	assert.Empty(t, out.String())
 }
 
 func TestOfferFirstStepIgnoresListStacksFailure(t *testing.T) {

--- a/pkg/cmd/pulumi/auth/onboarding_test.go
+++ b/pkg/cmd/pulumi/auth/onboarding_test.go
@@ -17,6 +17,8 @@ package auth
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -86,4 +88,62 @@ func TestOfferFirstStepIgnoresListStacksFailure(t *testing.T) {
 	err := offerFirstStep(t.Context(), be, t.TempDir(), out, display.Options{}, true)
 	require.NoError(t, err, "a failed emptiness check must not fail a successful login")
 	assert.Empty(t, out.String())
+}
+
+func TestValidateProjectDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	empty := filepath.Join(root, "empty")
+	require.NoError(t, os.Mkdir(empty, 0o700))
+
+	occupied := filepath.Join(root, "occupied")
+	require.NoError(t, os.Mkdir(occupied, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(occupied, "main.go"), []byte("package main"), 0o600))
+
+	tests := []struct {
+		name    string
+		answer  any
+		wantErr string
+	}{
+		{name: "a directory that does not exist yet", answer: filepath.Join(root, "new")},
+		{name: "an existing empty directory", answer: empty},
+		{
+			name:    "an existing directory with files in it",
+			answer:  occupied,
+			wantErr: "is not empty, please enter an empty or new directory",
+		},
+		{name: "an empty answer", answer: "  ", wantErr: "please enter a directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateProjectDirectory(tt.answer)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestSuggestDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "infra"), 0o700))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "infra-staging"), 0o700))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "other"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "infra.txt"), []byte("x"), 0o600))
+
+	suggestions := suggestDirectories(filepath.Join(root, "inf"))
+
+	assert.Equal(t, []string{
+		filepath.Join(root, "infra"),
+		filepath.Join(root, "infra-staging"),
+	}, suggestions, "only directories matching the prefix are suggested, never files")
 }


### PR DESCRIPTION
## Summary

**Why.** A user who signs up from `pulumi login` lands back in a terminal with no next step. Only ~24% of new signups reach a first successful `pulumi up` within 7 days, but roughly half of users who complete a CLI login get there — a path worth widening. Part of [Simplify getting to `pulumi up`](https://app.notion.com/p/3a3fdbdf1cce8107b49ff31368beeeb6); spec in [Improved `pulumi login` experience](https://app.notion.com/p/3a3fdbdf1cce80e5b8a5c6d2c267c20a); tracked by pulumi/pulumi-service#46594.

**What.** After a successful interactive `pulumi login`, a user whose account can see no stacks is offered a way into their first project:

```
Logged in to pulumi.com as mark (https://app.pulumi.com/mark)

You don't have any stacks yet. What would you like to do?
> Create a new Pulumi project
  View the getting started guide
  Skip for now
```

"Create a new Pulumi project" continues into `pulumi new` in-process; "Skip for now" prints a one-line pointer at `pulumi new`. When the current directory already has files in it, creating a project first asks where to put it and passes the answer to `pulumi new --dir`, which creates the directory and applies its own emptiness check.

The prompt appears only on an interactive terminal when the account has no stacks, so the single `ListStackNames` call happens only after the interactivity check passes. If that call fails it is ignored: login has already succeeded, and a cosmetic prompt must never fail it.

## Test plan

Unit tests in `pkg/cmd/pulumi/auth/onboarding_test.go` cover every path that must stay silent.

```
$ go test -count=1 -v -run TestOfferFirstStep ./cmd/pulumi/auth/
--- PASS: TestOfferFirstStepSaysNothingToAUserWithStacks (0.00s)
    --- PASS: TestOfferFirstStepSaysNothingToAUserWithStacks/https://api.pulumi.com (0.00s)
    --- PASS: TestOfferFirstStepSaysNothingToAUserWithStacks/file:///tmp/state (0.00s)
--- PASS: TestOfferFirstStepNeverCallsBackendWhenNotInteractive (0.00s)
--- PASS: TestOfferFirstStepIgnoresListStacksFailure (0.00s)
PASS
ok  	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/auth	0.648s
```

`pulumi new` is now reachable from `login`, so that package was run in full too:

```
$ go test -count=1 -tags all ./cmd/pulumi/project/newcmd/ ./cmd/pulumi/auth/
ok  	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd	51.284s
ok  	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/auth	1.172s
```

Verified by hand against a review stack: the trigger fires on an account with no stacks. The survey prompts themselves are not unit-tested, matching the existing `chooseAccount` prompt in the same file — which is why the tests above assert only on the paths that stay silent.

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation

- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes) — n/a, no SDK changes
- [ ] `make check_proto` — clean (if proto changes) — n/a, no proto changes

`make test_fast` exits 0 but its summary reads `1 failure` — a gotestsum attribution artifact on `newcmd`'s survey-prompt test, which writes raw ANSI escapes that break the JSON parser. It records `(unknown)` while the test prints `--- PASS`, reproduces on master, and passes standalone under `-count=3`.

## Changelog

- [x] Changelog entry added.

## Risk

This changes `pulumi login`, which every Pulumi user runs, so the blast radius is the whole user base if the gating is wrong. Non-interactive and CI runs produce byte-identical output to today and issue no extra API call; `TestOfferFirstStepNeverCallsBackendWhenNotInteractive` uses a `t.Fatal` mock backend to keep that true. Any user with at least one stack — cloud or DIY — also sees unchanged output, at the cost of one `ListStackNames` call on an interactive login.

Following review, the prompt now also covers DIY backends. `diyBackend.ListStackNames` enumerates the state store rather than making a paginated API call, so on a very large `s3://` or `file://` store that listing is the one new cost on an interactive login.

No public API or SDK surface changes. No proto changes. No engine, state, or resource-lifecycle changes.

One thing to know: if the user picks "Create a new Pulumi project" and `pulumi new` then fails, `pulumi login` exits non-zero even though the login itself succeeded. Reachable only from an interactive selection, so no scripted path is affected.

