### PR TITLE
Fix `auto.ImportResources` appending args after `--`

### DIFF
--- a/changelog/pending/auto-go-fix-20260731-112922.yaml
+++ b/changelog/pending/auto-go-fix-20260731-112922.yaml
@@ -2,3 +2,5 @@ component: auto/go
 kind: fix
 body: ImportResources no longer leaks `--stack` into the converter's arguments when converter args are passed
 time: 2026-07-31T11:29:22.89566+02:00
+custom:
+    PR: "24146"

--- a/changelog/pending/auto-go-fix-20260731-112922.yaml
+++ b/changelog/pending/auto-go-fix-20260731-112922.yaml
@@ -1,0 +1,4 @@
+component: auto/go
+kind: fix
+body: ImportResources no longer leaks `--stack` into the converter's arguments when converter args are passed
+time: 2026-07-31T11:29:22.89566+02:00

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -106,6 +106,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1577,8 +1578,15 @@ func (s *Stack) runPulumiCmdSync(
 	if err != nil {
 		return "", "", -1, fmt.Errorf("failed to exec command, error getting additional args: %w", err)
 	}
+	// Everything after a "--" separator is positional and must stay last; insert our flags before it.
+	var positional []string
+	if i := slices.Index(args, "--"); i >= 0 {
+		positional = args[i:]
+		args = args[:i:i]
+	}
 	args = append(args, additionalArgs...)
 	args = append(args, "--stack", s.Name())
+	args = append(args, positional...)
 
 	stdout, stderr, errCode, err := s.workspace.PulumiCommand().Run(
 		ctx,

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -491,3 +491,22 @@ func TestPreviewImportResources(t *testing.T) {
 	assert.Contains(t, result.StdOut, "Previewing")
 	assert.NotContains(t, result.StdOut, "Importing")
 }
+
+func TestRunPulumiCmdSyncStackFlagBeforeSeparator(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	m := mockPulumiCommand{}
+	ws, err := NewLocalWorkspace(ctx, WorkDir(filepath.Join(".", "test", "testproj")), Pulumi(&m))
+	require.NoError(t, err)
+	s, err := NewStack(ctx, "organization/testproj/teststack", ws)
+	require.NoError(t, err)
+
+	_, _, _, err = s.runPulumiCmdSync(ctx, nil, nil, "import", "--from", "converter", "--", "state.json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"import", "--from", "converter",
+		"--stack", "organization/testproj/teststack",
+		"--", "state.json",
+	}, m.capturedArgs)
+}


### PR DESCRIPTION
The Automation API's `runPulumiCmdSync` appended `--stack <name>` (and any workspace-serialized arguments) to the very end of the assembled command line. `ImportResources` terminates its argument list with the `--` separator followed by the caller's converter arguments, so the appended flags landed after the separator and were forwarded to the converter plugin as positional arguments. Converters that validate their argument count, such as `pulumi-converter-terraform`, then failed with an arity error.

`runPulumiCmdSync` now inserts its flags before the first `--` separator, keeping everything after it positional.

Fixes #24144.