### PR TITLE
Don't generate `providerInputs`, generate `resources`

### DIFF
--- a/changelog/pending/cli-import-fix-20260730-171014.yaml
+++ b/changelog/pending/cli-import-fix-20260730-171014.yaml
@@ -1,6 +1,6 @@
 component: cli/import
 kind: fix
-body: Generate explicit providers in the import file's resources list instead of the deprecated providerInputs section when creating import files from preview
+body: Generate explicit providers in the import file `resources` instead of the deprecated `providerInputs` section when creating import files from preview
 time: 2026-07-30T17:10:14.460366+02:00
 custom:
     PR: "24135"

--- a/changelog/pending/cli-import-fix-20260730-171014.yaml
+++ b/changelog/pending/cli-import-fix-20260730-171014.yaml
@@ -1,6 +1,6 @@
 component: cli/import
 kind: fix
-body: Generate explicit providers in the import file `resources` instead of the deprecated `providerInputs` section when creating import files from preview
+body: Generate explicit providers in the import file `resources`
 time: 2026-07-30T17:10:14.460366+02:00
 custom:
     PR: "24135"

--- a/changelog/pending/cli-import-fix-20260730-171014.yaml
+++ b/changelog/pending/cli-import-fix-20260730-171014.yaml
@@ -1,0 +1,4 @@
+component: cli/import
+kind: fix
+body: Generate explicit providers in the import file's resources list instead of the deprecated providerInputs section when creating import files from preview
+time: 2026-07-30T17:10:14.460366+02:00

--- a/changelog/pending/cli-import-fix-20260730-171014.yaml
+++ b/changelog/pending/cli-import-fix-20260730-171014.yaml
@@ -2,3 +2,5 @@ component: cli/import
 kind: fix
 body: Generate explicit providers in the import file's resources list instead of the deprecated providerInputs section when creating import files from preview
 time: 2026-07-30T17:10:14.460366+02:00
+custom:
+    PR: "24135"

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -397,9 +397,6 @@ func parseImportFile(
 			if spec.Component {
 				pusherrf("%v is a provider and may not be marked as a component", describeResource(i, spec))
 			}
-			if spec.Parent != "" {
-				pusherrf("%v is a provider and may not have a parent", describeResource(i, spec))
-			}
 			if len(spec.Outputs) > 0 {
 				pusherrf("%v is a provider and may not have outputs", describeResource(i, spec))
 			}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -597,12 +597,12 @@ func parseImportFile(
 				serializedInputs, ok = spec.Inputs, true
 			}
 			if ok {
-				providerInputs, err := resourcestack.DeserializeProperties(serializedInputs, dec)
+				inputs, err := resourcestack.DeserializeProperties(serializedInputs, dec)
 				if err != nil {
 					pusherrf("could not deserialize provider inputs for %v: %w",
 						describeResource(i, spec), err)
 				} else {
-					imp.ProviderInputs = providerInputs
+					imp.Inputs = inputs
 				}
 			}
 		} else {

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -675,8 +675,8 @@ func TestParseImportFileInputsOutputs(t *testing.T) {
 	require.Len(t, imports, 2)
 
 	// A provider spec's inputs become its configuration.
-	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[0].ProviderInputs["region"])
-	require.Nil(t, imports[0].Inputs)
+	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[0].Inputs["region"])
+	require.Nil(t, imports[0].ProviderInputs)
 
 	assert.Equal(t, resource.NewProperty("my-bucket"), imports[1].Inputs["bucket"])
 	assert.Equal(t, resource.NewProperty("arn:aws:s3:::my-bucket"), imports[1].Outputs["arn"])
@@ -709,8 +709,8 @@ func TestParseImportFileDeclaredProvider(t *testing.T) {
 	require.Len(t, imports, 2)
 
 	providerURN := resource.URN("urn:pulumi:stack::proj::pulumi:providers:aws::my-prov")
-	require.NotNil(t, imports[0].ProviderInputs)
-	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[0].ProviderInputs["region"])
+	require.NotNil(t, imports[0].Inputs)
+	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[0].Inputs["region"])
 	assert.Equal(t, providerURN, imports[1].Provider)
 }
 
@@ -743,7 +743,7 @@ func TestParseImportFileProviderWithParent(t *testing.T) {
 	require.Len(t, imports, 3)
 
 	assert.Equal(t, resource.URN("urn:pulumi:stack::proj::my:index:Comp::comp"), imports[1].Parent)
-	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[1].ProviderInputs["region"])
+	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[1].Inputs["region"])
 	assert.Equal(t,
 		resource.URN("urn:pulumi:stack::proj::my:index:Comp$pulumi:providers:aws::my-prov"),
 		imports[2].Provider)

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -714,6 +714,41 @@ func TestParseImportFileDeclaredProvider(t *testing.T) {
 	assert.Equal(t, providerURN, imports[1].Provider)
 }
 
+func TestParseImportFileProviderWithParent(t *testing.T) {
+	t.Parallel()
+
+	f := importFile{
+		Resources: []importSpec{
+			{
+				Name:      "comp",
+				Type:      "my:index:Comp",
+				Component: true,
+			},
+			{
+				Name:   "my-prov",
+				Type:   "pulumi:providers:aws",
+				Parent: "comp",
+				Inputs: map[string]any{"region": "eu-west-1"},
+			},
+			{
+				Name:     "thing",
+				ID:       "thing-id",
+				Type:     "aws:s3:Bucket",
+				Provider: "my-prov",
+			},
+		},
+	}
+	imports, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
+	require.NoError(t, err)
+	require.Len(t, imports, 3)
+
+	assert.Equal(t, resource.URN("urn:pulumi:stack::proj::my:index:Comp::comp"), imports[1].Parent)
+	assert.Equal(t, resource.NewProperty("eu-west-1"), imports[1].ProviderInputs["region"])
+	assert.Equal(t,
+		resource.URN("urn:pulumi:stack::proj::my:index:Comp$pulumi:providers:aws::my-prov"),
+		imports[2].Provider)
+}
+
 func TestParseImportFileProviderInputsWithoutEntry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -176,38 +176,9 @@ func buildImportFile(
 			// We're importing this URN so track that we've seen it.
 			importSet[urn] = struct{}{}
 
-			// Provider resources are not imported with an ID like regular resources. Instead,
-			// explicit providers are declared in the import file's resources with their full
-			// inputs so the import system can create them with the correct configuration.
-			// Default providers are created by the import system from ambient config.
-			if sdkproviders.IsProviderType(urn.Type()) {
-				if sdkproviders.IsDefaultProvider(urn) {
-					continue
-				}
-				contract.Assertf(preEvent.Metadata.Res.State != nil,
-					"%s: expected State to be non-nil for provider", urn)
-
-				var inputs map[string]any
-				if fullInputs := preEvent.Metadata.Res.State.Inputs; len(fullInputs) > 0 {
-					var serErr error
-					inputs, serErr = stack.SerializeProperties(ctx, fullInputs, enc, false)
-					if serErr != nil {
-						return importFile{}, fmt.Errorf(
-							"could not serialize provider inputs for %s: %w", urn, serErr)
-					}
-				}
-
-				var logicalName string
-				if name != urn.Name() {
-					logicalName = urn.Name()
-				}
-
-				imports.Resources = append(imports.Resources, importSpec{
-					Type:        urn.Type(),
-					Name:        name,
-					Inputs:      inputs,
-					LogicalName: logicalName,
-				})
+			// Default providers are not declared in the import file; the import system creates
+			// them from ambient config.
+			if sdkproviders.IsDefaultProvider(urn) {
 				continue
 			}
 
@@ -265,10 +236,26 @@ func buildImportFile(
 			}
 
 			var id resource.ID
-			// id only needs filling in for custom resources, set it to a placeholder so the user can easily
-			// search for that.
+			var inputs map[string]any
 			if new.Custom {
-				id = "<PLACEHOLDER>"
+				if sdkproviders.IsProviderType(urn.Type()) {
+					// Explicit providers are created by the import system rather than read from a
+					// cloud, so they are declared with their full inputs instead of an ID.
+					contract.Assertf(preEvent.Metadata.Res.State != nil,
+						"%s: expected State to be non-nil for provider", urn)
+					if fullInputs := preEvent.Metadata.Res.State.Inputs; len(fullInputs) > 0 {
+						var serErr error
+						inputs, serErr = stack.SerializeProperties(ctx, fullInputs, enc, false)
+						if serErr != nil {
+							return importFile{}, fmt.Errorf(
+								"could not serialize provider inputs for %s: %w", urn, serErr)
+						}
+					}
+				} else {
+					// id only needs filling in for other custom resources, set it to a placeholder
+					// so the user can easily search for that.
+					id = "<PLACEHOLDER>"
+				}
 			}
 
 			// We only want to set logical name if we need to
@@ -287,6 +274,7 @@ func buildImportFile(
 				Remote:            !new.Custom && new.Provider != "",
 				Version:           version,
 				PluginDownloadURL: pluginDownloadURL,
+				Inputs:            inputs,
 				LogicalName:       logicalName,
 			})
 		}

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -80,9 +80,6 @@ func buildImportFile(
 		importSet := map[resource.URN]struct{}{}
 		// All providers that we've seen so far, used to build Version and PluginDownloadURL.
 		providerInputs := map[resource.URN]resource.PropertyMap{}
-		// Full (unfiltered) provider inputs from the resource State, used to serialize into the
-		// import file for explicit providers that need creation.
-		providerFullInputs := map[resource.URN]resource.PropertyMap{}
 
 		imports := importFile{
 			NameTable: map[string]resource.URN{},
@@ -165,9 +162,6 @@ func buildImportFile(
 			// any resources that use it.
 			if sdkproviders.IsProviderType(urn.Type()) {
 				providerInputs[urn] = preEvent.Metadata.Res.Inputs
-				contract.Assertf(preEvent.Metadata.Res.State != nil,
-					"%s: expected State to be non-nil for provider", urn)
-				providerFullInputs[urn] = preEvent.Metadata.Res.State.Inputs
 			}
 
 			// Only interested in creates
@@ -183,9 +177,37 @@ func buildImportFile(
 			importSet[urn] = struct{}{}
 
 			// Provider resources are not imported with an ID like regular resources. Instead,
-			// their inputs are serialized into the import file's providerInputs section so the
-			// import system can create them with the correct configuration.
+			// explicit providers are declared in the import file's resources with their full
+			// inputs so the import system can create them with the correct configuration.
+			// Default providers are created by the import system from ambient config.
 			if sdkproviders.IsProviderType(urn.Type()) {
+				if sdkproviders.IsDefaultProvider(urn) {
+					continue
+				}
+				contract.Assertf(preEvent.Metadata.Res.State != nil,
+					"%s: expected State to be non-nil for provider", urn)
+
+				var inputs map[string]any
+				if fullInputs := preEvent.Metadata.Res.State.Inputs; len(fullInputs) > 0 {
+					var serErr error
+					inputs, serErr = stack.SerializeProperties(ctx, fullInputs, enc, false)
+					if serErr != nil {
+						return importFile{}, fmt.Errorf(
+							"could not serialize provider inputs for %s: %w", urn, serErr)
+					}
+				}
+
+				var logicalName string
+				if name != urn.Name() {
+					logicalName = urn.Name()
+				}
+
+				imports.Resources = append(imports.Resources, importSpec{
+					Type:        urn.Type(),
+					Name:        name,
+					Inputs:      inputs,
+					LogicalName: logicalName,
+				})
 				continue
 			}
 
@@ -213,30 +235,15 @@ func buildImportFile(
 					return importFile{}, fmt.Errorf("could not parse provider reference: %w", err)
 				}
 
-				// Providers are not imported as resources (we skip them above), but resources
-				// that use a new explicit provider can still be in the import file. We serialize
-				// the provider's full inputs so the import system can create it.
 				if !sdkproviders.IsDefaultProvider(ref.URN()) {
 					var has bool
 					provider, has = fullNameTable[ref.URN()]
 					contract.Assertf(has, "expected provider %q to be in full name table", new.Provider)
 
-					imports.NameTable[provider] = ref.URN()
-
-					// If this provider is being created in this deployment, serialize its full inputs
-					// so the import system can recreate it with the correct configuration.
-					if _, inImportSet := importSet[ref.URN()]; inImportSet {
-						if fullInputs, ok := providerFullInputs[ref.URN()]; ok {
-							serialized, serErr := stack.SerializeProperties(ctx, fullInputs, enc, false)
-							if serErr != nil {
-								return importFile{}, fmt.Errorf(
-									"could not serialize provider inputs for %s: %w", ref.URN(), serErr)
-							}
-							if imports.ProviderInputs == nil {
-								imports.ProviderInputs = map[string]map[string]any{}
-							}
-							imports.ProviderInputs[provider] = serialized
-						}
+					// Don't add to the import NameTable if we're creating the provider in the same
+					// deployment; it is declared in the resources list instead.
+					if _, inImportSet := importSet[ref.URN()]; !inImportSet {
+						imports.NameTable[provider] = ref.URN()
 					}
 				}
 

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -469,26 +469,30 @@ func TestBuildImportFile_NewProvider(t *testing.T) {
 	importFile, err := importFilePromise.Result(t.Context())
 	require.NoError(t, err)
 
-	// NameTable should include the provider so the resource can reference it
-	require.Len(t, importFile.NameTable, 1)
-	assert.Equal(t, providerState.URN, importFile.NameTable["prov"])
+	// The provider is declared in the resources list, so it doesn't need a nameTable entry
+	require.Len(t, importFile.NameTable, 0)
 
-	// Resource should be in the import file with the provider reference
-	require.Len(t, importFile.Resources, 1)
-	expected := importSpec{
+	// The provider should be declared with its full inputs, followed by the resource that
+	// references it
+	require.Len(t, importFile.Resources, 2)
+	assert.Equal(t, importSpec{
+		Type: "pulumi:providers:pkg",
+		Name: "prov",
+		Inputs: map[string]any{
+			"version": "1.2.3",
+			"region":  "eu-west-1",
+		},
+	}, importFile.Resources[0])
+	assert.Equal(t, importSpec{
 		ID:       "<PLACEHOLDER>",
 		Type:     "pkg:mod:typ",
 		Name:     "res",
 		Provider: "prov",
 		Version:  "1.2.3",
-	}
-	assert.Equal(t, expected, importFile.Resources[0])
+	}, importFile.Resources[1])
 
-	// ProviderInputs should contain the serialized provider inputs including region
-	require.Contains(t, importFile.ProviderInputs, "prov")
-	provInputs := importFile.ProviderInputs["prov"]
-	assert.Equal(t, "eu-west-1", provInputs["region"])
-	assert.Equal(t, "1.2.3", provInputs["version"])
+	// The deprecated providerInputs section should not be generated
+	assert.Nil(t, importFile.ProviderInputs)
 }
 
 // TestBuildImportFile_DuplicateNames test that if we try to import resources with the same name we add a

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -495,6 +495,53 @@ func TestBuildImportFile_NewProvider(t *testing.T) {
 	assert.Nil(t, importFile.ProviderInputs)
 }
 
+// TestBuildImportFile_NewProviderWithParent tests that a created explicit provider parented to
+// another resource is declared with its parent.
+func TestBuildImportFile_NewProviderWithParent(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(t.Context(), events, sdkconfig.NopEncrypter)
+
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	comp := makeStateMetadata(t, "comp", "my:index:Comp", false, stateOptions{})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, comp),
+	})
+
+	providerState := makeStateMetadata(t, "prov", "pulumi:providers:pkg", true, stateOptions{
+		Parent: comp.URN,
+		Inputs: resource.NewPropertyMapFromMap(map[string]any{
+			"region": "eu-west-1",
+		}),
+	})
+	providerState.ID = providers.UnknownID
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, providerState),
+	})
+
+	close(events)
+	importFile, err := importFilePromise.Result(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, importFile.NameTable, 0)
+	require.Len(t, importFile.Resources, 2)
+	assert.Equal(t, importSpec{
+		Type:      "my:index:Comp",
+		Name:      "comp",
+		Component: true,
+	}, importFile.Resources[0])
+	assert.Equal(t, importSpec{
+		Type:   "pulumi:providers:pkg",
+		Name:   "prov",
+		Parent: "comp",
+		Inputs: map[string]any{"region": "eu-west-1"},
+	}, importFile.Resources[1])
+}
+
 // TestBuildImportFile_DuplicateNames test that if we try to import resources with the same name we add a
 // suffix to their names to make them unique.
 func TestBuildImportFile_DuplicateNames(t *testing.T) {

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -360,7 +360,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		if !sdkproviders.IsProviderType(imp.Type) {
 			continue
 		}
-		urn := i.deployment.generateURN("", imp.Type, imp.Name)
+		urn := i.deployment.generateURN(imp.Parent, imp.Type, imp.Name)
 		if state, ok := i.deployment.olds[urn]; ok {
 			ref, err := sdkproviders.NewReference(urn, state.ID)
 			contract.AssertNoErrorf(err,
@@ -384,6 +384,9 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 			continue
 		}
 		if _, ok := explicitProvidersByURN[imp.Provider]; !ok {
+			// This import describes a resource that references the provider, not the provider
+			// itself, so its parent doesn't apply to the provider.
+			imp.Parent = ""
 			explicitProvidersByURN[imp.Provider] = imp
 		}
 	}
@@ -541,7 +544,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 			ID:                      "",
 			Inputs:                  inputs,
 			Outputs:                 nil,
-			Parent:                  "",
+			Parent:                  imp.Parent,
 			Protect:                 false,
 			Taint:                   false,
 			External:                false,

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -84,14 +84,14 @@ type Import struct {
 	// Mutually exclusive with Parameterization.
 	Extension *apitype.Extension
 
-	// ProviderInputs holds the full inputs for an explicit provider that is not yet in state.
-	// When set, these inputs are used to create the provider during import. Unlike default
-	// providers (which use ambient stack config via GetPackageConfig), explicit providers
-	// are configured solely from these inputs.
+	// ProviderInputs holds the full inputs for this resource's explicit provider when it is not
+	// yet in state, as supplied by the import file's deprecated providerInputs section. Imports
+	// of providers themselves carry their configuration in Inputs instead.
 	ProviderInputs resource.PropertyMap
 
 	// Inputs holds input properties supplied for the resource, if any. When the provider's Read cannot
 	// return a property supplied here (e.g. a write-only attribute), the supplied value is used instead.
+	// For an import of a provider, Inputs is its configuration.
 	Inputs resource.PropertyMap
 	// Outputs holds the full output state supplied for the resource, if any. When set, the resource is
 	// imported from these values directly and the provider's Read is skipped entirely.
@@ -351,7 +351,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		defaultProviders[urn] = struct{}{}
 	}
 	// Collect explicit providers that are not in state. Their full inputs may come from the
-	// import file (ProviderInputs), or they may have no config at all (e.g. the random provider).
+	// import file, or they may have no config at all (e.g. the random provider).
 	// Deduplicate by URN since multiple resources may reference the same explicit provider.
 	explicitProvidersByURN := map[resource.URN]Import{}
 	// Providers declared directly as imports are collected first so the declared entry, which carries
@@ -393,7 +393,7 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 				PluginDownloadURL: imp.PluginDownloadURL,
 				PluginChecksums:   imp.PluginChecksums,
 				Parameterization:  imp.Parameterization,
-				ProviderInputs:    imp.ProviderInputs,
+				Inputs:            imp.ProviderInputs,
 			}
 		}
 	}
@@ -508,10 +508,10 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		typ := providerURN.Type()
 
 		// Use the full provider inputs from the import file instead of ambient config.
-		// Some providers (e.g. random) don't need any config, so ProviderInputs may be nil.
+		// Some providers (e.g. random) don't need any config, so Inputs may be nil.
 		var inputs resource.PropertyMap
-		if imp.ProviderInputs != nil {
-			inputs = imp.ProviderInputs.Copy()
+		if imp.Inputs != nil {
+			inputs = imp.Inputs.Copy()
 		} else {
 			inputs = resource.PropertyMap{}
 		}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -384,10 +384,17 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 			continue
 		}
 		if _, ok := explicitProvidersByURN[imp.Provider]; !ok {
-			// This import describes a resource that references the provider, not the provider
-			// itself, so its parent doesn't apply to the provider.
-			imp.Parent = ""
-			explicitProvidersByURN[imp.Provider] = imp
+			// This import describes a resource that references the provider rather than the
+			// provider itself, so carry over only the fields that describe the provider: its
+			// inputs and the plugin (version/parameterization) needed to load it.
+			explicitProvidersByURN[imp.Provider] = Import{
+				Type:              imp.Type,
+				Version:           imp.Version,
+				PluginDownloadURL: imp.PluginDownloadURL,
+				PluginChecksums:   imp.PluginChecksums,
+				Parameterization:  imp.Parameterization,
+				ProviderInputs:    imp.ProviderInputs,
+			}
 		}
 	}
 

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -257,7 +257,7 @@ func TestImporter(t *testing.T) {
 						{
 							Type: "pulumi:providers:foo",
 							Name: "my-provider",
-							ProviderInputs: resource.PropertyMap{
+							Inputs: resource.PropertyMap{
 								"region": resource.NewProperty("eu-west-1"),
 							},
 						},
@@ -643,7 +643,7 @@ func TestImporterParameterizedDeclaredProvider(t *testing.T) {
 					Version: &version,
 					Type:    "pulumi:providers:ParameterizationName",
 					Name:    "my-provider",
-					ProviderInputs: resource.PropertyMap{
+					Inputs: resource.PropertyMap{
 						"region": resource.NewProperty("eu-west-1"),
 					},
 					Parameterization: &Parameterization{


### PR DESCRIPTION
Fixing a bug from #23972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)