### PR TITLE
Better type Go maps in program codegen

### DIFF
--- a/changelog/pending/programgen-go-improvement-20260731-061957.yaml
+++ b/changelog/pending/programgen-go-improvement-20260731-061957.yaml
@@ -1,0 +1,4 @@
+component: programgen/go
+kind: improvement
+body: Better typing for maps, using known types rather than `map[string]interface{}`
+time: 2026-07-31T06:19:57.614121+01:00

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -192,7 +192,7 @@ func TestArgumentTypeName(t *testing.T) {
 	})
 
 	plainUniformObjectType := g.argumentTypeName(uniformObjectType, false /*isInput*/)
-	assert.Equal(t, "map[string]interface{}", plainUniformObjectType)
+	assert.Equal(t, "map[string]int", plainUniformObjectType)
 	inputUniformObjectType := g.argumentTypeName(uniformObjectType, true /*isInput*/)
 	assert.Equal(t, "pulumi.IntMap", inputUniformObjectType)
 
@@ -325,7 +325,7 @@ func TestConditionalExpression(t *testing.T) {
 		},
 		{
 			hcl2Expr: "{foo = true ? 2.5 : 0.5}",
-			goCode:   "var tmp0 float64\nif true {\ntmp0 = 2.5\n} else {\ntmp0 = 0.5\n}\nmap[string]interface{}{\n\"foo\": tmp0,\n}",
+			goCode:   "var tmp0 float64\nif true {\ntmp0 = 2.5\n} else {\ntmp0 = 0.5\n}\nmap[string]float64{\n\"foo\": tmp0,\n}",
 		},
 	}
 	genFunc := func(w io.Writer, g *generator, e model.Expression) {
@@ -347,17 +347,21 @@ func TestObjectConsExpression(t *testing.T) {
 	scope := env.scope()
 	cases := []exprTestCase{
 		{
+			hcl2Expr: "{foo = 1.5, bar = \"baz\"}",
+			goCode:   "map[string]interface{}{\n\"foo\": 1.5,\n\"bar\": \"baz\",\n}",
+		},
+		{
 			// TODO probably a bug in the binder. Single value objects should just be maps
 			hcl2Expr: "{foo = 1.5}",
-			goCode:   "map[string]interface{}{\n\"foo\": 1.5,\n}",
+			goCode:   "map[string]float64{\n\"foo\": 1.5,\n}",
 		},
 		{
 			hcl2Expr: "{\"foo\" = 1.5}",
-			goCode:   "map[string]interface{}{\n\"foo\": 1.5,\n}",
+			goCode:   "map[string]float64{\n\"foo\": 1.5,\n}",
 		},
 		{
 			hcl2Expr: "{1 = 1.5}",
-			goCode:   "map[string]interface{}{\n\"1\": 1.5,\n}",
+			goCode:   "map[string]float64{\n\"1\": 1.5,\n}",
 		},
 		{
 			hcl2Expr: "{(a) = 1.5}",

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -372,14 +372,32 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 						}
 					default:
 						// For collection types (maps, objects, lists), wrap with pulumi.ToMap/ToArray.
+						// If the source has a typed Go representation (e.g. map[string]string,
+						// []int), use the matching typed converter (ToStringMap, ToIntArray)
+						// since pulumi.ToMap/ToArray only accept map[string]any / []any.
+						argGoType := g.argumentTypeName(arg.Type(), false)
 						switch scalarType.(type) {
 						case *model.ObjectType, *model.MapType:
-							g.Fgenf(w, "pulumi.ToMap(")
+							fn := "pulumi.ToMap"
+							if elm, ok := strings.CutPrefix(argGoType, "map[string]"); ok &&
+								elm != "interface{}" {
+								if title, ok := pulumiConverterSuffix(elm); ok {
+									fn = "pulumi.To" + title + "Map"
+								}
+							}
+							g.Fgenf(w, "%s(", fn)
 							g.genScopeTraversalExpression(w, arg, expr.Type())
 							g.Fgenf(w, ")")
 							return
 						case *model.ListType, *model.TupleType:
-							g.Fgenf(w, "pulumi.ToArray(")
+							fn := "pulumi.ToArray"
+							if elm, ok := strings.CutPrefix(argGoType, "[]"); ok &&
+								elm != "interface{}" {
+								if title, ok := pulumiConverterSuffix(elm); ok {
+									fn = "pulumi.To" + title + "Array"
+								}
+							}
+							g.Fgenf(w, "%s(", fn)
 							g.genScopeTraversalExpression(w, arg, expr.Type())
 							g.Fgenf(w, ")")
 							return
@@ -1477,22 +1495,42 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 				return "*" + md.TypeName
 			}
 		}
-		if isInput {
-			// check for element type uniformity and return appropriate type if so
-			allSameType := true
-			var elmType string
-			for _, v := range destType.Properties {
-				valType := g.argumentTypeName(v, true)
-				if elmType != "" && elmType != valType {
-					allSameType = false
-					break
-				}
-				elmType = valType
+		// check for element type uniformity and return appropriate type if so
+		allSameType := true
+		anyOptional := false
+		var elmType string
+		for _, v := range destType.Properties {
+			if model.IsOptionalType(v) {
+				anyOptional = true
 			}
+			valType := g.argumentTypeName(v, isInput)
+			if elmType != "" && elmType != valType {
+				allSameType = false
+				break
+			}
+			elmType = valType
+		}
+		if isInput {
 			if allSameType && elmType != "" {
 				return elmType + "Map"
 			}
 			return "pulumi.Map"
+		}
+		// Optional properties resolve to `*T`, but the Go SDK doesn't expose
+		// typed `*T` map/array/output containers (no `StringPtrMapOutput`).
+		// Fall back to map[string]interface{} so downstream ToSecret/ApplyT
+		// casts continue to work.
+		if allSameType && elmType != "" && !anyOptional {
+			// Nested ObjectType values whose schema resolves to a `...Args`
+			// struct are rendered as `&FooArgs{...}` (see
+			// genObjectConsExpressionWithTypeName), so the map value type
+			// must be the pointer form.
+			if strings.HasSuffix(elmType, "Args") && !strings.HasSuffix(elmType, "OutputArgs") &&
+				!strings.HasPrefix(elmType, "*") && !strings.HasPrefix(elmType, "map[") &&
+				!strings.HasPrefix(elmType, "[]") && !strings.HasPrefix(elmType, "pulumi.") {
+				elmType = "*" + elmType
+			}
+			return "map[string]" + elmType
 		}
 		return "map[string]interface{}"
 	case *model.MapType:
@@ -1662,7 +1700,63 @@ func (g *generator) secretOutputTypeName(expr *model.FunctionCallExpression) str
 	if argGoType == "map[string]interface{}" {
 		return "pulumi.Map"
 	}
+	// If the argument has a typed Go representation (e.g. map[string]*string,
+	// []int), the runtime output type follows the same shape (StringPtrMap,
+	// IntArray) — infer directly rather than relying on argumentTypeName of
+	// the expression's OutputType, which can lose pointer-ness.
+	if suffix, ok := pulumiConverterSuffix(argGoType); ok {
+		return "pulumi." + suffix
+	}
 	return g.argumentTypeName(expr.Type(), false)
+}
+
+// pulumiConverterSuffix maps a Go type name (e.g. "string", "*bool",
+// "map[string]int", "[]string") to the corresponding suffix used in Pulumi's
+// generated typed constructors and outputs (e.g. "String", "BoolPtr",
+// "IntMap", "StringArray"). Returns false if the Go type has no matching
+// typed converter — for example named struct types, unknown opaques, or
+// pointer element types nested inside a Map/Array (no `StringPtrMapOutput`
+// exists in the SDK).
+func pulumiConverterSuffix(goType string) (string, bool) {
+	if elm, ok := strings.CutPrefix(goType, "map[string]"); ok {
+		inner, ok := pulumiScalarSuffix(elm)
+		if !ok {
+			return "", false
+		}
+		return inner + "Map", true
+	}
+	if elm, ok := strings.CutPrefix(goType, "[]"); ok {
+		inner, ok := pulumiScalarSuffix(elm)
+		if !ok {
+			return "", false
+		}
+		return inner + "Array", true
+	}
+	if elm, ok := strings.CutPrefix(goType, "*"); ok {
+		inner, ok := pulumiScalarSuffix(elm)
+		if !ok {
+			return "", false
+		}
+		return inner + "Ptr", true
+	}
+	return pulumiScalarSuffix(goType)
+}
+
+// pulumiScalarSuffix returns the Pulumi suffix for a scalar Go type. Only
+// primitive scalars have generated Ptr/Map/Array containers in the SDK, so
+// callers use this to gate composition of the compound suffixes above.
+func pulumiScalarSuffix(goType string) (string, bool) {
+	switch goType {
+	case "string":
+		return "String", true
+	case "bool":
+		return "Bool", true
+	case "int":
+		return "Int", true
+	case "float64":
+		return "Float64", true
+	}
+	return "", false
 }
 
 // isTypedStructRoot reports whether the traversable represents a root whose
@@ -1730,9 +1824,14 @@ func (g *generator) genMapKeyAccess(w io.Writer, source model.Traversable, key s
 
 	// Non-schema ObjectTypes are represented as map[string]interface{} in Go,
 	// so map access returns interface{} and needs a type assertion.
-	// MapTypes use typed Go maps (e.g., map[string]string), so no assertion
-	// is needed since the access already returns the correct type.
+	// MapTypes (and ObjectTypes that unify to a typed map) use typed Go maps
+	// (e.g., map[string]string), so no assertion is needed since the access
+	// already returns the correct type.
 	if objType, ok := sourceType.(*model.ObjectType); ok {
+		sourceGoType := g.argumentTypeName(sourceType, false)
+		if strings.HasPrefix(sourceGoType, "map[string]") && sourceGoType != "map[string]interface{}" {
+			return
+		}
 		if propType, hasProp := objType.Properties[key]; hasProp {
 			propType = model.ResolveOutputs(propType)
 			propType = pcl.UnwrapOption(propType)

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l1-keyword-overlap/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l1-keyword-overlap/main.go
@@ -11,7 +11,7 @@ func main() {
 		export := "export_output_string"
 		_import := "import_output_string"
 		mod := "mod_output_string"
-		object := map[string]interface{}{
+		object := map[string]string{
 			"object": "object_output_string",
 		}
 		self := "self_output_string"
@@ -21,7 +21,7 @@ func main() {
 		ctx.Export("export", pulumi.String(export))
 		ctx.Export("import", pulumi.String(_import))
 		ctx.Export("mod", pulumi.String(mod))
-		ctx.Export("object", pulumi.ToMap(object))
+		ctx.Export("object", pulumi.ToStringMap(object))
 		ctx.Export("self", pulumi.String(self))
 		ctx.Export("this", pulumi.String(this))
 		ctx.Export("if", pulumi.String(_if))

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l1-proxy-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l1-proxy-index/main.go
@@ -15,26 +15,26 @@ func main() {
 		l := pulumi.ToSecret([]int{
 			1,
 		}).(pulumi.IntArrayOutput)
-		m := pulumi.ToSecret(map[string]interface{}{
+		m := pulumi.ToSecret(map[string]bool{
 			"key": true,
-		}).(pulumi.MapOutput)
+		}).(pulumi.BoolMapOutput)
 		c := pulumi.ToSecret(anObject).(pulumi.MapOutput)
-		o := pulumi.ToSecret(map[string]interface{}{
+		o := pulumi.ToSecret(map[string]string{
 			"property": "value",
-		}).(pulumi.MapOutput)
+		}).(pulumi.StringMapOutput)
 		a := pulumi.ToSecret(pulumi.Any(anyObject)).(pulumi.AnyOutput)
 		ctx.Export("l", l.ApplyT(func(l []int) (int, error) {
 			return l[0], nil
 		}).(pulumi.IntOutput))
-		ctx.Export("m", m.ApplyT(func(m map[string]interface{}) (bool, error) {
-			return m["key"].(bool), nil
+		ctx.Export("m", m.ApplyT(func(m map[string]bool) (bool, error) {
+			return m["key"], nil
 		}).(pulumi.BoolOutput))
 		ctx.Export("c", c.ApplyT(func(c map[string]interface{}) (*string, error) {
 			val := c["property"].(string)
 			return &val, nil
 		}).(pulumi.StringPtrOutput))
-		ctx.Export("o", o.ApplyT(func(o map[string]interface{}) (string, error) {
-			return o["property"].(string), nil
+		ctx.Export("o", o.ApplyT(func(o map[string]string) (string, error) {
+			return o["property"], nil
 		}).(pulumi.StringOutput))
 		ctx.Export("a", a.ApplyT(func(a interface{}) (interface{}, error) {
 			return a.(map[string]interface{})["property"], nil

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l1-keyword-overlap/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l1-keyword-overlap/main.go
@@ -11,7 +11,7 @@ func main() {
 		export := "export_output_string"
 		_import := "import_output_string"
 		mod := "mod_output_string"
-		object := map[string]interface{}{
+		object := map[string]string{
 			"object": "object_output_string",
 		}
 		self := "self_output_string"
@@ -21,7 +21,7 @@ func main() {
 		ctx.Export("export", pulumi.String(export))
 		ctx.Export("import", pulumi.String(_import))
 		ctx.Export("mod", pulumi.String(mod))
-		ctx.Export("object", pulumi.ToMap(object))
+		ctx.Export("object", pulumi.ToStringMap(object))
 		ctx.Export("self", pulumi.String(self))
 		ctx.Export("this", pulumi.String(this))
 		ctx.Export("if", pulumi.String(_if))

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l1-proxy-index/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l1-proxy-index/main.go
@@ -15,26 +15,26 @@ func main() {
 		l := pulumi.ToSecret([]int{
 			1,
 		}).(pulumi.IntArrayOutput)
-		m := pulumi.ToSecret(map[string]interface{}{
+		m := pulumi.ToSecret(map[string]bool{
 			"key": true,
-		}).(pulumi.MapOutput)
+		}).(pulumi.BoolMapOutput)
 		c := pulumi.ToSecret(anObject).(pulumi.MapOutput)
-		o := pulumi.ToSecret(map[string]interface{}{
+		o := pulumi.ToSecret(map[string]string{
 			"property": "value",
-		}).(pulumi.MapOutput)
+		}).(pulumi.StringMapOutput)
 		a := pulumi.ToSecret(pulumi.Any(anyObject)).(pulumi.AnyOutput)
 		ctx.Export("l", l.ApplyT(func(l []int) (int, error) {
 			return l[0], nil
 		}).(pulumi.IntOutput))
-		ctx.Export("m", m.ApplyT(func(m map[string]interface{}) (bool, error) {
-			return m["key"].(bool), nil
+		ctx.Export("m", m.ApplyT(func(m map[string]bool) (bool, error) {
+			return m["key"], nil
 		}).(pulumi.BoolOutput))
 		ctx.Export("c", c.ApplyT(func(c map[string]interface{}) (*string, error) {
 			val := c["property"].(string)
 			return &val, nil
 		}).(pulumi.StringPtrOutput))
-		ctx.Export("o", o.ApplyT(func(o map[string]interface{}) (string, error) {
-			return o["property"].(string), nil
+		ctx.Export("o", o.ApplyT(func(o map[string]string) (string, error) {
+			return o["property"], nil
 		}).(pulumi.StringOutput))
 		ctx.Export("a", a.ApplyT(func(a interface{}) (interface{}, error) {
 			return a.(map[string]interface{})["property"], nil

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-id-type/main.go
@@ -41,17 +41,17 @@ func main() {
 		if err != nil {
 			return err
 		}
-		idMap := map[string]interface{}{
+		idMap := map[string]pulumi.String{
 			"source1Token": source1.ID(),
 			"source2Token": source2.ID(),
 		}
 		_, err = primitive.NewResource(ctx, "sink1", &primitive.ResourceArgs{
 			Boolean: pulumi.Bool(false),
-			Float:   idMap["source1Token"].(string),
-			Integer: idMap["source1Token"].(string),
-			String:  idMap["source1Token"].(string),
+			Float:   idMap["source1Token"],
+			Integer: idMap["source1Token"],
+			String:  idMap["source1Token"],
 			NumberArray: pulumi.Float64Array{
-				idMap["source1Token"].(string),
+				idMap["source1Token"],
 			},
 			BooleanMap: pulumi.BoolMap{
 				"sink": pulumi.Bool(false),
@@ -61,7 +61,7 @@ func main() {
 			return err
 		}
 		sink2, err := primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
-			Boolean: idMap["source2Token"].(string),
+			Boolean: idMap["source2Token"],
 			Float:   pulumi.Float64(1),
 			Integer: pulumi.Int(2),
 			String:  pulumi.String("abc"),
@@ -69,7 +69,7 @@ func main() {
 				pulumi.Float64(3),
 			},
 			BooleanMap: pulumi.BoolMap{
-				"sink": idMap["source2Token"].(string),
+				"sink": idMap["source2Token"],
 			},
 		})
 		if err != nil {

--- a/tests/testdata/codegen/components-pp/go/components.go
+++ b/tests/testdata/codegen/components-pp/go/components.go
@@ -32,7 +32,7 @@ func main() {
 				0,
 				1,
 			},
-			CidrBlocks: map[string]interface{}{
+			CidrBlocks: map[string]string{
 				"one": "uno",
 				"two": "dos",
 			},
@@ -49,7 +49,7 @@ func main() {
 					Name: "Second",
 				},
 			},
-			DeploymentZones: map[string]interface{}{
+			DeploymentZones: map[string]*DeploymentZonesArgs{
 				"first": &DeploymentZonesArgs{
 					Zone: "First zone",
 				},

--- a/tests/testdata/codegen/unknown-invoke-pp/go/unknown-invoke.go
+++ b/tests/testdata/codegen/unknown-invoke-pp/go/unknown-invoke.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		data, err := unknown.GetData(ctx, map[string]interface{}{
+		data, err := unknown.GetData(ctx, map[string]string{
 			"input": "hello",
 		}, nil)
 		if err != nil {

--- a/tests/testdata/codegen/unknown-resource-pp/go/unknown-resource.go
+++ b/tests/testdata/codegen/unknown-resource-pp/go/unknown-resource.go
@@ -16,7 +16,7 @@ func main() {
 		}
 		main, err := unknown.NewMain(ctx, "main", &unknown.MainArgs{
 			First: "hello",
-			Second: map[string]interface{}{
+			Second: map[string]string{
 				"foo": "bar",
 			},
 		})


### PR DESCRIPTION
Non-input `ObjectType` used to render as `map[string]interface{}`, forcing value-side type assertions and losing information about the underlying schema. This change types those maps more precisely and updates the surrounding codegen so the produced Go still compiles and runs.

Changes to `pkg/codegen/go/gen_program_expressions.go`:

1. `argumentTypeName` (ObjectType branch) — non-input path now unifies to `map[string]X`, with:
    * `*FooArgs` when the ObjectType carries the `ObjectTypeFromConfigMetadata` annotation (component config).
    * `map[string]*FooArgs` when property values are schema-backed Args structs (rendered as `&FooArgs{}`).
    * Falls back to `map[string]interface{}` when any property is optional — the SDK has no `StringPtrMapOutput` etc., so leaving these untyped avoids broken cast chains.
3. `genMapKeyAccess` — skips the trailing `.(T)` type assertion when the source ObjectType already renders as a typed Go map.
4. `pulumi.ToMap` / `pulumi.ToArray` wrapping — uses the typed converter (e.g. `pulumi.ToStringMap`, `pulumi.ToBoolArray`) when the source's Go type matches a scalar Pulumi suffix.
5. `secretOutputTypeName` — derives the runtime output type from the argument's Go type via `pulumiConverterSuffix`, so `ToSecret(map[string]bool{})` casts to `pulumi.BoolMapOutput` rather than falling back to `pulumi.MapOutput`.
6. New helpers — `pulumiConverterSuffix` / `pulumiScalarSuffix` centralise the Go-type → Pulumi-suffix mapping used by (3) and (4).

Pretty much all Claude's work. But I've looked through this and it looks reasonable (at least as reasonable as the rest of the Go codegen). Conformance tests look better from this.
