### PR TITLE
Lazily load organization templates in guided `pulumi new`

### DIFF
--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -141,7 +141,7 @@ func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateNa
 
 	urlInfo, err := parseTemplateURL(templateName)
 	if err != nil {
-		s.addError(err)
+		s.addCloudError(err)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateNa
 	matches := NewTemplateMatcher(urlInfo, templateName)
 	for template, err := range r.ListTemplates(ctx, registry.ListTemplatesOptions{}) {
 		if err != nil {
-			s.addError(fmt.Errorf("could not get template: %w", err))
+			s.addCloudError(fmt.Errorf("could not get template: %w", err))
 			return
 		}
 
@@ -192,16 +192,16 @@ func (s *Source) getRegistryTemplateByVersion(
 
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
-			s.addError(fmt.Errorf("template '%s' version '%s' not found",
+			s.addCloudError(fmt.Errorf("template '%s' version '%s' not found",
 				displayName, version.String()))
 			return
 		}
-		s.addError(fmt.Errorf("could not resolve template: %w", err))
+		s.addCloudError(fmt.Errorf("could not resolve template: %w", err))
 		return
 	}
 
 	if template.Source == "github" && strings.HasPrefix(template.Name, "pulumi/templates/") {
-		s.addError(fmt.Errorf(
+		s.addCloudError(fmt.Errorf(
 			"template '%s' is VCS-backed and does not support specific versions",
 			displayName,
 		))
@@ -311,27 +311,27 @@ func (s *Source) getOrgTemplates(
 ) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		s.addError(fmt.Errorf("getting current working directory: %w", err))
+		s.addCloudError(fmt.Errorf("getting current working directory: %w", err))
 		return
 	}
 
 	ws := pkgWorkspace.Instance
 	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
-		s.addError(fmt.Errorf("could not read the current project: %w", err))
+		s.addCloudError(fmt.Errorf("could not read the current project: %w", err))
 		return
 	}
 
 	url, err := pkgWorkspace.GetCurrentCloudURL(ws, e, project)
 	if err != nil {
-		s.addError(fmt.Errorf("could not get current cloud url: %w", err))
+		s.addCloudError(fmt.Errorf("could not get current cloud url: %w", err))
 		return
 	}
 
 	b, err := cmdBackend.DefaultLoginManager.Current(ctx, ws, cmdutil.Diag(), url, project, false)
 	if err != nil {
 		if !errors.Is(err, backenderr.MissingEnvVarForNonInteractiveError{}) {
-			s.addError(fmt.Errorf("could not get the current backend: %w", err))
+			s.addCloudError(fmt.Errorf("could not get the current backend: %w", err))
 		}
 		slog.InfoContext(ctx, "could not get a backend for org templates")
 		return
@@ -346,7 +346,7 @@ func (s *Source) getOrgTemplates(
 			slog.InfoContext(ctx, "user is not logged in")
 			return // No current user - so don't proceed
 		}
-		s.addError(fmt.Errorf("could not get the current user for %s: %s", url, err))
+		s.addCloudError(fmt.Errorf("could not get the current user for %s: %s", url, err))
 		return
 	}
 
@@ -358,7 +358,7 @@ func (s *Source) getOrgTemplates(
 	slog.InfoContext(ctx, "Listing Org Templates from the cloud")
 	user, orgs, _, err := b.CurrentUser()
 	if err != nil {
-		s.addError(fmt.Errorf("could not get the current user: %w", err))
+		s.addCloudError(fmt.Errorf("could not get the current user: %w", err))
 		return
 	} else if user == "" {
 		return // No current user - so don't proceed.
@@ -377,7 +377,7 @@ func (s *Source) getOrgTemplates(
 				return
 			}
 		} else if err != nil {
-			s.addError(fmt.Errorf("list templates: %w", err))
+			s.addCloudError(fmt.Errorf("list templates: %w", err))
 			slog.WarnContext(ctx, "Failed to get templates", "org", org, "err", err.Error())
 			return
 		} else if orgTemplates.HasAccessError {

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -38,9 +38,10 @@ import (
 // Source is responsible for cleaning up old templates, and should always be [Close]d when
 // created.
 type Source struct {
-	templates    []Template
-	errorOnEmpty []error
-	errors       []error
+	templates     []Template
+	errorOnEmpty  []error
+	projectErrors []error
+	cloudErrors   []error
 
 	// cancel holds the function to cancel the context passed into the [New] that created the source.
 	cancel context.CancelFunc
@@ -49,8 +50,12 @@ type Source struct {
 	closed  bool
 
 	// m should be held whenever Source is mutated.
-	m  sync.Mutex
-	wg sync.WaitGroup
+	m sync.Mutex
+	// wgProject tracks the project fetcher (local disk and the curated template set); wgCloud
+	// tracks the registry/org fetcher, which is typically much slower. Splitting them lets
+	// [Source.ProjectTemplates] return without waiting on the cloud.
+	wgProject sync.WaitGroup
+	wgCloud   sync.WaitGroup
 }
 
 // Templates lists the templates available to the [Source].
@@ -58,17 +63,39 @@ type Source struct {
 // Templates *does not* produce a sorted list. If templates need to be sorted, then the
 // caller is responsible for sorting them.
 func (s *Source) Templates() ([]Template, error) {
-	s.wg.Wait() // Wait to ensure that all templates have been fetched before returning the template list.
+	// Wait to ensure that all templates have been fetched before returning the template list.
+	s.wgProject.Wait()
+	s.wgCloud.Wait()
 
 	s.lockOpen("read templates")
 	defer s.m.Unlock()
-	if err := errors.Join(s.errors...); err != nil {
+	if err := errors.Join(errors.Join(s.projectErrors...), errors.Join(s.cloudErrors...)); err != nil {
 		return nil, err
 	}
 	if len(s.templates) == 0 {
 		return nil, errors.Join(s.errorOnEmpty...)
 	}
 	return s.templates, nil
+}
+
+// ProjectTemplates lists only the templates found by the project fetcher (local disk and the
+// curated template set), without waiting for the much slower cloud/registry fetch, which keeps
+// running in the background. Use [Source.Templates] for the complete set.
+func (s *Source) ProjectTemplates() ([]Template, error) {
+	s.wgProject.Wait()
+
+	s.lockOpen("read project templates")
+	defer s.m.Unlock()
+	if err := errors.Join(s.projectErrors...); err != nil {
+		return nil, err
+	}
+	var templates []Template
+	for _, t := range s.templates {
+		if _, fromRegistry := t.Publisher(); !fromRegistry {
+			templates = append(templates, t)
+		}
+	}
+	return templates, nil
 }
 
 func (s *Source) addTemplate(t Template) {
@@ -84,9 +111,15 @@ func (s *Source) addCloser(f func() error) {
 	s.m.Unlock()
 }
 
-func (s *Source) addError(err error) {
-	s.lockOpen("add error")
-	s.errors = append(s.errors, err)
+func (s *Source) addProjectError(err error) {
+	s.lockOpen("add project error")
+	s.projectErrors = append(s.projectErrors, err)
+	s.m.Unlock()
+}
+
+func (s *Source) addCloudError(err error) {
+	s.lockOpen("add cloud error")
+	s.cloudErrors = append(s.cloudErrors, err)
 	s.m.Unlock()
 }
 
@@ -107,7 +140,9 @@ func (s *Source) lockOpen(action string) {
 func (s *Source) Close() error {
 	s.cancel()
 
-	s.wg.Wait() // Wait to ensure that all templates have been fetched so all closers are visible.
+	// Wait to ensure that all templates have been fetched so all closers are visible.
+	s.wgProject.Wait()
+	s.wgCloud.Wait()
 
 	s.lockOpen("close")
 	defer s.m.Unlock()
@@ -170,14 +205,14 @@ func newImpl(
 	source.cancel = cancel
 
 	if scope == ScopeAll || scope == ScopeLocal {
-		source.wg.Go(func() {
+		source.wgProject.Go(func() {
 			source.getProjectTemplates(ctx, templateNamePathOrURL, scope, templateKind, getProjectTemplates)
 		})
 	}
 
 	if scope == ScopeAll && templateKind == TemplateKindPulumiProject && isTemplateName(templateNamePathOrURL) {
-		source.wg.Go(func() {
-			source.getCloudTemplates(ctx, templateNamePathOrURL, &source.wg, e)
+		source.wgCloud.Go(func() {
+			source.getCloudTemplates(ctx, templateNamePathOrURL, &source.wgCloud, e)
 		})
 	}
 

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -40,7 +40,7 @@ func (s *Source) getProjectTemplates(
 		}
 		// Bail on all errors unless its a 401 from a Pulumi Cloud backend...
 		if !errors.Is(err, ErrPulumiCloudUnauthorized) {
-			s.addError(err)
+			s.addProjectError(err)
 			return
 		}
 
@@ -48,14 +48,14 @@ func (s *Source) getProjectTemplates(
 		// attempt to retrieve the template using the user's Pulumi Cloud credentials.
 		repo, err = retrievePrivatePulumiCloudTemplate(templateNamePathOrURL)
 		if err != nil {
-			s.addError(err)
+			s.addProjectError(err)
 			return
 		}
 	}
 	s.addCloser(repo.Delete)
 	projectTemplates, err := repo.Templates()
 	if err != nil {
-		s.addError(fmt.Errorf("could not get template from workspace: %w", err))
+		s.addProjectError(fmt.Errorf("could not get template from workspace: %w", err))
 		return
 	}
 


### PR DESCRIPTION
Stacked on #24084.

## Why

Interactive `pulumi new`'s first prompt currently waits for the full template listing. The registry/org-template fetch behind it costs ~4-5s server-side for orgs with VCS-backed template sources (the service downloads each source repo's archive per request), so members of those orgs stare at a blank terminal before the first menu. The curated templates the menu's provider rows need cost well under 1s.

## What

First commit (groundwork): split `templates.Source` so the two fetchers can be awaited independently:

- `ProjectTemplates()` returns the project fetcher's results (local disk + curated set) without waiting for the cloud fetch, which keeps running in the background.
- `Templates()` is unchanged and still waits for everything.
- Errors are attributed per fetcher, so a registry failure no longer blocks consumers that only need the curated set.

## Remaining work (this PR, in progress)

- Build the guided cloud menu from `ProjectTemplates()` (~1s) with a per-org "<org> templates" row instead of eager publisher rows; selecting an org row or "Browse all templates" blocks on the in-flight full fetch (usually already complete by then).
- Gate org rows on `GET /api/orgs/{orgName}/templates/summary` (pulumi/pulumi-service#47133), falling back to org-membership gating when the endpoint is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)