### PR TITLE
Fix Go codegen for nested object collections

### DIFF
--- a/changelog/pending/sdkgen-go-fix-20260802-nested-object-collections.yaml
+++ b/changelog/pending/sdkgen-go-fix-20260802-nested-object-collections.yaml
@@ -1,0 +1,4 @@
+component: sdkgen/go
+kind: fix
+body: Generate valid input types for nested object collections
+time: 2026-08-02T10:36:57Z

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3922,7 +3922,11 @@ func (pkg *pkgContext) nestedTypeToType(typ schema.Type) (string, bool) {
 		}
 		return "", false
 	case *schema.ObjectType:
-		return pkg.resolveObjectType(t), true
+		name := pkg.resolveObjectType(t)
+		if t.IsInputShape() {
+			name = strings.TrimSuffix(name, "Args")
+		}
+		return name, true
 	case *schema.EnumType:
 		return pkg.resolveEnumType(t), true
 	case *schema.UnionType:

--- a/tests/testdata/codegen/go-nested-collections/go/repro/foo.go
+++ b/tests/testdata/codegen/go-nested-collections/go/repro/foo.go
@@ -14,8 +14,9 @@ import (
 type Foo struct {
 	pulumi.CustomResourceState
 
-	ConditionSets   BarArrayArrayArrayOutput     `pulumi:"conditionSets"`
-	PrivateEndpoint pulumi.StringMapMapMapOutput `pulumi:"privateEndpoint"`
+	ConditionSets    BarArrayArrayArrayOutput         `pulumi:"conditionSets"`
+	PrivateEndpoint  pulumi.StringMapMapMapOutput     `pulumi:"privateEndpoint"`
+	ScalingResources ScalingResourceMapMapArrayOutput `pulumi:"scalingResources"`
 }
 
 // NewFoo registers a new resource with the given unique name, arguments, and options.
@@ -58,10 +59,12 @@ func (FooState) ElementType() reflect.Type {
 }
 
 type fooArgs struct {
+	ScalingResources []map[string]map[string]ScalingResource `pulumi:"scalingResources"`
 }
 
 // The set of arguments for constructing a Foo resource.
 type FooArgs struct {
+	ScalingResources ScalingResourceMapMapArrayInput
 }
 
 func (FooArgs) ElementType() reflect.Type {
@@ -157,6 +160,10 @@ func (o FooOutput) ConditionSets() BarArrayArrayArrayOutput {
 
 func (o FooOutput) PrivateEndpoint() pulumi.StringMapMapMapOutput {
 	return o.ApplyT(func(v *Foo) pulumi.StringMapMapMapOutput { return v.PrivateEndpoint }).(pulumi.StringMapMapMapOutput)
+}
+
+func (o FooOutput) ScalingResources() ScalingResourceMapMapArrayOutput {
+	return o.ApplyT(func(v *Foo) ScalingResourceMapMapArrayOutput { return v.ScalingResources }).(ScalingResourceMapMapArrayOutput)
 }
 
 type FooArrayOutput struct{ *pulumi.OutputState }

--- a/tests/testdata/codegen/go-nested-collections/go/repro/pulumiTypes.go
+++ b/tests/testdata/codegen/go-nested-collections/go/repro/pulumiTypes.go
@@ -55,6 +55,100 @@ func (o BarArrayOutput) Index(i pulumi.IntInput) BarOutput {
 	}).(BarOutput)
 }
 
+type ScalingResource struct {
+	Name string `pulumi:"name"`
+}
+
+// ScalingResourceInput is an input type that accepts ScalingResourceArgs and ScalingResourceOutput values.
+// You can construct a concrete instance of `ScalingResourceInput` via:
+//
+//	ScalingResourceArgs{...}
+type ScalingResourceInput interface {
+	pulumi.Input
+
+	ToScalingResourceOutput() ScalingResourceOutput
+	ToScalingResourceOutputWithContext(context.Context) ScalingResourceOutput
+}
+
+type ScalingResourceArgs struct {
+	Name pulumi.StringInput `pulumi:"name"`
+}
+
+func (ScalingResourceArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ScalingResource)(nil)).Elem()
+}
+
+func (i ScalingResourceArgs) ToScalingResourceOutput() ScalingResourceOutput {
+	return i.ToScalingResourceOutputWithContext(context.Background())
+}
+
+func (i ScalingResourceArgs) ToScalingResourceOutputWithContext(ctx context.Context) ScalingResourceOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ScalingResourceOutput)
+}
+
+// ScalingResourceMapInput is an input type that accepts ScalingResourceMap and ScalingResourceMapOutput values.
+// You can construct a concrete instance of `ScalingResourceMapInput` via:
+//
+//	ScalingResourceMap{ "key": ScalingResourceArgs{...} }
+type ScalingResourceMapInput interface {
+	pulumi.Input
+
+	ToScalingResourceMapOutput() ScalingResourceMapOutput
+	ToScalingResourceMapOutputWithContext(context.Context) ScalingResourceMapOutput
+}
+
+type ScalingResourceMap map[string]ScalingResourceInput
+
+func (ScalingResourceMap) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]ScalingResource)(nil)).Elem()
+}
+
+func (i ScalingResourceMap) ToScalingResourceMapOutput() ScalingResourceMapOutput {
+	return i.ToScalingResourceMapOutputWithContext(context.Background())
+}
+
+func (i ScalingResourceMap) ToScalingResourceMapOutputWithContext(ctx context.Context) ScalingResourceMapOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ScalingResourceMapOutput)
+}
+
+type ScalingResourceOutput struct{ *pulumi.OutputState }
+
+func (ScalingResourceOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ScalingResource)(nil)).Elem()
+}
+
+func (o ScalingResourceOutput) ToScalingResourceOutput() ScalingResourceOutput {
+	return o
+}
+
+func (o ScalingResourceOutput) ToScalingResourceOutputWithContext(ctx context.Context) ScalingResourceOutput {
+	return o
+}
+
+func (o ScalingResourceOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v ScalingResource) string { return v.Name }).(pulumi.StringOutput)
+}
+
+type ScalingResourceMapOutput struct{ *pulumi.OutputState }
+
+func (ScalingResourceMapOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]ScalingResource)(nil)).Elem()
+}
+
+func (o ScalingResourceMapOutput) ToScalingResourceMapOutput() ScalingResourceMapOutput {
+	return o
+}
+
+func (o ScalingResourceMapOutput) ToScalingResourceMapOutputWithContext(ctx context.Context) ScalingResourceMapOutput {
+	return o
+}
+
+func (o ScalingResourceMapOutput) MapIndex(k pulumi.StringInput) ScalingResourceOutput {
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) ScalingResource {
+		return vs[0].(map[string]ScalingResource)[vs[1].(string)]
+	}).(ScalingResourceOutput)
+}
+
 type BarArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (BarArrayArrayOutput) ElementType() reflect.Type {
@@ -95,9 +189,107 @@ func (o BarArrayArrayArrayOutput) Index(i pulumi.IntInput) BarArrayArrayOutput {
 	}).(BarArrayArrayOutput)
 }
 
+type ScalingResourceMapMap map[string]ScalingResourceMapInput
+
+func (ScalingResourceMapMap) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]map[string]ScalingResource)(nil)).Elem()
+}
+
+func (i ScalingResourceMapMap) ToScalingResourceMapMapOutput() ScalingResourceMapMapOutput {
+	return i.ToScalingResourceMapMapOutputWithContext(context.Background())
+}
+
+func (i ScalingResourceMapMap) ToScalingResourceMapMapOutputWithContext(ctx context.Context) ScalingResourceMapMapOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ScalingResourceMapMapOutput)
+}
+
+// ScalingResourceMapMapInput is an input type that accepts ScalingResourceMapMap and ScalingResourceMapMapOutput values.
+// You can construct a concrete instance of `ScalingResourceMapMapInput` via:
+//
+//	ScalingResourceMapMap{ "key": ScalingResourceMap{ "key": ScalingResourceArgs{...} } }
+type ScalingResourceMapMapInput interface {
+	pulumi.Input
+
+	ToScalingResourceMapMapOutput() ScalingResourceMapMapOutput
+	ToScalingResourceMapMapOutputWithContext(context.Context) ScalingResourceMapMapOutput
+}
+
+type ScalingResourceMapMapOutput struct{ *pulumi.OutputState }
+
+func (ScalingResourceMapMapOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]map[string]ScalingResource)(nil)).Elem()
+}
+
+func (o ScalingResourceMapMapOutput) ToScalingResourceMapMapOutput() ScalingResourceMapMapOutput {
+	return o
+}
+
+func (o ScalingResourceMapMapOutput) ToScalingResourceMapMapOutputWithContext(ctx context.Context) ScalingResourceMapMapOutput {
+	return o
+}
+
+func (o ScalingResourceMapMapOutput) MapIndex(k pulumi.StringInput) ScalingResourceMapOutput {
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) map[string]ScalingResource {
+		return vs[0].(map[string]map[string]ScalingResource)[vs[1].(string)]
+	}).(ScalingResourceMapOutput)
+}
+
+type ScalingResourceMapMapArray []ScalingResourceMapMapInput
+
+func (ScalingResourceMapMapArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]map[string]map[string]ScalingResource)(nil)).Elem()
+}
+
+func (i ScalingResourceMapMapArray) ToScalingResourceMapMapArrayOutput() ScalingResourceMapMapArrayOutput {
+	return i.ToScalingResourceMapMapArrayOutputWithContext(context.Background())
+}
+
+func (i ScalingResourceMapMapArray) ToScalingResourceMapMapArrayOutputWithContext(ctx context.Context) ScalingResourceMapMapArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ScalingResourceMapMapArrayOutput)
+}
+
+// ScalingResourceMapMapArrayInput is an input type that accepts ScalingResourceMapMapArray and ScalingResourceMapMapArrayOutput values.
+// You can construct a concrete instance of `ScalingResourceMapMapArrayInput` via:
+//
+//	ScalingResourceMapMapArray{ ScalingResourceMapMap{ "key": ScalingResourceMap{ "key": ScalingResourceArgs{...} } } }
+type ScalingResourceMapMapArrayInput interface {
+	pulumi.Input
+
+	ToScalingResourceMapMapArrayOutput() ScalingResourceMapMapArrayOutput
+	ToScalingResourceMapMapArrayOutputWithContext(context.Context) ScalingResourceMapMapArrayOutput
+}
+
+type ScalingResourceMapMapArrayOutput struct{ *pulumi.OutputState }
+
+func (ScalingResourceMapMapArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]map[string]map[string]ScalingResource)(nil)).Elem()
+}
+
+func (o ScalingResourceMapMapArrayOutput) ToScalingResourceMapMapArrayOutput() ScalingResourceMapMapArrayOutput {
+	return o
+}
+
+func (o ScalingResourceMapMapArrayOutput) ToScalingResourceMapMapArrayOutputWithContext(ctx context.Context) ScalingResourceMapMapArrayOutput {
+	return o
+}
+
+func (o ScalingResourceMapMapArrayOutput) Index(i pulumi.IntInput) ScalingResourceMapMapOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) map[string]map[string]ScalingResource {
+		return vs[0].([]map[string]map[string]ScalingResource)[vs[1].(int)]
+	}).(ScalingResourceMapMapOutput)
+}
+
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*ScalingResourceInput)(nil)).Elem(), ScalingResourceArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ScalingResourceMapInput)(nil)).Elem(), ScalingResourceMap{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ScalingResourceMapMapInput)(nil)).Elem(), ScalingResourceMapMap{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ScalingResourceMapMapArrayInput)(nil)).Elem(), ScalingResourceMapMapArray{})
 	pulumi.RegisterOutputType(BarOutput{})
 	pulumi.RegisterOutputType(BarArrayOutput{})
+	pulumi.RegisterOutputType(ScalingResourceOutput{})
+	pulumi.RegisterOutputType(ScalingResourceMapOutput{})
 	pulumi.RegisterOutputType(BarArrayArrayOutput{})
 	pulumi.RegisterOutputType(BarArrayArrayArrayOutput{})
+	pulumi.RegisterOutputType(ScalingResourceMapMapOutput{})
+	pulumi.RegisterOutputType(ScalingResourceMapMapArrayOutput{})
 }

--- a/tests/testdata/codegen/go-nested-collections/schema.json
+++ b/tests/testdata/codegen/go-nested-collections/schema.json
@@ -3,6 +3,20 @@
     "version": "0.1.0",
     "resources": {
         "repro:index:Foo": {
+            "inputProperties": {
+                "scalingResources": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/types/repro:index:ScalingResource"
+                            }
+                        }
+                    }
+                }
+            },
             "properties": {
                 "conditionSets": {
                     "type": "array",
@@ -24,6 +38,18 @@
                             "type": "object",
                             "additionalProperties": {
                                 "type": "string"
+                            }
+                        }
+                    }
+                },
+                "scalingResources": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/types/repro:index:ScalingResource"
                             }
                         }
                     }
@@ -63,6 +89,13 @@
             "properties": {
                 "prop": { "type": "string" }
             }
+        },
+        "repro:index:ScalingResource": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"]
         }
     },
     "language": {


### PR DESCRIPTION
## Summary

- Normalize Go input object names before composing nested collection helper names.
- Extend the existing nested-collection golden fixture with the `Array<Map<Map<Object>>>` shape from the issue.
- Generate consistent helper types so the resulting Go SDK compiles.

Fixes #24063

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation

- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [ ] `make tidy_fix` — the changed `pkg` module is clean under `go mod tidy -compat=1.23 -diff`; the repository-wide command exhausted local disk while unpacking an unrelated integration dependency
- [x] `make format` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Focused verification:

```text
go -C pkg test -count=1 -tags all ./codegen/go -run 'TestGeneratePackage/go-nested-collections' -v
```

## Changelog

- [x] Changelog entry added.

## Risk

The change is limited to helper-name composition for nested Go input object collections. The regression fixture verifies that the input field, nested map helpers, and array helpers use the same name and that the generated SDK builds and tests successfully.
