### PR TITLE
Restrict runtime operations in Python hooks

### DIFF
--- a/changelog/pending/sdk-python-fix-20260804-hook-callback-restrictions.yaml
+++ b/changelog/pending/sdk-python-fix-20260804-hook-callback-restrictions.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: fix
+body: Prevent resource and error hook callbacks from modifying the Pulumi deployment
+time: 2026-08-04T13:35:02+02:00

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -29,6 +29,7 @@ from collections.abc import Awaitable, Mapping, Sequence
 from . import _types
 from .resource_hooks import ResourceHookBinding
 from .runtime import known_types
+from .runtime._callback_context import _ensure_runtime_operation_allowed
 from .runtime.resource import (
     _pkg_from_type,
     get_resource,
@@ -915,6 +916,8 @@ class Resource:
             self._childResources = set()
             return
 
+        _ensure_runtime_operation_allowed("resource construction")
+
         if props is None:
             props = {}
         if not t:
@@ -1358,6 +1361,8 @@ def export(name: str, value: Any):
     :param str name: The name to assign to this output.
     :param Any value: The value of this output.
     """
+    _ensure_runtime_operation_allowed("export stack output")
+
     res = cast("Stack", get_root_resource())
     if known_types.is_stack(res):
         res.output(name, value)

--- a/sdk/python/lib/pulumi/resource_hooks.py
+++ b/sdk/python/lib/pulumi/resource_hooks.py
@@ -78,7 +78,13 @@ ResourceHookFunction = Callable[
     [ResourceHookArgs],
     Union[None, Awaitable[None]],
 ]
-"""ResourceHookFunction is a function that can be registered as a resource hook."""
+"""
+ResourceHookFunction is a function that can be registered as a resource hook.
+
+Resource hook callbacks may invoke provider functions and call external services,
+but they must not register Pulumi resources, hooks, or transforms, or otherwise
+modify the deployment.
+"""
 
 
 class ErrorHookArgs:
@@ -150,7 +156,14 @@ ErrorHookFunction = Callable[
     [ErrorHookArgs],
     Union[bool, Awaitable[bool]],
 ]
-"""ErrorHookFunction is a function that can be registered as an error hook. Returns True to retry, False to not retry."""
+"""
+ErrorHookFunction is a function that can be registered as an error hook. Returns
+True to retry and False to stop retrying.
+
+Error hook callbacks may invoke provider functions and call external services,
+but they must not register Pulumi resources, hooks, or transforms, or otherwise
+modify the deployment.
+"""
 
 
 class ErrorHook:

--- a/sdk/python/lib/pulumi/runtime/_callback_context.py
+++ b/sdk/python/lib/pulumi/runtime/_callback_context.py
@@ -1,0 +1,88 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Callback-local restrictions on re-entering the Pulumi runtime."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _CallbackRestrictions:
+    """
+    Describes the Pulumi runtime capabilities available to a callback.
+
+    Provider functions include Invoke and Call.
+    """
+
+    description: str
+    allow_provider_functions: bool
+    guidance: str
+
+
+_CALLBACK_RESTRICTIONS: ContextVar[_CallbackRestrictions | None] = ContextVar(
+    "callback_restrictions", default=None
+)
+
+
+@contextmanager
+def _callback_restrictions(
+    description: str,
+    *,
+    allow_provider_functions: bool,
+    guidance: str,
+) -> Iterator[None]:
+    """
+    Applies restrictions for the current callback's asynchronous context.
+
+    The restrictions remain active across normal asynchronous suspension and in
+    tasks created by the callback. The description and guidance appear in
+    user-visible errors.
+    """
+
+    token = _CALLBACK_RESTRICTIONS.set(
+        _CallbackRestrictions(
+            description=description,
+            allow_provider_functions=allow_provider_functions,
+            guidance=guidance,
+        )
+    )
+    try:
+        yield
+    finally:
+        _CALLBACK_RESTRICTIONS.reset(token)
+
+
+def _ensure_runtime_operation_allowed(
+    operation: str, *, provider_function: bool = False
+) -> None:
+    """
+    Raises when the active callback restrictions do not permit an operation.
+
+    ``provider_function`` means the operation is part of an Invoke or Call to a
+    provider.
+    """
+
+    restrictions = _CALLBACK_RESTRICTIONS.get()
+    if restrictions is None or (
+        provider_function and restrictions.allow_provider_functions
+    ):
+        return
+
+    raise RuntimeError(
+        f"Pulumi runtime operation {operation!r} is not allowed inside "
+        f"{restrictions.description}. {restrictions.guidance}"
+    )

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -33,6 +33,7 @@ from packaging import version
 
 from .. import log
 from ..invoke import InvokeOptions, InvokeTransform
+from ._callback_context import _callback_restrictions
 from .proto import (
     alias_pb2,
     callback_pb2,
@@ -58,6 +59,11 @@ if TYPE_CHECKING:
 
 
 _CallbackFunction = Callable[[bytes], Awaitable[Message]]
+
+_HOOK_CALLBACK_GUIDANCE = (
+    "Hook callbacks may invoke provider functions, but must not register resources "
+    "or otherwise modify the Pulumi deployment."
+)
 
 
 class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
@@ -352,20 +358,25 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
                     else None
                 )
 
-                maybeAwaitable = hook(
-                    ResourceHookArgs(
-                        urn=request.urn,
-                        id=request.id,
-                        name=request.name,
-                        type=request.type,
-                        new_inputs=new_inputs,
-                        old_inputs=old_inputs,
-                        new_outputs=new_outputs,
-                        old_outputs=old_outputs,
+                with _callback_restrictions(
+                    f"resource hook {hook.name!r} for resource {request.urn!r}",
+                    allow_provider_functions=True,
+                    guidance=_HOOK_CALLBACK_GUIDANCE,
+                ):
+                    maybeAwaitable = hook(
+                        ResourceHookArgs(
+                            urn=request.urn,
+                            id=request.id,
+                            name=request.name,
+                            type=request.type,
+                            new_inputs=new_inputs,
+                            old_inputs=old_inputs,
+                            new_outputs=new_outputs,
+                            old_outputs=old_outputs,
+                        )
                     )
-                )
-                if isinstance(maybeAwaitable, Awaitable):
-                    await maybeAwaitable
+                    if isinstance(maybeAwaitable, Awaitable):
+                        await maybeAwaitable
                 return resource_pb2.ResourceHookResponse()
             except Exception as e:  # noqa: BLE001 catch blind exception
                 log.debug(f"Exception while executing hook: {str(e)}")
@@ -448,11 +459,16 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
                     failed_operation=request.failed_operation,
                     errors=list(request.errors),
                 )
-                maybe_retry = hook(args)
-                if isinstance(maybe_retry, Awaitable):
-                    retry = await maybe_retry
-                else:
-                    retry = maybe_retry
+                with _callback_restrictions(
+                    f"error hook {hook.name!r} for resource {request.urn!r}",
+                    allow_provider_functions=True,
+                    guidance=_HOOK_CALLBACK_GUIDANCE,
+                ):
+                    maybe_retry = hook(args)
+                    if isinstance(maybe_retry, Awaitable):
+                        retry = await maybe_retry
+                    else:
+                        retry = maybe_retry
                 return resource_pb2.ErrorHookResponse(retry=retry)
             except Exception as e:  # noqa: BLE001 catch blind exception
                 log.debug(f"Exception while executing error hook: {str(e)}")

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -24,6 +24,7 @@ from collections.abc import Awaitable
 
 import grpc
 
+from ._callback_context import _ensure_runtime_operation_allowed
 from ._instrumentation import wrap_with_context
 from google.protobuf import struct_pb2
 
@@ -157,6 +158,7 @@ def invoke_output(
     can be a bag of computed values (Ts or Awaitable[T]s), and the result is an Output[T] that
     resolves when the invoke finishes.
     """
+    _ensure_runtime_operation_allowed("invoke", provider_function=True)
 
     # Setup the future for the output data.
     resolve_data: asyncio.Future[_OutputData[Any]] = asyncio.Future()
@@ -226,6 +228,7 @@ def _invoke(
     package_ref: Optional[Awaitable[Optional[str]]],
     check_dependencies: Optional[bool] = False,
 ) -> Awaitable[InvokeResult]:
+    _ensure_runtime_operation_allowed("invoke", provider_function=True)
     log.debug(f"Invoking function: tok={tok}")
     if opts is None:
         opts = InvokeOptions()
@@ -410,6 +413,7 @@ def call(
     call dynamically invokes the function, tok, which is offered by a provider plugin.  The inputs
     can be a bag of computed values (Ts or Awaitable[T]s).
     """
+    _ensure_runtime_operation_allowed("call", provider_function=True)
     log.debug(f"Calling function: tok={tok}")
 
     if typ and not _types.is_output_type(typ):

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -27,6 +27,7 @@ from collections.abc import Awaitable, Mapping, Sequence
 
 import grpc
 
+from ._callback_context import _ensure_runtime_operation_allowed
 from ._instrumentation import wrap_with_context
 from google.protobuf import struct_pb2
 
@@ -1278,6 +1279,8 @@ def register_resource(
 def register_resource_outputs(
     res: "Resource", outputs: "Union[Inputs, Output[Inputs]]"
 ):
+    _ensure_runtime_operation_allowed("register resource outputs")
+
     async def do_register_resource_outputs():
         urn = await res.urn.future()
         # serialize_properties expects a collection (empty is fine) but not None, but this is called pretty
@@ -1441,6 +1444,8 @@ async def _prepare_resource_hooks(
 
 
 def register_resource_hook(hook: "ResourceHook") -> asyncio.Future[None]:
+    _ensure_runtime_operation_allowed("register resource hook")
+
     async def do_register() -> None:
         callbacks = await _get_callbacks()
         if callbacks is None:
@@ -1464,6 +1469,8 @@ def register_resource_hook(hook: "ResourceHook") -> asyncio.Future[None]:
 
 
 def register_error_hook(hook: "ErrorHook") -> asyncio.Future[None]:
+    _ensure_runtime_operation_allowed("register error hook")
+
     async def do_register() -> None:
         callbacks = await _get_callbacks()
         if callbacks is None:

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -33,6 +33,7 @@ from google.protobuf import empty_pb2
 from .._utils import contextproperty
 from ..errors import RunError
 from ..runtime.proto import engine_pb2_grpc, resource_pb2, resource_pb2_grpc, engine_pb2
+from ._callback_context import _ensure_runtime_operation_allowed
 from ._callbacks import _CallbackServicer
 from ._grpc_settings import _GRPC_CHANNEL_OPTIONS
 from .rpc_manager import RPCManager
@@ -409,6 +410,8 @@ async def register_package(
     receive distinct refs. When extension is True, the package is registered as
     an extension parameterization rather than a replacement.
     """
+    _ensure_runtime_operation_allowed("register package", provider_function=True)
+
     key = "\0".join(
         [
             base_provider_name,

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -26,6 +26,7 @@ import grpc
 
 
 from . import settings
+from ._callback_context import _ensure_runtime_operation_allowed
 from ._instrumentation import wrap_with_context
 from .. import log
 from ..resource import (
@@ -471,6 +472,8 @@ def register_stack_transformation(t: ResourceTransformation):
     """
     Add a transformation to all future resources constructed in this Pulumi stack.
     """
+    _ensure_runtime_operation_allowed("register stack transformation")
+
     root_resource = get_root_resource()
     if root_resource is None:
         raise Exception(
@@ -486,6 +489,8 @@ def register_resource_transform(t: ResourceTransform) -> None:
     """
     Add a transform to all future resources constructed in this Pulumi stack.
     """
+    _ensure_runtime_operation_allowed("register resource transform")
+
     if not _sync_monitor_supports_transforms():
         raise Exception(
             "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
@@ -517,6 +522,8 @@ def register_invoke_transform(t: InvokeTransform) -> None:
     """
     Add a transforms to all future invokes called in this Pulumi stack.
     """
+
+    _ensure_runtime_operation_allowed("register invoke transform")
 
     if not _sync_monitor_supports_invoke_transforms():
         raise Exception(

--- a/sdk/python/lib/test/runtime/test_callbacks.py
+++ b/sdk/python/lib/test/runtime/test_callbacks.py
@@ -13,16 +13,54 @@
 # limitations under the License.
 
 import asyncio
+
 import grpc
-
 import pytest
+from google.protobuf import struct_pb2
 
+import pulumi
 from pulumi.resource import ResourceTransformArgs
+from pulumi.resource_hooks import ErrorHook, ResourceHook
+from pulumi.runtime import settings
 from pulumi.runtime._callbacks import _CallbackServicer
+from pulumi.runtime.proto import resource_pb2
 from pulumi.runtime.proto.provider_pb2 import InvokeRequest
 from pulumi.runtime.proto.resource_pb2_grpc import ResourceMonitorServicer
+from pulumi.runtime.settings import Settings
 
 from ..grpc_stubs import monitor_servicer_stub, callback_servicer_stub
+
+
+def _unregistered_resource_hook(name, callback):
+    # Use __new__ to bypass __init__, which would register the hook.
+    hook = ResourceHook.__new__(ResourceHook)
+    hook.name = name
+    hook.callback = callback
+    hook.opts = None
+    return hook
+
+
+def _unregistered_error_hook(name, callback):
+    # Use __new__ to bypass __init__, which would register the hook.
+    hook = ErrorHook.__new__(ErrorHook)
+    hook.name = name
+    hook.callback = callback
+    return hook
+
+
+class _InvokeMonitor:
+    def Invoke(self, _request):
+        result = struct_pb2.Struct()
+        result.update({"value": "ok"})
+        return resource_pb2.ResourceInvokeResponse(**{"return": result})
+
+
+def _untracked_callback_servicer(monitor):
+    servicer = _CallbackServicer(monitor)
+    # These tests invoke callbacks directly or manage the server themselves. Do
+    # not leak their servicers into the runtime's global shutdown registry.
+    _CallbackServicer._servicers.remove(servicer)
+    return servicer
 
 
 @pytest.mark.asyncio
@@ -46,10 +84,7 @@ async def test_callback_servicer_transform_errors():
         coro.throw(asyncio.CancelledError("noes"))
 
     async with monitor_servicer_stub(ResourceMonitorServicer()) as monitor_stub:
-        servicer = _CallbackServicer(monitor_stub)
-        servicer._servicers.remove(
-            servicer
-        )  # Remove this servicer from the global list, we manage the shutdown ourselves
+        servicer = _untracked_callback_servicer(monitor_stub)
         cb_exception = servicer.register_transform(transform_exception)
         cb_cancelled = servicer.register_transform(transform_cancelled_error)
 
@@ -75,3 +110,60 @@ async def test_callback_servicer_transform_errors():
                 assert 'CancelledError("noes")' in str(e)
 
             await servicer.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hook_kind", ["resource", "error"])
+async def test_hooks_reject_resource_construction(hook_kind):
+    urn = "urn:pulumi:stack::project::test:index:Resource::example"
+
+    async def construct_resource(_args):
+        # ContextVars must keep the restriction active after an async suspension.
+        await asyncio.sleep(0)
+        pulumi.ComponentResource("test:index:Component", "inside-hook")
+
+    servicer = _untracked_callback_servicer(_InvokeMonitor())
+
+    if hook_kind == "resource":
+        hook = _unregistered_resource_hook("mutating-hook", construct_resource)
+        registration = servicer.do_register_resource_hook(hook)
+        request = resource_pb2.ResourceHookRequest(urn=urn)
+    else:
+        hook = _unregistered_error_hook("mutating-hook", construct_resource)
+        registration = servicer.do_register_error_hook(hook)
+        request = resource_pb2.ErrorHookRequest(urn=urn)
+
+    callback = servicer._callbacks[registration.callback.token]
+    response = await callback(request.SerializeToString())
+
+    assert (
+        "Pulumi runtime operation 'resource construction' is not allowed"
+        in response.error
+    )
+    assert f"{hook_kind} hook 'mutating-hook'" in response.error
+    assert urn in response.error
+
+
+@pytest.mark.asyncio
+async def test_resource_hook_allows_provider_invokes():
+    monitor = _InvokeMonitor()
+    settings.configure(Settings(project="project", stack="stack", monitor=monitor))
+    result = None
+
+    async def invoke(_args):
+        nonlocal result
+        await asyncio.sleep(0)
+        result = await pulumi.runtime.invoke_async("test:index:getThing", {})
+
+    hook = _unregistered_resource_hook("invoking-hook", invoke)
+    servicer = _untracked_callback_servicer(monitor)
+    registration = servicer.do_register_resource_hook(hook)
+    callback = servicer._callbacks[registration.callback.token]
+    response = await callback(
+        resource_pb2.ResourceHookRequest(
+            urn="urn:pulumi:stack::project::test:index:Resource::example"
+        ).SerializeToString()
+    )
+
+    assert response.error == ""
+    assert result == {"value": "ok"}


### PR DESCRIPTION
Resource and error hooks run while the engine is waiting for a resource operation to finish. Re-entering deployment mutation APIs from a hook can create work that cannot make progress or alter the deployment outside the hook lifecycle contract.

Use a ContextVar to track the callback scope. Component state migrations will need the same mechanism but also disallow provider functions (invokes, calls).
