### PR TITLE
Fix Client.Insecure() always returning false

### DIFF
--- a/changelog/pending/20260730--backend-service--fix-client-insecure.yaml
+++ b/changelog/pending/20260730--backend-service--fix-client-insecure.yaml
@@ -1,0 +1,5 @@
+component: backend/service
+kind: fix
+body: Fix `pulumi login --insecure` not being reflected in the stack's service secrets
+    manager state, which caused TLS verification failures against self-hosted backends
+    using self-signed certificates

--- a/changelog/pending/20260730--backend-service--fix-client-insecure.yaml
+++ b/changelog/pending/20260730--backend-service--fix-client-insecure.yaml
@@ -3,3 +3,5 @@ kind: fix
 body: Fix `pulumi login --insecure` not being reflected in the stack's service secrets
     manager state, which caused TLS verification failures against self-hosted backends
     using self-signed certificates
+custom:
+    PR: "24134"

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -259,6 +259,7 @@ var newClient = func(apiURL, apiToken string, insecure bool, d diag.Sink) *Clien
 		apiURL:   apiURL,
 		apiToken: apiAccessToken(apiToken),
 		diag:     d,
+		insecure: insecure,
 		restClient: &defaultRESTClient{
 			client: &defaultHTTPClient{
 				client: httpClient,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -2158,3 +2158,12 @@ func TestClient_WithRefresh(t *testing.T) {
 		assert.Panics(t, func() { pc.WithRefresh("some-refresh", nil) })
 	})
 }
+
+func TestClientInsecure(t *testing.T) {
+	t.Parallel()
+
+	// Consumers such as the service secrets manager persist Insecure() into stack state and
+	// later rebuild a client from it, so the flag must survive construction.
+	assert.True(t, NewClient("https://api.example.com", "tok", true, nil).Insecure())
+	assert.False(t, NewClient("https://api.example.com", "tok", false, nil).Insecure())
+}


### PR DESCRIPTION
`newClient` uses its `insecure` argument to construct the TLS-skipping HTTP transport, but the field assignment on the returned `Client` was dropped in #21517 when `httpClient` was refactored into `restClient`. As a result, `Client.Insecure()` always returns `false`.

The visible consequence is in the service secrets manager, which persists `Insecure()` into the stack's secrets state: for stacks on self-hosted backends logged in with `pulumi login --insecure`, the state always records `insecure: false`, so a secrets manager rebuilt from state constructs a TLS-verifying client and decryption fails against self-signed certificates.

This assigns the field and adds a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)