### PR TITLE
fix version check in download-pulumi-cron

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -184,6 +184,8 @@ jobs:
     steps:
       - name: Install Pulumi CLI
         uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
+        with:
+          pulumi-version: latest
       - name: Pulumi Version Details
         id: vars
         run: |


### PR DESCRIPTION
This cron job is meant to check if we always have the latest pulumi version available everywhere.  However, since #23913, it uses `pulumi/actions` instead of `pulumi/action-install-pulumi-cli`.  While this is generally a good change, `pulumi/actions` by default just uses the latest version that's installed on the runner if there is one available, rather than always installing the latest version.

What we want to check here is always installing the latest version, so specify that explicitly.

Fixes #23922 