### PR TITLE
bun: only take output into account for trusted dependencies

### DIFF
--- a/changelog/pending/sdk-nodejs-fix-20260731-112755.yaml
+++ b/changelog/pending/sdk-nodejs-fix-20260731-112755.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: fix
+body: Fix trustedDependencies parsing for bun
+time: 2026-07-31T11:27:55.091863361+02:00

--- a/sdk/nodejs/npm/bun.go
+++ b/sdk/nodejs/npm/bun.go
@@ -108,9 +108,13 @@ func (bun *bunManager) Link(ctx context.Context, dir, packageName, path string) 
 	// https://bun.com/docs/install/lifecycle
 	cmd = exec.CommandContext(ctx, "bun", "pm", "pkg", "get", "trustedDependencies")
 	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("error running %s: %w, output: %s", cmd.String(), err, out)
+		msg := "error running " + cmd.String()
+		if len(bytes.TrimSpace(out)) > 0 {
+			msg += ", stdout: " + string(bytes.TrimSpace(out))
+		}
+		return errutil.ErrorWithStderr(err, msg)
 	}
 	out = bytes.TrimSpace(out)
 	var dependencies []string


### PR DESCRIPTION
Currently when getting the trusted dependencies for bun, we use `CombinedOutput`, and then try to parse the JSON from there.  I believe we do this because of error reporting, but `stderr` can contain output, even if `stdout` is valid.

Only parse the trusted dependencies from the actual output, while still including `stderr` and `stdout` in the error message.

Fixes #23786 