### PR TITLE
One Slack alert per Automation API update

### DIFF
--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -34,18 +34,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         run: |
           set -euo pipefail
+          branch=automation/update-automation-api
           git add -A
           if git diff --cached --quiet; then
             echo "Automation APIs are up to date."
             exit 0
           fi
+          if git fetch --depth=2 --quiet origin "$branch" 2>/dev/null; then
+            paths=$(git show --name-only --format= FETCH_HEAD; git diff --cached --name-only)
+            if git diff --quiet FETCH_HEAD -- $paths; then
+              echo "The open PR already contains these exact changes."
+              exit 0
+            fi
+          fi
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git switch --create automation/update-automation-api
+          git switch --create "$branch"
           git commit -m "Regenerate automation APIs from the CLI specification"
           git push --force origin HEAD
           # If a PR is already open for this branch, the force-push above refreshed it; reuse its URL.
-          existing=$(gh pr list --head automation/update-automation-api --state open --json url --jq '.[0].url')
+          existing=$(gh pr list --head "$branch" --state open --json url --jq '.[0].url')
           if [ -n "$existing" ]; then
             echo "PR already open: ${existing}; refreshed the branch."
             echo "url=${existing}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -41,8 +41,8 @@ jobs:
             exit 0
           fi
           if git fetch --depth=2 --quiet origin "$branch" 2>/dev/null; then
-            paths=$(git show --name-only --format= FETCH_HEAD; git diff --cached --name-only)
-            if git diff --quiet FETCH_HEAD -- $paths; then
+            mapfile -t paths < <(git show --name-only --format= FETCH_HEAD; git diff --cached --name-only)
+            if git diff --quiet FETCH_HEAD -- "${paths[@]}"; then
               echo "The open PR already contains these exact changes."
               exit 0
             fi


### PR DESCRIPTION
Currently, every push to `master` that happens between the Automation API going out of date and the update PR being merged will trigger a Slack alert. This PR adds a check: "Have we changed anything since the last time we updated the branch?" If we haven't, there's no need to alert anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)