### PR TITLE
remote up: make sure we detect failed deployments

### DIFF
--- a/changelog/pending/20260730--cli--remote-deployment-exit-code.yaml
+++ b/changelog/pending/20260730--cli--remote-deployment-exit-code.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: fix
+body: Exit non-zero from remote operations (`pulumi up --remote`, `pulumi deployment
+  run`) when the deployment fails
+time: 2026-07-30T00:00:00+00:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2788,6 +2788,19 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 		token = logs.NextToken
 	}
 
+	return b.checkDeploymentResult(ctx, stackID, id)
+}
+
+func (b *cloudBackend) checkDeploymentResult(
+	ctx context.Context, stackID client.StackIdentifier, id string,
+) error {
+	deployment, err := b.client.GetDeployment(ctx, stackID, id)
+	if err != nil {
+		return err
+	}
+	if deployment.Status == "failed" {
+		return errors.New("deployment failed")
+	}
 	return nil
 }
 
@@ -2835,6 +2848,7 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 	// The UpdateEvents API returns a continuation token to only get events after the previous call.
 	var continuationToken *string
 	var lastEvent engine.Event
+	var opResult apitype.OperationResult
 	for {
 		resp, err := b.client.GetUpdateEngineEvents(ctx, update, client.GetUpdateEngineEventsOptions{
 			ContinuationToken: continuationToken,
@@ -2843,6 +2857,9 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 			return err
 		}
 		for _, jsonEvent := range resp.Events {
+			if jsonEvent.SummaryEvent != nil {
+				opResult = jsonEvent.SummaryEvent.Result
+			}
 			event, err := display.ConvertJSONEvent(jsonEvent)
 			if err != nil {
 				return err
@@ -2861,6 +2878,13 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 
 			close(events)
 			<-done
+			switch opResult {
+			case apitype.OperationResultFailed:
+				return errors.New("deployment failed")
+			case apitype.OperationResultCanceled:
+				return backenderr.CancelledError{Operation: string(kind)}
+			case apitype.OperationResultSucceeded:
+			}
 			return nil
 		}
 

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -3008,3 +3008,108 @@ func (nopBatchDecrypter) BatchDecrypt(context.Context, []string) ([]string, erro
 func (nopBatchDecrypter) Enqueue(context.Context, string, *resource.Secret) error {
 	return nil
 }
+
+func TestShowDeploymentEventsResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		summaryResult apitype.OperationResult
+		wantErr       string
+		wantCancelled bool
+	}{
+		{name: "succeeded", summaryResult: apitype.OperationResultSucceeded},
+		{name: "no result", summaryResult: ""},
+		{name: "failed", summaryResult: apitype.OperationResultFailed, wantErr: "deployment failed"},
+		{name: "canceled", summaryResult: apitype.OperationResultCanceled, wantCancelled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				var err error
+				switch req.URL.Path {
+				case "/api/stacks/org/proj/stack/deployments/deployment-id/updates":
+					err = json.NewEncoder(rw).Encode([]apitype.GetDeploymentUpdatesUpdateInfo{
+						{UpdateID: "update-id", Version: 1},
+					})
+				case "/api/stacks/org/proj/stack/update/update-id/events":
+					err = json.NewEncoder(rw).Encode(apitype.GetUpdateEventsResponse{
+						Events: []apitype.EngineEvent{
+							{Sequence: 1, SummaryEvent: &apitype.SummaryEvent{Result: tt.summaryResult}},
+						},
+					})
+				default:
+					require.Failf(t, "unexpected request", "path %v", req.URL.Path)
+				}
+				require.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			b := &cloudBackend{client: client.NewClient(server.URL, "fake-token", true, nil)}
+			stackID := client.StackIdentifier{
+				Owner:   "org",
+				Project: "proj",
+				Stack:   tokens.MustParseStackName("stack"),
+			}
+			opts := display.Options{Color: colors.Never, Stdout: io.Discard, Stderr: io.Discard}
+
+			err := b.showDeploymentEvents(t.Context(), stackID, apitype.UpdateUpdate, "deployment-id", opts)
+			switch {
+			case tt.wantCancelled:
+				require.ErrorAs(t, err, &backenderr.CancelledError{})
+			case tt.wantErr != "":
+				require.ErrorContains(t, err, tt.wantErr)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckDeploymentResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  string
+		wantErr string
+	}{
+		{name: "succeeded", status: "succeeded"},
+		{name: "skipped", status: "skipped"},
+		{name: "running", status: "running"},
+		{name: "failed", status: "failed", wantErr: "deployment failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				require.Equal(t, "/api/stacks/org/proj/stack/deployments/deployment-id", req.URL.Path)
+				err := json.NewEncoder(rw).Encode(apitype.GetDeploymentResponse{
+					ID:     "deployment-id",
+					Status: tt.status,
+				})
+				require.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			b := &cloudBackend{client: client.NewClient(server.URL, "fake-token", true, nil)}
+			stackID := client.StackIdentifier{
+				Owner:   "org",
+				Project: "proj",
+				Stack:   tokens.MustParseStackName("stack"),
+			}
+
+			err := b.checkDeploymentResult(t.Context(), stackID, "deployment-id")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently when a deployment fails with `--remote`, we exit 0, which is quite confusing to the user, and incorrect.  Get the operation result from the summaryevent if available.

We also have to check the deployment status by fetching it, because for e.g. failing to install dependencies, we don't get to the actual deployment and don't have any engine events, and will thus not be able to detect the error otherwise.

Fixes https://github.com/pulumi/pulumi/issues/24051