### PR TITLE
Ignore deprecation warnings from the generated automation API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -208,6 +208,10 @@ linters:
         text: 'deprecated: Please use types in:? cloud.google.com/go/logging/apiv2/loggingpb'
       - linters:
           - staticcheck
+        path: ^sdk/go/auto/
+        text: SA1019
+      - linters:
+          - staticcheck
         text: 'error strings should not end with punctuation or newlines'
       - linters:
           - staticcheck


### PR DESCRIPTION
Automation API is supposed to provide all methods, including the deprecated ones. Therefore, it shouldn't fail to lint because of the deprecated methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)