### PR TITLE
Depend on pulumi/pulumi-hcl v0.13.0

### DIFF
--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -37,12 +37,10 @@ type knownLanguageRuntime struct {
 // previously-bundled language runtimes off the CLI release tarball, they are added here so
 // the CLI continues to know where to find them.
 var knownLanguageRuntimes = map[string]knownLanguageRuntime{
-	// The HCL language runtime lives in pulumi-labs/pulumi-hcl rather than pulumi/pulumi-hcl,
-	// so we have to point downloads at that repo explicitly.
 	"hcl": {
-		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
-		// renovate: datasource=github-releases depName=pulumi-labs/pulumi-hcl extractVersion=^v(?<version>.+)$
-		Version: semver.MustParse("0.12.0"),
+		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-hcl",
+		// renovate: datasource=github-releases depName=pulumi/pulumi-hcl extractVersion=^v(?<version>.+)$
+		Version: semver.MustParse("0.13.0"),
 	},
 }
 
@@ -67,7 +65,7 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 		// name (pulumi-hcl) that doesn't match the default pulumi-converter-<name> convention. We
 		// encode both pieces of information here so the auto-install machinery resolves the right
 		// release artifact.
-		spec.PluginDownloadURL = "github://api.github.com/pulumi-labs/pulumi-hcl"
+		spec.PluginDownloadURL = "github://api.github.com/pulumi/pulumi-hcl"
 		return true
 	}
 

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -69,7 +69,7 @@ func TestKnownLanguageRuntimeHCL(t *testing.T) {
 	assert.Equal(t, workspace.PluginDescriptor{
 		Name:              "hcl",
 		Kind:              apitype.LanguagePlugin,
-		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
+		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-hcl",
 	}, spec)
 }
 
@@ -87,7 +87,7 @@ func TestKnownLanguageRuntimePreservesExplicitVersion(t *testing.T) {
 	assert.Equal(t, workspace.PluginDescriptor{
 		Name:              "hcl",
 		Kind:              apitype.LanguagePlugin,
-		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
+		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-hcl",
 		Version:           &explicit,
 	}, spec)
 }


### PR DESCRIPTION
This needs to be a manual version bump since this is the first version hosted in the `pulumi` org. Future version bumps should be handled by renovate.