### PR TITLE
Add `--name` filter to `pulumi env ls`

### DIFF
--- a/changelog/pending/20260730--cli-env--ls-name-filter.yaml
+++ b/changelog/pending/20260730--cli-env--ls-name-filter.yaml
@@ -1,0 +1,3 @@
+component: cli/env
+kind: feat
+body: Add `--name` flag to `pulumi env ls` to filter environments by name substring

--- a/changelog/pending/20260730--cli-env--ls-name-filter.yaml
+++ b/changelog/pending/20260730--cli-env--ls-name-filter.yaml
@@ -1,3 +1,5 @@
 component: cli/env
 kind: feat
 body: Add `--name` flag to `pulumi env ls` to filter environments by name substring
+custom:
+    PR: "24141"

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -224,7 +224,7 @@ func (cmd *envCommand) getNewEnvRef(
 	}
 
 	// Check if project at <org-name>/<project-name> exists. Assume not if listing environments errors
-	allEnvs, _ := cmd.listEnvironments(ctx, "", "")
+	allEnvs, _ := cmd.listEnvironments(ctx, "", "", "")
 	existsProject := false
 	for _, e := range allEnvs {
 		if strings.EqualFold(e.Project, ref.projectName) {

--- a/pkg/cmd/esc/cli/env_ls.go
+++ b/pkg/cmd/esc/cli/env_ls.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +29,7 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 	var (
 		orgFilter     string
 		projectFilter string
+		nameFilter    string
 		output        string
 	)
 
@@ -51,7 +53,7 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			allEnvs, err := env.listEnvironments(ctx, orgFilter, projectFilter)
+			allEnvs, err := env.listEnvironments(ctx, orgFilter, projectFilter, nameFilter)
 			if err != nil {
 				return err
 			}
@@ -90,6 +92,8 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 		&orgFilter, "organization", "o", "", "Filter returned environments to those in a specific organization")
 	cmd.PersistentFlags().StringVarP(
 		&projectFilter, "project", "p", "", "Filter returned environments to those in a specific project")
+	cmd.PersistentFlags().StringVar(
+		&nameFilter, "name", "", "Filter returned environments to those whose name contains the given value")
 	addOutputFlag(cmd, &output)
 
 	return cmd
@@ -106,7 +110,7 @@ func envIdentifier(e client.OrgEnvironment) string {
 
 func (env *envCommand) listEnvironments(
 	ctx context.Context,
-	orgFilter, projectFilter string,
+	orgFilter, projectFilter, nameFilter string,
 ) ([]client.OrgEnvironment, error) {
 	user := env.esc.account.Username
 	continuationToken, allEnvs := "", []client.OrgEnvironment(nil)
@@ -131,6 +135,9 @@ func (env *envCommand) listEnvironments(
 				e.Organization = ""
 			}
 			if projectFilter != "" && e.Project != projectFilter {
+				continue
+			}
+			if nameFilter != "" && !strings.Contains(e.Name, nameFilter) {
 				continue
 			}
 			allEnvs = append(allEnvs, e)

--- a/pkg/cmd/esc/cli/testdata/env-ls-name-filter.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-ls-name-filter.yaml
@@ -1,0 +1,35 @@
+run: |
+  esc env ls --name env-2
+  esc env ls -o test-org --name env-2
+  esc env ls -p project-a --name env-2
+  esc env ls --name no-match
+environments:
+  test-org-2/default/env: true
+  test-org/default/env: true
+  test-org/default/env-2: true
+  test-org/project-a/env: true
+  test-org/project-a/env-2: true
+  test-org/project-b/env: true
+  test-org/project-b/env-2-extra: true
+  test-user/default/env: true
+  test-user/default/env-2: true
+
+---
+> esc env ls --name env-2
+default/env-2
+test-org/default/env-2
+test-org/project-a/env-2
+test-org/project-b/env-2-extra
+> esc env ls -o test-org --name env-2
+test-org/default/env-2
+test-org/project-a/env-2
+test-org/project-b/env-2-extra
+> esc env ls -p project-a --name env-2
+test-org/project-a/env-2
+> esc env ls --name no-match
+
+---
+> esc env ls --name env-2
+> esc env ls -o test-org --name env-2
+> esc env ls -p project-a --name env-2
+> esc env ls --name no-match


### PR DESCRIPTION
Adds a `--name` flag to `pulumi env ls` that filters returned environments to those whose name contains the given value, composing with the existing `-o` and `-p` filters. The filter is applied client-side alongside the existing project filter since the list APIs have no server-side name filtering.

Fixes #24140