### PR TITLE
Fix hooks and transforms panicing with mocks in Go

### DIFF
--- a/changelog/pending/sdk-go-fix-20260801-040915.yaml
+++ b/changelog/pending/sdk-go-fix-20260801-040915.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: fix
+body: Fix hooks and transforms causing panics with mocks
+time: 2026-08-01T04:09:15.736529+01:00

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -943,6 +943,40 @@ func TestRegisterResourceOutputs(t *testing.T) {
 	require.Equal(t, int32(2), count.Load(), "RegisterResourceOutputs should be called exactly twice")
 }
 
+// This test checks that transforms and hooks are no-ops under the mock monitor, rather than errors/panics.
+func TestHooksAndTransformsNoop(t *testing.T) {
+	t.Parallel()
+
+	mocks := &testMonitor{}
+
+	err := RunErr(func(ctx *Context) error {
+		err := ctx.RegisterResourceTransform(func(_ context.Context, args *ResourceTransformArgs) *ResourceTransformResult {
+			return &ResourceTransformResult{Props: args.Props, Opts: args.Opts}
+		})
+		require.NoError(t, err)
+
+		hook, err := ctx.RegisterResourceHook("test-hook", func(args *ResourceHookArgs) error {
+			return nil
+		}, nil)
+		require.NoError(t, err)
+
+		transform := func(_ context.Context, args *ResourceTransformArgs) *ResourceTransformResult {
+			return &ResourceTransformResult{Props: args.Props, Opts: args.Opts}
+		}
+
+		_, err = NewLoggingTestResource(t, ctx, "res", String("A"),
+			Transforms([]ResourceTransform{transform}),
+			ResourceHooks(&ResourceHookBinding{
+				BeforeCreate: []*ResourceHook{hook},
+				AfterCreate:  []*ResourceHook{hook},
+			}),
+		)
+		require.NoError(t, err)
+		return nil
+	}, WithMocks("project", "stack", mocks))
+	require.NoError(t, err)
+}
+
 // packageRefMonitor is a mock monitor that tracks RegisterPackage calls and
 // returns configurable refs. It embeds mockMonitor for the full interface.
 type packageRefMonitor struct {

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -110,6 +110,8 @@ type MockResourceArgs struct {
 }
 
 type mockMonitor struct {
+	pulumirpc.UnimplementedResourceMonitorServer
+
 	project   string
 	stack     string
 	mocks     MockResourceMonitor
@@ -382,25 +384,25 @@ func (m *mockMonitor) RegisterResourceOutputs(ctx context.Context, in *pulumirpc
 func (m *mockMonitor) RegisterStackTransform(ctx context.Context, in *pulumirpc.Callback,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
-	panic("not implemented")
+	return &emptypb.Empty{}, nil
 }
 
 func (m *mockMonitor) RegisterStackInvokeTransform(ctx context.Context, in *pulumirpc.Callback,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
-	panic("not implemented")
+	return &emptypb.Empty{}, nil
 }
 
 func (m *mockMonitor) RegisterResourceHook(ctx context.Context, in *pulumirpc.RegisterResourceHookRequest,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
-	panic("not implemented")
+	return &emptypb.Empty{}, nil
 }
 
 func (m *mockMonitor) RegisterErrorHook(ctx context.Context, in *pulumirpc.RegisterErrorHookRequest,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
-	panic("not implemented")
+	return &emptypb.Empty{}, nil
 }
 
 func (m *mockMonitor) RegisterPackage(ctx context.Context, in *pulumirpc.RegisterPackageRequest,


### PR DESCRIPTION
We don't do anything with hooks and transforms when running mocks, but a unit test still ought to be able to set them and just do nothing. Before this change it would panic.