### PR TITLE
fix(cli/cloud): accumulate repeated -H headers instead of overwriting

### DIFF
--- a/changelog/pending/20260803--cli-cloud--api-repeated-headers.yaml
+++ b/changelog/pending/20260803--cli-cloud--api-repeated-headers.yaml
@@ -1,0 +1,4 @@
+component: cli/cloud
+kind: fix
+body: "`pulumi api`: repeated `-H`/`--header` values for the same header name now all reach the wire, instead of each one silently overwriting the last"
+time: 2026-08-03T00:00:00+00:00

--- a/pkg/cmd/pulumi/cloud/api_test.go
+++ b/pkg/cmd/pulumi/cloud/api_test.go
@@ -495,6 +495,45 @@ func TestRawCall_ForwardsUserHeaders(t *testing.T) {
 		"Authorization must stay pinned to the resolved token")
 }
 
+// TestRawCall_RepeatedHeadersAccumulate is a regression test for
+// https://github.com/pulumi/pulumi/issues/23126: `-H`/`--header` is
+// documented as repeatable, but buildAPIHeaders used http.Header.Set for
+// every occurrence, so each repeated value for the same header name
+// silently discarded the one before it and only the last survived on the
+// wire. Repeated occurrences of the same name must accumulate instead,
+// matching `curl -H ... -H ...` and `gh api -H ... -H ...`. The first
+// user-supplied occurrence of a name must still replace an encoder default
+// (Accept/Content-Type) rather than being appended alongside it.
+func TestRawCall_RepeatedHeadersAccumulate(t *testing.T) {
+	t.Parallel()
+	var received http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	apiClient := client.NewClient(srv.URL, "my-token", false, nil)
+	hdrs := []ParsedHeader{
+		{Name: "X-Foo", Value: "a"},
+		{Name: "X-Foo", Value: "b"},
+		// Repeated user-supplied Content-Type: the first occurrence must
+		// replace the encoder default, the second must accumulate alongside
+		// it rather than either being dropped or the default lingering.
+		{Name: "Content-Type", Value: "text/plain"},
+		{Name: "Content-Type", Value: "application/x-yaml"},
+	}
+	resp, err := apiClient.RawCall(t.Context(), http.MethodGet, "/echo", nil, nil,
+		buildAPIHeaders("application/json", "application/json", hdrs), false)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, []string{"a", "b"}, received.Values("X-Foo"),
+		"repeated -H values for the same header name must all reach the wire")
+	assert.Equal(t, []string{"text/plain", "application/x-yaml"}, received.Values("Content-Type"),
+		"repeated user Content-Type values must accumulate without the encoder default lingering")
+}
+
 // TestValidateFlagCombos_BodyAndInputMutuallyExclusive pins the user-visible
 // error when both --body and --input are set.
 func TestValidateFlagCombos_BodyAndInputMutuallyExclusive(t *testing.T) {

--- a/pkg/cmd/pulumi/cloud/fields.go
+++ b/pkg/cmd/pulumi/cloud/fields.go
@@ -161,11 +161,11 @@ func buildAPIHeaders(contentType, accept string, headers []ParsedHeader) http.He
 		}
 		key := http.CanonicalHeaderKey(ph.Name)
 		if seenNames[key] {
-			h.Add(ph.Name, ph.Value)
+			h.Add(key, ph.Value)
 		} else {
 			// First user-supplied value for this name; replace whatever
 			// encoder default (or nothing) was there.
-			h.Set(ph.Name, ph.Value)
+			h.Set(key, ph.Value)
 			seenNames[key] = true
 		}
 	}

--- a/pkg/cmd/pulumi/cloud/fields.go
+++ b/pkg/cmd/pulumi/cloud/fields.go
@@ -139,7 +139,11 @@ func methodDefaultsToPost(fieldCount int, hasInput, hasBody bool) bool {
 // buildAPIHeaders folds contentType / accept / user `-H` headers into a
 // single http.Header for httpstate Client.RawCall. User headers win over
 // the encoder defaults (Accept, Content-Type); user-supplied Authorization
-// is dropped — RawCall pins it from the Client's token.
+// is dropped — RawCall pins it from the Client's token. `-H` is documented
+// as repeatable, so repeated occurrences of the same header name accumulate
+// (matching curl/gh's behavior) rather than each one silently overwriting
+// the last; only the first user-supplied occurrence of a given name
+// replaces an encoder default.
 func buildAPIHeaders(contentType, accept string, headers []ParsedHeader) http.Header {
 	h := http.Header{}
 	if accept != "" {
@@ -150,11 +154,20 @@ func buildAPIHeaders(contentType, accept string, headers []ParsedHeader) http.He
 	if contentType != "" {
 		h.Set("Content-Type", contentType)
 	}
+	seenNames := make(map[string]bool, len(headers))
 	for _, ph := range headers {
 		if strings.EqualFold(ph.Name, "Authorization") {
 			continue
 		}
-		h.Set(ph.Name, ph.Value)
+		key := http.CanonicalHeaderKey(ph.Name)
+		if seenNames[key] {
+			h.Add(ph.Name, ph.Value)
+		} else {
+			// First user-supplied value for this name; replace whatever
+			// encoder default (or nothing) was there.
+			h.Set(ph.Name, ph.Value)
+			seenNames[key] = true
+		}
 	}
 	return h
 }


### PR DESCRIPTION
Fixes #23126

## What this PR does / why we need it

`-H, --header` on `pulumi api` is documented as "Custom HTTP header `Key: Value` (repeatable)". `buildAPIHeaders` (`pkg/cmd/pulumi/cloud/fields.go`) folds every user-supplied `-H` value onto the outgoing `http.Header` via `h.Set(ph.Name, ph.Value)`. `Set` replaces the existing value for that key, so passing `-H` twice with the same header name silently drops the earlier value:

```
$ bin/pulumi api /api/user -H 'X-Foo: a' -H 'X-Foo: b' --verbose 2>&1 >/dev/null
> GET https://api.pulumi.com/api/user
> X-Foo: a
> X-Foo: b
```

The `--verbose` dump prints both lines as typed, but only `X-Foo: b` actually reaches the wire — the CLI never warns that the earlier value was dropped. Per RFC 7230 §3.2.2, repeated header fields with the same name are semantically a single comma-joined value, and both `curl -H ... -H ...` and `gh api -H ... -H ...` preserve all values. Any header that legitimately takes multiple values (`Cookie`, `X-Forwarded-For`, custom multi-value headers) can't currently be set correctly with `pulumi api`.

## Fix

`buildAPIHeaders` now tracks (via a local `seenNames` set, keyed by `http.CanonicalHeaderKey`) whether a user-supplied `-H` value has already been applied for a given header name:
- The **first** user-supplied occurrence of a name still uses `Set`, so it correctly replaces an encoder default (`Accept`/`Content-Type`) — preserving the existing "user headers win over encoder defaults" contract.
- Any **subsequent** occurrence of the same name uses `Add`, accumulating instead of overwriting.

`Authorization` continues to be dropped entirely regardless of repetition, unchanged from before.

## Testing

Added `TestRawCall_RepeatedHeadersAccumulate` in `pkg/cmd/pulumi/cloud/api_test.go`, following the existing `TestRawCall_ForwardsUserHeaders` pattern (a real `httptest` server capturing the actual received `http.Header`, driven through `buildAPIHeaders` → `Client.RawCall`, not just inspecting the header value in isolation). It covers both:
- A header with no encoder default (`X-Foo`) repeated twice — both values must reach the wire.
- `Content-Type` (which *does* have an encoder default) repeated twice — the first must still replace the default, and the second must accumulate alongside it, without the original default lingering.

Verified via `git stash` that reverting only `fields.go` (keeping the new test) reproduces the exact reported behavior — the test fails showing only the last value (`"b"`, `"application/x-yaml"`) survives instead of both. Restoring the fix makes it pass.

`go build ./cmd/pulumi/cloud/...`, `go vet ./cmd/pulumi/cloud/...`, and `go test ./cmd/pulumi/cloud/...` (from `pkg/`) all pass with no regressions, including the pre-existing `TestRawCall_ForwardsUserHeaders`.

Added a changelog entry via the `changie` format under `changelog/pending/`.
