### PR TITLE
Serve the package resolver to state converters

### DIFF
--- a/changelog/pending/20260803--cli-import--resolver-target-for-converters.yaml
+++ b/changelog/pending/20260803--cli-import--resolver-target-for-converters.yaml
@@ -1,0 +1,8 @@
+component: cli/import
+kind: improvement
+body: Serve the package-resolver service to state converters via `resolver_target`
+  on `ConvertStateRequest`, so converters can resolve package specifications the
+  same way the CLI does
+time: 2026-08-03T00:00:00+00:00
+custom:
+  PR: "24174"

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -962,17 +962,20 @@ func NewImportCmd() *cobra.Command {
 
 				mapperServer := convert.NewMapperServer(mapper)
 				loaderServer := schema.NewLoaderServer(schema.NewPluginLoader(pCtx))
+				resolverServer := packageworkspace.NewResolverServer(reg)(pCtx)
 				grpcServer, err := plugin.NewServer(pCtx,
 					convert.MapperRegistration(mapperServer),
-					schema.LoaderRegistration(loaderServer))
+					schema.LoaderRegistration(loaderServer),
+					packageworkspace.ResolverRegistration(resolverServer))
 				if err != nil {
 					return err
 				}
 
 				resp, err := converter.ConvertState(ctx, &plugin.ConvertStateRequest{
-					MapperTarget: grpcServer.Addr(),
-					Args:         args,
-					LoaderTarget: grpcServer.Addr(),
+					MapperTarget:   grpcServer.Addr(),
+					Args:           args,
+					LoaderTarget:   grpcServer.Addr(),
+					ResolverTarget: grpcServer.Addr(),
 				})
 				if err != nil {
 					rpcErr := rpcerror.Convert(err)

--- a/pkg/cmd/pulumi/packageworkspace/resolver.go
+++ b/pkg/cmd/pulumi/packageworkspace/resolver.go
@@ -34,7 +34,14 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/grpc"
 )
+
+// ResolverRegistration returns a function to register the given resolver service with a gRPC
+// server, for serving the resolver alongside other services on a single [plugin.NewServer].
+func ResolverRegistration(r pulumirpc.PackageResolverServer) func(*grpc.Server) {
+	return func(srv *grpc.Server) { pulumirpc.RegisterPackageResolverServer(srv, r) }
+}
 
 // resolverTracer instruments the package-resolution steps so the cost of
 // installing a plugin versus generating its schema is visible in traces.

--- a/pkg/resource/plugin/converter.go
+++ b/pkg/resource/plugin/converter.go
@@ -89,6 +89,9 @@ type ConvertStateRequest struct {
 	MapperTarget string
 	Args         []string
 	LoaderTarget string
+	// ResolverTarget is the target of a PackageResolver service the converter can use to resolve
+	// package specifications to concrete package dependencies. May be empty on older engines.
+	ResolverTarget string
 }
 
 type ConvertStateResponse struct {

--- a/pkg/resource/plugin/converter_plugin.go
+++ b/pkg/resource/plugin/converter_plugin.go
@@ -115,9 +115,10 @@ func (c *converter) ConvertState(ctx context.Context, req *ConvertStateRequest) 
 	logging.V(7).Infof("%s executing", label)
 
 	resp, err := c.clientRaw.ConvertState(ctx, &pulumirpc.ConvertStateRequest{
-		MapperTarget: req.MapperTarget,
-		Args:         req.Args,
-		LoaderTarget: req.LoaderTarget,
+		MapperTarget:   req.MapperTarget,
+		Args:           req.Args,
+		LoaderTarget:   req.LoaderTarget,
+		ResolverTarget: req.ResolverTarget,
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)

--- a/pkg/resource/plugin/converter_server.go
+++ b/pkg/resource/plugin/converter_server.go
@@ -37,9 +37,10 @@ func (c *converterServer) ConvertState(ctx context.Context,
 	req *pulumirpc.ConvertStateRequest,
 ) (*pulumirpc.ConvertStateResponse, error) {
 	resp, err := c.converter.ConvertState(ctx, &ConvertStateRequest{
-		MapperTarget: req.MapperTarget,
-		Args:         req.Args,
-		LoaderTarget: req.LoaderTarget,
+		MapperTarget:   req.MapperTarget,
+		Args:           req.Args,
+		LoaderTarget:   req.LoaderTarget,
+		ResolverTarget: req.ResolverTarget,
 	})
 	if err != nil {
 		return nil, err

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -44,6 +44,9 @@ message ConvertStateRequest {
     repeated string args = 2;
     // The target of a codegen.LoaderServer to use for loading schemas.
     string loader_target = 3;
+    // The target of a [](pulumirpc.PackageResolver) service the converter can use to resolve package
+    // specifications to concrete package dependencies. May be empty on older engines.
+    string resolver_target = 4;
 }
 
 // A ResourceImport specifies a resource to import.

--- a/sdk/nodejs/proto/converter_pb.d.ts
+++ b/sdk/nodejs/proto/converter_pb.d.ts
@@ -18,6 +18,8 @@ export class ConvertStateRequest extends jspb.Message {
     addArgs(value: string, index?: number): string;
     getLoaderTarget(): string;
     setLoaderTarget(value: string): ConvertStateRequest;
+    getResolverTarget(): string;
+    setResolverTarget(value: string): ConvertStateRequest;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): ConvertStateRequest.AsObject;
@@ -34,6 +36,7 @@ export namespace ConvertStateRequest {
         mapperTarget: string,
         argsList: Array<string>,
         loaderTarget: string,
+        resolverTarget: string,
     }
 }
 

--- a/sdk/nodejs/proto/converter_pb.js
+++ b/sdk/nodejs/proto/converter_pb.js
@@ -282,7 +282,8 @@ proto.pulumirpc.ConvertStateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
 mapperTarget: jspb.Message.getFieldWithDefault(msg, 1, ""),
 argsList: (f = jspb.Message.getRepeatedField(msg, 2)) == null ? undefined : f,
-loaderTarget: jspb.Message.getFieldWithDefault(msg, 3, "")
+loaderTarget: jspb.Message.getFieldWithDefault(msg, 3, ""),
+resolverTarget: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -331,6 +332,10 @@ proto.pulumirpc.ConvertStateRequest.deserializeBinaryFromReader = function(msg, 
       var value = /** @type {string} */ (reader.readString());
       msg.setLoaderTarget(value);
       break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setResolverTarget(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -378,6 +383,13 @@ proto.pulumirpc.ConvertStateRequest.serializeBinaryToWriter = function(message, 
   if (f.length > 0) {
     writer.writeString(
       3,
+      f
+    );
+  }
+  f = message.getResolverTarget();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
       f
     );
   }
@@ -454,6 +466,24 @@ proto.pulumirpc.ConvertStateRequest.prototype.getLoaderTarget = function() {
  */
 proto.pulumirpc.ConvertStateRequest.prototype.setLoaderTarget = function(value) {
   return jspb.Message.setProto3StringField(this, 3, value);
+};
+
+
+/**
+ * optional string resolver_target = 4;
+ * @return {string}
+ */
+proto.pulumirpc.ConvertStateRequest.prototype.getResolverTarget = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.pulumirpc.ConvertStateRequest} returns this
+ */
+proto.pulumirpc.ConvertStateRequest.prototype.setResolverTarget = function(value) {
+  return jspb.Message.setProto3StringField(this, 4, value);
 };
 
 

--- a/sdk/proto/go/converter.pb.go
+++ b/sdk/proto/go/converter.pb.go
@@ -45,9 +45,12 @@ type ConvertStateRequest struct {
 	// import from.
 	Args []string `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
 	// The target of a codegen.LoaderServer to use for loading schemas.
-	LoaderTarget  string `protobuf:"bytes,3,opt,name=loader_target,json=loaderTarget,proto3" json:"loader_target,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	LoaderTarget string `protobuf:"bytes,3,opt,name=loader_target,json=loaderTarget,proto3" json:"loader_target,omitempty"`
+	// The target of a [](pulumirpc.PackageResolver) service the converter can use to resolve package
+	// specifications to concrete package dependencies. May be empty on older engines.
+	ResolverTarget string `protobuf:"bytes,4,opt,name=resolver_target,json=resolverTarget,proto3" json:"resolver_target,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ConvertStateRequest) Reset() {
@@ -97,6 +100,13 @@ func (x *ConvertStateRequest) GetArgs() []string {
 func (x *ConvertStateRequest) GetLoaderTarget() string {
 	if x != nil {
 		return x.LoaderTarget
+	}
+	return ""
+}
+
+func (x *ConvertStateRequest) GetResolverTarget() string {
+	if x != nil {
+		return x.ResolverTarget
 	}
 	return ""
 }
@@ -846,11 +856,12 @@ var File_pulumi_converter_proto protoreflect.FileDescriptor
 
 const file_pulumi_converter_proto_rawDesc = "" +
 	"\n" +
-	"\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x1cgoogle/protobuf/struct.proto\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\"s\n" +
+	"\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x1cgoogle/protobuf/struct.proto\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\"\x9c\x01\n" +
 	"\x13ConvertStateRequest\x12#\n" +
 	"\rmapper_target\x18\x01 \x01(\tR\fmapperTarget\x12\x12\n" +
 	"\x04args\x18\x02 \x03(\tR\x04args\x12#\n" +
-	"\rloader_target\x18\x03 \x01(\tR\floaderTarget\"\xb8\x04\n" +
+	"\rloader_target\x18\x03 \x01(\tR\floaderTarget\x12'\n" +
+	"\x0fresolver_target\x18\x04 \x01(\tR\x0eresolverTarget\"\xb8\x04\n" +
 	"\x0eResourceImport\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x0e\n" +

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
@@ -16,7 +16,7 @@ from .codegen import hcl_pb2 as pulumi_dot_codegen_dot_hcl__pb2
 from .codegen import loader_pb2 as pulumi_dot_codegen_dot_loader__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x1cgoogle/protobuf/struct.proto\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\"Q\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x15\n\rloader_target\x18\x03 \x01(\t\"\x9c\x03\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\x12=\n\x10parameterization\x18\t \x01(\x0b\x32#.pulumirpc.ResourceParameterization\x12/\n\textension\x18\n \x01(\x0b\x32\x1c.pulumirpc.ResourceExtension\x12\x0e\n\x06parent\x18\x0b \x01(\t\x12\x12\n\nproperties\x18\x0c \x03(\t\x12\x10\n\x08provider\x18\r \x01(\t\x12\'\n\x06inputs\x18\x0e \x01(\x0b\x32\x17.google.protobuf.Struct\x12(\n\x07outputs\x18\x0f \x01(\x0b\x32\x17.google.protobuf.Struct\"V\n\x18ResourceParameterization\x12\x13\n\x0bplugin_name\x18\x01 \x01(\t\x12\x16\n\x0eplugin_version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"A\n\x11ResourceExtension\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xfe\x03\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x12\x42\n\tresources\x18\x07 \x03(\x0b\x32/.pulumirpc.ConvertSnippetRequest.ResourcesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1aN\n\x11ResourceReference\x12\r\n\x05token\x18\x01 \x01(\t\x12*\n\x07package\x18\x02 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x1a\x64\n\x0eResourcesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x41\n\x05value\x18\x02 \x01(\x0b\x32\x32.pulumirpc.ConvertSnippetRequest.ResourceReference:\x02\x38\x01\"\xec\x02\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x12\x45\n\nattributes\x18\x04 \x03(\x0b\x32\x31.pulumirpc.ConvertSnippetResponse.AttributesEntry\x12L\n\x0eresource_names\x18\x05 \x03(\x0b\x32\x34.pulumirpc.ConvertSnippetResponse.ResourceNamesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x34\n\x12ResourceNamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x1cgoogle/protobuf/struct.proto\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\"j\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x15\n\rloader_target\x18\x03 \x01(\t\x12\x17\n\x0fresolver_target\x18\x04 \x01(\t\"\x9c\x03\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\x12=\n\x10parameterization\x18\t \x01(\x0b\x32#.pulumirpc.ResourceParameterization\x12/\n\textension\x18\n \x01(\x0b\x32\x1c.pulumirpc.ResourceExtension\x12\x0e\n\x06parent\x18\x0b \x01(\t\x12\x12\n\nproperties\x18\x0c \x03(\t\x12\x10\n\x08provider\x18\r \x01(\t\x12\'\n\x06inputs\x18\x0e \x01(\x0b\x32\x17.google.protobuf.Struct\x12(\n\x07outputs\x18\x0f \x01(\x0b\x32\x17.google.protobuf.Struct\"V\n\x18ResourceParameterization\x12\x13\n\x0bplugin_name\x18\x01 \x01(\t\x12\x16\n\x0eplugin_version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"A\n\x11ResourceExtension\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x0c\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xfe\x03\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x12\x42\n\tresources\x18\x07 \x03(\x0b\x32/.pulumirpc.ConvertSnippetRequest.ResourcesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1aN\n\x11ResourceReference\x12\r\n\x05token\x18\x01 \x01(\t\x12*\n\x07package\x18\x02 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x1a\x64\n\x0eResourcesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x41\n\x05value\x18\x02 \x01(\x0b\x32\x32.pulumirpc.ConvertSnippetRequest.ResourceReference:\x02\x38\x01\"\xec\x02\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x12\x45\n\nattributes\x18\x04 \x03(\x0b\x32\x31.pulumirpc.ConvertSnippetResponse.AttributesEntry\x12L\n\x0eresource_names\x18\x05 \x03(\x0b\x32\x34.pulumirpc.ConvertSnippetResponse.ResourceNamesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x34\n\x12ResourceNamesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,33 +33,33 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _CONVERTSNIPPETRESPONSE_RESOURCENAMESENTRY._options = None
   _CONVERTSNIPPETRESPONSE_RESOURCENAMESENTRY._serialized_options = b'8\001'
   _globals['_CONVERTSTATEREQUEST']._serialized_start=122
-  _globals['_CONVERTSTATEREQUEST']._serialized_end=203
-  _globals['_RESOURCEIMPORT']._serialized_start=206
-  _globals['_RESOURCEIMPORT']._serialized_end=618
-  _globals['_RESOURCEPARAMETERIZATION']._serialized_start=620
-  _globals['_RESOURCEPARAMETERIZATION']._serialized_end=706
-  _globals['_RESOURCEEXTENSION']._serialized_start=708
-  _globals['_RESOURCEEXTENSION']._serialized_end=773
-  _globals['_CONVERTSTATERESPONSE']._serialized_start=775
-  _globals['_CONVERTSTATERESPONSE']._serialized_end=895
-  _globals['_CONVERTPROGRAMREQUEST']._serialized_start=898
-  _globals['_CONVERTPROGRAMREQUEST']._serialized_end=1070
-  _globals['_CONVERTPROGRAMRESPONSE']._serialized_start=1072
-  _globals['_CONVERTPROGRAMRESPONSE']._serialized_end=1148
-  _globals['_CONVERTSNIPPETREQUEST']._serialized_start=1151
-  _globals['_CONVERTSNIPPETREQUEST']._serialized_end=1661
-  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_start=1430
-  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_end=1479
-  _globals['_CONVERTSNIPPETREQUEST_RESOURCEREFERENCE']._serialized_start=1481
-  _globals['_CONVERTSNIPPETREQUEST_RESOURCEREFERENCE']._serialized_end=1559
-  _globals['_CONVERTSNIPPETREQUEST_RESOURCESENTRY']._serialized_start=1561
-  _globals['_CONVERTSNIPPETREQUEST_RESOURCESENTRY']._serialized_end=1661
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=1664
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=2028
-  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_start=1430
-  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_end=1479
-  _globals['_CONVERTSNIPPETRESPONSE_RESOURCENAMESENTRY']._serialized_start=1976
-  _globals['_CONVERTSNIPPETRESPONSE_RESOURCENAMESENTRY']._serialized_end=2028
-  _globals['_CONVERTER']._serialized_start=2031
-  _globals['_CONVERTER']._serialized_end=2303
+  _globals['_CONVERTSTATEREQUEST']._serialized_end=228
+  _globals['_RESOURCEIMPORT']._serialized_start=231
+  _globals['_RESOURCEIMPORT']._serialized_end=643
+  _globals['_RESOURCEPARAMETERIZATION']._serialized_start=645
+  _globals['_RESOURCEPARAMETERIZATION']._serialized_end=731
+  _globals['_RESOURCEEXTENSION']._serialized_start=733
+  _globals['_RESOURCEEXTENSION']._serialized_end=798
+  _globals['_CONVERTSTATERESPONSE']._serialized_start=800
+  _globals['_CONVERTSTATERESPONSE']._serialized_end=920
+  _globals['_CONVERTPROGRAMREQUEST']._serialized_start=923
+  _globals['_CONVERTPROGRAMREQUEST']._serialized_end=1095
+  _globals['_CONVERTPROGRAMRESPONSE']._serialized_start=1097
+  _globals['_CONVERTPROGRAMRESPONSE']._serialized_end=1173
+  _globals['_CONVERTSNIPPETREQUEST']._serialized_start=1176
+  _globals['_CONVERTSNIPPETREQUEST']._serialized_end=1686
+  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_start=1455
+  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_end=1504
+  _globals['_CONVERTSNIPPETREQUEST_RESOURCEREFERENCE']._serialized_start=1506
+  _globals['_CONVERTSNIPPETREQUEST_RESOURCEREFERENCE']._serialized_end=1584
+  _globals['_CONVERTSNIPPETREQUEST_RESOURCESENTRY']._serialized_start=1586
+  _globals['_CONVERTSNIPPETREQUEST_RESOURCESENTRY']._serialized_end=1686
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=1689
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=2053
+  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_start=1455
+  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_end=1504
+  _globals['_CONVERTSNIPPETRESPONSE_RESOURCENAMESENTRY']._serialized_start=2001
+  _globals['_CONVERTSNIPPETRESPONSE_RESOURCENAMESENTRY']._serialized_end=2053
+  _globals['_CONVERTER']._serialized_start=2056
+  _globals['_CONVERTER']._serialized_end=2328
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
@@ -35,10 +35,15 @@ class ConvertStateRequest(google.protobuf.message.Message):
     MAPPER_TARGET_FIELD_NUMBER: builtins.int
     ARGS_FIELD_NUMBER: builtins.int
     LOADER_TARGET_FIELD_NUMBER: builtins.int
+    RESOLVER_TARGET_FIELD_NUMBER: builtins.int
     mapper_target: builtins.str
     """the gRPC target of the mapper service."""
     loader_target: builtins.str
     """The target of a codegen.LoaderServer to use for loading schemas."""
+    resolver_target: builtins.str
+    """The target of a [](pulumirpc.PackageResolver) service the converter can use to resolve package
+    specifications to concrete package dependencies. May be empty on older engines.
+    """
     @property
     def args(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
         """the args passed to `pulumi import` for this conversion. Normally used to specifiy a state file to
@@ -51,8 +56,9 @@ class ConvertStateRequest(google.protobuf.message.Message):
         mapper_target: builtins.str = ...,
         args: collections.abc.Iterable[builtins.str] | None = ...,
         loader_target: builtins.str = ...,
+        resolver_target: builtins.str = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["args", b"args", "loader_target", b"loader_target", "mapper_target", b"mapper_target"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["args", b"args", "loader_target", b"loader_target", "mapper_target", b"mapper_target", "resolver_target", b"resolver_target"]) -> None: ...
 
 global___ConvertStateRequest = ConvertStateRequest
 


### PR DESCRIPTION
## Description

Adds `resolver_target` to `ConvertStateRequest`, giving state converters access to the engine's `PackageResolver` service during `pulumi import --from <converter>`.

Today a converter that needs a parameterized package descriptor (e.g. a dynamically bridged Terraform provider) has to hand-construct the parameterization value, duplicating the base plugin's private parameter encoding and guessing the version from a constraint string. Providers already get `resolver_target` in the provider handshake for exactly this reason; this extends the same service to the state-conversion channel:

- `ConvertStateRequest` gains `resolver_target` (optional; empty on older engines, mirroring the provider-handshake field).
- The `pulumi import --from` path registers the `PackageResolver` service on the gRPC server that already serves the mapper and loader, and passes its address to the converter.
- `packageworkspace.ResolverRegistration` is added alongside the existing `LoaderRegistration`/`MapperRegistration` helpers.

The first consumer is pulumi-hcl's state converter, which will resolve `terraform-provider` parameterizations through this service instead of fabricating the parameter value.

## Checklist

- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Cloud API version