### PR TITLE
[programgen/go] Fix plain invokes emitting ...ArgsArgs argument types

### DIFF
--- a/changelog/pending/20260803--programgen-go--plain-invoke-plain-arg-types.yaml
+++ b/changelog/pending/20260803--programgen-go--plain-invoke-plain-arg-types.yaml
@@ -1,0 +1,4 @@
+component: programgen/go
+kind: fix
+body: Fix plain invokes emitting nonexistent `...ArgsArgs` argument types
+time: 2026-08-03T00:00:00+00:00

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -85,7 +85,11 @@ type generator struct {
 	// inPlainObjectField indicates that the generator is producing a value for a plain (non-input)
 	// struct field, so the object literal should be emitted as a value rather than a pointer.
 	inPlainObjectField bool
-	isComponent        bool
+	// inPlainInvokeArgs indicates that the generator is producing the arguments for a plain
+	// (non-output-versioned) invoke, which uses the plain argument structs rather than the
+	// paired ...Args input shapes.
+	inPlainInvokeArgs bool
+	isComponent       bool
 
 	// User-configurable options
 	assignResourcesToVariables bool // Assign resource to a new variable instead of _.

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -498,6 +498,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 			// Unlike other languages, Go cannot leave out trailing optional parameters, so
 			// every parameter is emitted, passing nil for absent optional ones.
+			savedPlainInvokeArgs := g.inPlainInvokeArgs
+			g.inPlainInvokeArgs = !pcl.IsOutputVersionInvokeCall(expr)
 			for _, param := range pcl.SortedFunctionParameters(expr) {
 				g.Fgen(w, ", ")
 				if value, ok := arguments[param.Name]; ok {
@@ -506,6 +508,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 					g.Fgen(w, "nil")
 				}
 			}
+			g.inPlainInvokeArgs = savedPlainInvokeArgs
 		} else if isOut {
 			outTypeName, err := outputVersionFunctionArgTypeName(outArgsType, g.externalCache)
 			if err != nil {
@@ -527,7 +530,10 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			g.genObjectConsExpressionWithTypeName(w, outArgs, outArgsType, outTypeName)
 		} else {
 			g.Fgenf(w, "%s.%s(ctx, ", module, fn)
+			savedPlainInvokeArgs := g.inPlainInvokeArgs
+			g.inPlainInvokeArgs = true
 			g.Fgenf(w, "%.v", expr.Args[1])
+			g.inPlainInvokeArgs = savedPlainInvokeArgs
 		}
 
 		var options []string
@@ -899,7 +905,10 @@ func (g *generator) genObjectConsExpression(
 	// input shape. isInputty only detects a wrapping OutputType; for union
 	// members inside a resource input the model type is a bare ObjectType,
 	// so detect the InputShape directly to route to the ...Args form.
-	if !isInput {
+	// Plain invokes are exempt: they take the plain argument structs, and
+	// their anonymous inputs object is tokened "<fn>Args", so routing it to
+	// the input shape would name a nonexistent "...ArgsArgs" type.
+	if !isInput && !g.inPlainInvokeArgs {
 		if schemaType, ok := pcl.GetSchemaForType(destType); ok {
 			if obj, ok := codegen.UnwrapType(schemaType).(*schema.ObjectType); ok && obj.InputShape != nil {
 				isInput = true

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -475,6 +475,49 @@ func parseAndBindProgram(t *testing.T,
 	return pcl.BindProgram(parser.Files, schema.NewPluginLoader(utils.NewContext(testdataPath)), options...)
 }
 
+func TestPlainInvokeUsesPlainArgTypes(t *testing.T) {
+	t.Parallel()
+
+	source := `
+policy = invoke("infra:index:getPolicyDocument", {
+	statements = [{
+		sid = "1"
+	}]
+})`
+
+	program, diags, err := parseAndBindProgram(t, source, "plain_invoke.pp")
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors())
+
+	files, diags, err := GenerateProgram(program)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors())
+
+	assert.Equal(t, `package main
+
+import (
+	"example.com/pulumi-infra/sdk/go/infra"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := infra.GetPolicyDocument(ctx, &infra.GetPolicyDocumentArgs{
+			Statements: []infra.GetPolicyDocumentStatement{
+				{
+					Sid: pulumi.StringRef("1"),
+				},
+			},
+		}, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+`, string(files["main.go"]))
+}
+
 func TestGenerateProjectDoesNotPanicWhenMissingVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Since #22524, `genObjectConsExpression` promotes any schema-typed object whose `InputShape` is non-nil to the input form. A function's anonymous inputs object is bound with the token `<fn>Args` (see `bindFunctionDef`), so promoting it names its input shape `<fn>ArgsArgs` — a type that does not exist in any generated SDK. Plain (non-output-versioned) invokes take the plain argument structs, and their nested objects likewise use the plain type shapes.

For example, converting a program calling `aws:iam/getPolicyDocument:getPolicyDocument` produced:

```go
assumeRole, err := iam.GetPolicyDocument(ctx, &iam.GetPolicyDocumentArgsArgs{
```

where the SDK type is `iam.GetPolicyDocumentArgs`.

This surfaced in pulumi-terraform-bridge's example-conversion tests when upgrading to v3.255.0 (pulumi/pulumi-terraform-bridge#3552); upstream conformance tests did not catch it because the Go invoke conformance programs all use the output-versioned form.

## Fix

Track plain-invoke argument rendering with a generator flag (`inPlainInvokeArgs`) and skip the input-shape promotion while it is set. Multi-argument invokes get the same treatment for their non-output-versioned form.

## Testing

- New regression test `TestPlainInvokeUsesPlainArgTypes` (plain invoke with a nested object argument, asserting the full generated program).
- `go test ./pkg/codegen/go/...` passes (429 tests).
- Validated against pulumi-terraform-bridge: the failing `TestConvertExamples` cases pass with this fix.