### PR TITLE
Fix plugin discovery reporting all uv workspace members' dependencies

### DIFF
--- a/changelog/pending/20260723--sdk-python--fix-plugin-discovery-in-uv-workspaces.yaml
+++ b/changelog/pending/20260723--sdk-python--fix-plugin-discovery-in-uv-workspaces.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: fix
+body: Only discover plugins for the current project's dependencies in a uv workspace
+time: 2026-07-23T00:00:00Z

--- a/changelog/pending/20260723--sdk-python--fix-plugin-discovery-in-uv-workspaces.yaml
+++ b/changelog/pending/20260723--sdk-python--fix-plugin-discovery-in-uv-workspaces.yaml
@@ -2,3 +2,5 @@ component: sdk/python
 kind: fix
 body: Only discover plugins for the current project's dependencies in a uv workspace
 time: 2026-07-23T00:00:00Z
+custom:
+  PR: "24137"

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -308,39 +308,142 @@ func (u *uv) ListPackages(_ context.Context, transitive bool) ([]plugin.Dependen
 	if err != nil {
 		return nil, fmt.Errorf("could not read %s: %w", lockFilePath, err)
 	}
-	virtual, err := uvVirtualPackages(content)
-	if err != nil {
-		return nil, fmt.Errorf("could not identify virtual packages in %s: %w", lockFilePath, err)
+
+	var lock uvLockFile
+	if _, err := toml.Decode(string(content), &lock); err != nil {
+		return nil, fmt.Errorf("could not parse %s: %w", lockFilePath, err)
 	}
-	return listPackagesFromLockFile(lockFilePath, transitive, virtual)
+
+	// In a uv workspace `uv.lock` contains the dependencies of *all* workspace members, but `uv sync`
+	// only installs the current member's dependencies. Walk the lock's dependency graph so we only
+	// report its transitive dependencies.
+	if packages, ok := lock.scopeToMember(lockDir, u.root, transitive); ok {
+		return packages, nil
+	}
+
+	// Fall back to reading the whole lock file if we couldn't locate the current project within it
+	logging.V(5).Infof("could not locate %s within %s, reporting all locked packages", u.root, lockFilePath)
+	return listPackagesFromLockFile(lockFilePath, transitive, lock.virtualPackages())
 }
 
-// uvLockFile is a minimal representation of uv.lock for identifying virtual packages.
+// uvLockFile is a representation of uv.lock sufficient to walk its dependency graph and identify
+// workspace members.
 type uvLockFile struct {
 	Package []uvLockPackage `toml:"package"`
 }
 
-type uvLockPackage struct {
-	Name   string `toml:"name"`
-	Source struct {
-		Virtual string `toml:"virtual"`
-	} `toml:"source"`
+type uvLockDependency struct {
+	Name string `toml:"name"`
 }
 
-// uvVirtualPackages returns the names of packages that are virtual (i.e. the project root or workspace members) in a
-// uv.lock file. Virtual packages have source = { virtual = "..." } and are not real installable packages.
-func uvVirtualPackages(content []byte) (map[string]bool, error) {
-	var lock uvLockFile
-	if _, err := toml.Decode(string(content), &lock); err != nil {
-		return nil, err
+type uvLockPackage struct {
+	Name    string `toml:"name"`
+	Version string `toml:"version"`
+	Source  struct {
+		Virtual  string `toml:"virtual"`
+		Editable string `toml:"editable"`
+	} `toml:"source"`
+	Dependencies    []uvLockDependency            `toml:"dependencies"`
+	DevDependencies map[string][]uvLockDependency `toml:"dev-dependencies"`
+}
+
+// isMember reports whether the package is the project root or a workspace member rather than an installable
+// dependency.
+func (p *uvLockPackage) isMember() bool {
+	return p.Source.Virtual != "" || p.Source.Editable != ""
+}
+
+// memberPath returns the workspace-relative path recorded for the project root or a workspace member.
+func (p *uvLockPackage) memberPath() string {
+	if p.Source.Virtual != "" {
+		return p.Source.Virtual
 	}
+	return p.Source.Editable
+}
+
+// virtualPackages returns the names of packages that are virtual (i.e. the project root or workspace
+// members) in the lock file. These are not real installable packages.
+func (l *uvLockFile) virtualPackages() map[string]bool {
 	virtual := make(map[string]bool)
-	for _, pkg := range lock.Package {
+	for _, pkg := range l.Package {
 		if pkg.Source.Virtual != "" {
 			virtual[normalizePythonPackageName(pkg.Name)] = true
 		}
 	}
-	return virtual, nil
+	return virtual
+}
+
+// scopeToMember walks the lock's dependency graph starting from the workspace member located at root and
+// returns its (transitive) dependencies. The boolean result is false if the member could not be located in
+// the lock, in which case the caller should fall back to reporting all locked packages.
+func (l *uvLockFile) scopeToMember(lockDir, root string, transitive bool) ([]plugin.DependencyInfo, bool) {
+	// uv records member paths relative to the lock file directory, using forward slashes. The project root
+	// itself is recorded as ".".
+	rel, err := filepath.Rel(lockDir, root)
+	if err != nil {
+		return nil, false
+	}
+	rel = filepath.ToSlash(rel)
+
+	byName := make(map[string]*uvLockPackage, len(l.Package))
+	var current *uvLockPackage
+	for i := range l.Package {
+		pkg := &l.Package[i]
+		byName[normalizePythonPackageName(pkg.Name)] = pkg
+		if pkg.isMember() && pkg.memberPath() == rel {
+			current = pkg
+		}
+	}
+	if current == nil {
+		return nil, false
+	}
+
+	// Breadth-first walk from the current member. The member's own dependencies and dependency-group
+	// dependencies seed the queue; from there we follow runtime dependencies only, matching what gets
+	// installed into the virtualenv.
+	queue := make([]string, 0, len(current.Dependencies))
+	for _, dep := range current.Dependencies {
+		queue = append(queue, normalizePythonPackageName(dep.Name))
+	}
+	for _, group := range current.DevDependencies {
+		for _, dep := range group {
+			queue = append(queue, normalizePythonPackageName(dep.Name))
+		}
+	}
+
+	seen := make(map[string]bool)
+	var packages []plugin.DependencyInfo
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		pkg, ok := byName[name]
+		if !ok {
+			continue
+		}
+		for _, dep := range pkg.Dependencies {
+			queue = append(queue, normalizePythonPackageName(dep.Name))
+		}
+		// Workspace members (including the current one, if it appears as a dependency) are not installable
+		// packages, so leave them out of the reported set.
+		if pkg.isMember() {
+			continue
+		}
+		packages = append(packages, plugin.DependencyInfo{Name: name, Version: pkg.Version})
+	}
+
+	if transitive {
+		return packages, true
+	}
+	direct, err := filterDirectPythonDependencies(root, packages)
+	if err != nil {
+		return nil, false
+	}
+	return direct, true
 }
 
 func (u *uv) Command(ctx context.Context, args ...string) (*exec.Cmd, error) {

--- a/sdk/python/toolchain/uv_lockfile_test.go
+++ b/sdk/python/toolchain/uv_lockfile_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolchain
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+)
+
+// A synthetic workspace lock with two members that share transitive dependencies. member-a additionally
+// pulls in a package via a local path source and has a dev-group dependency.
+const workspaceLock = `
+version = 1
+
+[[package]]
+name = "ws-root"
+version = "0.1.0"
+source = { virtual = "." }
+
+[[package]]
+name = "member-a"
+version = "0.1.0"
+source = { virtual = "members/a" }
+dependencies = [
+    { name = "requests" },
+    { name = "pulumi-onepassword" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "iniconfig" },
+]
+
+[[package]]
+name = "member-b"
+version = "0.1.0"
+source = { virtual = "members/b" }
+dependencies = [
+    { name = "packaging" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+
+[[package]]
+name = "idna"
+version = "3.7"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "pulumi-onepassword"
+version = "1.1.3"
+source = { path = "wheels/pulumi_onepassword-1.1.3-py3-none-any.whl" }
+
+[[package]]
+name = "packaging"
+version = "24.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+`
+
+func decodeWorkspaceLock(t *testing.T) uvLockFile {
+	t.Helper()
+	var lock uvLockFile
+	_, err := toml.Decode(workspaceLock, &lock)
+	require.NoError(t, err)
+	return lock
+}
+
+func TestUvLockScopeToMember(t *testing.T) {
+	t.Parallel()
+
+	lockDir := filepath.FromSlash("/ws")
+
+	t.Run("member-b only sees its own transitive deps", func(t *testing.T) {
+		t.Parallel()
+		lock := decodeWorkspaceLock(t)
+		packages, ok := lock.scopeToMember(lockDir, filepath.Join(lockDir, "members", "b"), true /* transitive */)
+		require.True(t, ok)
+
+		got := map[string]string{}
+		for _, p := range packages {
+			got[p.Name] = p.Version
+		}
+		require.Equal(t, map[string]string{"packaging": "24.0"}, got,
+			"member B must not see member A's dependencies (requests, pulumi-onepassword, idna, iniconfig)")
+	})
+
+	t.Run("member-a sees runtime, path, transitive and dev deps", func(t *testing.T) {
+		t.Parallel()
+		lock := decodeWorkspaceLock(t)
+		packages, ok := lock.scopeToMember(lockDir, filepath.Join(lockDir, "members", "a"), true /* transitive */)
+		require.True(t, ok)
+
+		got := map[string]string{}
+		for _, p := range packages {
+			got[p.Name] = p.Version
+		}
+		require.Equal(t, map[string]string{
+			"requests":           "2.32.3", // direct runtime dep
+			"idna":               "3.7",    // transitive dep of requests
+			"pulumi-onepassword": "1.1.3",  // direct dep from a local path source (retains its version)
+			"iniconfig":          "2.0.0",  // dev-group dep, which uv sync installs by default
+		}, got)
+	})
+
+	t.Run("project root maps to '.'", func(t *testing.T) {
+		t.Parallel()
+		lock := decodeWorkspaceLock(t)
+		// ws-root has no dependencies of its own.
+		packages, ok := lock.scopeToMember(lockDir, lockDir, true /* transitive */)
+		require.True(t, ok)
+		require.Empty(t, packages)
+	})
+
+	t.Run("unknown directory falls back", func(t *testing.T) {
+		t.Parallel()
+		lock := decodeWorkspaceLock(t)
+		_, ok := lock.scopeToMember(lockDir, filepath.Join(lockDir, "members", "does-not-exist"), true)
+		require.False(t, ok, "an unlocatable member signals the caller to fall back to the whole lock")
+	})
+}
+
+func TestUvLockVirtualPackages(t *testing.T) {
+	t.Parallel()
+	lock := decodeWorkspaceLock(t)
+	require.Equal(t, map[string]bool{
+		"ws-root":  true,
+		"member-a": true,
+		"member-b": true,
+	}, lock.virtualPackages())
+}

--- a/sdk/python/toolchain/uv_test.go
+++ b/sdk/python/toolchain/uv_test.go
@@ -17,7 +17,9 @@ package toolchain
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -376,4 +378,77 @@ dependencies = []
 	err = uv.LinkPackages(t.Context(), map[string]string{"nope": "." + string(filepath.Separator) + "nope"})
 
 	require.ErrorContains(t, err, "expected version to start with a number, but no leading ASCII digits were found")
+}
+
+// TestUvWorkspaceListPackages verifies that in a uv workspace, ListPackages only returns the
+// dependencies of the current workspace member, not those of sibling members. In a workspace the
+// shared uv.lock contains every member's dependencies, but `uv sync` only installs the current
+// member's dependencies, so reporting all of them would cause plugin discovery to look for metadata
+// that isn't installed. Regression test for https://github.com/pulumi/pulumi/issues/24014.
+func TestUvWorkspaceListPackages(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO[pulumi/pulumi#19675]: Fix this test on Windows
+		t.Skip("Skipping tests on Windows")
+	}
+	t.Parallel()
+
+	root := t.TempDir()
+	memberA := filepath.Join(root, "members", "a")
+	memberB := filepath.Join(root, "members", "b")
+	require.NoError(t, os.MkdirAll(memberA, 0o755))
+	require.NoError(t, os.MkdirAll(memberB, 0o755))
+
+	writePyproject := func(dir, contents string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(contents), 0o600))
+	}
+	writePyproject(root, `[project]
+name = "ws-root"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["members/*"]
+`)
+	// iniconfig and packaging are tiny, dependency-free packages, pinned so no resolution surprises.
+	writePyproject(memberA, `[project]
+name = "member-a"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["iniconfig==2.0.0"]
+`)
+	writePyproject(memberB, `[project]
+name = "member-b"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["packaging==24.0"]
+`)
+
+	lockCmd := exec.Command("uv", "lock")
+	lockCmd.Dir = root
+	out, err := lockCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	listFor := func(programDir string) map[string]string {
+		opts := PythonOptions{Toolchain: Uv, Root: programDir, ProgramDir: programDir}
+		tc, err := ResolveToolchain(opts)
+		require.NoError(t, err)
+		packages, err := tc.ListPackages(t.Context(), true /* transitive */)
+		require.NoError(t, err)
+		versions := make(map[string]string, len(packages))
+		for _, p := range packages {
+			versions[p.Name] = p.Version
+		}
+		return versions
+	}
+
+	namesA := listFor(memberA)
+	require.Contains(t, namesA, "iniconfig")
+	require.NotContains(t, namesA, "packaging", "member A must not see member B's dependencies")
+
+	namesB := listFor(memberB)
+	require.Contains(t, namesB, "packaging")
+	require.NotContains(t, namesB, "iniconfig", "member B must not see member A's dependencies")
+	// The version must be a bare version, with the "==" operator from `uv export` stripped.
+	require.Equal(t, "24.0", namesB["packaging"])
 }


### PR DESCRIPTION
## Summary

In a `uv` workspace, `pulumi install` and plugin discovery reported the dependencies of *every* workspace member instead of only the current stack's. As a result Pulumi tried to install plugins for packages belonging to sibling members.

Fixes #24014.

### Root cause

#22072 (shipped in 3.226.0) switched the `uv` toolchain's `ListPackages` from `pip list` (scoped to the synced virtualenv) to parsing the whole `uv.lock`. In a workspace, `uv.lock` contains the union of all members' dependencies, so every member's packages were reported regardless of which project was being operated on.

### Fix

`ListPackages` now walks the `uv.lock` dependency graph starting from the current project (located by matching its workspace-relative path against the `virtual`/`editable` source recorded for each member) and reports only that member's runtime, dev-group, and transitive dependencies, matching what `uv sync` installs into the virtualenv. If the current project cannot be located in the lock, it falls back to the previous whole-lock behaviour.

Walking the lock graph keeps clean `name`/`version` pairs for local path/wheel dependencies which `uv export` drops.

## Test plan
- [x] Added appropriate unit tests - For all changes

- `TestUvLockScopeToMember` / `TestUvLockVirtualPackages`: offline graph-scoping unit tests over a synthetic two-member workspace lock (member isolation, runtime/path/dev/transitive deps, root maps to ".", unknown dir falls back).
- `TestUvWorkspaceListPackages`: builds a real two-member `uv` workspace, runs `uv lock`, and asserts each member's `ListPackages` sees only its own deps.

## Validation
- [x] `make lint` — clean
- [x] Relevant SDK tests pass — `sdk/python/toolchain` tests pass
- [x] `make tidy_fix` — no changes (no new dependencies)
- [x] `make format` — clean

## Changelog
- [x] Changelog entry added

## Risk

I feel this is low as it's scoped to the `uv` toolchain's package discovery. Behaviour is unchanged for single-project (non-workspace) uv setups. If the current project cannot be located in the lock, the code falls back to the prior whole-lock behaviour, so the worst case is the pre-fix behaviour.

No public API change.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
