### PR TITLE
do: add `get` subcommand

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -103,6 +103,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		cmd.AddCommand(pc.newStatefulResourceCreateCommand(res))
 		cmd.AddCommand(pc.newStatefulResourceUpsertCommand(res))
 	}
+	cmd.AddCommand(pc.newResourceGetCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))
 	cmd.AddCommand(pc.newResourceDeleteCommand(res))

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -370,6 +370,79 @@ func (pc *packageCommand) runStatefulSnippetDelete(
 	return nil
 }
 
+func (pc *packageCommand) newResourceGetCommand(res *schema.Resource) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <name>",
+		Short: "Show a resource tracked in the stack",
+		Long: "Show a resource tracked in the stack.\n\n" +
+			"Displays the state Pulumi tracks for the named resource, including its " +
+			"provider ID and outputs, without calling the provider.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if pc.stateless {
+				return errors.New("`get` shows the resource state tracked in the stack and is not " +
+					"available with --stateless; use `read <id>` to read directly from the provider")
+			}
+			if pc.proj == nil {
+				return fmt.Errorf("`%s` requires a Pulumi project (run inside a project directory)", cmd.Name())
+			}
+			ctx := cmd.Context()
+			displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+			stack, err := cmdStack.RequireStack(
+				ctx, pc.diagFwd, pc.ws, pc.lm,
+				"",                                 /*stackName — use currently selected*/
+				cmdStack.LoadOnly, displayOpts, "", /*configFile*/
+			)
+			if err != nil {
+				return fmt.Errorf("load stack: %w", err)
+			}
+			snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
+			if err != nil {
+				return fmt.Errorf("load stack snapshot: %w", err)
+			}
+			name := args[0]
+			snippetUUID, exists, err := resolveSnippetUUID(snap, name, res.Token)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return fmt.Errorf("resource %s %q does not exist in stack %s", res.Token, name, stack.Ref())
+			}
+			state := findSnippetResource(snap, snippetUUID, name, res.Token)
+			if state == nil {
+				return fmt.Errorf("no state is tracked yet for %s %q in stack %s; the last update may have failed",
+					res.Token, name, stack.Ref())
+			}
+			result := operationState(state.URN, state.ID, nil, state.Outputs)
+			if state.ID != "" {
+				result = resultState(state.URN, state.ID, nil, state.Outputs, res)
+			}
+			return pc.runDisplayedStep(cmd, displayedStep{
+				Op:  deploy.OpRead,
+				New: operationState(state.URN, state.ID, nil, nil),
+			}, func() (*pkgresource.State, error) {
+				return result, nil
+			})
+		},
+	}
+}
+
+func findSnippetResource(snap *deploy.Snapshot, snippetUUID, name, resourceToken string) *pkgresource.State {
+	var fallback *pkgresource.State
+	for _, state := range snap.Resources {
+		if state == nil || state.SnippetID != snippetUUID {
+			continue
+		}
+		if state.URN.Name() == name && string(state.URN.Type()) == resourceToken {
+			return state
+		}
+		if fallback == nil {
+			fallback = state
+		}
+	}
+	return fallback
+}
+
 // addStatefulSnippetUpdateFlags installs the flag set shared by stateful `create` and `upsert`.
 func addStatefulSnippetUpdateFlags(
 	cmd *cobra.Command, inputFile, inputFormat, resourcesFile *string, yes *bool, inputs []*schema.Property,

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -17,6 +17,7 @@ package do
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/gofrs/uuid"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -702,6 +704,74 @@ size = 2
 		require.NoError(t, cmd.Execute())
 		assert.Equal(t, []string{"read", "check", "create"}, calls)
 		assert.JSONEq(t, `{"id":"res-2","name":"new"}`, stdout.String())
+	})
+}
+
+//nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
+func TestDoCmdResourceStatefulGet(t *testing.T) {
+	snippet := resource.Snippet{
+		UUID: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+		Name: "myres", Type: "azure:index:myResource",
+		Code:       `name = "example"`,
+		Descriptor: resource.PackageDescriptor{Name: "azure"},
+	}
+	newGetCommand := func(t *testing.T, snap *deploy.Snapshot) (*cobra.Command, *bytes.Buffer) {
+		mws, mlm := installMockUpsertBackend(t, snap)
+		stub := func(_ context.Context, _ *pflag.FlagSet, _ StatefulUpdateRequest,
+		) (*StatefulUpdateResult, error) {
+			require.Fail(t, "runStatefulUpdate should not be invoked by get")
+			return nil, nil
+		}
+		loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
+			return &testProvider{spec: doResourceSpec(false)}, nil
+		}
+		var stdout bytes.Buffer
+		cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, stub)
+		cmd.SetOut(&stdout)
+		cmd.SetErr(io.Discard)
+		return cmd, &stdout
+	}
+
+	t.Run("shows the tracked ID and outputs", func(t *testing.T) {
+		cmd, stdout := newGetCommand(t, &deploy.Snapshot{
+			Snippets: []resource.Snippet{snippet},
+			Resources: []*pkgresource.State{{
+				Type:      tokens.Type("azure:index:myResource"),
+				URN:       resource.URN("urn:pulumi:dev::proj::azure:index:myResource::myres"),
+				Custom:    true,
+				ID:        "res-123",
+				SnippetID: snippet.UUID,
+				Outputs: resource.PropertyMap{
+					"name":     resource.NewProperty("example"),
+					"size":     resource.NewProperty(3.0),
+					"internal": resource.NewProperty("filtered"),
+				},
+			}},
+		})
+		cmd.SetArgs([]string{"azure:index:myResource", "get", "myres", "--output", "json"})
+		require.NoError(t, cmd.Execute())
+		assert.JSONEq(t, `{"id":"res-123","name":"example","size":3}`, stdout.String())
+	})
+
+	t.Run("errors when the resource is not in the stack", func(t *testing.T) {
+		cmd, _ := newGetCommand(t, &deploy.Snapshot{})
+		cmd.SetArgs([]string{"azure:index:myResource", "get", "myres"})
+		err := cmd.Execute()
+		require.ErrorContains(t, err, `resource azure:index:myResource "myres" does not exist in stack`)
+	})
+
+	t.Run("errors when the snippet has no tracked state", func(t *testing.T) {
+		cmd, _ := newGetCommand(t, &deploy.Snapshot{Snippets: []resource.Snippet{snippet}})
+		cmd.SetArgs([]string{"azure:index:myResource", "get", "myres"})
+		err := cmd.Execute()
+		require.ErrorContains(t, err, `no state is tracked yet for azure:index:myResource "myres"`)
+	})
+
+	t.Run("errors in stateless mode", func(t *testing.T) {
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "get", "myres"})
+		err := cmd.Execute()
+		require.ErrorContains(t, err, "not available with --stateless")
 	})
 }
 


### PR DESCRIPTION
Currently we don't have a good way to show the properties of an existing resource in stateful do.  We can read such a resource, but that always gets the properties from the cloud state.  We do have the properties in state, so add a new `pulumi do get` command to show the current state of a resource.

This can e.g. be used for getting the ID of a resource.

Before getting into code review here (I haven't really reviewed this clanker generated code myself yet), I'm more interested in a general "this is something that might be worth doing/this isn't something we want to do" type feedback, before I go back and review the code myself. 