### PR TITLE
improve output for upserted resources

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -137,7 +137,6 @@ func (pc *packageCommand) newStatefulResourceCreateCommand(res *schema.Resource)
 				inputFormat:   inputFormat,
 				resourcesFile: resourcesFile,
 				yes:           yes,
-				verb:          "created",
 				requireFresh:  true,
 			})
 		},

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -104,7 +104,6 @@ func (pc *packageCommand) newStatefulResourceUpsertCommand(res *schema.Resource)
 				inputFormat:   inputFormat,
 				resourcesFile: resourcesFile,
 				yes:           yes,
-				verb:          "upserted",
 				requireFresh:  false,
 			})
 		},
@@ -185,7 +184,6 @@ type statefulSnippetUpdate struct {
 	inputFormat   string
 	resourcesFile string
 	yes           bool
-	verb          string // completion-message verb, e.g. "created" or "upserted"
 	// requireFresh errors when a snippet with the same (Name, Type) already exists in the stack —
 	// the invariant `create` enforces to distinguish itself from `upsert`.
 	requireFresh bool
@@ -304,7 +302,11 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 		return err
 	}
 	if result != nil && !pc.dryrun {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s %s (snippet %s)\n", args.verb, args.name, result.SnippetUUID)
+		verb := "Created"
+		if existed {
+			verb = "Updated"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s (snippet %s)\n", verb, args.name, result.SnippetUUID)
 	}
 	return nil
 }
@@ -363,7 +365,7 @@ func (pc *packageCommand) runStatefulSnippetDelete(
 		return err
 	}
 	if result != nil && !pc.dryrun {
-		fmt.Fprintf(cmd.OutOrStdout(), "deleted %s (snippet %s)\n", name, result.SnippetUUID)
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s (snippet %s)\n", name, result.SnippetUUID)
 	}
 	return nil
 }

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -183,6 +183,7 @@ size = 2
 	assert.True(t, got.Yes)
 
 	assert.Contains(t, stdout.String(), got.Snippet.UUID)
+	assert.Contains(t, stdout.String(), "Created myres")
 	_ = stderr
 }
 
@@ -420,7 +421,7 @@ func TestDoCmdResourceUpsertReusesExistingSnippet(t *testing.T) {
 
 	assert.Equal(t, existing.UUID, got.Snippet.UUID, "existing snippet UUID should be reused")
 	assert.Equal(t, `name = "new"`, got.Snippet.Code, "code should be replaced with the new file contents")
-	_ = stdout
+	assert.Contains(t, stdout.String(), "Updated myres")
 	_ = stderr
 }
 
@@ -706,7 +707,7 @@ size = 2
 
 // TestDoCmdResourceStatefulCreateConstructsSnippet mirrors the upsert-constructs-snippet test but
 // for stateful `create`: the CLI takes a name arg, mints a fresh UUID, hands the snippet to
-// runStatefulUpdate, and the completion line uses "created" rather than "upserted".
+// runStatefulUpdate, and the completion line uses the "Created" verb.
 //
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
 func TestDoCmdResourceStatefulCreateConstructsSnippet(t *testing.T) {
@@ -740,7 +741,7 @@ func TestDoCmdResourceStatefulCreateConstructsSnippet(t *testing.T) {
 	assert.Equal(t, "azure:index:myResource", got.Snippet.Type)
 	assert.Contains(t, got.Snippet.Code, `name = "example"`)
 	require.NotEmpty(t, got.Snippet.UUID)
-	assert.Contains(t, stdout.String(), "created myres")
+	assert.Contains(t, stdout.String(), "Created myres")
 	_ = stderr
 }
 
@@ -893,7 +894,7 @@ func TestDoCmdResourceStatefulDeleteConstructsSnippetDelete(t *testing.T) {
 	assert.Equal(t, existing.UUID, got.Snippet.UUID)
 	assert.Equal(t, "myres", got.Snippet.Name)
 	assert.Equal(t, "azure:index:myResource", got.Snippet.Type)
-	assert.Contains(t, stdout.String(), "deleted myres")
+	assert.Contains(t, stdout.String(), "Deleted myres")
 	assert.Contains(t, stdout.String(), existing.UUID)
 	_ = stderr
 }


### PR DESCRIPTION
We know whether a resource is updated or created when using `pulumi do upsert`.  Show the correct verb in the completion message.  Also uppercase the first letter, as that matches the rest of our CLI better. 