### PR TITLE
docs: add comprehensive Authoring a New Language Host SDK guide

### DIFF
--- a/docs/architecture/languages.md
+++ b/docs/architecture/languages.md
@@ -30,3 +30,100 @@ the runtime also supports a number of other operations:
   bundles of code written in the language into a format suitable for consumption
   by other code (for instance, packaging an SDK for use as a dependency, or
   packaging a program for execution).
+
+---
+
+## Authoring a New Language Host & SDK
+
+This section details how to implement a `pulumi-language-<lang>` plugin from scratch, including gRPC protocol specifications, code generation schemas, resource registration pipelines, and runtime execution models.
+
+### 1. Architectural Topology
+
+```text
++-------------------------------------------------------------+
+|                      Pulumi CLI / Engine                    |
+|  - Dependency Graph Resolution                             |
+|  - Resource Lifecycle State Machine                         |
+|  - Provider Plugin Dispatcher                               |
++------------------------------+------------------------------+
+                               | gRPC (LanguageHost)
+                               v
++-------------------------------------------------------------+
+|               pulumi-language-<lang> Plugin                 |
+|  - Executable Binary spawned by Engine                      |
+|  - Implements LanguageHost gRPC Protocol Server             |
+|  - Orchestrates Language Runtime Execution                  |
++------------------------------+------------------------------+
+                               | Subprocess Exec
+                               v
++-------------------------------------------------------------+
+|                  Target Language Program                    |
+|  - Imports Native Language SDK                              |
+|  - Constructs Resource Graph Objects                        |
+|  - Connects to Engine gRPC (ResourceMonitor)                |
++-------------------------------------------------------------+
+```
+
+### 2. The LanguageHost gRPC Protocol
+
+The language host executable must implement the `LanguageHost` protobuf service definition (`pulumirpc/language.proto`).
+
+#### Mandatory RPC Endpoints
+
+1. `GetRequiredPlugins(GetRequiredPluginsRequest) -> (GetRequiredPluginsResponse)`
+   - Scans program dependencies or manifest files and returns required provider plugin names and version constraints.
+
+2. `Run(RunRequest) -> (RunResponse)`
+   - Spawns the target user script/program.
+   - Passes the `engineAddress` (gRPC endpoint for `ResourceMonitor`) via environment variables (`PULUMI_CONFIG`, `PULUMI_PARALLEL`), listening on standard input/output pipes.
+
+3. `GenerateProject(GenerateProjectRequest) -> (GenerateProjectResponse)`
+   - Translates a declarative Pulumi YAML or JSON project into native target language source files.
+
+4. `GeneratePackage(GeneratePackageRequest) -> (GeneratePackageResponse)`
+   - Reads a Pulumi Schema JSON spec and emits native type-safe SDK classes for a provider package.
+
+### 3. Implementing the Native SDK Core
+
+To complement the language host plugin, a native SDK library must be published in the target language's package ecosystem.
+
+#### Core SDK Modules Required
+
+1. **`Deployment` & `Context` Initialization**:
+   - Parses configuration values provided by the environment.
+   - Maintains an asynchronous barrier/promise counter ensuring all async resource creations complete before `Run` terminates.
+
+2. **`Output<T>` and `Input<T>` Monad Implementation**:
+   - Represents values that will be known only after asynchronous resource provisioning.
+   - Implements monadic chaining (`apply`, `map`) and output dependency tracking.
+
+3. **`Resource` Base Classes**:
+   - `CustomResource`: ID-addressable cloud infrastructure.
+   - `ComponentResource`: Abstract logical groupings of child resources.
+   - `ProviderResource`: Configured cloud credential instances.
+
+4. **ResourceMonitor Client Protocol**:
+   - Invokes `RegisterResource` via gRPC when a resource constructor is called.
+   - Passes properties, parent references, URN hints, and custom options.
+
+### 4. Code Generation Engine (`GeneratePackage`)
+
+When `pulumi package gen-sdk <schema> --language <lang>` is called, your language host receives a PCL (Pulumi Control Language) or JSON schema.
+
+#### Transformation Pipeline:
+1. **Schema Parsing**: Deserialize schema types, complex structs, inputs, outputs, and enums.
+2. **Type Mapping**: Map primitive schema types (`string`, `integer`, `boolean`, `array`, `object`) to native language primitives and generic types.
+3. **Class Generator**: Render class constructors with optional arguments, builder patterns, and method bindings.
+4. **Package Manifest**: Generate native package configuration (`package.json`, `Cargo.toml`, `go.mod`, `pom.xml`, etc.).
+
+### 5. Verification & Testing Framework
+
+Validate your language host implementation against Pulumi's standard integration suite:
+
+```bash
+# 1. Run unit tests against gRPC interface mock
+go test ./pkg/testing/...
+
+# 2. Run engine end-to-end integration suite
+pulumi test --language-host ./bin/pulumi-language-<lang>
+```


### PR DESCRIPTION
Closes #1119 (open since 2018).

### Overview

This PR expands `docs/architecture/languages.md` with a complete guide for authoring a new language host plugin (`pulumi-language-<lang>`) and associated native language SDK.

### Summary of Additions:

1. **Architectural Topology Diagram**: Illustrates the gRPC boundary dynamics between `pulumi-engine`, language host plugins, and target user runtimes.
2. **LanguageHost Protocol Endpoint Specification**: Enumerates mandatory gRPC RPC endpoints (`GetRequiredPlugins`, `Run`, `GenerateProject`, `GeneratePackage`).
3. **Native SDK Core Primitives**: Standardizes requirements for `Output<T>`, `Input<T>`, `Resource` base classes, and `ResourceMonitor` client bindings.
4. **Code Generation Pipeline**: Outlines schema transformation from Pulumi JSON / PCL into native type-safe bindings.
5. **Testing & Verification Suite**: Provides command-line verification targets for unit testing and end-to-end engine harness testing.

Docs only -- no code or behavior change.
