### PR TITLE
fix: harden credential envelope handling and Linux Secret Service probing

### DIFF
--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3016,16 +3017,16 @@ func (nopBatchDecrypter) Enqueue(context.Context, string, *resource.Secret) erro
 // Mirrors the report: PULUMI_BACKEND_URL set (so no earlier read fails),
 // explicit credentials path, no env token, no agent environment.
 //
-//nolint:paralleltest // mutates environment and the process-global secure-store mock
+//nolint:paralleltest // mutates environment
 func TestCurrentSurfacesUndecryptableCredentials(t *testing.T) {
 	t.Setenv("PULUMI_CREDENTIALS_PATH", t.TempDir())
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
-	securestore.MockInit(t)
 
-	// Construct an envelope whose key is then lost.
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	key, err := st.GetOrCreateKey()
+	// An envelope recording a backend that exists on no platform is
+	// undecryptable everywhere, which is what a lost key looks like.
+	unreachable := securestore.Backend("not-a-real-backend")
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
 	require.NoError(t, err)
 	cloudURL := "https://api.undecryptable-current.example.com"
 	payload, err := json.Marshal(workspace.Credentials{
@@ -3033,11 +3034,10 @@ func TestCurrentSurfacesUndecryptableCredentials(t *testing.T) {
 		AccessTokens: map[string]string{cloudURL: "pul-lost"},
 	})
 	require.NoError(t, err)
-	envelope, err := securestore.Seal(key, st.Backend(), payload)
+	envelope, err := securestore.Seal(key, unreachable, payload)
 	require.NoError(t, err)
 	credsFile := filepath.Join(os.Getenv("PULUMI_CREDENTIALS_PATH"), "credentials.json")
 	require.NoError(t, os.WriteFile(credsFile, envelope, 0o600))
-	require.NoError(t, st.DeleteKey())
 
 	_, err = defaultLoginManager{}.Current(t.Context(), cloudURL, false, false)
 	require.Error(t, err, "Current must not treat an undecryptable file as logged-out")

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -299,6 +299,8 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				parseRootPersistentFlags(cmd.Root().PersistentFlags(), args)
 			}
 
+			cmdutil.InteractivityStated = cmd.Root().PersistentFlags().Changed("non-interactive")
+
 			commandPath := strings.TrimSpace(strings.TrimPrefix(cmd.CommandPath(), "pulumi"))
 			client.SetUserAgentCommand(commandPath)
 			client.SetUserAgentAIAgent(agentdetect.Detect(os.Getenv))

--- a/sdk/go/common/util/cmdutil/console.go
+++ b/sdk/go/common/util/cmdutil/console.go
@@ -46,6 +46,19 @@ func EmojiOr(e, or string) string {
 // scenario, such as in continuous integration, or when using the Pulumi CLI/SDK in a programmatic way.
 var DisableInteractive bool
 
+// InteractivityStated reports whether the user said anything about
+// interactivity, so that --non-interactive=false can assert presence rather
+// than merely matching the default. Detection heuristics apply only when this
+// is false.
+var InteractivityStated bool
+
+// StatedInteractive returns the user's explicit choice, if they made one:
+// --non-interactive yields (false, true), --non-interactive=false yields
+// (true, true), and saying nothing yields (false, false).
+func StatedInteractive() (interactive, stated bool) {
+	return !DisableInteractive, InteractivityStated
+}
+
 // Interactive returns true if we should be running in interactive mode. That is, we have an interactive terminal
 // session, interactivity hasn't been explicitly disabled, and we're not running in a known CI system.
 func Interactive() bool {

--- a/sdk/go/common/util/cmdutil/interactivity_test.go
+++ b/sdk/go/common/util/cmdutil/interactivity_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:paralleltest // mutates the package-global interactivity flags
+func TestStatedInteractiveIsATriState(t *testing.T) {
+	prevDisable, prevStated := DisableInteractive, InteractivityStated
+	t.Cleanup(func() { DisableInteractive, InteractivityStated = prevDisable, prevStated })
+
+	DisableInteractive, InteractivityStated = false, false
+	interactive, stated := StatedInteractive()
+	assert.False(t, stated, "saying nothing must not read as a statement")
+	assert.True(t, interactive)
+
+	DisableInteractive, InteractivityStated = true, true
+	interactive, stated = StatedInteractive()
+	assert.True(t, stated)
+	assert.False(t, interactive, "--non-interactive states nobody is there")
+
+	DisableInteractive, InteractivityStated = false, true
+	interactive, stated = StatedInteractive()
+	assert.True(t, stated)
+	assert.True(t, interactive, "--non-interactive=false states someone is there")
+}

--- a/sdk/go/common/util/securestore/attended.go
+++ b/sdk/go/common/util/securestore/attended.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+func someoneCanAnswerAPasswordDialog() bool {
+	if interactive, stated := cmdutil.StatedInteractive(); stated {
+		return interactive
+	}
+	// ciutil knows vendor variables; the bare CI convention is checked too so
+	// this agrees with the rest of the CLI about what counts as headless.
+	if ciutil.IsCI() || os.Getenv("CI") != "" {
+		return false
+	}
+	return desktopSessionCanDrawDialogs()
+}
+
+func desktopSessionCanDrawDialogs() bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
+	return os.Getenv("WAYLAND_DISPLAY") != "" || os.Getenv("DISPLAY") != ""
+}

--- a/sdk/go/common/util/securestore/attended_test.go
+++ b/sdk/go/common/util/securestore/attended_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func statedInteractivity(t *testing.T, disable, stated bool) {
+	t.Helper()
+	prevDisable, prevStated := cmdutil.DisableInteractive, cmdutil.InteractivityStated
+	cmdutil.DisableInteractive, cmdutil.InteractivityStated = disable, stated
+	t.Cleanup(func() {
+		cmdutil.DisableInteractive, cmdutil.InteractivityStated = prevDisable, prevStated
+	})
+}
+
+//nolint:paralleltest // mutates interactivity globals and the environment
+func TestStatedInteractivityWinsOverDetection(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	statedInteractivity(t, false, true)
+	assert.True(t, someoneCanAnswerAPasswordDialog(), "--non-interactive=false asserts a user is present")
+
+	statedInteractivity(t, true, true)
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("DISPLAY", ":0")
+	assert.False(t, someoneCanAnswerAPasswordDialog(), "--non-interactive forbids prompting")
+}
+
+//nolint:paralleltest // mutates interactivity globals and the environment
+func TestDetectionWithoutAStatedPreference(t *testing.T) {
+	statedInteractivity(t, false, false)
+
+	t.Setenv("CI", "")
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("DISPLAY", ":0")
+	assert.False(t, someoneCanAnswerAPasswordDialog(), "CI has nobody to answer a dialog")
+
+	// The test host may itself be CI, so neutralise every detector before
+	// asserting on the display branch.
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "")
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "")
+	if runtime.GOOS == "linux" {
+		assert.False(t, someoneCanAnswerAPasswordDialog(), "no display means no dialog can be shown")
+		t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+		assert.True(t, someoneCanAnswerAPasswordDialog(), "a Wayland session can show one")
+		t.Setenv("WAYLAND_DISPLAY", "")
+		t.Setenv("DISPLAY", ":0")
+		assert.True(t, someoneCanAnswerAPasswordDialog(), "an X session can show one")
+	} else {
+		assert.True(t, someoneCanAnswerAPasswordDialog(),
+			"macOS and Windows refuse UI themselves rather than reading a display variable")
+	}
+}

--- a/sdk/go/common/util/securestore/envelope.go
+++ b/sdk/go/common/util/securestore/envelope.go
@@ -20,21 +20,34 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
 // envelopeVersion is bumped when the on-disk format changes.
 const envelopeVersion = 1
 
+const envelopeAlgo = "aes-256-gcm"
+
+// ErrUnsupportedVersion indicates an envelope whose version this build does
+// not understand. Detection (IsEnvelope) still succeeds for such files so
+// they are never mistaken for plaintext and overwritten.
+var ErrUnsupportedVersion = errors.New("was encrypted by a newer version of the Pulumi CLI")
+
 // envelope is the on-disk JSON shape of an encrypted file. The marker field
 // distinguishes it from any legacy plaintext credentials file, whose schema
-// has no key starting with "$".
+// has no key starting with "$". It is a pointer so that presence (any
+// version) and support (this version) are separate decisions.
 type envelope struct {
-	Marker  int    `json:"$pulumiSecureStore"`
+	Marker  *int   `json:"$pulumiSecureStore"`
 	Backend string `json:"backend"`
 	Algo    string `json:"algo"`
 	Nonce   string `json:"nonce"`
 	Data    string `json:"data"`
+}
+
+func aad(version int, backend Backend, algo string) []byte {
+	return fmt.Appendf(nil, "%d|%s|%s", version, backend, algo)
 }
 
 // Seal encrypts plaintext with AES-256-GCM under the given 32-byte key and
@@ -49,11 +62,12 @@ func Seal(key []byte, backend Backend, plaintext []byte) ([]byte, error) {
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, err
 	}
-	sealed := aead.Seal(nil, nonce, plaintext, nil)
+	sealed := aead.Seal(nil, nonce, plaintext, aad(envelopeVersion, backend, envelopeAlgo))
+	version := envelopeVersion
 	return json.MarshalIndent(envelope{
-		Marker:  envelopeVersion,
+		Marker:  &version,
 		Backend: string(backend),
-		Algo:    "aes-256-gcm",
+		Algo:    envelopeAlgo,
 		Nonce:   base64.StdEncoding.EncodeToString(nonce),
 		Data:    base64.StdEncoding.EncodeToString(sealed),
 	}, "", "    ")
@@ -64,6 +78,9 @@ func Open(key, data []byte) ([]byte, error) {
 	env, err := parseEnvelope(data)
 	if err != nil {
 		return nil, err
+	}
+	if env.Algo != envelopeAlgo {
+		return nil, fmt.Errorf("unsupported secure-store envelope algorithm %q", env.Algo)
 	}
 	aead, err := newAEAD(key)
 	if err != nil {
@@ -80,7 +97,7 @@ func Open(key, data []byte) ([]byte, error) {
 	if len(nonce) != aead.NonceSize() {
 		return nil, fmt.Errorf("invalid secure-store envelope nonce length %d", len(nonce))
 	}
-	plaintext, err := aead.Open(nil, nonce, sealed, nil)
+	plaintext, err := aead.Open(nil, nonce, sealed, aad(*env.Marker, Backend(env.Backend), env.Algo))
 	if err != nil {
 		return nil, ErrWrongKey
 	}
@@ -88,10 +105,14 @@ func Open(key, data []byte) ([]byte, error) {
 }
 
 // IsEnvelope reports whether data looks like a Seal-produced envelope rather
-// than a legacy plaintext file.
+// than a legacy plaintext file. It is detection only: it accepts any
+// envelope version, including ones this build cannot open, so callers never
+// treat an unreadable envelope as plaintext.
 func IsEnvelope(data []byte) bool {
-	_, err := parseEnvelope(data)
-	return err == nil
+	var probe struct {
+		Marker *int `json:"$pulumiSecureStore"`
+	}
+	return json.Unmarshal(data, &probe) == nil && probe.Marker != nil
 }
 
 // EnvelopeBackend returns the backend recorded in an envelope, so reads can
@@ -109,8 +130,11 @@ func parseEnvelope(data []byte) (envelope, error) {
 	if err := json.Unmarshal(data, &env); err != nil {
 		return envelope{}, fmt.Errorf("parsing secure-store envelope: %w", err)
 	}
-	if env.Marker != envelopeVersion {
-		return envelope{}, fmt.Errorf("unsupported secure-store envelope version %d", env.Marker)
+	if env.Marker == nil {
+		return envelope{}, errors.New("not a secure-store envelope")
+	}
+	if *env.Marker != envelopeVersion {
+		return envelope{}, fmt.Errorf("%w (envelope version %d)", ErrUnsupportedVersion, *env.Marker)
 	}
 	return env, nil
 }

--- a/sdk/go/common/util/securestore/keyring.go
+++ b/sdk/go/common/util/securestore/keyring.go
@@ -17,6 +17,7 @@ package securestore
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/zalando/go-keyring"
 )
@@ -28,32 +29,63 @@ const (
 	keyringAccount = "credentials-key"
 )
 
+type getCache struct {
+	mu    sync.Mutex
+	valid bool
+	value string
+	err   error
+}
+
 // keyringStore is an itemStore over zalando/go-keyring, which selects the
 // platform mechanism automatically: /usr/bin/security on macOS (prompt-free
 // for any binary, incl. across rebuilds), Credential Manager on Windows, and
 // Secret Service on Linux. preCheck lets platforms fail fast before touching
 // the store (e.g. the Linux D-Bus/locked-collection probes).
 type keyringStore struct {
-	preCheck func() error
+	preCheck func() (Outcome, error)
+	cache    *getCache
 }
 
-func (s keyringStore) available() error {
+func newKeyringStore(preCheck func() (Outcome, error)) keyringStore {
+	return keyringStore{preCheck: preCheck, cache: &getCache{}}
+}
+
+func (s keyringStore) available() (Outcome, error) {
 	if s.preCheck != nil {
-		if err := s.preCheck(); err != nil {
-			return err
+		if outcome, err := s.preCheck(); outcome != Ready {
+			return outcome, err
 		}
 	}
-	_, err := s.get()
+	value, err := s.fetch()
+	if s.cache != nil {
+		s.cache.mu.Lock()
+		s.cache.valid, s.cache.value, s.cache.err = true, value, err
+		s.cache.mu.Unlock()
+	}
 	if err == nil || errors.Is(err, ErrKeyNotFound) {
-		return nil
+		return Ready, nil
 	}
 	if errors.Is(err, ErrUnavailable) {
-		return err
+		return Absent, err
 	}
-	return fmt.Errorf("%w: %v", ErrUnavailable, err)
+	return Absent, fmt.Errorf("%w: %v", ErrUnavailable, err)
 }
 
 func (s keyringStore) get() (string, error) {
+	if s.cache != nil {
+		s.cache.mu.Lock()
+		if s.cache.valid {
+			value, err := s.cache.value, s.cache.err
+			s.cache.valid = false
+			s.cache.mu.Unlock()
+			return value, err
+		}
+		s.cache.mu.Unlock()
+	}
+	return s.fetch()
+}
+
+func (s keyringStore) fetch() (string, error) {
 	value, err := withTimeout(func() (string, error) {
 		return keyring.Get(keyringService, keyringAccount)
 	})
@@ -63,7 +95,16 @@ func (s keyringStore) get() (string, error) {
 	return value, err
 }
 
+func (s keyringStore) invalidate() {
+	if s.cache != nil {
+		s.cache.mu.Lock()
+		s.cache.valid = false
+		s.cache.mu.Unlock()
+	}
+}
+
 func (s keyringStore) set(value string) error {
+	s.invalidate()
 	_, err := withTimeout(func() (struct{}, error) {
 		return struct{}{}, keyring.Set(keyringService, keyringAccount, value)
 	})
@@ -71,6 +112,7 @@ func (s keyringStore) set(value string) error {
 }
 
 func (s keyringStore) delete() error {
+	s.invalidate()
 	_, err := withTimeout(func() (struct{}, error) {
 		return struct{}{}, keyring.Delete(keyringService, keyringAccount)
 	})

--- a/sdk/go/common/util/securestore/keyring_test.go
+++ b/sdk/go/common/util/securestore/keyring_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCacheServesTheProbeFetchExactlyOnce(t *testing.T) {
+	t.Parallel()
+	cache := &getCache{}
+	cache.mu.Lock()
+	cache.valid, cache.value = true, "from-the-probe"
+	cache.mu.Unlock()
+	store := keyringStore{cache: cache}
+
+	value, err := store.get()
+	require.NoError(t, err)
+	assert.Equal(t, "from-the-probe", value)
+
+	cache.mu.Lock()
+	valid := cache.valid
+	cache.mu.Unlock()
+	assert.False(t, valid, "the cached fetch must not be served twice")
+}
+
+func TestWritesInvalidateTheCachedFetch(t *testing.T) {
+	t.Parallel()
+	for _, write := range []struct {
+		name string
+		do   func(keyringStore) error
+	}{
+		{"set", func(s keyringStore) error { _ = s.set("x"); return nil }},
+		{"delete", func(s keyringStore) error { _ = s.delete(); return nil }},
+	} {
+		cache := &getCache{}
+		cache.mu.Lock()
+		cache.valid, cache.value = true, "stale"
+		cache.mu.Unlock()
+		store := keyringStore{cache: cache}
+
+		require.NoError(t, write.do(store))
+
+		cache.mu.Lock()
+		valid := cache.valid
+		cache.mu.Unlock()
+		assert.False(t, valid, "%s must invalidate the cached fetch", write.name)
+	}
+}

--- a/sdk/go/common/util/securestore/mock_test.go
+++ b/sdk/go/common/util/securestore/mock_test.go
@@ -27,7 +27,7 @@ type memStore struct {
 	set_  bool
 }
 
-func (m *memStore) available() error { return nil }
+func (m *memStore) available() (Outcome, error) { return Ready, nil }
 
 func (m *memStore) get() (string, error) {
 	m.mu.Lock()
@@ -68,9 +68,9 @@ type gatedStore struct {
 	enabled *bool
 }
 
-func (g *gatedStore) available() error {
+func (g *gatedStore) available() (Outcome, error) {
 	if !*g.enabled {
-		return fmt.Errorf("%w: mock backend not yet enabled", ErrUnavailable)
+		return Absent, fmt.Errorf("%w: mock backend not yet enabled", ErrUnavailable)
 	}
 	return g.inner.available()
 }
@@ -79,9 +79,12 @@ func (g *gatedStore) get() (string, error)   { return g.inner.get() }
 func (g *gatedStore) set(value string) error { return g.inner.set(value) }
 func (g *gatedStore) delete() error          { return g.inner.delete() }
 
+type refusingStore struct{ memStore }
+
+func (*refusingStore) available() (Outcome, error) { return Declined, ErrDeclined }
+
 // MockInit replaces platform backend resolution with a single in-memory
-// backend for the duration of a test. Tests that touch the secure store MUST
-// call this to avoid writing to the developer's real keychain/TPM.
+// backend for the duration of a test.
 func MockInit(t *testing.T) {
 	t.Helper()
 	mem := &memStore{}
@@ -91,12 +94,8 @@ func MockInit(t *testing.T) {
 	t.Cleanup(func() { mockResolver = nil })
 }
 
-// MockInitDual installs two in-memory backends: BackendMockStrong (preferred
-// by Resolve but initially unavailable) and BackendMock (always available).
-// The returned promote function makes the strong backend available,
-// simulating a platform gaining a better protection tier — such as a signed
-// binary unlocking the native macOS keychain, or a TPM becoming usable — so
-// tests can exercise the cross-backend upgrade of encrypted data.
+// MockInitDual installs a preferred backend that only becomes available once
+// promote is called, so tests can exercise the cross-backend upgrade.
 func MockInitDual(t *testing.T) (promote func()) {
 	t.Helper()
 	enabled := false

--- a/sdk/go/common/util/securestore/native_darwin.go
+++ b/sdk/go/common/util/securestore/native_darwin.go
@@ -63,7 +63,7 @@ type nativeStore struct {
 // pass the code-signing self-check and the keychain must answer our item
 // query without requiring interaction. Both checks are prompt-free and the
 // whole probe is time-bounded.
-func (s *nativeStore) available() error {
+func (s *nativeStore) available() (Outcome, error) {
 	_, err := withTimeout(func() (struct{}, error) {
 		if err := nativeSelfCheck(); err != nil {
 			if errors.Is(err, ErrUnavailable) {
@@ -74,7 +74,10 @@ func (s *nativeStore) available() error {
 		}
 		return struct{}{}, s.probe()
 	})
-	return err
+	if err != nil {
+		return Absent, err
+	}
+	return Ready, nil
 }
 
 // probe asks the keychain about our item without returning data. A missing

--- a/sdk/go/common/util/securestore/native_darwin_test.go
+++ b/sdk/go/common/util/securestore/native_darwin_test.go
@@ -83,8 +83,9 @@ func TestNativeSelfCheckRejectsTestBinary(t *testing.T) {
 	err := nativeSelfCheck()
 	require.Error(t, err, "an ad-hoc-signed test binary must not pass the self-check")
 
-	availErr := nativeKeychainBackend().available()
+	outcome, availErr := nativeKeychainBackend().available()
 	require.Error(t, availErr)
+	assert.Equal(t, Absent, outcome)
 	assert.True(t, errors.Is(availErr, ErrUnavailable), "available() = %v, want ErrUnavailable", availErr)
 }
 
@@ -93,7 +94,7 @@ func TestNativeStoreRoundTrip(t *testing.T) {
 	withSelfCheckOverride(t, func() error { return nil })
 	store := testNativeStore(t)
 
-	if err := store.available(); err != nil {
+	if _, err := store.available(); err != nil {
 		if errors.Is(err, ErrUnavailable) {
 			t.Skipf("keychain not usable in this environment: %v", err)
 		}
@@ -120,7 +121,8 @@ func TestNativeStoreRoundTrip(t *testing.T) {
 	assert.Equal(t, second, got)
 
 	// available() with an existing item still reports usable.
-	require.NoError(t, store.available())
+	_, availableErr := store.available()
+	require.NoError(t, availableErr)
 
 	// Delete, then the item is gone and delete stays idempotent.
 	require.NoError(t, store.delete())
@@ -133,7 +135,7 @@ func TestNativeStoreRoundTrip(t *testing.T) {
 func TestNativeAvailableUsesSelfCheckError(t *testing.T) {
 	boom := errors.New("not signed enough")
 	withSelfCheckOverride(t, func() error { return boom })
-	err := (&nativeStore{service: "unused", account: "unused"}).available()
+	_, err := (&nativeStore{service: "unused", account: "unused"}).available()
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrUnavailable))
 	assert.Contains(t, err.Error(), "not signed enough")

--- a/sdk/go/common/util/securestore/outcome.go
+++ b/sdk/go/common/util/securestore/outcome.go
@@ -1,0 +1,63 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import "errors"
+
+// Outcome is the result of probing one backend. Fallback keys off the
+// outcome, not off the raw error: only Absent and Locked mean "try something
+// else".
+type Outcome int
+
+const (
+	// Ready means the backend is present and usable right now.
+	Ready Outcome = iota
+	// Absent means there is nothing to use here: no provider, no session
+	// bus, no TPM.
+	Absent
+	// Locked means the store exists but needs an unlock we were not
+	// permitted to ask for.
+	Locked
+	// Declined means the store exists, we asked, and the user said no.
+	Declined
+)
+
+func (o Outcome) String() string {
+	switch o {
+	case Ready:
+		return "ready"
+	case Absent:
+		return "absent"
+	case Locked:
+		return "locked"
+	case Declined:
+		return "declined"
+	default:
+		return "unknown"
+	}
+}
+
+func outcomeOf(err error) Outcome {
+	switch {
+	case err == nil:
+		return Ready
+	case errors.Is(err, ErrDeclined):
+		return Declined
+	case errors.Is(err, ErrLocked):
+		return Locked
+	default:
+		return Absent
+	}
+}

--- a/sdk/go/common/util/securestore/probe_linux.go
+++ b/sdk/go/common/util/securestore/probe_linux.go
@@ -17,9 +17,12 @@
 package securestore
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/godbus/dbus/v5"
 )
@@ -34,23 +37,49 @@ const (
 	// collectionLockedProperty is the standard Locked property on a
 	// collection.
 	collectionLockedProperty = "org.freedesktop.Secret.Collection.Locked"
+	secretServicePath        = dbus.ObjectPath("/org/freedesktop/secrets")
+)
+
+type precheckResult struct {
+	outcome Outcome
+	err     error
+}
+
+var (
+	precheckMu      sync.Mutex
+	precheckResults = map[bool]precheckResult{}
 )
 
 // secretServicePrecheck fast-fails before go-keyring ever touches the Secret
-// Service, guaranteeing the probe is prompt-free: it verifies a session bus
-// exists, that a Secret Service provider is actually running, and that the
-// default collection is unlocked. It never calls Unlock — unlocking may pop
-// an OS dialog, which this package must never trigger.
-func secretServicePrecheck() error {
+// Service: it verifies a session bus exists, that a provider is actually
+// running, and that the default collection is unlocked. A locked collection
+// gets one unlock attempt, which only draws a dialog when allowPrompt says
+// someone is there to answer it.
+func secretServicePrecheck(allowPrompt bool) (Outcome, error) {
+	// Memoized per process, keyed on whether prompting was allowed: one
+	// command probes several times (reading the existing file, checking
+	// stickiness, then writing) and each probe of a locked collection would
+	// otherwise raise its own dialog.
+	precheckMu.Lock()
+	defer precheckMu.Unlock()
+	if done, ok := precheckResults[allowPrompt]; ok {
+		return done.outcome, done.err
+	}
+	outcome, err := probeSecretService(allowPrompt)
+	precheckResults[allowPrompt] = precheckResult{outcome, err}
+	return outcome, err
+}
+
+func probeSecretService(allowPrompt bool) (Outcome, error) {
 	// Cheap environment check first: no session bus address and no
 	// user-runtime bus socket means connecting is pointless.
 	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
 		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
 		if runtimeDir == "" {
-			return fmt.Errorf("%w: no D-Bus session bus", ErrUnavailable)
+			return Absent, fmt.Errorf("%w: no D-Bus session bus", ErrUnavailable)
 		}
 		if _, err := os.Stat(filepath.Join(runtimeDir, "bus")); err != nil {
-			return fmt.Errorf("%w: no D-Bus session bus", ErrUnavailable)
+			return Absent, fmt.Errorf("%w: no D-Bus session bus", ErrUnavailable)
 		}
 	}
 
@@ -66,25 +95,201 @@ func secretServicePrecheck() error {
 		var owner string
 		err = conn.BusObject().Call("org.freedesktop.DBus.GetNameOwner", 0, secretServiceBusName).Store(&owner)
 		if err != nil || owner == "" {
-			return struct{}{}, fmt.Errorf("%w: no Secret Service provider", ErrUnavailable)
+			return struct{}{}, fmt.Errorf("%w: no Secret Service provider is running", ErrUnavailable)
 		}
+		provider := nameOwnerProcess(conn, owner)
 
 		// Reading the Locked property is side-effect free; anything but an
 		// unlocked default collection means using the store would prompt.
 		locked, err := conn.Object(secretServiceBusName, defaultCollectionPath).GetProperty(collectionLockedProperty)
 		if err != nil {
-			return struct{}{}, fmt.Errorf("%w: cannot read the default secret collection: %v", ErrUnavailable, err)
+			return struct{}{}, fmt.Errorf("%w: cannot read the default secret collection%s: %v",
+				ErrUnavailable, provider, err)
 		}
 		isLocked, ok := locked.Value().(bool)
 		if !ok {
-			return struct{}{}, fmt.Errorf("%w: cannot read the default secret collection: "+
-				"unexpected Locked property type %T", ErrUnavailable, locked.Value())
+			return struct{}{}, fmt.Errorf("%w: cannot read the default secret collection%s: "+
+				"unexpected Locked property type %T", ErrUnavailable, provider, locked.Value())
 		}
 		if isLocked {
-			return struct{}{}, fmt.Errorf(
-				"%w: secret collection is locked; unlocking would require a prompt", ErrUnavailable)
+			return struct{}{}, lockedCollectionError{provider: provider}
 		}
 		return struct{}{}, nil
 	})
+	var locked lockedCollectionError
+	if errors.As(err, &locked) {
+		unlockErr := unlockDefaultCollection(allowPrompt)
+		switch {
+		case unlockErr == nil:
+			return Ready, nil
+		case errors.Is(unlockErr, ErrDeclined):
+			return Declined, unlockErr
+		default:
+			return Locked, fmt.Errorf("%w%s: %v", ErrLocked, locked.provider, unlockErr)
+		}
+	}
+	if err != nil {
+		return Absent, err
+	}
+	return Ready, nil
+}
+
+type lockedCollectionError struct{ provider string }
+
+func (lockedCollectionError) Error() string { return "the default secret collection is locked" }
+
+func unlockDefaultCollection(mayAskUser bool) error {
+	if mayAskUser {
+		return onSessionBus(unlockAndWaitForUser)
+	}
+	_, err := withTimeout(func() (struct{}, error) {
+		return struct{}{}, onSessionBus(unlockWithoutDrawingUI)
+	})
 	return err
+}
+
+func onSessionBus(do func(*dbus.Conn) error) error {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return do(conn)
+}
+
+func unlockWithoutDrawingUI(conn *dbus.Conn) error {
+	unlocked, promptPath, err := requestUnlock(conn)
+	if err != nil {
+		return err
+	}
+	if len(unlocked) > 0 {
+		return nil
+	}
+	if promptPath != "" && promptPath != "/" {
+		_ = conn.Object(secretServiceBusName, promptPath).Call("org.freedesktop.Secret.Prompt.Dismiss", 0).Err
+	}
+	return errors.New("it needs a password prompt, and none can be shown here")
+}
+
+func confirmUnlocked(conn *dbus.Conn) error {
+	locked, err := conn.Object(secretServiceBusName, defaultCollectionPath).GetProperty(collectionLockedProperty)
+	if err != nil {
+		return err
+	}
+	if isLocked, ok := locked.Value().(bool); !ok || isLocked {
+		return errors.New("the collection is still locked after the unlock attempt")
+	}
+	return nil
+}
+
+func requestUnlock(conn *dbus.Conn) (unlocked []dbus.ObjectPath, prompt dbus.ObjectPath, err error) {
+	err = conn.Object(secretServiceBusName, secretServicePath).
+		Call("org.freedesktop.Secret.Service.Unlock", 0, []dbus.ObjectPath{defaultCollectionPath}).
+		Store(&unlocked, &prompt)
+	return unlocked, prompt, err
+}
+
+func unlockAndWaitForUser(conn *dbus.Conn) error {
+	unlocked, promptPath, err := requestUnlock(conn)
+	if err != nil {
+		return err
+	}
+	if len(unlocked) > 0 {
+		return nil
+	}
+	if promptPath == "" || promptPath == "/" {
+		return errors.New("unlock returned neither an unlocked collection nor a prompt")
+	}
+
+	matchOpts := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(promptPath),
+		dbus.WithMatchInterface("org.freedesktop.Secret.Prompt"),
+		dbus.WithMatchMember("Completed"),
+	}
+	if err := conn.AddMatchSignal(matchOpts...); err != nil {
+		return err
+	}
+	defer func() { _ = conn.RemoveMatchSignal(matchOpts...) }()
+	ownerOpts := []dbus.MatchOption{
+		dbus.WithMatchInterface("org.freedesktop.DBus"),
+		dbus.WithMatchMember("NameOwnerChanged"),
+		dbus.WithMatchArg(0, secretServiceBusName),
+	}
+	if err := conn.AddMatchSignal(ownerOpts...); err != nil {
+		return err
+	}
+	defer func() { _ = conn.RemoveMatchSignal(ownerOpts...) }()
+	signals := make(chan *dbus.Signal, 8)
+	conn.Signal(signals)
+	defer conn.RemoveSignal(signals)
+
+	prompt := conn.Object(secretServiceBusName, promptPath)
+	// The command ends when the user answers, so the only prompt we ever
+	// take down is one we are abandoning ourselves.
+	defer func() { _ = prompt.Call("org.freedesktop.Secret.Prompt.Dismiss", 0).Err }()
+	shown := showDialogNonBlocking(prompt)
+	notifyWaitingForUnlock()
+
+	for {
+		select {
+		case call := <-shown:
+			// The method reply says only whether the dialog was raised. A
+			// failure here means no Completed signal is ever coming, so the
+			// wait must end rather than hang on a dialog nobody can see.
+			if call.Err != nil {
+				return call.Err
+			}
+			shown = nil
+		case sig, ok := <-signals:
+			if !ok {
+				return errors.New("the session bus closed before the unlock prompt completed")
+			}
+			switch {
+			case sig.Name == "org.freedesktop.DBus.NameOwnerChanged" && providerVanished(sig):
+				return errors.New("the credential store stopped while its password prompt was open")
+			case sig.Path == promptPath && sig.Name == "org.freedesktop.Secret.Prompt.Completed":
+				if len(sig.Body) > 0 {
+					if dismissed, isBool := sig.Body[0].(bool); isBool && !dismissed {
+						return confirmUnlocked(conn)
+					}
+				}
+				// Providers also report "dismissed" when no prompter could be
+				// reached at all, so do not claim the user did it.
+				return fmt.Errorf("%w: its password prompt was dismissed or could not be shown", ErrDeclined)
+			}
+		}
+	}
+}
+
+func showDialogNonBlocking(prompt dbus.BusObject) <-chan *dbus.Call {
+	done := make(chan *dbus.Call, 1)
+	prompt.Go("org.freedesktop.Secret.Prompt.Prompt", 0, done, "")
+	return done
+}
+
+func providerVanished(sig *dbus.Signal) bool {
+	if len(sig.Body) < 3 {
+		return false
+	}
+	name, _ := sig.Body[0].(string)
+	newOwner, _ := sig.Body[2].(string)
+	return name == secretServiceBusName && newOwner == ""
+}
+
+var notifyWaitingForUnlock = func() {
+	fmt.Fprintln(os.Stderr,
+		"Pulumi needs the key protecting your credentials: answer your keyring's password prompt to continue.")
+}
+
+func nameOwnerProcess(conn *dbus.Conn, owner string) string {
+	var pid uint32
+	err := conn.BusObject().Call("org.freedesktop.DBus.GetConnectionUnixProcessID", 0, owner).Store(&pid)
+	if err != nil {
+		return ""
+	}
+	comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf(" (provider %q)", strings.TrimSpace(string(comm)))
 }

--- a/sdk/go/common/util/securestore/probe_linux_test.go
+++ b/sdk/go/common/util/securestore/probe_linux_test.go
@@ -19,6 +19,8 @@ package securestore
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,17 +32,69 @@ func TestSecretServicePrecheckNoSessionBus(t *testing.T) {
 	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
 	t.Setenv("XDG_RUNTIME_DIR", t.TempDir()) // exists, but has no "bus" socket
 
-	err := secretServicePrecheck()
+	outcome, err := secretServicePrecheck(false)
+	assert.Equal(t, Absent, outcome)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnavailable)
 	assert.Contains(t, err.Error(), "no D-Bus session bus")
+}
+
+func statePrompting(t *testing.T, attended bool) *[]bool {
+	t.Helper()
+	var granted []bool
+	restore := platformCandidatesHook
+	platformCandidatesHook = func(allowPrompt bool) []backendImpl {
+		granted = append(granted, allowPrompt)
+		return nil
+	}
+	t.Cleanup(func() { platformCandidatesHook = restore })
+
+	prevDisable, prevStated := cmdutil.DisableInteractive, cmdutil.InteractivityStated
+	cmdutil.DisableInteractive, cmdutil.InteractivityStated = !attended, true
+	t.Cleanup(func() {
+		cmdutil.DisableInteractive, cmdutil.InteractivityStated = prevDisable, prevStated
+	})
+	return &granted
+}
+
+//nolint:paralleltest // swaps package-global resolution and interactivity state
+func TestPromptPolicy(t *testing.T) {
+	granted := statePrompting(t, true)
+
+	_, _ = Resolve(ModeAuto)
+	assert.True(t, (*granted)[0], "auto opted in, so it may ask rather than downgrade")
+
+	*granted = nil
+	_, _ = Resolve(ModeOS)
+	assert.True(t, (*granted)[0], "os may ask")
+
+	*granted = nil
+	_, _ = ForBackend(BackendLinuxSecretService)
+	assert.True(t, (*granted)[0], "reading an encrypted file may ask")
+
+	*granted = nil
+	_, _ = Resolve(ModeDefault)
+	assert.Empty(t, *granted, "the default mode never reaches a backend")
+}
+
+//nolint:paralleltest // swaps package-global resolution and interactivity state
+func TestPromptPolicyUnattended(t *testing.T) {
+	granted := statePrompting(t, false)
+
+	_, _ = Resolve(ModeOS)
+	assert.False(t, (*granted)[0], "--non-interactive forbids prompting even in os mode")
+
+	*granted = nil
+	_, _ = ForBackend(BackendLinuxSecretService)
+	assert.False(t, (*granted)[0], "reads must not ask when nobody can answer")
 }
 
 func TestSecretServicePrecheckNoRuntimeDir(t *testing.T) {
 	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
 	t.Setenv("XDG_RUNTIME_DIR", "")
 
-	err := secretServicePrecheck()
+	outcome, err := secretServicePrecheck(false)
+	assert.Equal(t, Absent, outcome)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUnavailable)
 }

--- a/sdk/go/common/util/securestore/resolve_darwin.go
+++ b/sdk/go/common/util/securestore/resolve_darwin.go
@@ -19,9 +19,9 @@ package securestore
 // platformCandidates returns macOS backends in preference order: the native
 // SecItem backend (per-app ACL, Developer-ID-signed builds only) first, then
 // the /usr/bin/security fallback that works for any binary without prompts.
-func platformCandidates() []backendImpl {
+func platformCandidates(bool) []backendImpl {
 	return []backendImpl{
 		nativeKeychainBackend(),
-		{id: BackendMacOSSecurity, store: keyringStore{}, wrap: rawWrapper{}},
+		{id: BackendMacOSSecurity, store: newKeyringStore(nil), wrap: rawWrapper{}},
 	}
 }

--- a/sdk/go/common/util/securestore/resolve_linux.go
+++ b/sdk/go/common/util/securestore/resolve_linux.go
@@ -20,8 +20,8 @@ package securestore
 // Service holding a TPM2-sealed blob where a TPM is present, the Secret
 // Service with the raw key otherwise, and a TPM-sealed file when a TPM
 // exists but no Secret Service is usable (headless servers).
-func platformCandidates() []backendImpl {
-	ss := keyringStore{preCheck: secretServicePrecheck}
+func platformCandidates(allowPrompt bool) []backendImpl {
+	ss := newKeyringStore(func() (Outcome, error) { return secretServicePrecheck(allowPrompt) })
 	return []backendImpl{
 		{id: BackendLinuxSecretServiceTPM, store: ss, wrap: tpmWrapper{}},
 		{id: BackendLinuxSecretService, store: ss, wrap: rawWrapper{}},

--- a/sdk/go/common/util/securestore/resolve_other.go
+++ b/sdk/go/common/util/securestore/resolve_other.go
@@ -18,4 +18,4 @@ package securestore
 
 // platformCandidates: no protective backends on this platform; callers fall
 // back to plaintext.
-func platformCandidates() []backendImpl { return nil }
+func platformCandidates(bool) []backendImpl { return nil }

--- a/sdk/go/common/util/securestore/resolve_windows.go
+++ b/sdk/go/common/util/securestore/resolve_windows.go
@@ -20,10 +20,10 @@ package securestore
 // Credential Manager holding a TPM-wrapped blob where a TPM is present, the
 // Credential Manager with the raw key otherwise, and a TPM-sealed file when
 // a TPM exists but the credential store is unusable (e.g. SSH sessions).
-func platformCandidates() []backendImpl {
+func platformCandidates(bool) []backendImpl {
 	return []backendImpl{
-		{id: BackendWindowsCredManTPM, store: keyringStore{}, wrap: tpmWrapper{}},
-		{id: BackendWindowsCredMan, store: keyringStore{}, wrap: rawWrapper{}},
+		{id: BackendWindowsCredManTPM, store: newKeyringStore(nil), wrap: tpmWrapper{}},
+		{id: BackendWindowsCredMan, store: newKeyringStore(nil), wrap: rawWrapper{}},
 		{id: BackendTPMFile, store: newTPMFileStore(), wrap: tpmWrapper{}},
 	}
 }

--- a/sdk/go/common/util/securestore/securestore.go
+++ b/sdk/go/common/util/securestore/securestore.go
@@ -29,9 +29,14 @@
 //   - Linux: a Secret Service item with the same TPM upgrade; with a TPM but
 //     no Secret Service (headless servers) the sealed blob lives in a file.
 //
-// Every operation is prompt-free and time-bounded by construction: probing
-// never triggers OS dialogs and never blocks beyond a short timeout, so the
-// package is safe to use from CI and AI-agent contexts.
+// Operations are prompt-free and time-bounded by default, so the package is
+// safe to use from CI and AI-agent contexts. The exception is unlocking a
+// locked Linux Secret Service collection, which may wait on an OS password
+// dialog when the user opted in (PULUMI_CREDENTIAL_STORE is "auto" or "os")
+// or an already-encrypted file is being read, and when someone could answer
+// it. That wait has no deadline, matching sudo and gpg. Everywhere else an
+// unlock is accepted only if the provider grants it with no prompt at all,
+// so no dialog is ever drawn.
 package securestore
 
 import (
@@ -97,6 +102,19 @@ var (
 	// ErrUnavailable indicates no usable protective backend in this
 	// environment (headless session, missing daemon/TPM, timeout, ...).
 	ErrUnavailable = errors.New("no usable OS credential protection")
+	// ErrBackendUnsupported indicates an envelope recorded under a backend
+	// this build has no implementation for, so its data cannot be read here
+	// no matter what the user does locally.
+	ErrBackendUnsupported = fmt.Errorf("%w: no such credential store on this platform", ErrUnavailable)
+	// ErrLocked indicates a store that exists but is locked, and could not be
+	// unlocked without a password prompt nobody was there to answer. It wraps
+	// ErrUnavailable because the effect is the same, while naming the cause.
+	ErrLocked = fmt.Errorf("%w: the OS credential store is locked", ErrUnavailable)
+	// ErrDeclined indicates a backend that exists and could have been used,
+	// but the user dismissed the unlock prompt. Unlike ErrUnavailable this is
+	// never a reason to fall back: falling back to plaintext, or to another
+	// store, would contradict what the user just said.
+	ErrDeclined = errors.New("the OS credential store was not unlocked")
 	// ErrKeyNotFound indicates the backend works but holds no key yet.
 	ErrKeyNotFound = errors.New("no key stored in the OS credential store")
 	// ErrWrongKey is returned by Open when decryption fails authentication,
@@ -109,7 +127,7 @@ var (
 type itemStore interface {
 	// available reports nil when the store is usable right now, without any
 	// risk of prompting or blocking.
-	available() error
+	available() (Outcome, error)
 	// get returns the stored item, or ErrKeyNotFound if absent.
 	get() (string, error)
 	set(value string) error
@@ -133,42 +151,54 @@ type backendImpl struct {
 	wrap  keyWrapper
 }
 
-func (b backendImpl) available() error {
-	if err := b.store.available(); err != nil {
-		return err
+func (b backendImpl) available() (Outcome, error) {
+	outcome, err := b.store.available()
+	if outcome != Ready {
+		return outcome, err
 	}
-	return b.wrap.available()
+	if err := b.wrap.available(); err != nil {
+		return Absent, err
+	}
+	return Ready, nil
 }
 
 // Store is a resolved secure store the caller can read and write the key
 // through.
 type Store struct {
-	b backendImpl
+	b              backendImpl
+	fallbackReason error
 }
 
 // Backend reports which mechanism this store uses.
 func (s *Store) Backend() Backend { return s.b.id }
 
+// FallbackReason reports why a ModeAuto resolution fell back to plaintext,
+// or nil for any other resolution.
+func (s *Store) FallbackReason() error { return s.fallbackReason }
+
 // mockResolver, when non-nil, overrides platform resolution (tests only).
 var mockResolver func() []backendImpl
 
 // candidates returns the platform's backends in preference order.
-func candidates() []backendImpl {
+func candidates(allowPrompt bool) []backendImpl {
 	if mockResolver != nil {
 		return mockResolver()
 	}
-	return platformCandidates()
+	return platformCandidatesHook(allowPrompt && someoneCanAnswerAPasswordDialog())
 }
+
+var platformCandidatesHook = platformCandidates
 
 // Resolve picks the backend for writing under the given mode. A plaintext
 // resolution returns a *Store whose Backend() is BackendPlaintext and whose
 // key operations fail with ErrUnavailable; callers use it as the signal to
-// keep today's plaintext behavior. The returned error is non-nil only in
-// ModeOS when no protective backend is usable, or on an invalid mode.
+// keep today's plaintext behavior. The returned error is non-nil when the
+// user declined an unlock in any mode, when ModeOS finds no usable backend,
+// or on an invalid mode.
 func Resolve(mode Mode) (*Store, error) {
 	switch mode {
 	case ModePlaintext, ModeDefault:
-		return &Store{backendImpl{id: BackendPlaintext}}, nil
+		return &Store{b: backendImpl{id: BackendPlaintext}}, nil
 	case ModeAuto, ModeOS:
 		// fall through to probing
 	default:
@@ -176,27 +206,34 @@ func Resolve(mode Mode) (*Store, error) {
 	}
 
 	var firstErr error
-	for _, cand := range candidates() {
-		if err := cand.available(); err != nil {
-			logging.V(7).Infof("secure store backend %q not usable: %v", cand.id, err)
+	optedIn := mode == ModeAuto || mode == ModeOS
+	for _, cand := range candidates(optedIn) {
+		outcome, err := cand.available()
+		switch outcome {
+		case Ready:
+		case Declined:
+			logging.V(7).Infof("secure store backend %q: %s", cand.id, outcome)
+			return nil, err
+		case Absent, Locked:
+			logging.V(7).Infof("secure store backend %q: %s (%v)", cand.id, outcome, err)
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
 		logging.V(7).Infof("secure store resolved to backend %q", cand.id)
-		return &Store{cand}, nil
+		return &Store{b: cand}, nil
 	}
 	logging.V(7).Infof("no secure store backend usable")
+	if firstErr == nil {
+		firstErr = ErrUnavailable
+	}
 	if mode == ModeOS {
-		if firstErr == nil {
-			firstErr = ErrUnavailable
-		}
 		return nil, fmt.Errorf("PULUMI_CREDENTIAL_STORE=os but %w "+
 			"(set PULUMI_CREDENTIAL_STORE=plaintext to override): %v",
 			ErrUnavailable, firstErr)
 	}
-	return &Store{backendImpl{id: BackendPlaintext}}, nil
+	return &Store{b: backendImpl{id: BackendPlaintext}, fallbackReason: firstErr}, nil
 }
 
 // ForBackend returns a store for the exact backend that produced an existing
@@ -205,17 +242,23 @@ func Resolve(mode Mode) (*Store, error) {
 // machine, missing TPM, changed binary signature, locked keychain, ...).
 func ForBackend(id Backend) (*Store, error) {
 	if id == BackendPlaintext {
-		return &Store{backendImpl{id: BackendPlaintext}}, nil
+		return &Store{b: backendImpl{id: BackendPlaintext}}, nil
 	}
-	for _, cand := range candidates() {
+	const mayPrompt = true // the alternative is unreadable credentials, not a fallback
+	for _, cand := range candidates(mayPrompt) {
 		if cand.id == id {
-			if err := cand.available(); err != nil {
+			outcome, err := cand.available()
+			if outcome == Declined {
+				return nil, err
+			}
+			if err != nil {
 				return nil, fmt.Errorf("credential store backend %q is not usable here: %w", id, err)
 			}
-			return &Store{cand}, nil
+			return &Store{b: cand}, nil
 		}
 	}
-	return nil, fmt.Errorf("credential store backend %q is not available on this platform: %w", id, ErrUnavailable)
+	return nil, fmt.Errorf("credential store backend %q is not available on this platform: %w",
+		id, ErrBackendUnsupported)
 }
 
 // GetKey returns the stored 32-byte key without ever creating one. It returns

--- a/sdk/go/common/util/securestore/securestore_test.go
+++ b/sdk/go/common/util/securestore/securestore_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -75,6 +76,43 @@ func TestIsEnvelopeRejectsLegacyCredentials(t *testing.T) {
 	assert.False(t, IsEnvelope([]byte(`{"current":"x","accessTokens":{"x":"tok"}}`)))
 	assert.False(t, IsEnvelope([]byte("")))
 	assert.False(t, IsEnvelope([]byte("not json")))
+}
+
+func TestUnsupportedEnvelopeVersion(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	future := bytes.Replace(env, []byte(`"$pulumiSecureStore": 1`), []byte(`"$pulumiSecureStore": 2`), 1)
+	require.NotEqual(t, env, future)
+
+	assert.True(t, IsEnvelope(future), "a future-version envelope must still be detected as an envelope")
+	_, err = EnvelopeBackend(future)
+	assert.True(t, errors.Is(err, ErrUnsupportedVersion))
+	_, err = Open(key, future)
+	assert.True(t, errors.Is(err, ErrUnsupportedVersion))
+}
+
+func TestOpenRejectsUnknownAlgo(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	tampered := bytes.Replace(env, []byte(`"algo": "aes-256-gcm"`), []byte(`"algo": "rot13"`), 1)
+	require.NotEqual(t, env, tampered)
+	_, err = Open(key, tampered)
+	assert.ErrorContains(t, err, "algorithm")
+}
+
+func TestOpenRejectsTamperedHeader(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	tampered := bytes.Replace(env, []byte(`"backend": "mock"`), []byte(`"backend": "mock-strong"`), 1)
+	require.NotEqual(t, env, tampered)
+	_, err = Open(key, tampered)
+	assert.True(t, errors.Is(err, ErrWrongKey), "header edits must fail authentication")
 }
 
 func TestSealRejectsBadKeyLength(t *testing.T) {
@@ -162,6 +200,39 @@ func TestResolveModes(t *testing.T) {
 	assert.Equal(t, BackendMock, st.Backend())
 }
 
+func TestOutcomeClassification(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, Ready, outcomeOf(nil))
+	assert.Equal(t, Declined, outcomeOf(fmt.Errorf("wrapped: %w", ErrDeclined)))
+	assert.Equal(t, Locked, outcomeOf(fmt.Errorf("wrapped: %w", ErrLocked)))
+	assert.Equal(t, Absent, outcomeOf(ErrUnavailable))
+	assert.Equal(t, Absent, outcomeOf(errors.New("something else")))
+
+	assert.True(t, errors.Is(ErrLocked, ErrUnavailable), "locked still means unusable, so fallback keeps working")
+	assert.False(t, errors.Is(ErrDeclined, ErrUnavailable), "a refusal must never look like absence")
+}
+
+//nolint:paralleltest // mutates the package-global mock resolver
+func TestDeclinedStopsTheChain(t *testing.T) {
+	fallback := &memStore{}
+	mockResolver = func() []backendImpl {
+		return []backendImpl{
+			{id: BackendMockStrong, store: &refusingStore{}, wrap: rawWrapper{}},
+			{id: BackendMock, store: fallback, wrap: rawWrapper{}},
+		}
+	}
+	t.Cleanup(func() { mockResolver = nil })
+
+	for _, mode := range []Mode{ModeAuto, ModeOS} {
+		st, err := Resolve(mode)
+		require.Error(t, err, "a refusal must fail the resolution, not fall back")
+		assert.True(t, errors.Is(err, ErrDeclined))
+		assert.Nil(t, st)
+	}
+	_, err := fallback.get()
+	assert.True(t, errors.Is(err, ErrKeyNotFound), "the next backend must not have been used")
+}
+
 //nolint:paralleltest // MockInit swaps a package-global resolver
 func TestForBackendUnknown(t *testing.T) {
 	MockInit(t)
@@ -181,7 +252,7 @@ type raceLosingStore struct {
 	gets   int
 }
 
-func (r *raceLosingStore) available() error { return nil }
+func (r *raceLosingStore) available() (Outcome, error) { return Ready, nil }
 
 func (r *raceLosingStore) get() (string, error) {
 	r.gets++

--- a/sdk/go/common/util/securestore/tpmfile.go
+++ b/sdk/go/common/util/securestore/tpmfile.go
@@ -64,7 +64,7 @@ func pulumiHomeDir() (string, error) {
 // available reports whether the key file's directory exists (creating it if
 // needed) and is actually writable, proven by creating and removing a probe
 // file without touching the real item.
-func (s tpmFileStore) available() error {
+func (s tpmFileStore) available() (Outcome, error) {
 	_, err := withTimeout(func() (struct{}, error) {
 		if s.err != nil {
 			return struct{}{}, s.err
@@ -84,11 +84,11 @@ func (s tpmFileStore) available() error {
 	})
 	if err != nil {
 		if errors.Is(err, ErrUnavailable) {
-			return err
+			return Absent, err
 		}
-		return fmt.Errorf("%w: TPM key file location is not usable: %v", ErrUnavailable, err)
+		return Absent, fmt.Errorf("%w: TPM key file location is not usable: %v", ErrUnavailable, err)
 	}
-	return nil
+	return Ready, nil
 }
 
 func (s tpmFileStore) get() (string, error) {

--- a/sdk/go/common/util/securestore/tpmfile_test.go
+++ b/sdk/go/common/util/securestore/tpmfile_test.go
@@ -31,9 +31,11 @@ func TestTPMFileStoreLifecycle(t *testing.T) {
 	t.Setenv("PULUMI_HOME", home)
 
 	store := newTPMFileStore()
-	require.NoError(t, store.available(), "a writable home dir must be available")
+	outcome, err := store.available()
+	require.NoError(t, err)
+	require.Equal(t, Ready, outcome, "a writable home dir must be available")
 
-	_, err := store.get()
+	_, err = store.get()
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 
 	require.NoError(t, store.set("first-value"))
@@ -70,7 +72,9 @@ func TestTPMFileStoreAvailableCreatesDir(t *testing.T) {
 	t.Setenv("PULUMI_HOME", home)
 
 	store := newTPMFileStore()
-	require.NoError(t, store.available())
+	outcome, err := store.available()
+	require.NoError(t, err)
+	require.Equal(t, Ready, outcome)
 	info, err := os.Stat(home)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -157,7 +157,7 @@ func DeleteAllAccounts() error {
 	// via the best currently-available backend, since they can differ.
 	if raw, readErr := os.ReadFile(credsFile); readErr == nil && securestore.IsEnvelope(raw) {
 		if backend, backendErr := securestore.EnvelopeBackend(raw); backendErr == nil {
-			if st, stErr := securestore.ForBackend(backend); stErr == nil {
+			if st, stErr := stores.ForBackend(backend); stErr == nil {
 				if err = st.DeleteKey(); err != nil {
 					logging.V(3).Infof("could not delete credentials encryption key: %v", err)
 				}
@@ -168,11 +168,7 @@ func DeleteAllAccounts() error {
 	if err = os.Remove(credsFile); err != nil && !os.IsNotExist(err) {
 		result = errors.Join(result, err)
 	}
-	if st, stErr := securestore.Resolve(securestore.ModeAuto); stErr == nil {
-		if err = st.DeleteKey(); err != nil {
-			logging.V(3).Infof("could not delete credentials encryption key: %v", err)
-		}
-	}
+	deleteCurrentBackendKey()
 	if statePath, stErr := credStoreStatePath(); stErr == nil {
 		if err = os.Remove(statePath); err != nil && !os.IsNotExist(err) {
 			logging.V(3).Infof("could not delete credential-store state: %v", err)
@@ -401,6 +397,9 @@ func ensurePrivateAgentCredentialDir(dir string) error {
 
 // readCredentialsFile loads credentials from a specific file path.
 func readCredentialsFile(credsFile string) (Credentials, error) {
+	if _, err := credentialStoreMode(); err != nil {
+		return Credentials{}, err
+	}
 	c, err := lockedfile.Read(credsFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -474,20 +473,38 @@ func IsUndecryptableCredentials(err error) bool {
 func decryptCredentials(credsFile string, data []byte) ([]byte, error) {
 	backend, err := securestore.EnvelopeBackend(data)
 	if err != nil {
+		if errors.Is(err, securestore.ErrUnsupportedVersion) {
+			return nil, fmt.Errorf("credentials file '%s' %w: upgrade the Pulumi CLI, "+
+				"or run `pulumi logout --all` to discard the stored credentials", credsFile, err)
+		}
 		return nil, fmt.Errorf("reading encrypted credentials file '%s': %w", credsFile, err)
 	}
-	st, err := securestore.ForBackend(backend)
-	if err != nil {
+	st, err := stores.ForBackend(backend)
+	if errors.Is(err, securestore.ErrBackendUnsupported) {
+		// No implementation for that backend here, so the data is unreadable
+		// on this machine however long the user waits: `pulumi login` may
+		// replace it.
 		return nil, &UndecryptableCredentialsError{Path: credsFile, Err: fmt.Errorf(
 			"credentials file '%s' is encrypted but cannot be decrypted here: %w. "+
 				"Run `pulumi login` in this environment or set PULUMI_ACCESS_TOKEN", credsFile, err)}
+	}
+	if err != nil {
+		// Deliberately not an UndecryptableCredentialsError: recovery paths
+		// treat that as "the data is gone" and replace the file. A store that
+		// is merely locked, refused or absent right now says nothing about
+		// the credentials, which stay readable once it is usable again.
+		return nil, fmt.Errorf("credentials file '%s' is encrypted and the credential store "+
+			"protecting it is not usable here: %w. Unlock your keyring and retry, set "+
+			"PULUMI_ACCESS_TOKEN, or run `pulumi logout --all` to discard the stored credentials",
+			credsFile, err)
 	}
 	key, err := st.GetKey()
 	if err != nil {
 		if errors.Is(err, securestore.ErrKeyNotFound) {
 			return nil, &UndecryptableCredentialsError{Path: credsFile, Err: fmt.Errorf(
 				"credentials file '%s' is encrypted but its key is missing from the "+
-					"OS credential store (was it deleted, or is this a restored or copied home directory?): "+
+					"OS credential store (a different credential store provider may now be active, "+
+					"the key may have been deleted, or this may be a restored or copied home directory): "+
 					"run `pulumi login` to re-authenticate", credsFile)}
 		}
 		return nil, &UndecryptableCredentialsError{Path: credsFile, Err: fmt.Errorf(
@@ -524,23 +541,30 @@ func writeCredentialsFile(credsFile string, creds Credentials) error {
 	if err != nil {
 		return err
 	}
-	// Encryption is sticky: when no mode is configured, a file that is
-	// already an envelope keeps being written as one — otherwise every
-	// command run without PULUMI_CREDENTIAL_STORE set would silently
-	// downgrade migrated credentials back to plaintext. Only the explicit
-	// "plaintext" mode decrypts on write.
-	if st.Backend() == securestore.BackendPlaintext {
-		if mode, _ := credentialStoreMode(); mode == securestore.ModeDefault {
-			if existing, readErr := os.ReadFile(credsFile); readErr == nil && securestore.IsEnvelope(existing) {
-				backend, backendErr := securestore.EnvelopeBackend(existing)
-				if backendErr == nil {
-					sticky, stickyErr := securestore.ForBackend(backend)
-					if stickyErr != nil {
-						return fmt.Errorf("refusing to overwrite encrypted credentials with plaintext: %w. "+
-							"Set PULUMI_CREDENTIAL_STORE=plaintext to store credentials unencrypted", stickyErr)
-					}
-					st = sticky
+	// Encryption is sticky: a file that is already an envelope keeps being
+	// written as one, or every command run without PULUMI_CREDENTIAL_STORE
+	// set would silently downgrade migrated credentials back to plaintext.
+	// Only the explicit "plaintext" mode decrypts on write, and an envelope
+	// this build cannot parse is never overwritten at all.
+	sticky := false
+	if mode, _ := credentialStoreMode(); mode != securestore.ModePlaintext {
+		if existing, readErr := os.ReadFile(credsFile); readErr == nil && securestore.IsEnvelope(existing) {
+			backend, backendErr := securestore.EnvelopeBackend(existing)
+			if backendErr != nil {
+				return fmt.Errorf("refusing to overwrite credentials that %w. "+
+					"Upgrade the Pulumi CLI, or set PULUMI_CREDENTIAL_STORE=plaintext to store credentials unencrypted",
+					backendErr)
+			}
+			if st.Backend() == securestore.BackendPlaintext {
+				stickyStore, stickyErr := stores.ForBackend(backend)
+				if errors.Is(stickyErr, securestore.ErrDeclined) {
+					return stickyErr
 				}
+				if stickyErr != nil {
+					return fmt.Errorf("refusing to overwrite encrypted credentials with plaintext: %w. "+
+						"Set PULUMI_CREDENTIAL_STORE=plaintext to store credentials unencrypted", stickyErr)
+				}
+				st, sticky = stickyStore, true
 			}
 		}
 	}
@@ -548,7 +572,9 @@ func writeCredentialsFile(credsFile string, creds Credentials) error {
 		key, keyErr := st.GetOrCreateKey()
 		if keyErr != nil {
 			mode, _ := credentialStoreMode()
-			if mode == securestore.ModeOS {
+			// Falling back would write plaintext over a file we just proved
+			// is an envelope, so a sticky store's failure is always fatal.
+			if sticky || mode == securestore.ModeOS || errors.Is(keyErr, securestore.ErrDeclined) {
 				return fmt.Errorf("getting credentials encryption key: %w", keyErr)
 			}
 			// In auto mode a store that probed available but then failed is
@@ -562,7 +588,11 @@ func writeCredentialsFile(credsFile string, creds Credentials) error {
 			logging.V(7).Infof("Writing credentials with secure store backend %q", st.Backend())
 		}
 	} else if mode, _ := credentialStoreMode(); mode == securestore.ModeAuto {
-		warnPlaintextFallback(securestore.ErrUnavailable)
+		reason := st.FallbackReason()
+		if reason == nil {
+			reason = securestore.ErrUnavailable
+		}
+		warnPlaintextFallback(reason)
 	}
 
 	return lockedfile.Write(credsFile, bytes.NewReader(raw), 0o600)
@@ -576,34 +606,21 @@ func GetStoredCredentials() (Credentials, error) {
 	}
 
 	logging.V(7).Infof("Reading Pulumi credentials from %q", credsFile)
-	creds, err := readCredentialsFile(credsFile)
-	if err != nil {
-		return creds, err
-	}
-	migrateCredentialsToSecureStore(credsFile, creds)
-	return creds, nil
+	// A plaintext file is migrated to an envelope by the next write, never by
+	// a read, so read-only commands cannot opt a user into encryption.
+	return readCredentialsFile(credsFile)
 }
 
-// migrateCredentialsToSecureStore re-writes a plaintext credentials file as
-// an encrypted envelope the first time it is read while a secure backend is
-// usable. Best effort: a failed migration must never break reading.
-func migrateCredentialsToSecureStore(credsFile string, creds Credentials) {
-	if len(creds.AccessTokens) == 0 {
+func deleteCurrentBackendKey() {
+	mode, err := credentialStoreMode()
+	if err != nil || (mode != securestore.ModeAuto && mode != securestore.ModeOS) {
 		return
 	}
-	st, err := writeStore()
-	if err != nil || st.Backend() == securestore.BackendPlaintext {
-		return
+	if st, stErr := stores.Resolve(securestore.ModeAuto); stErr == nil {
+		if err := st.DeleteKey(); err != nil {
+			logging.V(3).Infof("could not delete credentials encryption key: %v", err)
+		}
 	}
-	raw, err := os.ReadFile(credsFile)
-	if err != nil || securestore.IsEnvelope(raw) {
-		return
-	}
-	if err := writeCredentialsFile(credsFile, creds); err != nil {
-		logging.V(3).Infof("could not migrate credentials to encrypted storage: %v", err)
-		return
-	}
-	logging.V(7).Infof("Migrated credentials to secure store backend %q", st.Backend())
 }
 
 // ResetStoredCredentials removes the stored credentials file along with the
@@ -619,18 +636,14 @@ func ResetStoredCredentials() error {
 	// best currently-available backend — they can differ. Best effort.
 	if raw, readErr := os.ReadFile(credsFile); readErr == nil && securestore.IsEnvelope(raw) {
 		if backend, backendErr := securestore.EnvelopeBackend(raw); backendErr == nil {
-			if st, stErr := securestore.ForBackend(backend); stErr == nil {
+			if st, stErr := stores.ForBackend(backend); stErr == nil {
 				if err := st.DeleteKey(); err != nil {
 					logging.V(3).Infof("could not delete credentials encryption key: %v", err)
 				}
 			}
 		}
 	}
-	if st, stErr := securestore.Resolve(securestore.ModeAuto); stErr == nil {
-		if err := st.DeleteKey(); err != nil {
-			logging.V(3).Infof("could not delete credentials encryption key: %v", err)
-		}
-	}
+	deleteCurrentBackendKey()
 	if err := os.Remove(credsFile); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/sdk/go/common/workspace/credstore.go
+++ b/sdk/go/common/workspace/credstore.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -28,11 +29,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/securestore"
 )
 
-// credentialStoreMode maps PULUMI_CREDENTIAL_STORE to a secure-store mode.
-// An unset variable currently keeps today's plaintext behavior for writes;
-// reads of an already-encrypted file always use its recorded backend.
+// credentialStoreMode maps PULUMI_CREDENTIAL_STORE, case-insensitively. An
+// unset variable keeps today's plaintext behavior for writes; reads of an
+// already-encrypted file always use its recorded backend.
 func credentialStoreMode() (securestore.Mode, error) {
-	switch value := env.CredentialStore.Value(); value {
+	value := env.CredentialStore.Value()
+	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "":
 		return securestore.ModeDefault, nil
 	case "auto":
@@ -57,12 +59,12 @@ func resetWriteStoreForTesting() {
 	writeStore = sync.OnceValues(resolveWriteStore)
 }
 
-func resolveWriteStore() (*securestore.Store, error) {
+func resolveWriteStore() (keyStore, error) {
 	mode, err := credentialStoreMode()
 	if err != nil {
 		return nil, err
 	}
-	return securestore.Resolve(mode)
+	return stores.Resolve(mode)
 }
 
 // credStoreState is a small non-secret marker file next to credentials.json

--- a/sdk/go/common/workspace/credstore_test.go
+++ b/sdk/go/common/workspace/credstore_test.go
@@ -31,9 +31,7 @@ func pinSecureCreds(t *testing.T, mode string) {
 	t.Helper()
 	t.Setenv(PulumiCredentialsPathEnvVar, t.TempDir())
 	t.Setenv("PULUMI_CREDENTIAL_STORE", mode)
-	securestore.MockInit(t)
-	resetWriteStoreForTesting()
-	t.Cleanup(resetWriteStoreForTesting)
+	useFakeStores(t)
 }
 
 func testCreds() Credentials {
@@ -88,7 +86,7 @@ func TestStoreCredentialsPlaintextModeExplicit(t *testing.T) {
 }
 
 //nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
-func TestGetStoredCredentialsMigratesPlaintextOnDemand(t *testing.T) {
+func TestPlaintextFileMigratesOnWriteNotRead(t *testing.T) {
 	pinSecureCreds(t, "auto")
 
 	// Simulate a pre-existing plaintext credentials file from an older CLI.
@@ -97,16 +95,21 @@ func TestGetStoredCredentialsMigratesPlaintextOnDemand(t *testing.T) {
 	require.NoError(t, os.WriteFile(credsFile,
 		[]byte(`{"current":"https://api.pulumi.com","accessTokens":{"https://api.pulumi.com":"pul-legacy"}}`), 0o600))
 
+	// Reads must not rewrite the file: read-only commands cannot opt the
+	// user into encryption as a side effect.
 	creds, err := GetStoredCredentials()
 	require.NoError(t, err)
 	assert.Equal(t, "pul-legacy", creds.AccessTokens["https://api.pulumi.com"])
-
 	raw, err := os.ReadFile(credsFile)
 	require.NoError(t, err)
-	assert.True(t, securestore.IsEnvelope(raw), "plaintext file must be migrated to an envelope on read")
+	assert.False(t, securestore.IsEnvelope(raw), "a read must leave the file untouched")
+
+	require.NoError(t, StoreCredentials(creds))
+	raw, err = os.ReadFile(credsFile)
+	require.NoError(t, err)
+	assert.True(t, securestore.IsEnvelope(raw), "the next write must encrypt the file")
 	assert.False(t, bytes.Contains(raw, []byte("pul-legacy")))
 
-	// And it still reads back after migration.
 	creds, err = GetStoredCredentials()
 	require.NoError(t, err)
 	assert.Equal(t, "pul-legacy", creds.AccessTokens["https://api.pulumi.com"])
@@ -148,11 +151,9 @@ func TestLostKeyProducesActionableError(t *testing.T) {
 	pinSecureCreds(t, "auto")
 	require.NoError(t, StoreCredentials(testCreds()))
 
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	require.NoError(t, st.DeleteKey())
+	require.NoError(t, fakeStore(t).DeleteKey())
 
-	_, err = GetStoredCredentials()
+	_, err := GetStoredCredentials()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pulumi login")
 }
@@ -162,9 +163,8 @@ func TestDeleteAllAccountsRemovesKeyAndState(t *testing.T) {
 	pinSecureCreds(t, "auto")
 	require.NoError(t, StoreCredentials(testCreds()))
 
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	_, err = st.GetKey()
+	st := fakeStore(t)
+	_, err := st.GetKey()
 	require.NoError(t, err, "key exists after storing")
 
 	require.NoError(t, DeleteAllAccounts())
@@ -273,10 +273,8 @@ func TestStoreAccountRecoversFromUndecryptableFile(t *testing.T) {
 	require.NoError(t, StoreCredentials(testCreds()))
 
 	// Lose the key: reads must fail with the typed error...
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	require.NoError(t, st.DeleteKey())
-	_, err = GetStoredCredentials()
+	require.NoError(t, fakeStore(t).DeleteKey())
+	_, err := GetStoredCredentials()
 	require.Error(t, err)
 	assert.True(t, IsUndecryptableCredentials(err))
 
@@ -295,9 +293,7 @@ func TestResetStoredCredentialsClearsUndecryptableState(t *testing.T) {
 	pinSecureCreds(t, "auto")
 	require.NoError(t, StoreCredentials(testCreds()))
 
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	require.NoError(t, st.DeleteKey())
+	require.NoError(t, fakeStore(t).DeleteKey())
 
 	require.NoError(t, ResetStoredCredentials())
 
@@ -317,9 +313,7 @@ func TestDeleteAllAccountsWorksWhenUndecryptable(t *testing.T) {
 	pinSecureCreds(t, "auto")
 	require.NoError(t, StoreCredentials(testCreds()))
 
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	require.NoError(t, st.DeleteKey())
+	require.NoError(t, fakeStore(t).DeleteKey())
 
 	require.NoError(t, DeleteAllAccounts(), "logout --all must not require reading the file")
 
@@ -327,6 +321,161 @@ func TestDeleteAllAccountsWorksWhenUndecryptable(t *testing.T) {
 	require.NoError(t, err)
 	_, err = os.Stat(credsFile)
 	assert.True(t, os.IsNotExist(err))
+}
+
+func futureEnvelope(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	env, err := securestore.Seal(key, fakeBackend, []byte(`{"accessTokens":{"x":"tok"}}`))
+	require.NoError(t, err)
+	future := bytes.Replace(env, []byte(`"$pulumiSecureStore": 1`), []byte(`"$pulumiSecureStore": 99`), 1)
+	require.NotEqual(t, env, future)
+	return future
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestFutureEnvelopeIsNotReadAsLoggedOut(t *testing.T) {
+	pinSecureCreds(t, "")
+	credsFile, err := getCredsFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(credsFile, futureEnvelope(t), 0o600))
+
+	_, err = GetStoredCredentials()
+	require.Error(t, err, "a future-version envelope must error, not read as empty credentials")
+	assert.Contains(t, err.Error(), "newer version")
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestWriteRefusesToClobberFutureEnvelope(t *testing.T) {
+	for _, mode := range []string{"", "auto"} {
+		pinSecureCreds(t, mode)
+		credsFile, err := getCredsFilePath()
+		require.NoError(t, err)
+		future := futureEnvelope(t)
+		require.NoError(t, os.WriteFile(credsFile, future, 0o600))
+
+		err = StoreCredentials(testCreds())
+		require.Error(t, err, "mode %q must refuse to overwrite a future-version envelope", mode)
+
+		raw, err := os.ReadFile(credsFile)
+		require.NoError(t, err)
+		assert.Equal(t, future, raw, "the file must be left untouched")
+	}
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestDeclinedUnlockNeverWritesPlaintext(t *testing.T) {
+	t.Setenv(PulumiCredentialsPathEnvVar, t.TempDir())
+	t.Setenv("PULUMI_CREDENTIAL_STORE", "auto")
+	st := useFakeStores(t)
+	st.declineErr = securestore.ErrDeclined
+
+	err := StoreCredentials(testCreds())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, securestore.ErrDeclined)
+
+	credsFile, err := getCredsFilePath()
+	require.NoError(t, err)
+	_, statErr := os.Stat(credsFile)
+	assert.True(t, os.IsNotExist(statErr), "nothing may be written when the store was refused")
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestDeclinedUnlockOnReadIsNotAdviceToReAuthenticate(t *testing.T) {
+	// Dismissing the dialog while reading must say the store was not
+	// unlocked, not send the user off to `pulumi login`: their credentials
+	// are intact and one click away.
+	pinSecureCreds(t, "auto")
+	require.NoError(t, StoreCredentials(testCreds()))
+
+	fakeStore(t).declineErr = securestore.ErrDeclined
+	_, err := GetStoredCredentials()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, securestore.ErrDeclined)
+	assert.NotContains(t, err.Error(), "re-authenticate")
+	// Crucially not an UndecryptableCredentialsError: `pulumi login` reacts to
+	// that by deleting the file, so a dismissed dialog would destroy readable
+	// credentials and write plaintext in their place.
+	assert.False(t, IsUndecryptableCredentials(err))
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestUnusableStoreIsNotTreatedAsUnreadableCredentials(t *testing.T) {
+	// A locked or absent store says nothing about the credentials: they stay
+	// readable once it works again. Reporting this as undecryptable would let
+	// `pulumi login` delete the file and write plaintext in its place.
+	pinSecureCreds(t, "auto")
+	require.NoError(t, StoreCredentials(testCreds()))
+
+	fakeStore(t).absent = true
+	_, err := GetStoredCredentials()
+	require.Error(t, err)
+	assert.False(t, IsUndecryptableCredentials(err),
+		"a store that is unusable right now must not authorise replacing the file")
+	assert.Contains(t, err.Error(), "not usable here")
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestLostKeyStillAllowsRecovery(t *testing.T) {
+	// The opposite case: the key is genuinely gone, so the data cannot be
+	// recovered and `pulumi login` may replace it.
+	pinSecureCreds(t, "auto")
+	require.NoError(t, StoreCredentials(testCreds()))
+
+	require.NoError(t, fakeStore(t).DeleteKey())
+	_, err := GetStoredCredentials()
+	require.Error(t, err)
+	assert.True(t, IsUndecryptableCredentials(err))
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestDeclinedUnlockOnStickyWriteKeepsTheEnvelope(t *testing.T) {
+	// An existing envelope plus a refused unlock must fail, not fall through
+	// to the "refusing to overwrite" path, and must leave the file alone.
+	pinSecureCreds(t, "auto")
+	require.NoError(t, StoreCredentials(testCreds()))
+	credsFile, err := getCredsFilePath()
+	require.NoError(t, err)
+	before, err := os.ReadFile(credsFile)
+	require.NoError(t, err)
+
+	t.Setenv("PULUMI_CREDENTIAL_STORE", "")
+	resetWriteStoreForTesting()
+	fakeStore(t).declineErr = securestore.ErrDeclined
+
+	err = StoreCredentials(testCreds())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, securestore.ErrDeclined)
+	after, err := os.ReadFile(credsFile)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "the encrypted file must be left untouched")
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestPlaintextFallbackWarningNamesTheReason(t *testing.T) {
+	t.Setenv(PulumiCredentialsPathEnvVar, t.TempDir())
+	t.Setenv("PULUMI_CREDENTIAL_STORE", "auto")
+	t.Setenv("CI", "")
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_TTY", "")
+	t.Setenv("AI_AGENT", "")
+	if headlessEnvironment() {
+		t.Skip("cannot force a non-headless environment here")
+	}
+	absent := &fakeKeyStore{backend: fakeBackend, absent: true}
+	installStores(t, &fakeStores{
+		byBackend: map[securestore.Backend]*fakeKeyStore{fakeBackend: absent},
+		preferred: []securestore.Backend{fakeBackend},
+	})
+
+	var buf bytes.Buffer
+	warnWriter = &buf
+	t.Cleanup(func() { warnWriter = os.Stderr })
+
+	require.NoError(t, StoreCredentials(testCreds()))
+	assert.Contains(t, buf.String(), "plaintext")
+	assert.Contains(t, buf.String(), securestore.ErrUnavailable.Error(),
+		"the warning must carry the reason the store was unusable")
 }
 
 //nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
@@ -337,15 +486,32 @@ func TestInvalidModeSurfacesOnWrite(t *testing.T) {
 	assert.Contains(t, err.Error(), "PULUMI_CREDENTIAL_STORE")
 }
 
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestInvalidModeSurfacesOnRead(t *testing.T) {
+	pinSecureCreds(t, "bogus")
+	_, err := GetStoredCredentials()
+	require.Error(t, err, "read-only commands must reject an invalid mode too")
+	assert.Contains(t, err.Error(), "PULUMI_CREDENTIAL_STORE")
+}
+
+//nolint:paralleltest // t.Setenv and the package-global secure-store mock forbid parallel runs
+func TestModeIsCaseInsensitive(t *testing.T) {
+	pinSecureCreds(t, "OS")
+	require.NoError(t, StoreCredentials(testCreds()))
+	credsFile, err := getCredsFilePath()
+	require.NoError(t, err)
+	raw, err := os.ReadFile(credsFile)
+	require.NoError(t, err)
+	assert.True(t, securestore.IsEnvelope(raw), `"OS" must mean "os", not silent plaintext`)
+}
+
 //nolint:paralleltest // t.Setenv, the package-global secure-store mock, and the real credentials file
 func TestAgentFallbackSurfacesUndecryptableCredentials(t *testing.T) {
 	// The agent fallback must not mask an undecryptable default credentials
 	// file as "not logged in" when no usable agent credentials stand in.
 	// Follows the established agent-test pattern: temporarily operate on the
 	// real credentials path (saved and restored), agent dir redirected.
-	securestore.MockInit(t)
-	resetWriteStoreForTesting()
-	t.Cleanup(resetWriteStoreForTesting)
+	useFakeStores(t)
 
 	oldCreds, err := GetStoredCredentials()
 	require.NoError(t, err)
@@ -369,9 +535,7 @@ func TestAgentFallbackSurfacesUndecryptableCredentials(t *testing.T) {
 	require.NoError(t, StoreAccount(cloudURL, Account{AccessToken: "tok"}, true))
 
 	// Lose the key: the file is now an undecryptable envelope.
-	st, err := securestore.Resolve(securestore.ModeAuto)
-	require.NoError(t, err)
-	require.NoError(t, st.DeleteKey())
+	require.NoError(t, fakeStore(t).DeleteKey())
 
 	_, _, err = GetAccountWithAgentFallback(cloudURL)
 	require.Error(t, err, "agent fallback must not swallow the undecryptable error")
@@ -387,9 +551,7 @@ func TestWriteUpgradesToStrongerBackend(t *testing.T) {
 	// staying readable throughout via the envelope's recorded backend.
 	t.Setenv(PulumiCredentialsPathEnvVar, t.TempDir())
 	t.Setenv("PULUMI_CREDENTIAL_STORE", "auto")
-	promote := securestore.MockInitDual(t)
-	resetWriteStoreForTesting()
-	t.Cleanup(resetWriteStoreForTesting)
+	promote := useUpgradableStores(t)
 
 	// Phase 1: only the weaker backend is available.
 	require.NoError(t, StoreCredentials(testCreds()))
@@ -399,7 +561,7 @@ func TestWriteUpgradesToStrongerBackend(t *testing.T) {
 	require.NoError(t, err)
 	backend, err := securestore.EnvelopeBackend(raw)
 	require.NoError(t, err)
-	require.Equal(t, securestore.BackendMock, backend)
+	require.Equal(t, fakeBackend, backend)
 
 	// Phase 2: the stronger backend becomes available (new release).
 	promote()
@@ -419,7 +581,7 @@ func TestWriteUpgradesToStrongerBackend(t *testing.T) {
 	require.NoError(t, err)
 	backend, err = securestore.EnvelopeBackend(raw)
 	require.NoError(t, err)
-	assert.Equal(t, securestore.BackendMockStrong, backend, "write must upgrade to the stronger backend")
+	assert.Equal(t, fakeStrongBackend, backend, "write must upgrade to the stronger backend")
 	assert.False(t, bytes.Contains(raw, []byte("pul-second-token")))
 
 	upgraded, err := GetStoredCredentials()
@@ -429,7 +591,7 @@ func TestWriteUpgradesToStrongerBackend(t *testing.T) {
 
 	// The weaker backend's key is deliberately left in place: the shared
 	// agent credentials file may still be encrypted under it.
-	weak, err := securestore.ForBackend(securestore.BackendMock)
+	weak, err := stores.ForBackend(fakeBackend)
 	require.NoError(t, err)
 	_, err = weak.GetKey()
 	require.NoError(t, err)

--- a/sdk/go/common/workspace/credstoredeps.go
+++ b/sdk/go/common/workspace/credstoredeps.go
@@ -1,0 +1,58 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import "github.com/pulumi/pulumi/sdk/v3/go/common/util/securestore"
+
+// keyStore is the slice of the secure store this package calls: the key that
+// encrypts the credentials file, and which mechanism protects it.
+// *securestore.Store satisfies it implicitly.
+type keyStore interface {
+	Backend() securestore.Backend
+	GetKey() ([]byte, error)
+	GetOrCreateKey() ([]byte, error)
+	DeleteKey() error
+	FallbackReason() error
+}
+
+// keyStores resolves the store to use, either by mode for writes or by the
+// backend an existing envelope records.
+type keyStores interface {
+	Resolve(mode securestore.Mode) (keyStore, error)
+	ForBackend(id securestore.Backend) (keyStore, error)
+}
+
+// stores is the wiring point for this package. Production uses the real
+// secure store; tests substitute a fake, so no test double is exported from
+// securestore itself.
+var stores keyStores = secureStores{}
+
+type secureStores struct{}
+
+func (secureStores) Resolve(mode securestore.Mode) (keyStore, error) {
+	st, err := securestore.Resolve(mode)
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
+func (secureStores) ForBackend(id securestore.Backend) (keyStore, error) {
+	st, err := securestore.ForBackend(id)
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
+}

--- a/sdk/go/common/workspace/credstorefake_test.go
+++ b/sdk/go/common/workspace/credstorefake_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/securestore"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeBackend       = securestore.Backend("fake")
+	fakeStrongBackend = securestore.Backend("fake-strong")
+)
+
+// fakeKeyStore keeps one key in memory, standing in for an OS credential
+// store that is present and unlocked.
+type fakeKeyStore struct {
+	backend    securestore.Backend
+	key        []byte
+	absent     bool
+	declineErr error
+}
+
+func (f *fakeKeyStore) Backend() securestore.Backend { return f.backend }
+
+func (f *fakeKeyStore) GetKey() ([]byte, error) {
+	if f.key == nil {
+		return nil, securestore.ErrKeyNotFound
+	}
+	return f.key, nil
+}
+
+func (f *fakeKeyStore) GetOrCreateKey() ([]byte, error) {
+	if f.declineErr != nil {
+		return nil, f.declineErr
+	}
+	if f.key == nil {
+		f.key = make([]byte, 32)
+		if _, err := rand.Read(f.key); err != nil {
+			return nil, err
+		}
+	}
+	return f.key, nil
+}
+
+func (f *fakeKeyStore) DeleteKey() error {
+	f.key = nil
+	return nil
+}
+
+func (f *fakeKeyStore) FallbackReason() error { return nil }
+
+// fakeStores resolves the fakes a test installed, mirroring how the real
+// resolver picks the first usable backend and honours an envelope's recorded
+// one.
+type fakeStores struct {
+	byBackend map[securestore.Backend]*fakeKeyStore
+	preferred []securestore.Backend
+}
+
+func (f *fakeStores) Resolve(mode securestore.Mode) (keyStore, error) {
+	switch mode {
+	case securestore.ModePlaintext, securestore.ModeDefault:
+		return plaintextKeyStore{}, nil
+	case securestore.ModeAuto, securestore.ModeOS:
+	default:
+		return nil, fmt.Errorf("invalid secure store mode %d", mode)
+	}
+	var firstAbsent error
+	for _, id := range f.preferred {
+		st := f.byBackend[id]
+		switch {
+		case st == nil:
+		case st.declineErr != nil:
+			// A refusal stops the search, as it does in production.
+			return nil, st.declineErr
+		case st.absent:
+			if firstAbsent == nil {
+				firstAbsent = securestore.ErrUnavailable
+			}
+		default:
+			return st, nil
+		}
+	}
+	if mode == securestore.ModeOS {
+		return nil, fmt.Errorf("PULUMI_CREDENTIAL_STORE=os but %w", securestore.ErrUnavailable)
+	}
+	if firstAbsent == nil {
+		firstAbsent = securestore.ErrUnavailable
+	}
+	return plaintextKeyStore{reason: firstAbsent}, nil
+}
+
+func (f *fakeStores) ForBackend(id securestore.Backend) (keyStore, error) {
+	if id == securestore.BackendPlaintext {
+		return plaintextKeyStore{}, nil
+	}
+	st := f.byBackend[id]
+	if st == nil {
+		return nil, fmt.Errorf("credential store backend %q is not available on this platform: %w",
+			id, securestore.ErrBackendUnsupported)
+	}
+	if st.declineErr != nil {
+		return nil, st.declineErr
+	}
+	if st.absent {
+		return nil, fmt.Errorf("credential store backend %q is not usable here: %w",
+			id, securestore.ErrUnavailable)
+	}
+	return st, nil
+}
+
+// plaintextKeyStore is the "no protection available" store, whose key
+// operations fail the way the real plaintext backend's do.
+type plaintextKeyStore struct{ reason error }
+
+func (plaintextKeyStore) Backend() securestore.Backend { return securestore.BackendPlaintext }
+func (plaintextKeyStore) GetKey() ([]byte, error)      { return nil, securestore.ErrUnavailable }
+func (plaintextKeyStore) GetOrCreateKey() ([]byte, error) {
+	return nil, securestore.ErrUnavailable
+}
+func (plaintextKeyStore) DeleteKey() error        { return nil }
+func (p plaintextKeyStore) FallbackReason() error { return p.reason }
+
+// useFakeStores installs a single usable fake backend for the duration of a
+// test, and returns it so the test can drop its key or make it refuse.
+func useFakeStores(t *testing.T) *fakeKeyStore {
+	t.Helper()
+	st := &fakeKeyStore{backend: fakeBackend}
+	installStores(t, &fakeStores{
+		byBackend: map[securestore.Backend]*fakeKeyStore{fakeBackend: st},
+		preferred: []securestore.Backend{fakeBackend},
+	})
+	return st
+}
+
+func installStores(t *testing.T, s keyStores) {
+	t.Helper()
+	previous := stores
+	stores = s
+	t.Cleanup(func() { stores = previous })
+	resetWriteStoreForTesting()
+	t.Cleanup(resetWriteStoreForTesting)
+}
+
+// fakeStore returns the single fake backend installed by useFakeStores.
+func fakeStore(t *testing.T) *fakeKeyStore {
+	t.Helper()
+	fakes, ok := stores.(*fakeStores)
+	require.True(t, ok, "no fake stores installed")
+	return fakes.byBackend[fakeBackend]
+}
+
+// useUpgradableStores installs a weak backend plus a stronger one that only
+// becomes available once promote is called, mirroring a platform that gains a
+// better protection tier.
+func useUpgradableStores(t *testing.T) (promote func()) {
+	t.Helper()
+	weak := &fakeKeyStore{backend: fakeBackend}
+	strong := &fakeKeyStore{backend: fakeStrongBackend, absent: true}
+	installStores(t, &fakeStores{
+		byBackend: map[securestore.Backend]*fakeKeyStore{fakeBackend: weak, fakeStrongBackend: strong},
+		preferred: []securestore.Backend{fakeStrongBackend, fakeBackend},
+	})
+	return func() { strong.absent = false }
+}


### PR DESCRIPTION
fix: harden credential envelope handling and Linux Secret Service probing

Stacked on #24076. Findings from testing that PR on KDE Plasma against a real Secret Service, first on a machine where `gnome-keyring` had taken over `org.freedesktop.secrets`, then against KDE's own `ksecretd`.

The unlock policy below was agreed in the appendices of [Secure CLI credentials: OS keychain encryption](https://app.notion.com/p/Secure-CLI-credentials-OS-keychain-encryption-3a4fdbdf1cce810a8374d93e94f1075c?source=copy_link#3aefdbdf1cce801ebe9fc1f623f97fa5).

## Data loss

A file written by a newer CLI parsed as ordinary JSON with no access tokens, which is indistinguishable from "not logged in", and the stickiness check used the same predicate, so the next `login` overwrote it with plaintext. Detection now keys off the presence of `$pulumiSecureStore` and is separate from support.

A store that was merely unusable reported the same error type as a lost key, which `login` handles by deleting the file and re-authenticating. A locked keyring was therefore enough to destroy readable credentials and write plaintext in their place, with no user involved: `pulumi login --non-interactive` on a locked wallet did exactly that. Only genuinely unreadable data now authorises replacement, meaning a missing key, a failed decryption, or an envelope recorded under a backend this platform has no implementation for. A store that is locked, absent or refused is a plain error telling the user to unlock and retry.

Dismissing the unlock dialog had the same effect for the same reason, so a single click destroyed credentials. A refusal is now its own outcome and never a reason to fall back.

A key operation failing after the probe succeeded fell through to a plaintext write over a file the same function had just refused to downgrade. That path is now fatal.

`Open` ignored `envelope.Algo`, so `"algo": "rot13"` still decrypted, and the header sat outside the AEAD's additional data. Unknown algorithms are rejected and the header is authenticated. Envelopes sealed before this commit no longer decrypt, which is acceptable while the feature is unreleased.

## Probing

Probing a backend returns one of four outcomes rather than an error to classify: `ready`, `absent`, `locked`, `declined`. Only `absent` and `locked` permit a fallback.

`ksecretd` reports its collection locked after every daemon start, so after every boot, even when the wallet is available. Treating that as unusable made encrypted credentials unreadable after each reboot, and the suggested `pulumi login` recovery rewrote them as plaintext. A locked collection now gets one unlock attempt.

Whether that attempt may wait on a dialog is decided by policy, not by `isatty`. The opt-in modes and reads of an already-encrypted file may ask, since their alternative is failing something explicitly requested; everywhere else an unlock is accepted only if the provider needs no prompt, so no dialog is drawn. Asking also requires someone who could answer, which is a session question rather than a file-descriptor one: `pulumi up | tee log` pipes stdout while the user sits at the desk, and `ssh host pulumi whoami` gives a terminal where no dialog can be shown. The test is a display plus a session bus, minus CI, and `--non-interactive` overrides it in either direction.

A permitted wait has no deadline, matching `sudo`, `git` and `gpg`. KWallet's `KSecretD::internalOpen` loops on a wrong password with no attempt limit and emits no `Completed` signal until the user succeeds or cancels, so any deadline would cut someone off mid-retry. The wait ends early if the provider leaves the bus, and the collection's `Locked` property is re-read afterwards because a wrong password also completes a prompt undismissed.

`--non-interactive` becomes a tri-state so detection can be overridden both ways: given means unattended, `=false` asserts a user is present, absent means infer. No new configuration surface, and the Automation API already passes the flag on every invocation. Agent sessions are not special-cased: an agent in your terminal is attended, a background agent has no display and is already covered.

## Diagnostics

`Resolve` computed a specific failure reason that the plaintext fallback warning discarded, leaving `no usable OS credential protection` and a `-v=7` hunt. The reason is passed through, and probe errors name the process owning the bus name, since several daemons compete for it. Before blocking on a dialog the CLI names itself on stderr, because the Secret Service API has no field for a caller label and KWallet's compatibility layer passes none, leaving its dialog to say only that "KDE" wants the wallet.

The lost-key error offered only "deleted" or "copied home directory"; on Linux the usual cause is a different provider answering, now listed first.

## Everything else

- `PULUMI_CREDENTIAL_STORE` is validated on reads, not just writes, and matched case-insensitively
- Reads no longer rewrite the credentials file; migration happens on the next write
- The probe is memoized per process, so one command cannot raise a dialog per resolution, and its Secret Service read is reused by the key fetch that follows
- `logout` and reset only probe the keyring when the user opted in
- `workspace` declares the narrow interface it calls and resolves through it, so its tests inject a hand-written fake and `securestore` exports no mocks: what was a regular file importing `testing` is now `mock_test.go`

Left for the base PR: lost-key recovery still writes plaintext when no mode is configured, `os` mode still reads a plaintext file without complaint, `HardenProcess` still runs unconditionally, and `PULUMI_ACCESS_TOKEN` alone cannot rescue an undecryptable file because `GetCurrentCloudURL` fails first.

## Test plan

- Automated: unsupported envelope version, rejected algorithm, tampered header, invalid and case-insensitive modes, migrate-on-write, outcome classification, refusal stopping the chain, refusal on read not reporting as a lost key, refusal on sticky write leaving the file intact, the prompt-permission matrix, tri-state `--non-interactive`, and the probe fetch cache. `securestore`, `workspace`, `cmdutil` and `httpstate` pass with `-race`; gofmt, `go vet` and the repo linter are clean; `darwin`, `windows` and `js/wasm` build.
- Manual on CachyOS with Plasma 6.7.3 and `ksecretd`: 16 scenarios, 29 assertions, all passing. Both wallet configurations were covered. With a passwordless `kdewallet` every path is silent; with a real wallet password, answering unlocks and writes an encrypted file, dismissing fails the command instead of writing plaintext, and an unattended run falls back naming `ksecretd` as the provider. A freshly restarted daemon decrypts through the silent unlock, which is the reboot scenario that previously failed. 20 parallel first-run logins still produce exactly one key.

Full review notes, including findings not addressed here, are in the review doc attached to #24076.
