### PR TITLE
auto: don't try to read generated code when we didn't generate it

### DIFF
--- a/changelog/pending/auto-go-fix-20260731-114222.yaml
+++ b/changelog/pending/auto-go-fix-20260731-114222.yaml
@@ -1,0 +1,4 @@
+component: auto/go
+kind: fix
+body: Fix `ImportResources` when `GenerateCode(false)` is set
+time: 2026-07-31T11:42:22.152630722+02:00

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -2596,6 +2596,43 @@ func TestStackImportResources(t *testing.T) {
 	require.NoError(t, err, "failed to destroy stack")
 }
 
+func TestStackImportResourcesWithoutGenerateCode(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, "import", sName)
+	pDir := filepath.Join(".", "test", "import")
+	stack, err := UpsertStackLocalSource(ctx, stackName, pDir)
+	require.NoError(t, err, "failed to initialize stack")
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
+
+	randomPluginVersion := "4.16.3"
+	err = stack.Workspace().InstallPlugin(ctx, "random", randomPluginVersion)
+	require.NoError(t, err, "failed to install plugin")
+	resourcesToImport := []*optimport.ImportResource{
+		{
+			Type: "random:index/randomPassword:RandomPassword",
+			ID:   "supersecret",
+			Name: "randomPassword",
+		},
+	}
+
+	importResult, err := stack.ImportResources(ctx,
+		optimport.Resources(resourcesToImport),
+		optimport.Protect(false),
+		optimport.GenerateCode(false))
+
+	require.NoError(t, err, "failed to import resources")
+	require.Equal(t, "succeeded", importResult.Summary.Result)
+	require.Empty(t, importResult.GeneratedCode)
+	_, err = stack.Destroy(ctx)
+	require.NoError(t, err, "failed to destroy stack")
+}
+
 func TestSupportsStackOutputs(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -613,9 +613,12 @@ func (s *Stack) ImportResources(ctx context.Context, opts ...optimport.Option) (
 		return res, fmt.Errorf("failed to import resources: %w", err)
 	}
 
-	generatedCode, err := os.ReadFile(generatedCodePath)
-	if err != nil {
-		return res, fmt.Errorf("failed to read generated code: %w", err)
+	var generatedCode []byte
+	if importOpts.GenerateCode == nil || *importOpts.GenerateCode {
+		generatedCode, err = os.ReadFile(generatedCodePath)
+		if err != nil {
+			return res, fmt.Errorf("failed to read generated code: %w", err)
+		}
 	}
 
 	var summary UpdateSummary


### PR DESCRIPTION
When `GenerateCode` is set to false, we currently still try to read the code from disk and fail.  We shouldn't be doing that.  Check if we actually generate code, and only read it in that case.

Note that the automation API in other languages already works this way, so there's nothing we need to do there.

Fixes #24103 