### PR TITLE
Canonicalize consecutive secret envelopes in the Node.js runtime

### DIFF
--- a/changelog/pending/20260801--sdk-nodejs--canonicalize-nested-rpc-secrets.yaml
+++ b/changelog/pending/20260801--sdk-nodejs--canonicalize-nested-rpc-secrets.yaml
@@ -1,0 +1,7 @@
+component: sdk/nodejs
+kind: fix
+body: Canonicalize consecutive secret envelopes to a single envelope when
+  serializing and deserializing properties, so nested secrets produced by older
+  engines or providers no longer survive an RPC round trip and inflate the
+  statefile
+time: 2026-08-01T11:30:00+09:00

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -383,6 +383,12 @@ export const specialOutputValueSig = "d0e6a833031e9bbcd3f4e8bde6ca49a4";
 
 /** @internal */
 export function serializeSecretValue(value: any): any {
+    if (isRpcSecret(value)) {
+        // Already a secret envelope. Wrapping it again would nest secrets, and every
+        // extra envelope roughly doubles the JSON-escaped size of the value in the
+        // statefile without making it any more secret.
+        return value;
+    }
     return {
         [specialSigKey]: specialSecretSig,
         // coerce 'undefined' to 'null' as required by the protobuf system.
@@ -652,13 +658,14 @@ export function isRpcSecret(obj: any): boolean {
 
 /**
  * Returns the underlying value for a secret, or the value itself if it was not
- * a secret.
+ * a secret. Consecutive secret envelopes, which can occur in values produced by
+ * older engines or providers, are all removed.
  */
 export function unwrapRpcSecret(obj: any): any {
-    if (!isRpcSecret(obj)) {
-        return obj;
+    while (isRpcSecret(obj)) {
+        obj = obj.value;
     }
-    return obj.value;
+    return obj;
 }
 
 function isPrimitive(value: unknown): boolean {
@@ -690,7 +697,10 @@ export function unwrapSecretValues(value: unknown): [unknown, boolean] {
     if (isPrimitive(value)) {
         return [value, false];
     } else if (isRpcSecret(value)) {
-        return [unwrapRpcSecret(value), true];
+        // Recurse into the payload so that secrets nested anywhere below this
+        // envelope are unwrapped as well.
+        const [unwrapped] = unwrapSecretValues(unwrapRpcSecret(value));
+        return [unwrapped, true];
     } else if (value instanceof Array) {
         let hadSecret = false;
         const result = [];
@@ -779,11 +789,16 @@ export function deserializeProperty(prop: any, keepUnknowns?: boolean): any {
                     } else {
                         throw new Error("Invalid archive encountered when unmarshaling resource property");
                     }
-                case specialSecretSig:
+                case specialSecretSig: {
+                    const secretValue = deserializeProperty(prop["value"], keepUnknowns);
+                    // Collapse consecutive secret envelopes into one: Secret(Secret(x)) carries
+                    // the same information as Secret(x), but doubles the serialized size of the
+                    // value every time it round-trips through the state.
                     return {
                         [specialSigKey]: specialSecretSig,
-                        value: deserializeProperty(prop["value"], keepUnknowns),
+                        value: unwrapRpcSecret(secretValue),
                     };
+                }
                 case specialResourceSig:
                     // Deserialize the resource into a live Resource reference
                     const urn = prop["urn"];

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -274,6 +274,49 @@ describe("runtime", () => {
             assert.strictEqual(result.secret1, 1);
             assert.strictEqual(result.secret2, undefined);
         });
+        it("canonicalizes nested secrets to a single envelope", async () => {
+            state.getStore().supportsSecrets = true;
+
+            // A value that arrives shaped as Secret(Secret("...")), e.g. from state written
+            // by an engine or provider that nested secret envelopes, must round-trip as a
+            // canonical single envelope rather than gaining or keeping extra layers.
+            const nested = {
+                [runtime.specialSigKey]: runtime.specialSecretSig,
+                value: {
+                    [runtime.specialSigKey]: runtime.specialSecretSig,
+                    value: "shh",
+                },
+            };
+
+            // Deserialization collapses the envelopes.
+            const deserialized = runtime.deserializeProperties(gstruct.Struct.fromJavaScript({ prop: nested }));
+            assert.ok(runtime.isRpcSecret(deserialized.prop));
+            assert.strictEqual(deserialized.prop.value, "shh");
+
+            // unwrapRpcSecret removes all consecutive envelopes.
+            assert.strictEqual(runtime.unwrapRpcSecret(nested), "shh");
+
+            // Serializing an already-serialized secret envelope must not wrap it again.
+            const inputs: Inputs = {
+                secret: secret(deserialized.prop),
+            };
+            const serialized = await runtime.serializeProperties("test", inputs);
+            assert.ok(runtime.isRpcSecret(serialized.secret));
+            assert.strictEqual(serialized.secret.value, "shh");
+
+            // Objects and arrays with secret descendants still hoist a single envelope.
+            const roundTripped = runtime.deserializeProperties(
+                gstruct.Struct.fromJavaScript({
+                    map: { plain: "a value", nested: nested },
+                    list: ["a value", nested],
+                }),
+            );
+            assert.ok(runtime.isRpcSecret(roundTripped.map));
+            assert.ok(!runtime.isRpcSecret(roundTripped.map.value.nested));
+            assert.strictEqual(roundTripped.map.value.nested, "shh");
+            assert.ok(runtime.isRpcSecret(roundTripped.list));
+            assert.strictEqual(roundTripped.list.value[1], "shh");
+        });
         it("marshals resource references correctly during preview", async () => {
             runtime._setIsDryRun(true);
             runtime.setMocks(new TestMocks());


### PR DESCRIPTION
## What

`Secret(Secret(x))` carries the same information as `Secret(x)`, but each extra envelope roughly doubles the JSON-escaped size of the value in the statefile. Nested envelopes produced elsewhere (e.g. pulumi/pulumi-aws-native#3113 — refresh of secret write-only properties doubled nesting per refresh until refresh was OOM-killed) previously survived a Node.js RPC round trip:

- `deserializeProperty` preserved nested envelopes verbatim,
- `serializeSecretValue` wrapped unconditionally, even if the value was already an envelope,
- `unwrapRpcSecret` removed only one envelope.

## Fix

Collapse consecutive envelopes during deserialization, make `serializeSecretValue` idempotent, and make `unwrapRpcSecret`/`unwrapSecretValues` remove all consecutive envelopes, so nested secrets become a canonical single envelope instead of compounding. Secretness itself is always preserved.

## Tests

Round-trip test: `Secret(Secret("shh"))` deserializes to a single envelope, re-serializing an envelope does not double-wrap, and secretness hoisting for arrays/objects is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)