### PR TITLE
Extract shared backend.Preview helper

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -271,6 +271,19 @@ func confirmBeforeUpdating(ctx context.Context, kind apitype.UpdateKind, stackRe
 	}
 }
 
+// Preview runs a preview of the given operation by invoking apply with DryRun set. It exists so that
+// backends can share a single implementation of Backend.Preview rather than each duplicating the same
+// ApplierOptions setup and apply call.
+func Preview(ctx context.Context, stack Stack, op UpdateOperation, apply Applier,
+	events chan<- engine.Event,
+) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
+	opts := ApplierOptions{
+		DryRun:   true,
+		ShowLink: true,
+	}
+	return apply(ctx, apitype.PreviewUpdate, stack, op, opts, events)
+}
+
 func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, stack Stack,
 	op UpdateOperation, apply Applier, explainer Explainer, events chan<- engine.Event,
 ) (sdkDisplay.ResourceChanges, error) {

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1145,12 +1145,7 @@ func (b *diyBackend) PackPolicies(
 func (b *diyBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
-	// We can skip PreviewThenPromptThenExecute and just go straight to Execute.
-	opts := backend.ApplierOptions{
-		DryRun:   true,
-		ShowLink: true,
-	}
-	return b.apply(ctx, apitype.PreviewUpdate, stack, op, opts, events)
+	return backend.Preview(ctx, stack, op, b.apply, events)
 }
 
 func (b *diyBackend) Update(ctx context.Context, stack backend.Stack,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1466,13 +1466,7 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stack backend.Stack,
 func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, events chan<- engine.Event,
 ) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
-	// We can skip PreviewThenPromptThenExecute, and just go straight to Execute.
-	opts := backend.ApplierOptions{
-		DryRun:   true,
-		ShowLink: true,
-	}
-	return b.apply(
-		ctx, apitype.PreviewUpdate, stack, op, opts, events)
+	return backend.Preview(ctx, stack, op, b.apply, events)
 }
 
 func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,


### PR DESCRIPTION
The diy and httpstate backends had identical Preview implementations. Move the shared logic into pkg/backend and reduce both to one-line delegations, matching the existing pattern used for backend.Watch.