### PR TITLE
Update converter plugin to use property.Map

### DIFF
--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func parseResourceSpec(spec string) (string, resource.URN, error) {
@@ -96,11 +97,12 @@ func parseResourceSpec(spec string) (string, resource.URN, error) {
 func makeImportFileFromResourceList(ctx context.Context, resources []plugin.ResourceImport) (importFile, error) {
 	// Serialized with secrets in plain text, marked with the secret signature: the converter response
 	// carries them the same way, and parseImportFile deserializes them back into secret values.
-	serialize := func(props resource.PropertyMap, name, kind string) (map[string]any, error) {
+	serialize := func(props *property.Map, name, kind string) (map[string]any, error) {
 		if props == nil {
 			return nil, nil
 		}
-		serialized, err := resourcestack.SerializeProperties(ctx, props, sdkconfig.NopEncrypter, true /*showSecrets*/)
+		mprops := resource.ToResourcePropertyMap(*props)
+		serialized, err := resourcestack.SerializeProperties(ctx, mprops, sdkconfig.NopEncrypter, true /*showSecrets*/)
 		if err != nil {
 			return nil, fmt.Errorf("serializing %s for resource %q: %w", kind, name, err)
 		}

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	sdkconfig "github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -616,6 +617,10 @@ func TestParseImportFileProviderInputs(t *testing.T) {
 	assert.Equal(t, resource.NewProperty("6.0.0"), imports[0].ProviderInputs["version"])
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestMakeImportFileFromResourceListInputsOutputs(t *testing.T) {
 	t.Parallel()
 
@@ -624,12 +629,12 @@ func TestMakeImportFileFromResourceListInputsOutputs(t *testing.T) {
 			Type: "aws:s3/bucket:Bucket",
 			Name: "thing",
 			ID:   "thing-id",
-			Inputs: resource.PropertyMap{
-				"password": resource.MakeSecret(resource.NewProperty("shh")),
-			},
-			Outputs: resource.PropertyMap{
-				"arn": resource.NewProperty("some:arn"),
-			},
+			Inputs: ptr(property.NewMap(map[string]property.Value{
+				"password": property.New("shh").WithSecret(true),
+			})),
+			Outputs: ptr(property.NewMap(map[string]property.Value{
+				"arn": property.New("some:arn"),
+			})),
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/resource/plugin/converter.go
+++ b/pkg/resource/plugin/converter.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
@@ -58,10 +58,10 @@ type ResourceImport struct {
 	// Inputs holds input properties supplied for the resource. Values the provider's Read cannot return
 	// (e.g. write-only attributes) are taken from here instead. For a provider declared in the response,
 	// Inputs is its configuration.
-	Inputs resource.PropertyMap
+	Inputs *property.Map
 	// Outputs holds the resource's full output state. When set, the resource is imported from these
 	// values directly and the provider's Read is skipped entirely.
-	Outputs resource.PropertyMap
+	Outputs *property.Map
 }
 
 // ResourceParameterization describes the base plugin that a resource's parameterized provider is built

--- a/pkg/resource/plugin/converter_plugin.go
+++ b/pkg/resource/plugin/converter_plugin.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -126,47 +127,49 @@ func (c *converter) ConvertState(ctx context.Context, req *ConvertStateRequest) 
 	}
 
 	resources := make([]ResourceImport, len(resp.Resources))
-	for i, resource := range resp.Resources {
+	for i, res := range resp.Resources {
 		resources[i] = ResourceImport{
-			Type:              resource.Type,
-			Name:              resource.Name,
-			ID:                resource.Id,
-			Version:           resource.Version,
-			PluginDownloadURL: resource.PluginDownloadURL,
-			LogicalName:       resource.LogicalName,
-			IsRemote:          resource.IsRemote,
-			IsComponent:       resource.IsComponent,
-			Parent:            resource.Parent,
-			Properties:        resource.Properties,
-			Provider:          resource.Provider,
+			Type:              res.Type,
+			Name:              res.Name,
+			ID:                res.Id,
+			Version:           res.Version,
+			PluginDownloadURL: res.PluginDownloadURL,
+			LogicalName:       res.LogicalName,
+			IsRemote:          res.IsRemote,
+			IsComponent:       res.IsComponent,
+			Parent:            res.Parent,
+			Properties:        res.Properties,
+			Provider:          res.Provider,
 		}
-		if p := resource.Parameterization; p != nil {
+		if p := res.Parameterization; p != nil {
 			resources[i].Parameterization = &ResourceParameterization{
 				PluginName:    p.PluginName,
 				PluginVersion: p.PluginVersion,
 				Value:         p.Value,
 			}
 		}
-		if e := resource.Extension; e != nil {
+		if e := res.Extension; e != nil {
 			resources[i].Extension = &ResourceExtension{
 				Name:    e.Name,
 				Version: e.Version,
 				Value:   e.Value,
 			}
 		}
-		if resource.Inputs != nil {
-			inputs, err := UnmarshalProperties(resource.Inputs, MarshalOptions{Label: label, KeepSecrets: true})
+		if res.Inputs != nil {
+			inputs, err := UnmarshalProperties(res.Inputs, MarshalOptions{Label: label, KeepSecrets: true})
 			if err != nil {
-				return nil, fmt.Errorf("unmarshaling inputs for resource %q: %w", resource.Name, err)
+				return nil, fmt.Errorf("unmarshaling inputs for resource %q: %w", res.Name, err)
 			}
-			resources[i].Inputs = inputs
+			minputs := resource.FromResourcePropertyMap(inputs)
+			resources[i].Inputs = &minputs
 		}
-		if resource.Outputs != nil {
-			outputs, err := UnmarshalProperties(resource.Outputs, MarshalOptions{Label: label, KeepSecrets: true})
+		if res.Outputs != nil {
+			outputs, err := UnmarshalProperties(res.Outputs, MarshalOptions{Label: label, KeepSecrets: true})
 			if err != nil {
-				return nil, fmt.Errorf("unmarshaling outputs for resource %q: %w", resource.Name, err)
+				return nil, fmt.Errorf("unmarshaling outputs for resource %q: %w", res.Name, err)
 			}
-			resources[i].Outputs = outputs
+			moutputs := resource.FromResourcePropertyMap(outputs)
+			resources[i].Outputs = &moutputs
 		}
 	}
 

--- a/pkg/resource/plugin/converter_plugin_test.go
+++ b/pkg/resource/plugin/converter_plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	"github.com/stretchr/testify/assert"
@@ -181,13 +182,13 @@ func TestConverterPlugin_State(t *testing.T) {
 	assert.Equal(t, "test:parent", res.Parent)
 	assert.Equal(t, []string{"prop1", "prop2"}, res.Properties)
 	assert.Equal(t, "test:provider", res.Provider)
-	assert.Equal(t, resource.PropertyMap{
-		"region": resource.NewProperty("us-east-1"),
-		"secret": resource.MakeSecret(resource.NewProperty("shh")),
-	}, res.Inputs)
-	assert.Equal(t, resource.PropertyMap{
-		"arn": resource.NewProperty("test:arn"),
-	}, res.Outputs)
+	assert.Equal(t, ptr(property.NewMap(map[string]property.Value{
+		"region": property.New("us-east-1"),
+		"secret": property.New("shh").WithSecret(true),
+	})), res.Inputs)
+	assert.Equal(t, ptr(property.NewMap(map[string]property.Value{
+		"arn": property.New("test:arn"),
+	})), res.Outputs)
 
 	diag := resp.Diagnostics[0]
 	assert.Equal(t, hcl.DiagError, diag.Severity)

--- a/pkg/resource/plugin/converter_server.go
+++ b/pkg/resource/plugin/converter_server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
@@ -46,45 +47,45 @@ func (c *converterServer) ConvertState(ctx context.Context,
 	}
 
 	resources := make([]*pulumirpc.ResourceImport, len(resp.Resources))
-	for i, resource := range resp.Resources {
+	for i, res := range resp.Resources {
 		resources[i] = &pulumirpc.ResourceImport{
-			Type:              resource.Type,
-			Name:              resource.Name,
-			Id:                resource.ID,
-			Version:           resource.Version,
-			PluginDownloadURL: resource.PluginDownloadURL,
-			LogicalName:       resource.LogicalName,
-			IsRemote:          resource.IsRemote,
-			IsComponent:       resource.IsComponent,
-			Parent:            resource.Parent,
-			Properties:        resource.Properties,
-			Provider:          resource.Provider,
+			Type:              res.Type,
+			Name:              res.Name,
+			Id:                res.ID,
+			Version:           res.Version,
+			PluginDownloadURL: res.PluginDownloadURL,
+			LogicalName:       res.LogicalName,
+			IsRemote:          res.IsRemote,
+			IsComponent:       res.IsComponent,
+			Parent:            res.Parent,
+			Properties:        res.Properties,
+			Provider:          res.Provider,
 		}
-		if p := resource.Parameterization; p != nil {
+		if p := res.Parameterization; p != nil {
 			resources[i].Parameterization = &pulumirpc.ResourceParameterization{
 				PluginName:    p.PluginName,
 				PluginVersion: p.PluginVersion,
 				Value:         p.Value,
 			}
 		}
-		if e := resource.Extension; e != nil {
+		if e := res.Extension; e != nil {
 			resources[i].Extension = &pulumirpc.ResourceExtension{
 				Name:    e.Name,
 				Version: e.Version,
 				Value:   e.Value,
 			}
 		}
-		if resource.Inputs != nil {
-			inputs, err := MarshalProperties(resource.Inputs, MarshalOptions{KeepSecrets: true})
+		if res.Inputs != nil {
+			inputs, err := MarshalProperties(resource.ToResourcePropertyMap(*res.Inputs), MarshalOptions{KeepSecrets: true})
 			if err != nil {
-				return nil, fmt.Errorf("marshaling inputs for resource %q: %w", resource.Name, err)
+				return nil, fmt.Errorf("marshaling inputs for resource %q: %w", res.Name, err)
 			}
 			resources[i].Inputs = inputs
 		}
-		if resource.Outputs != nil {
-			outputs, err := MarshalProperties(resource.Outputs, MarshalOptions{KeepSecrets: true})
+		if res.Outputs != nil {
+			outputs, err := MarshalProperties(resource.ToResourcePropertyMap(*res.Outputs), MarshalOptions{KeepSecrets: true})
 			if err != nil {
-				return nil, fmt.Errorf("marshaling outputs for resource %q: %w", resource.Name, err)
+				return nil, fmt.Errorf("marshaling outputs for resource %q: %w", res.Name, err)
 			}
 			resources[i].Outputs = outputs
 		}

--- a/pkg/resource/plugin/converter_server_test.go
+++ b/pkg/resource/plugin/converter_server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	"github.com/stretchr/testify/assert"
@@ -79,13 +80,13 @@ func (c *testConverter) ConvertState(
 				Parent:     "test:parent",
 				Properties: []string{"prop1", "prop2"},
 				Provider:   "test:provider",
-				Inputs: resource.PropertyMap{
-					"region": resource.NewProperty("us-east-1"),
-					"secret": resource.MakeSecret(resource.NewProperty("shh")),
-				},
-				Outputs: resource.PropertyMap{
-					"arn": resource.NewProperty("test:arn"),
-				},
+				Inputs: ptr(property.NewMap(map[string]property.Value{
+					"region": property.New("us-east-1"),
+					"secret": property.New("shh").WithSecret(true),
+				})),
+				Outputs: ptr(property.NewMap(map[string]property.Value{
+					"arn": property.New("test:arn"),
+				})),
 			},
 		},
 		Diagnostics: diags,


### PR DESCRIPTION
Continuing the `property.Map` migration across pkg. This updates the converter plugin. Note we need to use `property.Map` pointers here so we can support empty inputs/outputs vs unset inputs/outputs.