### PR TITLE
Change extension packages to bind tokens to their package name

### DIFF
--- a/changelog/pending/20260731--sdkgen--extension-token-namespace.yaml
+++ b/changelog/pending/20260731--sdkgen--extension-token-namespace.yaml
@@ -1,0 +1,4 @@
+component: sdkgen
+kind: chore
+body: Extension-parameterized packages now namespace their resource and function
+    tokens under their own package name rather than the base provider's

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -931,10 +931,6 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 			} else {
 				mod = g.resolveModule(token)
 			}
-			// Extension resources import the extension's SDK package, not the base.
-			if r.Schema != nil && r.Schema.PackageReference != nil {
-				pkg = r.Schema.PackageReference.Name()
-			}
 			vPath, err := g.getVersionPath(program, pkg)
 			if err != nil {
 				if r.Schema != nil {
@@ -951,9 +947,6 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 				continue
 			}
 			mod := g.resolveModule(token)
-			if r.Schema != nil && r.Schema.PackageReference != nil {
-				pkg = r.Schema.PackageReference.Name()
-			}
 			vPath, err := g.getVersionPath(program, pkg)
 			if err != nil {
 				if r.Schema != nil {
@@ -985,7 +978,6 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 
 					contract.Assertf(len(diagnostics) == 0, "Expected no diagnostics, got %d", len(diagnostics))
 
-					pkg = g.functionPackage(token)
 					vPath, err := g.getVersionPath(program, pkg)
 					if err != nil {
 						panic(err)
@@ -1608,10 +1600,6 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 	}
 	if pkg == "pulumi" && mod == "pulumi" {
 		mod = ""
-	}
-	// Extension resources are emitted from the extension's SDK package, not the base.
-	if r.Schema != nil && r.Schema.PackageReference != nil {
-		pkg = r.Schema.PackageReference.Name()
 	}
 	if mod == "" || strings.HasPrefix(mod, "/") || mod == IndexToken {
 		originalMod = mod

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -2027,32 +2027,13 @@ func (g *generator) literalKey(x model.Expression) (string, bool) {
 	return strKey, true
 }
 
-// functionPackage resolves the package that defines the function token. For
-// extensions the token lives in the base namespace but the owner is the
-// extension; fall back to the token prefix.
-func (g *generator) functionPackage(token string) string {
-	pkg, _, _, _ := pcl.DecomposeToken(token, hcl.Range{})
-	if _, ok := g.packages[pkg]; ok {
-		return pkg
-	}
-	for name, p := range g.packages {
-		if _, ok := p.GetFunction(token); ok {
-			return name
-		}
-	}
-	return pkg
-}
-
 // functionName computes the go package, module, and name for the given function token.
 func (g *generator) functionName(tokenArg model.Expression) (string, string, string, hcl.Diagnostics) {
 	token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
 	tokenRange := tokenArg.SyntaxNode().Range()
 
-	// Compute the resource type from the Pulumi type token. The package that
-	// defines the function may differ from the token's namespace (e.g. an invoke
-	// that resolves through an extension), so prefer functionPackage.
-	_, _, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
-	pkg := g.functionPackage(token)
+	// Compute the resource type from the Pulumi type token.
+	pkg, _, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
 	module := g.resolveModule(token)
 	if strings.HasPrefix(member, "get") {
 		if g.useLookupInvokeForm(token) {

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -626,8 +626,6 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 			var packageRef schema.PackageReference
 			if n.Schema != nil && n.Schema.PackageReference != nil {
 				packageRef = n.Schema.PackageReference
-				// Extension resources import the extension's SDK package, not the base.
-				pkg = packageRef.Name()
 			}
 			visitPkg(pkg, packageRef)
 		case *pcl.ReadResource:
@@ -635,7 +633,6 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 			var packageRef schema.PackageReference
 			if n.Schema != nil && n.Schema.PackageReference != nil {
 				packageRef = n.Schema.PackageReference
-				pkg = packageRef.Name()
 			}
 			visitPkg(pkg, packageRef)
 		case *pcl.Component:
@@ -1122,9 +1119,6 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 
 	if r.Schema != nil {
 		module = moduleName(module, r.Schema.PackageReference)
-		if r.Schema.PackageReference != nil {
-			pkg = r.Schema.PackageReference.Name()
-		}
 	}
 
 	return pkg, module, cgstrings.UppercaseFirst(member), diagnostics
@@ -1135,9 +1129,6 @@ func readResourceTypeName(r *pcl.ReadResource) (string, string, string, hcl.Diag
 
 	if r.Schema != nil {
 		module = moduleName(module, r.Schema.PackageReference)
-		if r.Schema.PackageReference != nil {
-			pkg = r.Schema.PackageReference.Name()
-		}
 	}
 
 	return pkg, module, cgstrings.UppercaseFirst(member), diagnostics

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -275,27 +275,6 @@ func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagno
 	return pkg, module, member, diagnostics
 }
 
-// functionPackage resolves the package that defines the function token. For
-// extensions the token lives in the base namespace but the owner is the
-// extension; fall back to the token prefix.
-func (g *generator) functionPackage(tokenArg model.Expression) string {
-	token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
-	pkg, _, _, _ := pcl.DecomposeToken(token, tokenArg.SyntaxNode().Range())
-	for _, ref := range g.program.PackageReferences() {
-		if ref.Name() == pkg {
-			return pkg
-		}
-	}
-	for _, ref := range g.program.PackageReferences() {
-		if def, err := ref.Definition(); err == nil {
-			if _, ok := def.GetFunction(token); ok {
-				return ref.Name()
-			}
-		}
-	}
-	return pkg
-}
-
 func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, entries bool) {
 	var from, to model.Expression
 	switch len(call.Args) {
@@ -371,9 +350,9 @@ func (g *generator) visitFunctionImports(
 		return
 	}
 
-	_, _, _, diags := functionName(x.Args[0])
+	pkg, _, _, diags := functionName(x.Args[0])
 	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
-	visitPackageImport(g.functionPackage(x.Args[0]))
+	visitPackageImport(pkg)
 }
 
 func enumName(enum *model.EnumType) (string, error) {
@@ -599,9 +578,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			g.Fprint(w, ")")
 		}
 	case pcl.Invoke:
-		_, module, fn, diags := functionName(expr.Args[0])
+		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
-		pkg := g.functionPackage(expr.Args[0])
 		if module != "" {
 			module = "." + module
 		}

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -1075,54 +1074,6 @@ func ReadPackageDescriptors(file *syntax.File) (map[string]*schema.PackageDescri
 		}
 	}
 	return packageDescriptors, diagnostics
-}
-
-// extensionDescriptorsForBase returns the descriptors that extend the given base
-// package name.
-func (b *binder) extensionDescriptorsForBase(base tokens.PackageName) []*schema.PackageDescriptor {
-	var descriptors []*schema.PackageDescriptor
-	for _, descriptor := range b.packageDescriptors {
-		if descriptor.Parameterization != nil && tokens.PackageName(descriptor.Name) == base {
-			descriptors = append(descriptors, descriptor)
-		}
-	}
-	return descriptors
-}
-
-// loadDeclaredOrBarePackageSchema loads the schema for name: the package declared
-// under that name when the program supplied a descriptor for it, otherwise a bare
-// load by name. It does not consider extensions layered on name as a base —
-// callers reach those through extensionDescriptorsForBase.
-func (b *binder) loadDeclaredOrBarePackageSchema(
-	ctx context.Context, name, version, pluginDownloadURL string,
-) (*packageSchema, error) {
-	if descriptor, ok := b.packageDescriptors[name]; ok {
-		return b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, descriptor)
-	}
-	return b.options.packageCache.loadPackageSchema(ctx, b.options.loader, name, version, pluginDownloadURL)
-}
-
-// candidateSchemasForToken loads the schemas a token with package portion pkg
-// could live in: the package named pkg, plus every extension layered on it. The
-// caller looks the token up in each. The error is returned only when nothing
-// loaded, so the caller can tell an unknown package from an unknown member.
-func (b *binder) candidateSchemasForToken(ctx context.Context, pkg string) ([]*packageSchema, error) {
-	var schemas []*packageSchema
-	var firstErr error
-	add := func(s *packageSchema, err error) {
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			return
-		}
-		schemas = append(schemas, s)
-	}
-	add(b.loadDeclaredOrBarePackageSchema(ctx, pkg, "", ""))
-	for _, descriptor := range b.extensionDescriptorsForBase(tokens.PackageName(pkg)) {
-		add(b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, descriptor))
-	}
-	return schemas, firstErr
 }
 
 // declareNode declares a single top-level node. If a node with the same name has already been declared, it returns an

--- a/pkg/codegen/pcl/binder_multi_extension_test.go
+++ b/pkg/codegen/pcl/binder_multi_extension_test.go
@@ -30,8 +30,7 @@ import (
 
 // multiExtensionLoader serves a bare base provider ("extbase") plus two
 // extensions layered on it ("exta", "extb"), each defining one distinct
-// resource in the base provider's namespace. All three resource tokens share
-// the "extbase:" prefix; only the schema says who owns which.
+// resource in its own namespace.
 type multiExtensionLoader struct{}
 
 func (l multiExtensionLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {
@@ -53,9 +52,9 @@ func (multiExtensionLoader) LoadPackageV2(
 			},
 		}
 	case d.Parameterization.Name == "exta":
-		spec = extensionSpecFor("exta", "extbase:index:Aye")
+		spec = extensionSpecFor("exta", "exta:index:Aye")
 	case d.Parameterization.Name == "extb":
-		spec = extensionSpecFor("extb", "extbase:index:Bee")
+		spec = extensionSpecFor("extb", "extb:index:Bee")
 	default:
 		return nil, fmt.Errorf("unexpected package %q", d.PackageName())
 	}
@@ -71,7 +70,7 @@ func (multiExtensionLoader) LoadPackageV2(
 }
 
 // extensionSpecFor builds an extension package named `name` that defines one
-// resource `token` in the base provider's ("extbase") namespace.
+// resource `token` in its own namespace.
 func extensionSpecFor(name, token string) schema.PackageSpec {
 	return schema.PackageSpec{
 		Name:    name,
@@ -110,9 +109,9 @@ package {
     }
 }
 
-resource a "extbase:index:Aye" { }
+resource a "exta:index:Aye" { }
 
-resource b "extbase:index:Bee" { }
+resource b "extb:index:Bee" { }
 
 resource base "extbase:index:Base" { }
 `
@@ -125,5 +124,5 @@ resource base "extbase:index:Base" { }
 	require.NoError(t, err)
 	require.NotNil(t, program, "program should bind")
 	require.False(t, diags.HasErrors(),
-		"all three resources should resolve (Aye->exta, Bee->extb, Base->bare extbase); diags: %v", diags)
+		"all three resources should resolve in their own namespaces; diags: %v", diags)
 }

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -76,16 +76,19 @@ func (b *binder) resolveSchemaResourceForBind(
 		pkg, isProvider = name, true
 	}
 
+	var pkgSchema *packageSchema
+	var err error
 	// It is important that we call `loadPackageSchema`/`loadPackageSchemaFromDescriptor`
 	// instead of `getPackageSchema` here  because the version may be wrong. When the version should not be empty,
 	// `loadPackageSchema` will load the default version while `getPackageSchema` will
 	// simply fail. We can't give a populated version field since we have not processed
 	// the body, and thus the version yet.
-	// The token's package portion may be a plain package or a base provider whose
-	// resources are supplied by one or more extensions layered on it; the resource
-	// is defined by whichever candidate schema contains the token.
-	candidates, err := b.candidateSchemasForToken(ctx, pkg)
-	if len(candidates) == 0 {
+	if packageDescriptor, ok := b.packageDescriptors[pkg]; ok {
+		pkgSchema, err = b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, packageDescriptor)
+	} else {
+		pkgSchema, err = b.options.packageCache.loadPackageSchema(ctx, b.options.loader, pkg, "", "")
+	}
+	if err != nil {
 		e := unknownPackage(pkg, tokenRange)
 		e.Detail = err.Error()
 
@@ -99,7 +102,7 @@ func (b *binder) resolveSchemaResourceForBind(
 
 	var res *schema.Resource
 	if isProvider {
-		provider, err := candidates[0].schema.Provider()
+		r, err := pkgSchema.schema.Provider()
 		if err != nil {
 			if b.options.skipResourceTypecheck {
 				makeResourceDynamic()
@@ -107,41 +110,32 @@ func (b *binder) resolveSchemaResourceForBind(
 			}
 			return nil, token, hcl.Diagnostics{resourceLoadError(token, err, tokenRange)}
 		}
-		res = provider
+		res = r
 	} else {
-		for _, candidate := range candidates {
-			resource, canonicalToken, found, err := candidate.LookupResource(token)
-			if err != nil {
-				if b.options.skipResourceTypecheck {
-					makeResourceDynamic()
-					return nil, token, diagnostics
-				}
+		r, tk, ok, err := pkgSchema.LookupResource(token)
+		if err != nil {
+			if b.options.skipResourceTypecheck {
+				makeResourceDynamic()
+				return nil, token, diagnostics
+			}
 
-				return nil, token, hcl.Diagnostics{resourceLoadError(token, err, tokenRange)}
-			}
-			if found {
-				res = resource
-				if _, ok := b.referencedPackages[candidate.schema.Name()]; !ok {
-					b.referencedPackages[candidate.schema.Name()] = candidate.schema
-				}
-				// For pulumi built-in resources (e.g. pulumi:pulumi:StackReference), canonicalizeToken
-				// strips the module to produce "pulumi::StackReference" because TokenToModule returns ""
-				// for the pulumi:pulumi module. Reconstruct the full token from the decomposed parts.
-				if pkg == pulumiPackage {
-					token = fmt.Sprintf("%s:%s:%s", pkg, module, name)
-				} else {
-					token = canonicalToken
-				}
-				break
-			}
-		}
-		if res == nil {
+			return nil, token, hcl.Diagnostics{resourceLoadError(token, err, tokenRange)}
+		} else if !ok {
 			if b.options.skipResourceTypecheck {
 				makeResourceDynamic()
 				return nil, token, diagnostics
 			}
 
 			return nil, token, hcl.Diagnostics{unknownResourceType(token, tokenRange)}
+		}
+		res = r
+		// For pulumi built-in resources (e.g. pulumi:pulumi:StackReference), canonicalizeToken
+		// strips the module to produce "pulumi::StackReference" because TokenToModule returns ""
+		// for the pulumi:pulumi module. Reconstruct the full token from the decomposed parts.
+		if pkg == pulumiPackage {
+			token = fmt.Sprintf("%s:%s:%s", pkg, module, name)
+		} else {
+			token = tk
 		}
 	}
 

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -227,12 +226,9 @@ func (c *PackageCache) loadPackageSchemaFromDescriptor(
 }
 
 // canonicalizeToken converts a Pulumi token into its canonical "pkg:module:member" form.
-// The package portion is taken from the token itself rather than pkg.Name() so that
-// extension-parameterized schemas, whose tokens live in the base provider's namespace,
-// keep that namespace after canonicalization.
 func canonicalizeToken(tok string, pkg schema.PackageReference) string {
-	pkgName, _, member, _ := DecomposeToken(tok, hcl.Range{})
-	return fmt.Sprintf("%s:%s:%s", pkgName, pkg.TokenToModule(tok), member)
+	_, _, member, _ := DecomposeToken(tok, hcl.Range{})
+	return fmt.Sprintf("%s:%s:%s", pkg.Name(), pkg.TokenToModule(tok), member)
 }
 
 // getPkgOpts gets the package options from an unbound resource node.
@@ -384,24 +380,16 @@ func (b *binder) loadReferencedPackageSchemas(ctx context.Context, n Node) error
 			continue
 		}
 
-		_, declared := b.packageDescriptors[name]
-		if extDescriptors := b.extensionDescriptorsForBase(tokens.PackageName(name)); !declared && len(extDescriptors) > 0 {
-			// name is a base plugin; record each extension that layers on it under the
-			// extension's own name (what dependency checks expect), found via the base.
-			for _, extDescriptor := range extDescriptors {
-				extPkg, extErr := b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, extDescriptor)
-				if extErr != nil {
-					if b.options.skipResourceTypecheck || b.options.skipInvokeTypecheck {
-						continue
-					}
-					return extErr
-				}
-				b.referencedPackages[extPkg.schema.Name()] = extPkg.schema
-			}
-			continue
+		var pkg *packageSchema
+		var err error
+		if packageDescriptor, ok := b.packageDescriptors[name]; ok {
+			pkg, err = b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, packageDescriptor)
+		} else {
+			pkg, err = b.options.packageCache.loadPackageSchema(
+				ctx, b.options.loader,
+				name, pkgOpts.version, pkgOpts.pluginDownloadURL,
+			)
 		}
-
-		pkg, err := b.loadDeclaredOrBarePackageSchema(ctx, name, pkgOpts.version, pkgOpts.pluginDownloadURL)
 		if err != nil {
 			if b.options.skipResourceTypecheck || b.options.skipInvokeTypecheck {
 				continue

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -174,11 +174,14 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), diagnostics
 	}
 
-	// The function token's package portion may be a plain package or a base
-	// provider whose functions are supplied by an extension layered on it; the
-	// function is defined by whichever candidate schema contains the token.
-	candidates, err := b.candidateSchemasForToken(context.TODO(), pkg)
-	if len(candidates) == 0 {
+	var pkgSchema *packageSchema
+	var err error
+	if packageDescriptor, ok := b.packageDescriptors[pkg]; ok {
+		pkgSchema, err = b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, packageDescriptor)
+	} else {
+		pkgSchema, err = b.options.packageCache.loadPackageSchema(context.TODO(), b.options.loader, pkg, "", "")
+	}
+	if err != nil {
 		if b.options.skipInvokeTypecheck {
 			return b.zeroSignature(), nil
 		}
@@ -188,26 +191,14 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), hcl.Diagnostics{asWarningDiagnostic(e)}
 	}
 
-	var fn *schema.Function
-	var canonicalToken string
-	for _, candidate := range candidates {
-		function, tk, found, err := candidate.LookupFunction(token)
-		if err != nil {
-			if b.options.skipInvokeTypecheck {
-				return b.zeroSignature(), nil
-			}
+	fn, tk, ok, err := pkgSchema.LookupFunction(token)
+	if err != nil {
+		if b.options.skipInvokeTypecheck {
+			return b.zeroSignature(), nil
+		}
 
-			return b.zeroSignature(), hcl.Diagnostics{functionLoadError(token, err, tokenRange)}
-		}
-		if found {
-			fn, canonicalToken = function, tk
-			if _, ok := b.referencedPackages[candidate.schema.Name()]; !ok {
-				b.referencedPackages[candidate.schema.Name()] = candidate.schema
-			}
-			break
-		}
-	}
-	if fn == nil {
+		return b.zeroSignature(), hcl.Diagnostics{functionLoadError(token, err, tokenRange)}
+	} else if !ok {
 		if b.options.skipInvokeTypecheck {
 			return b.zeroSignature(), nil
 		}
@@ -215,7 +206,7 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), hcl.Diagnostics{unknownFunction(token, tokenRange)}
 	}
 
-	lit.Value = cty.StringVal(canonicalToken)
+	lit.Value = cty.StringVal(tk)
 
 	if len(args) < 2 {
 		return b.zeroSignature(), hcl.Diagnostics{errorf(tokenRange, "missing second arg")}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -679,7 +679,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 			if pkg == "pulumi" {
 				continue
 			}
-			var packageName, schemaPkg string
+			var packageName string
 			if schemaRes != nil && schemaRes.PackageReference != nil {
 				pkgDef, err := schemaRes.PackageReference.Definition()
 				if err == nil {
@@ -690,14 +690,12 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 				if packageName == "" {
 					packageName = PyPack(pkgDef.Namespace, pkgDef.Name)
 				}
-				schemaPkg = pkgDef.Name
 			} else {
 				packageName = "pulumi_" + makeValidIdentifier(pkg)
-				schemaPkg = pkg
 			}
 			importSet[packageName] = Import{
 				ImportAs: true,
-				Pkg:      g.ensurePackageImportAlias(schemaPkg, usedImportAliases),
+				Pkg:      g.ensurePackageImportAlias(pkg, usedImportAliases),
 			}
 		}
 		diags := n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
@@ -705,17 +703,9 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 				if call.Name == pcl.Invoke {
 					pkg, _, _, invokeDiags := functionName(call.Args[0])
 					contract.Assertf(len(invokeDiags) == 0, "unexpected diagnostics reported: %v", invokeDiags)
-					// Import an extension by its real package name but alias it under the
-					// token's base name, matching how its resources are imported.
-					packageName := "pulumi_" + makeValidIdentifier(pkg)
-					schemaPkg := pkg
-					if def := g.functionPackage(call.Args[0]); def != nil {
-						packageName = PyPack(def.Namespace, def.Name)
-						schemaPkg = def.Name
-					}
-					importSet[packageName] = Import{
+					importSet["pulumi_"+makeValidIdentifier(pkg)] = Import{
 						ImportAs: true,
-						Pkg:      g.ensurePackageImportAlias(schemaPkg, usedImportAliases),
+						Pkg:      g.ensurePackageImportAlias(pkg, usedImportAliases),
 					}
 				}
 				if i := g.getFunctionImports(call); len(i) > 0 && i[0] != "" {
@@ -837,15 +827,13 @@ func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) 
 	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
 
 	// Normalize module.
-	schemaPkg := pkg
 	if r.Schema != nil {
-		schemaPkg = r.Schema.PackageReference.Name()
 		// pulumi:pulumi:* resources (e.g. StackReference) belong to the root of the
 		// package, not a "pulumi" submodule.
 		if r.Schema.PackageReference.Name() == "pulumi" && module == "pulumi" {
 			module = ""
 		}
-		pkgDef, err := r.Schema.PackageReference.Definition()
+		pkg, err := r.Schema.PackageReference.Definition()
 		if err != nil {
 			diagnostics = append(diagnostics, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -854,9 +842,9 @@ func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) 
 				Subject:  r.Definition.Syntax.DefRange().Ptr(),
 			})
 		} else {
-			err = pkgDef.ImportLanguages(map[string]schema.Language{"python": Importer})
-			contract.AssertNoErrorf(err, "failed to import python language plugin for package %s", pkgDef.Name)
-			if lang, ok := pkgDef.Language["python"]; ok {
+			err = pkg.ImportLanguages(map[string]schema.Language{"python": Importer})
+			contract.AssertNoErrorf(err, "failed to import python language plugin for package %s", pkg.Name)
+			if lang, ok := pkg.Language["python"]; ok {
 				if pkgInfo, ok := lang.(PackageInfo); ok {
 					if m, ok := pkgInfo.ModuleNameOverrides[module]; ok {
 						module = m
@@ -866,16 +854,14 @@ func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) 
 		}
 	}
 
-	return tokenToQualifiedName(g.packageAlias(schemaPkg), module, member), diagnostics
+	return tokenToQualifiedName(g.packageAlias(pkg), module, member), diagnostics
 }
 
 func (g *generator) readResourceTypeName(r *pcl.ReadResource) (string, hcl.Diagnostics) {
 	token, tokenRange := r.GetToken()
 	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
 
-	schemaPkg := pkg
 	if r.Schema != nil {
-		schemaPkg = r.Schema.PackageReference.Name()
 		pkgDef, err := r.Schema.PackageReference.Definition()
 		if err != nil {
 			diagnostics = append(diagnostics, &hcl.Diagnostic{
@@ -897,7 +883,7 @@ func (g *generator) readResourceTypeName(r *pcl.ReadResource) (string, hcl.Diagn
 		}
 	}
 
-	return tokenToQualifiedName(g.packageAlias(schemaPkg), module, member), diagnostics
+	return tokenToQualifiedName(g.packageAlias(pkg), module, member), diagnostics
 }
 
 func (g *generator) typedDictEnabled(expr model.Expression, typ model.Type) bool {
@@ -942,7 +928,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type)
 	tokenRange := expr.SyntaxNode().Range()
 
 	// Example: aws, s3/BucketLogging, BucketLogging, []Diagnostics
-	_, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
+	pkgName, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
 	contract.Assertf(len(diagnostics) == 0, "unexpected diagnostics reported: %v", diagnostics)
 
 	modName := objType.PackageReference.TokenToModule(token)
@@ -957,7 +943,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type)
 			}
 		}
 	}
-	return tokenToQualifiedName(g.packageAlias(objType.PackageReference.Name()), modName, member) + "Args"
+	return tokenToQualifiedName(g.packageAlias(pkgName), modName, member) + "Args"
 }
 
 // makeResourceName returns the expression that should be emitted for a resource's "name" parameter given its base name

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -276,27 +276,6 @@ func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagno
 	return makeValidIdentifier(pkg), strings.ReplaceAll(module, "/", "."), cgstrings.UppercaseFirst(member), diagnostics
 }
 
-// functionPackage resolves the package that defines the function token. For
-// extensions the token lives in the base namespace but the owner is the
-// extension. Returns nil if no loaded package defines the token.
-func (g *generator) functionPackage(tokenArg model.Expression) *schema.Package {
-	token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
-	pkg, _, _, _ := pcl.DecomposeToken(token, tokenArg.SyntaxNode().Range())
-	for _, ref := range g.program.PackageReferences() {
-		def, err := ref.Definition()
-		if err != nil {
-			continue
-		}
-		if ref.Name() == pkg {
-			return def
-		}
-		if _, ok := def.GetFunction(token); ok {
-			return def
-		}
-	}
-	return nil
-}
-
 var functionImports = map[string][]string{
 	"fileArchive":      {"pulumi"},
 	"remoteArchive":    {"pulumi"},
@@ -519,11 +498,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		if module != "" {
 			module = "." + module
 		}
-		schemaPkg := pkg
-		if def := g.functionPackage(expr.Args[0]); def != nil {
-			schemaPkg = def.Name
-		}
-		name := fmt.Sprintf("%s%s.%s", g.packageAlias(schemaPkg), module, PyName(fn))
+		name := fmt.Sprintf("%s%s.%s", g.packageAlias(pkg), module, PyName(fn))
 
 		isOut := pcl.IsOutputVersionInvokeCall(expr)
 		if isOut {

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -622,13 +622,7 @@ func (spec *PackageSpec) validateTypeToken(
 
 	modules, ok := allowedNameSpecs[parts[0]]
 	if !ok {
-		// Extension tokens must use the base provider's namespace, not the
-		// extension's own name, so point the author at the base.
-		expectedName := spec.Name
-		if spec.ExtensionParameterization != nil {
-			expectedName = spec.ExtensionParameterization.BaseProvider.Name
-		}
-		err := errorf(path, "invalid token '%s' (must have package name '%s')", token, expectedName)
+		err := errorf(path, "invalid token '%s' (must have package name '%s')", token, spec.Name)
 		diags = diags.Append(err)
 	}
 	if (parts[1] == "" || strings.EqualFold(parts[1], "index")) && strings.EqualFold(parts[2], "provider") {
@@ -669,16 +663,7 @@ func (spec *PackageSpec) validateTypeToken(
 // This is for validating non-reference type tokens.
 func (spec *PackageSpec) validateTypeTokens() hcl.Diagnostics {
 	var diags hcl.Diagnostics
-	allowedNameSpecs := map[string][]string{}
-	if spec.ExtensionParameterization != nil {
-		// Extension resources are served at runtime by the base provider, and the
-		// whole base->extension resolution path is keyed on the base namespace, so
-		// their tokens must use the base provider's name — not the extension's own
-		// (renamed-SDK) name.
-		allowedNameSpecs[spec.ExtensionParameterization.BaseProvider.Name] = nil
-	} else {
-		allowedNameSpecs[spec.Name] = nil
-	}
+	allowedNameSpecs := map[string][]string{spec.Name: nil}
 	for _, prefix := range spec.AllowedPackageNames {
 		allowedNameSpecs[prefix] = nil
 	}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -3065,12 +3065,12 @@ func TestExtensionTokenNamespace(t *testing.T) {
 		wantRejected bool
 	}{
 		{
-			name:  "base-namespaced token is allowed",
-			token: "extbase:index:Greeting",
+			name:  "extension-own-namespace token is allowed",
+			token: "myext:index:Greeting",
 		},
 		{
-			name:         "extension-own-namespace token is rejected",
-			token:        "myext:index:Greeting",
+			name:         "base-namespaced token is rejected",
+			token:        "extbase:index:Greeting",
 			wantRejected: true,
 		},
 	}
@@ -3094,7 +3094,7 @@ func TestExtensionTokenNamespace(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			want := fmt.Sprintf("invalid token '%s' (must have package name 'extbase')", tt.token)
+			want := fmt.Sprintf("invalid token '%s' (must have package name 'myext')", tt.token)
 			rejected := false
 			for _, d := range diags {
 				if d.Severity == hcl.DiagError && strings.Contains(d.Summary, want) {
@@ -3104,7 +3104,8 @@ func TestExtensionTokenNamespace(t *testing.T) {
 			if tt.wantRejected {
 				assert.True(t, rejected, "expected rejection diagnostic %q, got %v", want, diags)
 			} else {
-				assert.False(t, diags.HasErrors(), "base-namespaced token should bind without errors, got %v", diags)
+				assert.False(t, diags.HasErrors(),
+					"extension-namespaced token should bind without errors, got %v", diags)
 			}
 		})
 	}
@@ -3176,7 +3177,7 @@ func TestBindExtensionParameterized(t *testing.T) {
   "name": "extensionref",
   "version": "1.0.0",
   "resources": {
-    "test-base:index:Root": {
+    "extensionref:index:Root": {
       "type": "object",
       "properties": { "data": { "type": "string" } }
     }

--- a/pkg/codegen/testing/utils/rapidschema/rapidschema.go
+++ b/pkg/codegen/testing/utils/rapidschema/rapidschema.go
@@ -130,18 +130,36 @@ type pkgCtx struct {
 func drawPackageSpec(t *rapid.T) schema.PackageSpec {
 	name := drawPackageName(t, "pkgName")
 
+	ctx := &pkgCtx{
+		name:             name,
+		enumTokensByBase: map[string][]string{},
+		typeDefs:         map[string]schema.ComplexTypeSpec{},
+	}
+
+	nResources := rapid.IntRange(0, 4).Draw(t, "nResources")
+	resourceTokens := make([]string, nResources)
+	for i := range nResources {
+		module := drawModule(t, ctx, fmt.Sprintf("res%d:module", i))
+		resourceTokens[i] = fmt.Sprintf("%s:%s:Res%d", name, module, i)
+	}
+
+	resources := make(map[string]schema.ResourceSpec, nResources)
+	for _, tok := range resourceTokens {
+		resources[tok] = drawResourceSpec(t, ctx, tok)
+	}
+
+	spec := schema.PackageSpec{
+		Name:      name,
+		Version:   Version().Draw(t, "version").String(),
+		Types:     ctx.typeDefs,
+		Resources: resources,
+	}
+
 	emptyProvider := func() *schema.ResourceSpec {
 		// Provider is required by the binder; an empty object satisfies it
 		// without contributing any properties.
 		return &schema.ResourceSpec{ObjectTypeSpec: schema.ObjectTypeSpec{Type: "object"}}
 	}
-
-	// Settle the parameterization before drawing any tokens: extension
-	// parameterized packages must namespace their tokens under the base
-	// provider rather than their own name, so the token namespace has to be
-	// known up front.
-	var spec schema.PackageSpec
-	tokenNamespace := name
 	switch rapid.IntRange(0, 2).Draw(t, "parameterization") {
 	case 0:
 		spec.Provider = emptyProvider()
@@ -152,31 +170,7 @@ func drawPackageSpec(t *rapid.T) schema.PackageSpec {
 	case 2:
 		e := drawExtensionParameterizationSpec(t, "extensionParameterization")
 		spec.ExtensionParameterization = &e
-		tokenNamespace = e.BaseProvider.Name
 	}
-
-	ctx := &pkgCtx{
-		name:             tokenNamespace,
-		enumTokensByBase: map[string][]string{},
-		typeDefs:         map[string]schema.ComplexTypeSpec{},
-	}
-
-	nResources := rapid.IntRange(0, 4).Draw(t, "nResources")
-	resourceTokens := make([]string, nResources)
-	for i := range nResources {
-		module := drawModule(t, ctx, fmt.Sprintf("res%d:module", i))
-		resourceTokens[i] = fmt.Sprintf("%s:%s:Res%d", tokenNamespace, module, i)
-	}
-
-	resources := make(map[string]schema.ResourceSpec, nResources)
-	for _, tok := range resourceTokens {
-		resources[tok] = drawResourceSpec(t, ctx, tok)
-	}
-
-	spec.Name = name
-	spec.Version = Version().Draw(t, "version").String()
-	spec.Types = ctx.typeDefs
-	spec.Resources = resources
 
 	return spec
 }

--- a/pkg/importer/hcl2_rapid_test.go
+++ b/pkg/importer/hcl2_rapid_test.go
@@ -46,12 +46,7 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 	t.Parallel()
 
 	rapid.Check(t, func(t *rapid.T) {
-		// This round-trip reloads packages by name, but extension tokens are
-		// base-namespaced, so exclude extension-parameterized packages.
-		pkg := rapidschema.Package().
-			Filter(hasSelectableResource).
-			Filter(func(pkg *schema.Package) bool { return pkg.ExtensionParameterization == nil }).
-			Draw(t, "pkg")
+		pkg := rapidschema.Package().Filter(hasSelectableResource).Draw(t, "pkg")
 		sample := rapidimporter.State(pkg).Draw(t, "sample")
 
 		if checkPropertyMap(sample.State.Inputs, property.Value.IsNull) {

--- a/pkg/pcl/runtime/interpreter.go
+++ b/pkg/pcl/runtime/interpreter.go
@@ -81,11 +81,7 @@ type Interpreter struct {
 	// the resource is registered as "myComp-res". Nested components accumulate the prefix.
 	namePrefix string
 
-	// packageRefs maps a fully-qualified token (resource, function, or
-	// pulumi:providers:<pkg>) to the package reference RegisterPackage returned.
-	// Keying on the exact token, not package name, keeps extensions that share the
-	// base provider's namespace distinct. A miss resolves to the empty ref, and so
-	// to the default provider.
+	// packageRefs are package references returned by RegisterPackage keyed by package name.
 	packageRefs map[string]string
 
 	// callbacks is the server that handles resource hook callbacks.
@@ -716,28 +712,23 @@ func (i *Interpreter) lookupResource(ctx context.Context, token string) (*schema
 		pkgName = typ
 	}
 
-	var loadErr error
-	for _, descriptor := range i.lookupPackageDescriptors(pkgName) {
-		pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
-		if err != nil {
-			loadErr = errors.Join(loadErr, fmt.Errorf("load package for token %s: %w", token, err))
-			continue
-		}
-		if pkg == "pulumi" && mod == "providers" {
-			return pkgref.Provider()
-		}
-		schemaResource, ok, err := pkgref.Resources().Get(token)
-		if err != nil {
-			return nil, fmt.Errorf("get resource from package for token %s: %w", token, err)
-		}
-		if ok {
-			return schemaResource, nil
-		}
+	descriptor := i.lookupPackageDescriptor(pkgName)
+	pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("load package for token %s: %w", token, err)
 	}
-	if loadErr != nil {
-		return nil, loadErr
+	if pkg == "pulumi" && mod == "providers" {
+		return pkgref.Provider()
 	}
-	return nil, fmt.Errorf("get resource from package for token %s", token)
+	resources := pkgref.Resources()
+	schemaResource, ok, err := resources.Get(token)
+	if err != nil {
+		return nil, fmt.Errorf("get resource from package for token %s: %w", token, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("get resource from package for token %s", token)
+	}
+	return schemaResource, nil
 }
 
 func (i *Interpreter) lookupFunction(ctx context.Context, token string) (*schema.Function, error) {
@@ -746,42 +737,27 @@ func (i *Interpreter) lookupFunction(ctx context.Context, token string) (*schema
 
 	token = fmt.Sprintf("%s:%s:%s", pkg, mod, typ)
 
-	var loadErr error
-	for _, descriptor := range i.lookupPackageDescriptors(pkg) {
-		pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
-		if err != nil {
-			loadErr = errors.Join(loadErr, fmt.Errorf("load package for token %s: %w", token, err))
-			continue
-		}
-		schemaFunction, ok, err := pkgref.Functions().Get(token)
-		if err != nil {
-			return nil, fmt.Errorf("get function from package for token %s: %w", token, err)
-		}
-		if ok {
-			return schemaFunction, nil
-		}
+	descriptor := i.lookupPackageDescriptor(pkg)
+	pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("load package for token %s: %w", token, err)
 	}
-	if loadErr != nil {
-		return nil, loadErr
+	functions := pkgref.Functions()
+	schemaFunction, ok, err := functions.Get(token)
+	if err != nil {
+		return nil, fmt.Errorf("get function from package for token %s: %w", token, err)
 	}
-	return nil, fmt.Errorf("get function from package for token %s", token)
+	if !ok {
+		return nil, fmt.Errorf("get function from package for token %s", token)
+	}
+	return schemaFunction, nil
 }
 
-// lookupPackageDescriptors returns the packages a pkgName-namespaced token could
-// resolve to: pkgName itself plus every extension layered on it.
-func (i *Interpreter) lookupPackageDescriptors(pkgName string) []*schema.PackageDescriptor {
-	var candidates []*schema.PackageDescriptor
+func (i *Interpreter) lookupPackageDescriptor(pkgName string) *schema.PackageDescriptor {
 	if descriptor, ok := i.info.PackageDescriptors[pkgName]; ok && descriptor != nil {
-		candidates = append(candidates, descriptor)
-	} else {
-		candidates = append(candidates, &schema.PackageDescriptor{Name: pkgName})
+		return descriptor
 	}
-	for _, descriptor := range i.info.PackageDescriptors {
-		if descriptor != nil && descriptor.Parameterization != nil && descriptor.Name == pkgName {
-			candidates = append(candidates, descriptor)
-		}
-	}
-	return candidates
+	return &schema.PackageDescriptor{Name: pkgName}
 }
 
 func PackageNameFromToken(token string) (string, error) {
@@ -798,7 +774,11 @@ func PackageNameFromToken(token string) (string, error) {
 	return pkg, nil
 }
 
-func (i *Interpreter) getPackageRefFromToken(token string) string { return i.packageRefs[token] }
+func (i *Interpreter) getPackageRefFromToken(token string) string {
+	pkgName, err := PackageNameFromToken(token)
+	contract.AssertNoErrorf(err, "invalid token %q", token)
+	return i.packageRefs[pkgName]
+}
 
 func (i *Interpreter) registerPackages(ctx context.Context) error {
 	if i.monitor == nil {
@@ -855,15 +835,8 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 			return fmt.Errorf("register package %q returned empty reference", key)
 		}
 
-		// Index every token the package defines, plus its provider ref (see packageRefs).
-		ref := resp.GetRef()
-		i.packageRefs["pulumi:providers:"+descriptor.PackageName()] = ref
-		for _, r := range def.Resources {
-			i.packageRefs[r.Token] = ref
-		}
-		for _, f := range def.Functions {
-			i.packageRefs[f.Token] = ref
-		}
+		i.packageRefs[key] = resp.GetRef()
+		i.packageRefs[descriptor.PackageName()] = resp.GetRef()
 	}
 
 	return nil

--- a/pkg/pcl/runtime/interpreter_multi_extension_test.go
+++ b/pkg/pcl/runtime/interpreter_multi_extension_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 // multiExtensionRuntimeLoader serves two extensions over the same base provider
-// ("extbase"): "exta" defines extbase:index:Aye and "extb" defines
-// extbase:index:Bee. Both resource tokens live in the base namespace.
+// ("extbase"): "exta" defines exta:index:Aye and "extb" defines extb:index:Bee,
+// each in its own namespace.
 type multiExtensionRuntimeLoader struct{}
 
 func (l *multiExtensionRuntimeLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {
@@ -42,9 +42,9 @@ func (l *multiExtensionRuntimeLoader) LoadPackageV2(
 	var name, token string
 	switch {
 	case d.Parameterization != nil && d.Parameterization.Name == "exta":
-		name, token = "exta", "extbase:index:Aye"
+		name, token = "exta", "exta:index:Aye"
 	case d.Parameterization != nil && d.Parameterization.Name == "extb":
-		name, token = "extb", "extbase:index:Bee"
+		name, token = "extb", "extb:index:Bee"
 	default:
 		return nil, fmt.Errorf("unexpected package %q", d.PackageName())
 	}
@@ -106,10 +106,8 @@ func (registerPackageMonitor) RegisterPackage(
 }
 
 // TestPackageRefResolutionAcrossExtensionsOnSameBase registers two extensions
-// over the same base provider and checks that each base-namespaced resource
-// token resolves to its OWN extension's package reference. Because tokens live
-// in the base namespace, resolving by the base name alone collapses both
-// extensions onto one ref (last registration wins).
+// over the same base provider and checks that each extension's resource token
+// resolves to its OWN extension's package reference.
 func TestPackageRefResolutionAcrossExtensionsOnSameBase(t *testing.T) {
 	t.Parallel()
 
@@ -141,11 +139,11 @@ func TestPackageRefResolutionAcrossExtensionsOnSameBase(t *testing.T) {
 
 	require.NoError(t, i.registerPackages(t.Context()))
 
-	ayeRef := i.getPackageRefFromToken("extbase:index:Aye")
-	beeRef := i.getPackageRefFromToken("extbase:index:Bee")
+	ayeRef := i.getPackageRefFromToken("exta:index:Aye")
+	beeRef := i.getPackageRefFromToken("extb:index:Bee")
 
-	require.Equal(t, "ref-exta", ayeRef, "extbase:index:Aye is defined by the exta extension")
-	require.Equal(t, "ref-extb", beeRef, "extbase:index:Bee is defined by the extb extension")
+	require.Equal(t, "ref-exta", ayeRef, "exta:index:Aye is defined by the exta extension")
+	require.Equal(t, "ref-extb", beeRef, "extb:index:Bee is defined by the extb extension")
 	require.NotEqual(t, ayeRef, beeRef,
 		"resources from different extensions on the same base must not share a package ref")
 }

--- a/pkg/testing/pulumi-test-language/l2_extension_and_base_resource_test.go
+++ b/pkg/testing/pulumi-test-language/l2_extension_and_base_resource_test.go
@@ -192,7 +192,7 @@ func (h *L2ExtensionAndBaseResourceLanguageHost) Run(
 			return nil, fmt.Errorf("could not get package reference: %w", err)
 		}
 		res, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
-			Type:       "extbase:index:Greeting",
+			Type:       "myext:index:Greeting",
 			Custom:     true,
 			Name:       "greeting",
 			PackageRef: ref,

--- a/pkg/testing/pulumi-test-language/l2_extension_parameterized_resource_test.go
+++ b/pkg/testing/pulumi-test-language/l2_extension_parameterized_resource_test.go
@@ -75,6 +75,15 @@ func (h *L2ExtensionParameterizedResourceLanguageHost) GenerateProject(
 	if project.Name != "l2-extension-parameterized-resource" {
 		return nil, fmt.Errorf("unexpected project name %s", project.Name)
 	}
+	// Assert that only the extension package is listed in the project dependencies
+	for name := range req.LocalDependencies {
+		if name == "pulumi" {
+			continue
+		}
+		if name != "myext" {
+			return nil, fmt.Errorf("unexpected local dependency %s", name)
+		}
+	}
 	project.Runtime = workspace.NewProjectRuntimeInfo("mock", nil)
 	projectYaml, err := yaml.Marshal(project)
 	if err != nil {

--- a/pkg/testing/pulumi-test-language/l2_extension_parameterized_resource_test.go
+++ b/pkg/testing/pulumi-test-language/l2_extension_parameterized_resource_test.go
@@ -179,7 +179,7 @@ func (h *L2ExtensionParameterizedResourceLanguageHost) Run(
 			return nil, fmt.Errorf("could not get package reference: %w", err)
 		}
 		res, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
-			Type:       "extbase:index:Greeting",
+			Type:       "myext:index:Greeting",
 			Custom:     true,
 			Name:       "greeting",
 			PackageRef: ref,
@@ -197,7 +197,7 @@ func (h *L2ExtensionParameterizedResourceLanguageHost) Run(
 			return nil, fmt.Errorf("could not get package reference: %w", err)
 		}
 		res, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
-			Type:       "extbase:index:GreetingComponent",
+			Type:       "myext:index:GreetingComponent",
 			Remote:     true,
 			Name:       "greetingComp",
 			PackageRef: ref,
@@ -224,7 +224,7 @@ func (h *L2ExtensionParameterizedResourceLanguageHost) Run(
 		return nil, fmt.Errorf("could not get package reference: %w", err)
 	}
 	invokeResp, err := monitor.Invoke(ctx, &pulumirpc.ResourceInvokeRequest{
-		Tok:        "extbase:index:greet",
+		Tok:        "myext:index:greet",
 		PackageRef: ref,
 		Args: &structpb.Struct{
 			Fields: map[string]*structpb.Value{

--- a/pkg/testing/pulumi-test-language/providers/extension_parameterized_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/extension_parameterized_provider.go
@@ -30,8 +30,8 @@ import (
 
 // ExtensionParameterizedProvider models a base plugin that accepts extension
 // parameterization arguments. The emitted schema sets Name to the extension
-// identity, leaves Provider nil, and keeps every resource token in the base
-// provider's namespace.
+// identity, leaves Provider nil, and puts every extension resource token in
+// the extension package's own namespace.
 type ExtensionParameterizedProvider struct {
 	plugin.UnimplementedProvider
 	mu               sync.Mutex
@@ -115,9 +115,9 @@ func (p *ExtensionParameterizedProvider) GetSchema(
 		version = req.SubpackageVersion.String()
 	}
 
-	token := extensionBaseName + ":index:Greeting"
+	token := name + ":index:Greeting"
 	componentToken := token + "Component"
-	greetToken := extensionBaseName + ":index:greet"
+	greetToken := name + ":index:greet"
 
 	greetingSpec := schema.ObjectTypeSpec{
 		Type: "object",
@@ -174,7 +174,8 @@ func (p *ExtensionParameterizedProvider) CheckConfig(
 func (p *ExtensionParameterizedProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
-	greeting := extensionBaseName + ":index:Greeting"
+	extName, _, _ := p.snapshot()
+	greeting := extName + ":index:Greeting"
 	base := extensionBaseName + ":index:Base"
 	if t := string(req.URN.Type()); t != greeting && t != base {
 		return plugin.CheckResponse{
@@ -192,10 +193,10 @@ func (p *ExtensionParameterizedProvider) Create(
 	if req.Preview {
 		id = ""
 	}
-	_, _, value := p.snapshot()
+	extName, _, value := p.snapshot()
 	var properties resource.PropertyMap
 	switch t := string(req.URN.Type()); t {
-	case extensionBaseName + ":index:Greeting":
+	case extName + ":index:Greeting":
 		properties = resource.NewPropertyMapFromMap(map[string]any{
 			"parameterValue": string(value),
 		})
@@ -217,8 +218,8 @@ func (p *ExtensionParameterizedProvider) Create(
 func (p *ExtensionParameterizedProvider) Construct(
 	_ context.Context, req plugin.ConstructRequest,
 ) (plugin.ConstructResponse, error) {
-	token := extensionBaseName + ":index:GreetingComponent"
-	_, _, value := p.snapshot()
+	extName, _, value := p.snapshot()
+	token := extName + ":index:GreetingComponent"
 	return plugin.ConstructResponse{
 		URN: resource.CreateURN(req.Name, token, req.Parent, req.Info.Project, req.Info.Stack),
 		Outputs: resource.PropertyMap{
@@ -230,11 +231,11 @@ func (p *ExtensionParameterizedProvider) Construct(
 func (p *ExtensionParameterizedProvider) Invoke(
 	_ context.Context, req plugin.InvokeRequest,
 ) (plugin.InvokeResponse, error) {
-	expected := extensionBaseName + ":index:greet"
+	extName, _, value := p.snapshot()
+	expected := extName + ":index:greet"
 	if string(req.Tok) != expected {
 		return plugin.InvokeResponse{}, fmt.Errorf("invalid invoke token %s, expected %s", req.Tok, expected)
 	}
-	_, _, value := p.snapshot()
 	return plugin.InvokeResponse{
 		Properties: resource.NewPropertyMapFromMap(map[string]any{
 			"greeting": string(value) + ", " + req.Args["name"].StringValue(),

--- a/pkg/testing/pulumi-test-language/tests/l2_extension_and_base_resource.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_extension_and_base_resource.go
@@ -41,7 +41,7 @@ func init() {
 					AssertPropertyMapMember(l, stack.Outputs, "parameterValue", resource.NewProperty("Hello"))
 					AssertPropertyMapMember(l, stack.Outputs, "baseValue", resource.NewProperty("base"))
 
-					greeting := RequireSingleResource(l, snap.Resources, "extbase:index:Greeting")
+					greeting := RequireSingleResource(l, snap.Resources, "myext:index:Greeting")
 					require.NotEmpty(l, greeting.ExtensionRef,
 						"extension resource state must carry an ExtensionRef")
 					require.Contains(l, greeting.Provider, "pulumi:providers:extbase::",

--- a/pkg/testing/pulumi-test-language/tests/l2_extension_parameterized_resource.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_extension_parameterized_resource.go
@@ -46,11 +46,10 @@ func init() {
 					AssertPropertyMapMember(l, stack.Outputs, "invokeGreeting",
 						resource.NewProperty("Hello, Pulumi"))
 
-					// The Greeting custom resource lives under the BASE provider's
-					// namespace, not the extension's. Its state must carry an
-					// ExtensionRef so the engine can re-hydrate the extension on
-					// subsequent runs.
-					greeting := RequireSingleResource(l, snap.Resources, "extbase:index:Greeting")
+					// The Greeting custom resource lives under the extension's own
+					// namespace. Its state must carry an ExtensionRef so the engine
+					// can re-hydrate the extension on subsequent runs.
+					greeting := RequireSingleResource(l, snap.Resources, "myext:index:Greeting")
 					require.NotEmpty(l, greeting.ExtensionRef,
 						"extension resource state must carry an ExtensionRef")
 					require.Contains(l, greeting.Provider, "pulumi:providers:extbase::",

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-extension-and-base-resource/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-extension-and-base-resource/main.pp
@@ -1,5 +1,6 @@
 // An extension resource (Greeting) and a base-provider resource (Base) used
-// together; both live in the base provider's namespace ("extbase").
+// together; Greeting lives in the extension's namespace ("myext") and Base
+// lives in the base provider's namespace ("extbase").
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,7 +11,7 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
 resource base "extbase:index:Base" { }
 

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-extension-parameterized-resource/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-extension-parameterized-resource/main.pp
@@ -1,5 +1,5 @@
-// Extension parameterization: the SDK is published as "myext" but the resource
-// tokens live in the base provider's namespace ("extbase").
+// Extension parameterization: the SDK is published as "myext" and the resource
+// tokens live in the extension's own namespace.
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,9 +10,9 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
-resource greetingComp "extbase:index:GreetingComponent" { }
+resource greetingComp "myext:index:GreetingComponent" { }
 
 output "parameterValue" {
     value = greeting.parameterValue
@@ -23,5 +23,5 @@ output "parameterValueFromComponent" {
 }
 
 output "invokeGreeting" {
-    value = invoke("extbase:index:greet", { name = "Pulumi" }).greeting
+    value = invoke("myext:index:greet", { name = "Pulumi" }).greeting
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/greet.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/greet.go
@@ -18,7 +18,7 @@ func Greet(ctx *pulumi.Context, args *GreetArgs, opts ...pulumi.InvokeOption) (*
 		return nil, err
 	}
 	var rv GreetResult
-	err = ctx.InvokePackage("extbase:index:greet", args, &rv, ref, opts...)
+	err = ctx.InvokePackage("myext:index:greet", args, &rv, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func GreetOutput(ctx *pulumi.Context, args GreetOutputArgs, opts ...pulumi.Invok
 				return GreetResultOutput{}, err
 			}
 			options.PackageRef = ref
-			return ctx.InvokeOutput("extbase:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
+			return ctx.InvokeOutput("myext:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
 		}).(GreetResultOutput)
 }
 

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/greeting.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/greeting.go
@@ -30,7 +30,7 @@ func NewGreeting(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource Greeting
-	err = ctx.RegisterPackageResource("extbase:index:Greeting", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageResource("myext:index:Greeting", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func GetGreeting(ctx *pulumi.Context,
 	if err != nil {
 		return nil, err
 	}
-	err = ctx.ReadPackageResource("extbase:index:Greeting", name, id, state, &resource, ref, opts...)
+	err = ctx.ReadPackageResource("myext:index:Greeting", name, id, state, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/greetingComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/greetingComponent.go
@@ -30,7 +30,7 @@ func NewGreetingComponent(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource GreetingComponent
-	err = ctx.RegisterPackageRemoteComponentResource("extbase:index:GreetingComponent", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageRemoteComponentResource("myext:index:GreetingComponent", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/init.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/myext-2.0.0/myext/init.go
@@ -21,9 +21,9 @@ func (m *module) Version() semver.Version {
 
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
-	case "extbase:index:Greeting":
+	case "myext:index:Greeting":
 		r = &Greeting{}
-	case "extbase:index:GreetingComponent":
+	case "myext:index:GreetingComponent":
 		r = &GreetingComponent{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/greet.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/greet.go
@@ -18,7 +18,7 @@ func Greet(ctx *pulumi.Context, args *GreetArgs, opts ...pulumi.InvokeOption) (*
 		return nil, err
 	}
 	var rv GreetResult
-	err = ctx.InvokePackage("extbase:index:greet", args, &rv, ref, opts...)
+	err = ctx.InvokePackage("myext:index:greet", args, &rv, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func GreetOutput(ctx *pulumi.Context, args GreetOutputArgs, opts ...pulumi.Invok
 				return GreetResultOutput{}, err
 			}
 			options.PackageRef = ref
-			return ctx.InvokeOutput("extbase:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
+			return ctx.InvokeOutput("myext:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
 		}).(GreetResultOutput)
 }
 

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/greeting.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/greeting.go
@@ -30,7 +30,7 @@ func NewGreeting(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource Greeting
-	err = ctx.RegisterPackageResource("extbase:index:Greeting", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageResource("myext:index:Greeting", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func GetGreeting(ctx *pulumi.Context,
 	if err != nil {
 		return nil, err
 	}
-	err = ctx.ReadPackageResource("extbase:index:Greeting", name, id, state, &resource, ref, opts...)
+	err = ctx.ReadPackageResource("myext:index:Greeting", name, id, state, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/greetingComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/greetingComponent.go
@@ -30,7 +30,7 @@ func NewGreetingComponent(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource GreetingComponent
-	err = ctx.RegisterPackageRemoteComponentResource("extbase:index:GreetingComponent", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageRemoteComponentResource("myext:index:GreetingComponent", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/init.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-and-base-resource/sdks/myext-2.0.0/myext/init.go
@@ -21,9 +21,9 @@ func (m *module) Version() semver.Version {
 
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
-	case "extbase:index:Greeting":
+	case "myext:index:Greeting":
 		r = &Greeting{}
-	case "extbase:index:GreetingComponent":
+	case "myext:index:GreetingComponent":
 		r = &GreetingComponent{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/greet.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/greet.go
@@ -18,7 +18,7 @@ func Greet(ctx *pulumi.Context, args *GreetArgs, opts ...pulumi.InvokeOption) (*
 		return nil, err
 	}
 	var rv GreetResult
-	err = ctx.InvokePackage("extbase:index:greet", args, &rv, ref, opts...)
+	err = ctx.InvokePackage("myext:index:greet", args, &rv, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func GreetOutput(ctx *pulumi.Context, args GreetOutputArgs, opts ...pulumi.Invok
 				return GreetResultOutput{}, err
 			}
 			options.PackageRef = ref
-			return ctx.InvokeOutput("extbase:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
+			return ctx.InvokeOutput("myext:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
 		}).(GreetResultOutput)
 }
 

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/greeting.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/greeting.go
@@ -30,7 +30,7 @@ func NewGreeting(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource Greeting
-	err = ctx.RegisterPackageResource("extbase:index:Greeting", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageResource("myext:index:Greeting", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func GetGreeting(ctx *pulumi.Context,
 	if err != nil {
 		return nil, err
 	}
-	err = ctx.ReadPackageResource("extbase:index:Greeting", name, id, state, &resource, ref, opts...)
+	err = ctx.ReadPackageResource("myext:index:Greeting", name, id, state, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/greetingComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/greetingComponent.go
@@ -30,7 +30,7 @@ func NewGreetingComponent(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource GreetingComponent
-	err = ctx.RegisterPackageRemoteComponentResource("extbase:index:GreetingComponent", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageRemoteComponentResource("myext:index:GreetingComponent", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/init.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-extension-parameterized-resource/sdks/myext-2.0.0/myext/init.go
@@ -21,9 +21,9 @@ func (m *module) Version() semver.Version {
 
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
-	case "extbase:index:Greeting":
+	case "myext:index:Greeting":
 		r = &Greeting{}
-	case "extbase:index:GreetingComponent":
+	case "myext:index:GreetingComponent":
 		r = &GreetingComponent{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/greet.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/greet.go
@@ -18,7 +18,7 @@ func Greet(ctx *pulumi.Context, args *GreetArgs, opts ...pulumi.InvokeOption) (*
 		return nil, err
 	}
 	var rv GreetResult
-	err = ctx.InvokePackage("extbase:index:greet", args, &rv, ref, opts...)
+	err = ctx.InvokePackage("myext:index:greet", args, &rv, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func GreetOutput(ctx *pulumi.Context, args GreetOutputArgs, opts ...pulumi.Invok
 				return GreetResultOutput{}, err
 			}
 			options.PackageRef = ref
-			return ctx.InvokeOutput("extbase:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
+			return ctx.InvokeOutput("myext:index:greet", args, GreetResultOutput{}, options).(GreetResultOutput), nil
 		}).(GreetResultOutput)
 }
 

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/greeting.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/greeting.go
@@ -30,7 +30,7 @@ func NewGreeting(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource Greeting
-	err = ctx.RegisterPackageResource("extbase:index:Greeting", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageResource("myext:index:Greeting", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func GetGreeting(ctx *pulumi.Context,
 	if err != nil {
 		return nil, err
 	}
-	err = ctx.ReadPackageResource("extbase:index:Greeting", name, id, state, &resource, ref, opts...)
+	err = ctx.ReadPackageResource("myext:index:Greeting", name, id, state, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/greetingComponent.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/greetingComponent.go
@@ -30,7 +30,7 @@ func NewGreetingComponent(ctx *pulumi.Context,
 		return nil, err
 	}
 	var resource GreetingComponent
-	err = ctx.RegisterPackageRemoteComponentResource("extbase:index:GreetingComponent", name, args, &resource, ref, opts...)
+	err = ctx.RegisterPackageRemoteComponentResource("myext:index:GreetingComponent", name, args, &resource, ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/init.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/myext-2.0.0/myext/init.go
@@ -21,9 +21,9 @@ func (m *module) Version() semver.Version {
 
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
-	case "extbase:index:Greeting":
+	case "myext:index:Greeting":
 		r = &Greeting{}
-	case "extbase:index:GreetingComponent":
+	case "myext:index:GreetingComponent":
 		r = &GreetingComponent{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/greet.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/greet.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export function greet(args: GreetArgs, opts?: pulumi.InvokeOptions): Promise<GreetResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invoke("extbase:index:greet", {
+    return pulumi.runtime.invoke("myext:index:greet", {
         "name": args.name,
     }, opts, utilities.getPackage());
 }
@@ -20,7 +20,7 @@ export interface GreetResult {
 }
 export function greetOutput(args: GreetOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GreetResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeOutput("extbase:index:greet", {
+    return pulumi.runtime.invokeOutput("myext:index:greet", {
         "name": args.name,
     }, opts, utilities.getPackage());
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/greeting.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/greeting.ts
@@ -18,7 +18,7 @@ export class Greeting extends pulumi.CustomResource {
     }
 
     /** @internal */
-    public static readonly __pulumiType = 'extbase:index:Greeting';
+    public static readonly __pulumiType = 'myext:index:Greeting';
 
     /**
      * Returns true if the given object is an instance of Greeting.  This is designed to work even

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/greetingComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/greetingComponent.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export class GreetingComponent extends pulumi.ComponentResource {
     /** @internal */
-    public static readonly __pulumiType = 'extbase:index:GreetingComponent';
+    public static readonly __pulumiType = 'myext:index:GreetingComponent';
 
     /**
      * Returns true if the given object is an instance of GreetingComponent.  This is designed to work even

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/myext-2.0.0/index.ts
@@ -25,9 +25,9 @@ const _module = {
     version: utilities.getVersion(),
     construct: (name: string, type: string, urn: string): pulumi.Resource => {
         switch (type) {
-            case "extbase:index:Greeting":
+            case "myext:index:Greeting":
                 return new Greeting(name, <any>undefined, { urn })
-            case "extbase:index:GreetingComponent":
+            case "myext:index:GreetingComponent":
                 return new GreetingComponent(name, <any>undefined, { urn })
             default:
                 throw new Error(`unknown resource type ${type}`);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/greet.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/greet.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export function greet(args: GreetArgs, opts?: pulumi.InvokeOptions): Promise<GreetResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invoke("extbase:index:greet", {
+    return pulumi.runtime.invoke("myext:index:greet", {
         "name": args.name,
     }, opts, utilities.getPackage());
 }
@@ -20,7 +20,7 @@ export interface GreetResult {
 }
 export function greetOutput(args: GreetOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GreetResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeOutput("extbase:index:greet", {
+    return pulumi.runtime.invokeOutput("myext:index:greet", {
         "name": args.name,
     }, opts, utilities.getPackage());
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/greeting.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/greeting.ts
@@ -18,7 +18,7 @@ export class Greeting extends pulumi.CustomResource {
     }
 
     /** @internal */
-    public static readonly __pulumiType = 'extbase:index:Greeting';
+    public static readonly __pulumiType = 'myext:index:Greeting';
 
     /**
      * Returns true if the given object is an instance of Greeting.  This is designed to work even

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/greetingComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/greetingComponent.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export class GreetingComponent extends pulumi.ComponentResource {
     /** @internal */
-    public static readonly __pulumiType = 'extbase:index:GreetingComponent';
+    public static readonly __pulumiType = 'myext:index:GreetingComponent';
 
     /**
      * Returns true if the given object is an instance of GreetingComponent.  This is designed to work even

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/myext-2.0.0/index.ts
@@ -25,9 +25,9 @@ const _module = {
     version: utilities.getVersion(),
     construct: (name: string, type: string, urn: string): pulumi.Resource => {
         switch (type) {
-            case "extbase:index:Greeting":
+            case "myext:index:Greeting":
                 return new Greeting(name, <any>undefined, { urn })
-            case "extbase:index:GreetingComponent":
+            case "myext:index:GreetingComponent":
                 return new GreetingComponent(name, <any>undefined, { urn })
             default:
                 throw new Error(`unknown resource type ${type}`);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/greet.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/greet.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export function greet(args: GreetArgs, opts?: pulumi.InvokeOptions): Promise<GreetResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invoke("extbase:index:greet", {
+    return pulumi.runtime.invoke("myext:index:greet", {
         "name": args.name,
     }, opts, utilities.getPackage());
 }
@@ -20,7 +20,7 @@ export interface GreetResult {
 }
 export function greetOutput(args: GreetOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GreetResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
-    return pulumi.runtime.invokeOutput("extbase:index:greet", {
+    return pulumi.runtime.invokeOutput("myext:index:greet", {
         "name": args.name,
     }, opts, utilities.getPackage());
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/greeting.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/greeting.ts
@@ -18,7 +18,7 @@ export class Greeting extends pulumi.CustomResource {
     }
 
     /** @internal */
-    public static readonly __pulumiType = 'extbase:index:Greeting';
+    public static readonly __pulumiType = 'myext:index:Greeting';
 
     /**
      * Returns true if the given object is an instance of Greeting.  This is designed to work even

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/greetingComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/greetingComponent.ts
@@ -6,7 +6,7 @@ import * as utilities from "./utilities";
 
 export class GreetingComponent extends pulumi.ComponentResource {
     /** @internal */
-    public static readonly __pulumiType = 'extbase:index:GreetingComponent';
+    public static readonly __pulumiType = 'myext:index:GreetingComponent';
 
     /**
      * Returns true if the given object is an instance of GreetingComponent.  This is designed to work even

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/myext-2.0.0/index.ts
@@ -25,9 +25,9 @@ const _module = {
     version: utilities.getVersion(),
     construct: (name: string, type: string, urn: string): pulumi.Resource => {
         switch (type) {
-            case "extbase:index:Greeting":
+            case "myext:index:Greeting":
                 return new Greeting(name, <any>undefined, { urn })
-            case "extbase:index:GreetingComponent":
+            case "myext:index:GreetingComponent":
                 return new GreetingComponent(name, <any>undefined, { urn })
             default:
                 throw new Error(`unknown resource type ${type}`);

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-extension-and-base-resource/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-extension-and-base-resource/main.pp
@@ -1,5 +1,6 @@
 // An extension resource (Greeting) and a base-provider resource (Base) used
-// together; both live in the base provider's namespace ("extbase").
+// together; Greeting lives in the extension's namespace ("myext") and Base
+// lives in the base provider's namespace ("extbase").
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,7 +11,7 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
 resource base "extbase:index:Base" { }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-extension-parameterized-resource/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-extension-parameterized-resource/main.pp
@@ -1,5 +1,5 @@
-// Extension parameterization: the SDK is published as "myext" but the resource
-// tokens live in the base provider's namespace ("extbase").
+// Extension parameterization: the SDK is published as "myext" and the resource
+// tokens live in the extension's own namespace.
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,9 +10,9 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
-resource greetingComp "extbase:index:GreetingComponent" { }
+resource greetingComp "myext:index:GreetingComponent" { }
 
 output "parameterValue" {
     value = greeting.parameterValue
@@ -23,5 +23,5 @@ output "parameterValueFromComponent" {
 }
 
 output "invokeGreeting" {
-    value = invoke("extbase:index:greet", { name = "Pulumi" }).greeting
+    value = invoke("myext:index:greet", { name = "Pulumi" }).greeting
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-extension-and-base-resource/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-extension-and-base-resource/main.pp
@@ -1,5 +1,6 @@
 // An extension resource (Greeting) and a base-provider resource (Base) used
-// together; both live in the base provider's namespace ("extbase").
+// together; Greeting lives in the extension's namespace ("myext") and Base
+// lives in the base provider's namespace ("extbase").
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,7 +11,7 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
 resource base "extbase:index:Base" { }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-extension-parameterized-resource/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-extension-parameterized-resource/main.pp
@@ -1,5 +1,5 @@
-// Extension parameterization: the SDK is published as "myext" but the resource
-// tokens live in the base provider's namespace ("extbase").
+// Extension parameterization: the SDK is published as "myext" and the resource
+// tokens live in the extension's own namespace.
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,9 +10,9 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
-resource greetingComp "extbase:index:GreetingComponent" { }
+resource greetingComp "myext:index:GreetingComponent" { }
 
 output "parameterValue" {
     value = greeting.parameterValue
@@ -23,5 +23,5 @@ output "parameterValueFromComponent" {
 }
 
 output "invokeGreeting" {
-    value = invoke("extbase:index:greet", { name = "Pulumi" }).greeting
+    value = invoke("myext:index:greet", { name = "Pulumi" }).greeting
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-extension-and-base-resource/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-extension-and-base-resource/main.pp
@@ -1,5 +1,6 @@
 // An extension resource (Greeting) and a base-provider resource (Base) used
-// together; both live in the base provider's namespace ("extbase").
+// together; Greeting lives in the extension's namespace ("myext") and Base
+// lives in the base provider's namespace ("extbase").
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,7 +11,7 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
 resource base "extbase:index:Base" { }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-extension-parameterized-resource/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-extension-parameterized-resource/main.pp
@@ -1,5 +1,5 @@
-// Extension parameterization: the SDK is published as "myext" but the resource
-// tokens live in the base provider's namespace ("extbase").
+// Extension parameterization: the SDK is published as "myext" and the resource
+// tokens live in the extension's own namespace.
 package {
     baseProviderName = "extbase"
     baseProviderVersion = "45.0.0"
@@ -10,9 +10,9 @@ package {
     }
 }
 
-resource greeting "extbase:index:Greeting" { }
+resource greeting "myext:index:Greeting" { }
 
-resource greetingComp "extbase:index:GreetingComponent" { }
+resource greetingComp "myext:index:GreetingComponent" { }
 
 output "parameterValue" {
     value = greeting.parameterValue
@@ -23,5 +23,5 @@ output "parameterValueFromComponent" {
 }
 
 output "invokeGreeting" {
-    value = invoke("extbase:index:greet", { name = "Pulumi" }).greeting
+    value = invoke("myext:index:greet", { name = "Pulumi" }).greeting
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/__init__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/__init__.py
@@ -17,8 +17,8 @@ _utilities.register(
   "mod": "index",
   "fqn": "pulumi_myext",
   "classes": {
-   "extbase:index:Greeting": "Greeting",
-   "extbase:index:GreetingComponent": "GreetingComponent"
+   "myext:index:Greeting": "Greeting",
+   "myext:index:GreetingComponent": "GreetingComponent"
   }
  }
 ]

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/greet.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/greet.py
@@ -46,7 +46,7 @@ def greet(name: Optional[_builtins.str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
+    __ret__ = pulumi.runtime.invoke('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
 
     return AwaitableGreetResult(
         greeting=pulumi.get(__ret__, 'greeting'))
@@ -58,6 +58,6 @@ def greet_output(name: pulumi.Input[Optional[_builtins.str]] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke_output('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
+    __ret__ = pulumi.runtime.invoke_output('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
     return __ret__.apply(lambda __response__: GreetResult(
         greeting=pulumi.get(__response__, 'greeting')))

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/greeting.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/greeting.py
@@ -20,7 +20,7 @@ class GreetingArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:Greeting")
+@pulumi.type_token("myext:index:Greeting")
 class Greeting(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -68,7 +68,7 @@ class Greeting(pulumi.CustomResource):
 
             __props__.__dict__["parameter_value"] = None
         super(Greeting, __self__).__init__(
-            'extbase:index:Greeting',
+            'myext:index:Greeting',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
@@ -20,7 +20,7 @@ class GreetingComponentArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:GreetingComponent")
+@pulumi.type_token("myext:index:GreetingComponent")
 class GreetingComponent(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
@@ -70,7 +70,7 @@ class GreetingComponent(pulumi.ComponentResource):
 
             __props__.__dict__["parameter_value"] = None
         super(GreetingComponent, __self__).__init__(
-            'extbase:index:GreetingComponent',
+            'myext:index:GreetingComponent',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/__init__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/__init__.py
@@ -17,8 +17,8 @@ _utilities.register(
   "mod": "index",
   "fqn": "pulumi_myext",
   "classes": {
-   "extbase:index:Greeting": "Greeting",
-   "extbase:index:GreetingComponent": "GreetingComponent"
+   "myext:index:Greeting": "Greeting",
+   "myext:index:GreetingComponent": "GreetingComponent"
   }
  }
 ]

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/greet.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/greet.py
@@ -46,7 +46,7 @@ def greet(name: Optional[_builtins.str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
+    __ret__ = pulumi.runtime.invoke('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
 
     return AwaitableGreetResult(
         greeting=pulumi.get(__ret__, 'greeting'))
@@ -58,6 +58,6 @@ def greet_output(name: pulumi.Input[Optional[_builtins.str]] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke_output('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
+    __ret__ = pulumi.runtime.invoke_output('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
     return __ret__.apply(lambda __response__: GreetResult(
         greeting=pulumi.get(__response__, 'greeting')))

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/greeting.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/greeting.py
@@ -20,7 +20,7 @@ class GreetingArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:Greeting")
+@pulumi.type_token("myext:index:Greeting")
 class Greeting(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -68,7 +68,7 @@ class Greeting(pulumi.CustomResource):
 
             __props__.__dict__["parameter_value"] = None
         super(Greeting, __self__).__init__(
-            'extbase:index:Greeting',
+            'myext:index:Greeting',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
@@ -20,7 +20,7 @@ class GreetingComponentArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:GreetingComponent")
+@pulumi.type_token("myext:index:GreetingComponent")
 class GreetingComponent(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
@@ -70,7 +70,7 @@ class GreetingComponent(pulumi.ComponentResource):
 
             __props__.__dict__["parameter_value"] = None
         super(GreetingComponent, __self__).__init__(
-            'extbase:index:GreetingComponent',
+            'myext:index:GreetingComponent',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/__init__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/__init__.py
@@ -17,8 +17,8 @@ _utilities.register(
   "mod": "index",
   "fqn": "pulumi_myext",
   "classes": {
-   "extbase:index:Greeting": "Greeting",
-   "extbase:index:GreetingComponent": "GreetingComponent"
+   "myext:index:Greeting": "Greeting",
+   "myext:index:GreetingComponent": "GreetingComponent"
   }
  }
 ]

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/greet.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/greet.py
@@ -51,7 +51,7 @@ def greet(name: Optional[_builtins.str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
+    __ret__ = pulumi.runtime.invoke('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
 
     return AwaitableGreetResult(
         greeting=pulumi.get(__ret__, 'greeting'))
@@ -63,6 +63,6 @@ def greet_output(name: pulumi.Input[Optional[_builtins.str]] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke_output('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
+    __ret__ = pulumi.runtime.invoke_output('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
     return __ret__.apply(lambda __response__: GreetResult(
         greeting=pulumi.get(__response__, 'greeting')))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/greeting.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/greeting.py
@@ -25,7 +25,7 @@ class GreetingArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:Greeting")
+@pulumi.type_token("myext:index:Greeting")
 class Greeting(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -73,7 +73,7 @@ class Greeting(pulumi.CustomResource):
 
             __props__.__dict__["parameter_value"] = None
         super(Greeting, __self__).__init__(
-            'extbase:index:Greeting',
+            'myext:index:Greeting',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
@@ -25,7 +25,7 @@ class GreetingComponentArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:GreetingComponent")
+@pulumi.type_token("myext:index:GreetingComponent")
 class GreetingComponent(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
@@ -75,7 +75,7 @@ class GreetingComponent(pulumi.ComponentResource):
 
             __props__.__dict__["parameter_value"] = None
         super(GreetingComponent, __self__).__init__(
-            'extbase:index:GreetingComponent',
+            'myext:index:GreetingComponent',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/__init__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/__init__.py
@@ -17,8 +17,8 @@ _utilities.register(
   "mod": "index",
   "fqn": "pulumi_myext",
   "classes": {
-   "extbase:index:Greeting": "Greeting",
-   "extbase:index:GreetingComponent": "GreetingComponent"
+   "myext:index:Greeting": "Greeting",
+   "myext:index:GreetingComponent": "GreetingComponent"
   }
  }
 ]

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/greet.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/greet.py
@@ -51,7 +51,7 @@ def greet(name: Optional[_builtins.str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
+    __ret__ = pulumi.runtime.invoke('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
 
     return AwaitableGreetResult(
         greeting=pulumi.get(__ret__, 'greeting'))
@@ -63,6 +63,6 @@ def greet_output(name: pulumi.Input[Optional[_builtins.str]] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke_output('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
+    __ret__ = pulumi.runtime.invoke_output('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
     return __ret__.apply(lambda __response__: GreetResult(
         greeting=pulumi.get(__response__, 'greeting')))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/greeting.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/greeting.py
@@ -25,7 +25,7 @@ class GreetingArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:Greeting")
+@pulumi.type_token("myext:index:Greeting")
 class Greeting(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -73,7 +73,7 @@ class Greeting(pulumi.CustomResource):
 
             __props__.__dict__["parameter_value"] = None
         super(Greeting, __self__).__init__(
-            'extbase:index:Greeting',
+            'myext:index:Greeting',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
@@ -25,7 +25,7 @@ class GreetingComponentArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:GreetingComponent")
+@pulumi.type_token("myext:index:GreetingComponent")
 class GreetingComponent(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
@@ -75,7 +75,7 @@ class GreetingComponent(pulumi.ComponentResource):
 
             __props__.__dict__["parameter_value"] = None
         super(GreetingComponent, __self__).__init__(
-            'extbase:index:GreetingComponent',
+            'myext:index:GreetingComponent',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/__init__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/__init__.py
@@ -17,8 +17,8 @@ _utilities.register(
   "mod": "index",
   "fqn": "pulumi_myext",
   "classes": {
-   "extbase:index:Greeting": "Greeting",
-   "extbase:index:GreetingComponent": "GreetingComponent"
+   "myext:index:Greeting": "Greeting",
+   "myext:index:GreetingComponent": "GreetingComponent"
   }
  }
 ]

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/greet.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/greet.py
@@ -51,7 +51,7 @@ def greet(name: Optional[_builtins.str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
+    __ret__ = pulumi.runtime.invoke('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
 
     return AwaitableGreetResult(
         greeting=pulumi.get(__ret__, 'greeting'))
@@ -63,6 +63,6 @@ def greet_output(name: pulumi.Input[Optional[_builtins.str]] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke_output('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
+    __ret__ = pulumi.runtime.invoke_output('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
     return __ret__.apply(lambda __response__: GreetResult(
         greeting=pulumi.get(__response__, 'greeting')))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/greeting.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/greeting.py
@@ -25,7 +25,7 @@ class GreetingArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:Greeting")
+@pulumi.type_token("myext:index:Greeting")
 class Greeting(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -73,7 +73,7 @@ class Greeting(pulumi.CustomResource):
 
             __props__.__dict__["parameter_value"] = None
         super(Greeting, __self__).__init__(
-            'extbase:index:Greeting',
+            'myext:index:Greeting',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
@@ -25,7 +25,7 @@ class GreetingComponentArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:GreetingComponent")
+@pulumi.type_token("myext:index:GreetingComponent")
 class GreetingComponent(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
@@ -75,7 +75,7 @@ class GreetingComponent(pulumi.ComponentResource):
 
             __props__.__dict__["parameter_value"] = None
         super(GreetingComponent, __self__).__init__(
-            'extbase:index:GreetingComponent',
+            'myext:index:GreetingComponent',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/__init__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/__init__.py
@@ -17,8 +17,8 @@ _utilities.register(
   "mod": "index",
   "fqn": "pulumi_myext",
   "classes": {
-   "extbase:index:Greeting": "Greeting",
-   "extbase:index:GreetingComponent": "GreetingComponent"
+   "myext:index:Greeting": "Greeting",
+   "myext:index:GreetingComponent": "GreetingComponent"
   }
  }
 ]

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/greet.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/greet.py
@@ -51,7 +51,7 @@ def greet(name: Optional[_builtins.str] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
+    __ret__ = pulumi.runtime.invoke('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package()).value
 
     return AwaitableGreetResult(
         greeting=pulumi.get(__ret__, 'greeting'))
@@ -63,6 +63,6 @@ def greet_output(name: pulumi.Input[Optional[_builtins.str]] = None,
     __args__ = dict()
     __args__['name'] = name
     opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
-    __ret__ = pulumi.runtime.invoke_output('extbase:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
+    __ret__ = pulumi.runtime.invoke_output('myext:index:greet', __args__, opts=opts, typ=GreetResult, package_ref=_utilities.get_package())
     return __ret__.apply(lambda __response__: GreetResult(
         greeting=pulumi.get(__response__, 'greeting')))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/greeting.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/greeting.py
@@ -25,7 +25,7 @@ class GreetingArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:Greeting")
+@pulumi.type_token("myext:index:Greeting")
 class Greeting(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -73,7 +73,7 @@ class Greeting(pulumi.CustomResource):
 
             __props__.__dict__["parameter_value"] = None
         super(Greeting, __self__).__init__(
-            'extbase:index:Greeting',
+            'myext:index:Greeting',
             resource_name,
             __props__,
             opts,

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/greeting_component.py
@@ -25,7 +25,7 @@ class GreetingComponentArgs:
         pass
 
 
-@pulumi.type_token("extbase:index:GreetingComponent")
+@pulumi.type_token("myext:index:GreetingComponent")
 class GreetingComponent(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
@@ -75,7 +75,7 @@ class GreetingComponent(pulumi.ComponentResource):
 
             __props__.__dict__["parameter_value"] = None
         super(GreetingComponent, __self__).__init__(
-            'extbase:index:GreetingComponent',
+            'myext:index:GreetingComponent',
             resource_name,
             __props__,
             opts,


### PR DESCRIPTION
This updates extension packages to expect their type tokens to be namespace'd to their package name, as opposed to the base package name. 

That is given an extension package "ext" on top of "base" we expect type tokens like "ext:index:ExtensionResource" rather than "base:index:ExtensionResource".

This simplifies a lot of logic, and maintains the logic that package tokens point to their packages. It also seems to fix https://github.com/pulumi/pulumi/pull/24138 as we now assert that for the l2-extension-parameterized-resource we only pass the extension package as a dependency.