### PR TITLE
cli/do: report emptied-state reads as not-found on stateless delete : #23916

### DIFF
--- a/changelog/pending/20260804--cli-do--not-found-on-emptied-read.yaml
+++ b/changelog/pending/20260804--cli-do--not-found-on-emptied-read.yaml
@@ -1,0 +1,28 @@
+component: cli/do
+kind: bugfix
+body: |-
+  Treat a resource read back as an echoed ID over emptied state as not found. Some bridged
+  providers answer that way once the resource is gone, and `pulumi do --stateless delete` went on
+  to call Delete with no state, which the provider rejected with an error such as
+  `MissingParameter: groupName or groupId` — indistinguishable from a real failure to a caller
+  retrying the delete. `read` and `patch` report it as not found as well, and `upsert` now creates
+  the resource instead of trying to update one that is no longer there.
+
+  Operations that report a missing resource now exit with code 10 (`ExitResourceNotFound`) instead
+  of the generic 1, so callers can tell "already gone, stop retrying" from "this failed, retry"
+  without matching on error text. The message is unchanged.
+
+  A delete or patch that fails is now re-read once, so a resource deleted concurrently by someone
+  else is also reported as not found rather than surfacing the provider's own already-gone error.
+  The original error is kept whenever the re-read is inconclusive. `upsert` is unaffected: it
+  creates what it does not find, so a failure there stays retryable.
+
+  The re-read costs one extra API call per failing delete or patch, and can be switched off with
+  `PULUMI_DO_SKIP_RECHECK=true` while a provider is rate limiting. Both the classification of each
+  pre-flight read and each re-read are recorded as structured log events (`pulumi.do.read.verdict`
+  and `pulumi.do.mutation.recheck`), visible with `-v=1 --logtostderr`.
+
+  This covers resources whose read comes back emptied. It does not change cases where a resource is
+  reported missing because the provider could not resolve the ID it was given, such as the
+  `aws:cloudwatch/eventTarget` create/read ID-format mismatch, which is a provider-side bug.
+time: 2026-08-04T00:00:00+00:00

--- a/pkg/cmd/pulumi/cmd/exit_codes.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes.go
@@ -36,7 +36,12 @@ const (
 	ExitNoChanges           = 7
 	ExitCancelled           = 8
 	ExitTimeout             = 9
-	ExitInternalError       = 255
+	// ExitResourceNotFound reports that the resource an operation targeted does not exist. It is
+	// distinct from ExitCodeError so that callers driving the CLI — retry loops and controllers
+	// reconciling against a desired state in particular — can tell "there is nothing left to do
+	// here" apart from "this failed, try again" without matching on error text.
+	ExitResourceNotFound = 10
+	ExitInternalError    = 255
 )
 
 // An error that specifies it's own error code.
@@ -65,8 +70,13 @@ func ExitCodeFor(err error) int {
 		return ExitSuccess
 	}
 
-	if c, ok := err.(CustomExitCodeError); ok {
-		return c.CustomExitCode()
+	// Matched with errors.As rather than a bare type assertion: these errors are routinely wrapped
+	// on the way out (processCmdErrors wraps in a BailError to suppress double-printing, and
+	// callers add context), and a wrapped error would otherwise silently fall through to the
+	// generic default. Same reasoning as the cloud.APIError branch below.
+	var custom CustomExitCodeError
+	if errors.As(err, &custom) {
+		return custom.CustomExitCode()
 	}
 
 	// `pulumi api` carries its own semantic exit code on the error so

--- a/pkg/cmd/pulumi/cmd/exit_codes_test.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,18 @@ func TestExitCodeFor_KnownErrors(t *testing.T) {
 			name: "bail error",
 			err:  result.BailError(errors.New("bail")),
 			want: ExitCodeError,
+		},
+		{
+			name: "custom exit code",
+			err:  customExitCodeErr{code: ExitResourceNotFound},
+			want: ExitResourceNotFound,
+		},
+		{
+			// Errors pick up context on the way out, so the code has to survive wrapping. A bare
+			// type assertion would miss this and collapse it to the generic error code.
+			name: "wrapped custom exit code",
+			err:  fmt.Errorf("delete failed: %w", customExitCodeErr{code: ExitResourceNotFound}),
+			want: ExitResourceNotFound,
 		},
 		{
 			name: "login required",
@@ -129,3 +142,10 @@ func TestExitCodeFor_KnownErrors(t *testing.T) {
 func wrap(outer error, inner error) error {
 	return errors.Join(outer, inner)
 }
+
+// customExitCodeErr is a stand-in for any error carrying its own exit code, e.g. the not-found
+// error `pulumi do` reports.
+type customExitCodeErr struct{ code int }
+
+func (e customExitCodeErr) Error() string       { return "custom" }
+func (e customExitCodeErr) CustomExitCode() int { return e.code }

--- a/pkg/cmd/pulumi/do/do_display.go
+++ b/pkg/cmd/pulumi/do/do_display.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	backenddisplay "github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -126,7 +127,7 @@ func (pc *packageCommand) runDisplayedStep(
 			Status:   resource.StatusOK,
 			Steps:    1,
 		})
-		err = result.BailError(err)
+		err = bailPreservingExitCode(err)
 	} else {
 		if state != nil {
 			metadata.New = engine.MakeStepEventStateMetadata(state, pc.showSecrets)
@@ -185,8 +186,44 @@ func tidyProviderError(err error, urn resource.URN, subject string) error {
 	if msg == err.Error() {
 		return err
 	}
-	return errors.New(msg)
+	// Keep the original in the chain. Rewriting the message is a presentation concern, and
+	// returning a bare errors.New would discard whatever the error was — including a custom exit
+	// code, which ExitCodeFor recovers with errors.As.
+	return retitledError{msg: msg, err: err}
 }
+
+// retitledError presents a rewritten message while leaving the underlying error reachable.
+type retitledError struct {
+	msg string
+	err error
+}
+
+func (e retitledError) Error() string { return e.msg }
+func (e retitledError) Unwrap() error { return e.err }
+
+// bailPreservingExitCode marks err as a bail, so its message is not printed a second time, without
+// losing a custom exit code it carries.
+//
+// result.BailError deliberately does not implement Unwrap, so anything underneath a bail is
+// invisible to errors.As — a CustomExitCodeError placed there would silently collapse to the
+// generic exit code. Carrying the code on the outside keeps both signals: ExitCodeFor matches this
+// wrapper directly, and result.IsBail still finds the bail underneath it.
+func bailPreservingExitCode(err error) error {
+	bail := result.BailError(err)
+	var custom cmdCmd.CustomExitCodeError
+	if !errors.As(err, &custom) {
+		return bail
+	}
+	return exitCodeBail{error: bail, code: custom.CustomExitCode()}
+}
+
+type exitCodeBail struct {
+	error
+	code int
+}
+
+func (e exitCodeBail) CustomExitCode() int { return e.code }
+func (e exitCodeBail) Unwrap() error       { return e.error }
 
 func (s displayedStep) metadata(showSecrets bool) engine.StepEventMetadata {
 	oldMeta := engine.MakeStepEventStateMetadata(s.Old, showSecrets)

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"strings"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schemainfo"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -36,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -269,8 +272,10 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 				if err != nil {
 					return nil, err
 				}
-				if readNotFound(response) {
-					return nil, fmt.Errorf("resource %q was not found", args[0])
+				verdict := classifyRead(response)
+				logReadVerdict(ctx, "read", res.Token, resource.ID(args[0]), verdict)
+				if verdict.missing() {
+					return nil, errResourceNotFound(args[0])
 				}
 				if response.ID != "" {
 					id = response.ID
@@ -313,8 +318,10 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			if err != nil {
 				return err
 			}
-			if readNotFound(read) {
-				return fmt.Errorf("resource %q was not found", args[0])
+			verdict := classifyRead(read)
+			logReadVerdict(ctx, "patch", res.Token, id, verdict)
+			if verdict.missing() {
+				return errResourceNotFound(args[0])
 			}
 			// AllowMissingProperties because a patch typically only specifies the fields being changed; the binder
 			// would otherwise reject any partial patch that omits a required input.
@@ -328,7 +335,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 
 			newInputs := read.Inputs.Copy()
 			maps.Copy(newInputs, patch)
-			return pc.runStatelessUpdate(cmd, res, id, read, newInputs, "patch", yes)
+			return pc.runStatelessUpdate(cmd, res, id, read, newInputs, "patch", reportMissing, yes)
 		},
 	}
 	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Format of the configuration files")
@@ -339,9 +346,25 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 	return cmd
 }
 
+// missingPolicy says what an operation should report when its provider call fails and the resource
+// turns out to have been deleted underneath it.
+type missingPolicy bool
+
+const (
+	// reportMissing suits operations that have nothing left to do once the resource is gone, so a
+	// resource that vanished mid-flight is reported exactly as the pre-flight Read would have
+	// reported it: not found.
+	reportMissing missingPolicy = true
+	// keepFailure suits operations for which "not found" is not a meaningful outcome — upsert would
+	// have created the resource had it known, so answering not-found would tell a caller to stop
+	// when the correct response is to run again and create it.
+	keepFailure missingPolicy = false
+)
+
 func (pc *packageCommand) runStatelessUpdate(
 	cmd *cobra.Command, res *schema.Resource, id resource.ID,
-	read plugin.ReadResponse, newInputs resource.PropertyMap, operation string, yes bool,
+	read plugin.ReadResponse, newInputs resource.PropertyMap, operation string,
+	missing missingPolicy, yes bool,
 ) error {
 	ctx := cmd.Context()
 	urn := resourceURN(res)
@@ -387,6 +410,11 @@ func (pc *packageCommand) runStatelessUpdate(
 			Preview:    pc.dryrun,
 		})
 		if err != nil {
+			// Same race as the delete path: the resource can be removed between our pre-flight Read
+			// and this call, leaving a provider error a caller cannot classify.
+			if missing == reportMissing && pc.resourceGoneAfterFailure(ctx, operation, urn, id) {
+				return nil, errResourceNotFound(string(id))
+			}
 			return nil, err
 		}
 		return resultState(urn, id, checked, response.Properties, res), nil
@@ -430,8 +458,10 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			if err != nil {
 				return err
 			}
-			if readNotFound(response) {
-				return fmt.Errorf("resource %q was not found", args[0])
+			verdict := classifyRead(response)
+			logReadVerdict(ctx, "delete", res.Token, resource.ID(args[0]), verdict)
+			if verdict.missing() {
+				return errResourceNotFound(args[0])
 			}
 			id := response.ID
 			if id == "" {
@@ -458,6 +488,9 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 					Inputs:  response.Inputs,
 					Outputs: response.Outputs,
 				})
+				if err != nil && pc.resourceGoneAfterFailure(ctx, "delete", urn, id) {
+					return nil, errResourceNotFound(args[0])
+				}
 				return nil, err
 			})
 		},
@@ -592,8 +625,223 @@ func (pc *packageCommand) checkResourceInputs(
 	return checked.Properties, nil
 }
 
+// readNotFound reports whether a Read response describes a resource that is no longer there.
+//
+// Providers signal absence in more than one shape. The obvious ones are a nil state bag or a blank
+// ID. Bridged providers add a third: when the refresh behind Read 404s they warn ("Automatically
+// removing from Terraform State"), drop the state, and still echo the requested import ID back,
+// leaving a non-blank ID paired with an empty property bag. Reading that as "found" is what makes a
+// repeated delete of an already-deleted resource issue a real Delete against emptied state, which
+// the provider rejects with its own error (`MissingParameter: groupName or groupId`) instead of the
+// not-found a caller can branch on.
+//
+// So an ID on its own does not count as found. Delete and Update both need the resource's real
+// inputs/outputs — as the Read-before-Delete comment above notes, the terraform-pf bridge fails
+// outright when handed an ID and no state — so a response carrying no state is one we could not act
+// on even if the resource did exist.
+//
+// Explicitly NOT covered: the converse half of #23916, where `aws:cloudwatch/eventTarget` reports a
+// resource that is still there as missing. Its create hands back an ID joined with a dash
+// (`<rule>-<target>`) while its Read expects the slash form, so Read is handed an ID it cannot
+// resolve, legitimately finds nothing, and we correctly conclude "not found" from what we were
+// given. That is an ID-format bug on the provider side and is invisible from here.
+//
+// Mind the direction before extending this function to chase it: that failure is a resource we
+// skipped deleting, so anything that widens not-found detection makes it *worse*, not better —
+// more live resources silently orphaned, which is the more damaging of the two failure modes. The
+// two halves of that issue pull in opposite directions and only one of them lives in this file.
 func readNotFound(read plugin.ReadResponse) bool {
-	return read.Outputs == nil || read.ID == ""
+	return classifyRead(read).missing()
+}
+
+// Stable identifiers for the structured records this package emits. Consumers key off these rather
+// than off message text, which is not a compatibility surface.
+const (
+	// eventReadVerdict is emitted once per pre-flight Read, whatever the outcome, so a log pipeline
+	// can see the normal paths as well as the missing ones.
+	eventReadVerdict = "pulumi.do.read.verdict"
+	// eventRecheck is emitted only when a Delete or Update failed and resourceGoneAfterFailure ran,
+	// which makes its presence the signal that the re-read path fired.
+	eventRecheck = "pulumi.do.mutation.recheck"
+)
+
+// readVerdict records which rule decided whether a Read described a live resource. Keeping the
+// reason rather than a bare bool is what lets the logs distinguish an ordinary absence (the
+// provider blanked the ID) from the #23916 shape (an echoed ID over an empty bag), which are the
+// same outcome but very different provider behaviour.
+type readVerdict string
+
+const (
+	readPresent readVerdict = "present"
+	// readBlankID is the shape a well-behaved provider returns for a missing resource.
+	readBlankID readVerdict = "blank-id"
+	// readNilState is a provider that returned no property bag at all.
+	readNilState readVerdict = "nil-state"
+	// readEmptyState is the #23916 shape: a non-blank ID over a bag with nothing in it. A spike
+	// here is the signal that a provider is echoing IDs for resources that are gone.
+	readEmptyState readVerdict = "empty-state"
+)
+
+func (v readVerdict) missing() bool { return v != readPresent }
+
+// classifyRead is the decision behind readNotFound, split out so the reason survives for logging
+// and so the rules can be tested exhaustively without going through a command.
+//
+// The three rules do not rest on equally firm ground, which is worth knowing before changing them:
+//
+//   - readNilState is the documented contract. plugin.ReadResult.Outputs says "if this field is
+//     nil, the resource does not exist", and Provider.Read repeats it. Any provider, any version.
+//   - readBlankID is undocumented — ReadResult.ID claims it "will always be populated" — but it is
+//     what the engine's refresh has always done (see RefreshStep.Apply, "if the ID is blank treat
+//     this as a delete"). A provider that violated it would have visibly broken `pulumi refresh`
+//     long ago, so it is safe in practice even though the doc comment disagrees.
+//   - readEmptyState is neither documented nor used by the engine. It is inferred from observed
+//     bridge behaviour and is the one assumption here that could misfire: it reads a live resource
+//     that genuinely has no properties as missing. Note that it can only trigger where a provider
+//     has already broken the documented contract by returning non-nil Outputs for a resource that
+//     is gone — for a conforming provider this branch is unreachable on the missing path.
+//
+// None of this keys on a provider name or version; the rules are about response shape only.
+func classifyRead(read plugin.ReadResponse) readVerdict {
+	switch {
+	case read.ID == "":
+		return readBlankID
+	case read.Outputs == nil:
+		return readNilState
+	case !hasResourceState(read.Inputs) && !hasResourceState(read.Outputs):
+		return readEmptyState
+	default:
+		return readPresent
+	}
+}
+
+// logReadVerdict records how a pre-flight Read was classified. Emitted on every operation that
+// reads before acting, present or missing, so the absence of a record is never ambiguous.
+func logReadVerdict(ctx context.Context, operation, resourceType string, id resource.ID, v readVerdict) {
+	slog.InfoContext(ctx, "do: classified resource read",
+		"event", eventReadVerdict,
+		"operation", operation,
+		"resourceType", resourceType,
+		"resourceId", string(id),
+		"verdict", string(v),
+		"missing", v.missing(),
+	)
+}
+
+// resourceNotFoundError reports that the resource an operation targeted is not there.
+//
+// It carries cmdCmd.ExitResourceNotFound so a caller can classify the outcome from the process exit
+// code rather than by matching error text, which is not a stable interface across releases — the
+// distinction between "already gone, stop retrying" and "this failed, retry" is exactly what a
+// reconcile loop needs and exactly what a shared exit code of 1 destroys.
+//
+// The message is byte-for-byte what the plain fmt.Errorf produced before, so callers already
+// matching on the text keep working; the exit code is additive.
+type resourceNotFoundError struct {
+	id string
+}
+
+func (e resourceNotFoundError) Error() string {
+	return fmt.Sprintf("resource %q was not found", e.id)
+}
+
+// CustomExitCode implements cmdCmd.CustomExitCodeError.
+func (e resourceNotFoundError) CustomExitCode() int {
+	return cmdCmd.ExitResourceNotFound
+}
+
+// errResourceNotFound builds the not-found error every operation in this package reports, so the
+// message and the exit code stay in step across all of them.
+func errResourceNotFound(id string) error {
+	return resourceNotFoundError{id: id}
+}
+
+// resourceGoneAfterFailure re-reads a resource whose Delete or Update has just failed, to tell "the
+// operation failed" apart from "something else deleted it in between". Callers that retry on their
+// own timers can have two invocations in flight at once: both clear the pre-flight Read, one
+// deletes, and the other gets whatever the provider says about operating on an object that is
+// already gone — a message with no not-found marker to branch on, which is the same classification
+// problem readNotFound solves for the emptied-read case.
+//
+// The bound here is structural rather than a retry budget: this issues exactly one Read and never
+// re-attempts the failed operation, so an invocation makes at most three provider calls (Read,
+// Delete or Update, Read) no matter what any of them return. There is no edge back to the mutation,
+// so there is no loop to bound.
+//
+// The failed operation's error is the default answer; this only overrides it on positive evidence of
+// absence. If the re-read errors, or comes back carrying any state at all — including the partial
+// state an eventually-consistent backend may serve while it settles — the original error is
+// reported unchanged. A caller retrying on a timer then gets the clean not-found from a later
+// invocation's pre-flight Read once the backend has converged, which is the right place for that
+// wait: the caller already has a retry policy, and a second one nested inside a single invocation
+// would only fight it.
+func (pc *packageCommand) resourceGoneAfterFailure(
+	ctx context.Context, operation string, urn resource.URN, id resource.ID,
+) bool {
+	// One record per re-read, covering every outcome. Emitting on the failure paths too is what
+	// makes this usable as a rate: a rising share of "read-failed" means the re-read is not
+	// answering the question, not that the race stopped happening.
+	log := func(outcome string, v readVerdict, detail error) {
+		attrs := []any{
+			"event", eventRecheck,
+			"operation", operation,
+			"resourceType", string(urn.Type()),
+			"resourceId", string(id),
+			"outcome", outcome,
+			"reclassified", outcome == "gone",
+		}
+		if v != "" {
+			attrs = append(attrs, "verdict", string(v))
+		}
+		if detail != nil {
+			attrs = append(attrs, "err", detail.Error())
+		}
+		slog.InfoContext(ctx, "do: re-read resource after failed mutation", attrs...)
+	}
+
+	// An incident lever, not a circuit breaker — a breaker cannot work here, because each
+	// invocation is one process performing one mutation and so issues at most one re-read; there is
+	// no sequence of failures for in-process state to observe. What this does buy is the ability to
+	// shed the extra call fleet-wide, without redeploying, while a provider is rate limiting and
+	// the re-read is likely to be throttled too (adding load and returning no classification).
+	// Still logged, so a dashboard shows the switch being thrown rather than going quiet in a way
+	// that looks like the race stopped happening.
+	if env.Global().GetBool(env.DoSkipRecheck) {
+		log("skipped", "", nil)
+		return false
+	}
+
+	response, err := pc.provider.Read(ctx, plugin.ReadRequest{
+		URN:    urn,
+		Name:   urn.Name(),
+		Type:   urn.Type(),
+		ID:     id,
+		Inputs: resource.PropertyMap{},
+		State:  resource.PropertyMap{},
+	})
+	if err != nil {
+		log("read-failed", "", err)
+		return false
+	}
+	verdict := classifyRead(response)
+	if verdict.missing() {
+		log("gone", verdict, nil)
+		return true
+	}
+	log("present", verdict, nil)
+	return false
+}
+
+// hasResourceState reports whether a property bag carries anything beyond the resource's own ID.
+// A lone "id" is ignored: it just duplicates ReadResponse.ID and says nothing about whether the
+// remote object is still there.
+func hasResourceState(props resource.PropertyMap) bool {
+	for key := range props {
+		if key != "id" {
+			return true
+		}
+	}
+	return false
 }
 
 func resultOutputs(id resource.ID, outputs resource.PropertyMap, res *schema.Resource) resource.PropertyMap {

--- a/pkg/cmd/pulumi/do/do_resource_bridge_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_bridge_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file stress-tests readNotFound against a resource type it was never written against, to pin
+// down which "resource is gone but the provider echoed its ID back" shapes it does and does not
+// classify as missing.
+//
+// `azure:index:linkAttachment` is invented. It stands in for the family of bridged resources whose
+// import ID is composite — the TF importer splits the ID into fields and seeds them into state
+// before the refresh runs, so a 404'd refresh can leave behind either nothing at all or a partial
+// bag of ID-derived fields, depending on the resource. Its delete needs both halves of the ID,
+// mirroring `RevokeSecurityGroupIngress` needing a groupId and `DeleteEnvironment` needing an
+// application/environment pair.
+func doSyntheticBridgeSpec() schema.PackageSpec {
+	props := map[string]schema.PropertySpec{
+		"meshId": {TypeSpec: schema.TypeSpec{Type: "string"}},
+		"linkId": {TypeSpec: schema.TypeSpec{Type: "string"}},
+		"region": {TypeSpec: schema.TypeSpec{Type: "string"}},
+	}
+	return schema.PackageSpec{
+		Name: "azure",
+		Resources: map[string]schema.ResourceSpec{
+			"azure:index:linkAttachment": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "A synthetic bridged resource with a composite import ID.",
+					Properties:  props,
+				},
+				InputProperties: props,
+				RequiredInputs:  []string{"meshId", "linkId"},
+			},
+		},
+	}
+}
+
+// residue is what a bridged provider leaves in the state it returns from Read once the refresh
+// behind it has 404'd. The ID is echoed back regardless — that is the behaviour that makes these
+// resources interesting; what varies between them is how much of the ID-derived state survives.
+type residue func(meshID, linkID string) (inputs, outputs resource.PropertyMap)
+
+// bridgeOutcome is what a caller driving `pulumi do` observes from a delete.
+type bridgeOutcome string
+
+const (
+	// reportedNotFound is the outcome a controller can branch on: no provider call, clean signal.
+	reportedNotFound bridgeOutcome = "reported not found"
+	// deleteRejected is the #23916 failure: we called Delete with unusable state and the provider
+	// threw its own error, which is indistinguishable from a real failure and so retries forever.
+	deleteRejected bridgeOutcome = "delete rejected by provider"
+	// deleteIssued means Delete ran against the (already absent) remote object without erroring.
+	deleteIssued bridgeOutcome = "delete issued"
+)
+
+// runSyntheticBridgeDelete drives `do ... delete` against the synthetic bridge and reports what the
+// caller would see. `live` controls whether the remote object still exists; `leftover` controls what
+// the bridge hands back when it does not.
+func runSyntheticBridgeDelete(t *testing.T, live bool, leftover residue) (bridgeOutcome, error) {
+	t.Helper()
+
+	const (
+		meshID   = "mesh-a1b2"
+		linkID   = "link-c3d4"
+		importID = meshID + "/" + linkID
+	)
+
+	provider := &testProvider{
+		spec: doSyntheticBridgeSpec(),
+		MockProvider: plugin.MockProvider{
+			ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+				parts := strings.SplitN(string(req.ID), "/", 2)
+				require.Len(t, parts, 2, "the synthetic bridge only handles composite import IDs")
+
+				if live {
+					state := resource.PropertyMap{
+						"meshId": resource.NewProperty(parts[0]),
+						"linkId": resource.NewProperty(parts[1]),
+						"region": resource.NewProperty("westus"),
+					}
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID: req.ID, Inputs: state.Copy(), Outputs: state,
+					}}, nil
+				}
+
+				// The refresh 404s. A bridge warns, drops the resource from state, and — the crux —
+				// still hands the requested import ID back to us.
+				inputs, outputs := leftover(parts[0], parts[1])
+				return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+					ID: req.ID, Inputs: inputs, Outputs: outputs,
+				}}, nil
+			},
+			DeleteF: func(_ context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+				// Stand in for the cloud API: the call is malformed unless both halves of the ID
+				// reached us as state. An echoed req.ID is not enough, exactly as the terraform-pf
+				// bridge cannot delete from an ID alone.
+				has := func(key resource.PropertyKey) bool {
+					return req.Inputs.HasValue(key) || req.Outputs.HasValue(key)
+				}
+				if !has("meshId") || !has("linkId") {
+					return plugin.DeleteResponse{}, fmt.Errorf(
+						"[ERROR] operation error Mesh: DetachLink, api error MissingParameter: " +
+							"The request must contain the parameter meshId or linkId")
+				}
+				return plugin.DeleteResponse{}, nil
+			},
+		},
+	}
+
+	cmd, _, _ := newDoResourceCommand(t, provider)
+	cmd.SetArgs([]string{"--stateless", "azure:index:linkAttachment", "delete", importID, "--yes"})
+	err := cmd.Execute()
+
+	switch {
+	case err == nil:
+		return deleteIssued, nil
+	case strings.Contains(err.Error(), "was not found"):
+		return reportedNotFound, err
+	default:
+		return deleteRejected, err
+	}
+}
+
+func TestDoCmdResourceSyntheticBridgeEmptiedRead(t *testing.T) {
+	t.Parallel()
+
+	// A control: while the remote object is there, the delete must still go through. Any change to
+	// readNotFound that starts reporting live resources as missing would orphan them silently.
+	t.Run("live resource still deletes", func(t *testing.T) {
+		t.Parallel()
+		outcome, err := runSyntheticBridgeDelete(t, true, nil)
+		require.NoError(t, err)
+		assert.Equal(t, deleteIssued, outcome)
+	})
+
+	shapes := []struct {
+		name     string
+		leftover residue
+		want     bridgeOutcome
+	}{
+		{
+			// The shape the real security-group-rule and appconfig resources produce.
+			name: "drops all state",
+			leftover: func(_, _ string) (resource.PropertyMap, resource.PropertyMap) {
+				return resource.PropertyMap{}, resource.PropertyMap{}
+			},
+			want: reportedNotFound,
+		},
+		{
+			name: "drops all state and omits inputs entirely",
+			leftover: func(_, _ string) (resource.PropertyMap, resource.PropertyMap) {
+				return nil, resource.PropertyMap{}
+			},
+			want: reportedNotFound,
+		},
+		{
+			name: "keeps the echoed id as a property",
+			leftover: func(mesh, link string) (resource.PropertyMap, resource.PropertyMap) {
+				id := resource.NewProperty(mesh + "/" + link)
+				return resource.PropertyMap{"id": id}, resource.PropertyMap{"id": id}
+			},
+			want: reportedNotFound,
+		},
+		{
+			// The importer seeded a provider-level default that survived the 404. It is real state
+			// by any structural measure, but useless to the delete.
+			name: "keeps a provider default the delete cannot use",
+			leftover: func(_, _ string) (resource.PropertyMap, resource.PropertyMap) {
+				return resource.PropertyMap{"region": resource.NewProperty("westus")}, resource.PropertyMap{}
+			},
+			want: deleteRejected,
+		},
+		{
+			name: "keeps one half of the parsed composite id",
+			leftover: func(mesh, _ string) (resource.PropertyMap, resource.PropertyMap) {
+				return resource.PropertyMap{}, resource.PropertyMap{"meshId": resource.NewProperty(mesh)}
+			},
+			want: deleteRejected,
+		},
+		{
+			// Both halves survive, so the delete is at least well-formed and the caller sees a
+			// success rather than a retry loop — but we have issued a provider call for a resource
+			// we were told is gone.
+			name: "keeps both halves of the parsed composite id",
+			leftover: func(mesh, link string) (resource.PropertyMap, resource.PropertyMap) {
+				return resource.PropertyMap{
+					"meshId": resource.NewProperty(mesh),
+					"linkId": resource.NewProperty(link),
+				}, resource.PropertyMap{}
+			},
+			want: deleteIssued,
+		},
+	}
+
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			t.Parallel()
+			outcome, err := runSyntheticBridgeDelete(t, false, shape.leftover)
+			assert.Equal(t, shape.want, outcome, "unexpected outcome (err: %v)", err)
+			if outcome == deleteRejected {
+				// Pin the symptom this leaves a caller with: a provider error carrying no
+				// not-found marker to classify by.
+				assert.ErrorContains(t, err, "MissingParameter")
+				assert.NotContains(t, err.Error(), "was not found")
+			}
+		})
+	}
+}

--- a/pkg/cmd/pulumi/do/do_resource_concurrent_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_concurrent_test.go
@@ -1,0 +1,457 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// providerAlreadyGone is what a provider reports when asked to delete something that is no longer
+// there. Note what it lacks: any marker a caller could classify as "not found".
+const providerAlreadyGone = "api error InvalidPermission.NotFound: the specified rule does not exist"
+
+// racingCloud is a single backing store shared by concurrent delete invocations — the stand-in for
+// the cloud itself, which is the only thing two `pulumi do` processes actually share.
+type racingCloud struct {
+	mu   sync.Mutex
+	live map[resource.ID]resource.PropertyMap
+
+	reads   atomic.Int32
+	deletes atomic.Int32
+
+	// preflight is closed once both invocations' first Read has landed. Holding both there until
+	// they have each seen the resource forces the interleaving we care about — both pass their
+	// pre-flight check, then both attempt the delete — instead of leaving it to chance.
+	preflight     chan struct{}
+	preflightSize int32
+}
+
+func newRacingCloud(ids ...resource.ID) *racingCloud {
+	c := &racingCloud{
+		live:          map[resource.ID]resource.PropertyMap{},
+		preflight:     make(chan struct{}),
+		preflightSize: 2,
+	}
+	for _, id := range ids {
+		c.live[id] = resource.PropertyMap{"name": resource.NewProperty(string(id))}
+	}
+	return c
+}
+
+func (c *racingCloud) Read(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+	// Only the pre-flight reads synchronise. Any later read — the one issued after a failed delete
+	// — must not wait, or it would deadlock behind a barrier that is already satisfied.
+	if n := c.reads.Add(1); n <= c.preflightSize {
+		if n == c.preflightSize {
+			close(c.preflight)
+		}
+		select {
+		case <-c.preflight:
+		case <-time.After(30 * time.Second):
+			// Fail via assertions rather than hanging the suite forever.
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	state, ok := c.live[req.ID]
+	if !ok {
+		// Gone — and in the #23916 shape: the requested ID echoed back over emptied state.
+		return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+			ID:      req.ID,
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{},
+		}}, nil
+	}
+	return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+		ID: req.ID, Inputs: state.Copy(), Outputs: state.Copy(),
+	}}, nil
+}
+
+func (c *racingCloud) Delete(_ context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+	c.deletes.Add(1)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.live[req.ID]; !ok {
+		return plugin.DeleteResponse{}, errors.New(providerAlreadyGone)
+	}
+	delete(c.live, req.ID)
+	return plugin.DeleteResponse{}, nil
+}
+
+func (c *racingCloud) stillLive(id resource.ID) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.live[id]
+	return ok
+}
+
+// TestDoCmdResourceConcurrentDelete runs two delete invocations against one backing store at the
+// same time, with both held at their pre-flight Read until each has seen the resource. One wins the
+// delete; the other must come back classifiable as not-found rather than surfacing the provider's
+// own already-gone error.
+func TestDoCmdResourceConcurrentDelete(t *testing.T) {
+	t.Parallel()
+
+	const invocations = 2
+	cloud := newRacingCloud("res-1")
+	provider := &testProvider{
+		spec: doResourceSpec(false),
+		MockProvider: plugin.MockProvider{
+			ReadF:   cloud.Read,
+			DeleteF: cloud.Delete,
+		},
+	}
+
+	errs := make([]error, invocations)
+	var wg sync.WaitGroup
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each invocation gets its own command tree, as it would its own process; the only
+			// thing they share is the cloud behind the provider.
+			cmd, _, _ := newDoResourceCommand(t, provider)
+			cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+			errs[i] = cmd.Execute()
+		}()
+	}
+	wg.Wait()
+
+	var succeeded int
+	var failures []error
+	for _, err := range errs {
+		if err == nil {
+			succeeded++
+			continue
+		}
+		failures = append(failures, err)
+	}
+
+	assert.Equal(t, 1, succeeded, "exactly one invocation should win the delete")
+	require.Len(t, failures, 1, "exactly one invocation should lose the race")
+
+	// The loser must be classifiable. Before the re-read it surfaced the provider's own error,
+	// which carries nothing a caller could branch on.
+	assert.ErrorContains(t, failures[0], `resource "res-1" was not found`)
+	assert.NotContains(t, failures[0].Error(), providerAlreadyGone)
+
+	// Both invocations really did attempt the delete — i.e. they actually raced rather than
+	// serialising by luck, which would make the assertions above vacuous.
+	assert.Equal(t, int32(invocations), cloud.deletes.Load(), "both invocations should reach Delete")
+
+	// The hard bound: two pre-flight reads plus exactly one re-read by the loser. If the re-read
+	// ever grew into a retry loop, this count would climb.
+	assert.Equal(t, int32(invocations+1), cloud.reads.Load(),
+		"expected one re-read by the losing invocation and no more")
+
+	assert.False(t, cloud.stillLive("res-1"), "the resource should be gone from the backing store")
+
+	// The signal a caller actually branches on. Matching the message text is not a stable contract
+	// across releases; the exit code is.
+	assert.Equal(t, cmdCmd.ExitResourceNotFound, cmdCmd.ExitCodeFor(failures[0]),
+		"a resource deleted out from under us should exit as not-found, not a generic error")
+}
+
+// TestDoCmdResourcePatchDeletedMidFlight covers patch losing the same race delete can lose: the
+// pre-flight Read finds the resource, it is deleted before the Update lands, and the provider
+// answers with an error carrying nothing to classify. Patch has nothing left to do once the
+// resource is gone, so it must reach the caller as not-found, exactly as delete does.
+func TestDoCmdResourcePatchDeletedMidFlight(t *testing.T) {
+	t.Parallel()
+
+	const updateFailure = "api error ResourceNotFoundException: no such resource"
+
+	tests := map[string]struct {
+		// gone says whether the resource has vanished by the time the post-failure re-read runs.
+		gone           bool
+		wantNotFound   bool
+		wantExitCode   int
+		wantErrContain string
+	}{
+		"deleted between the read and the update": {
+			gone:           true,
+			wantNotFound:   true,
+			wantExitCode:   cmdCmd.ExitResourceNotFound,
+			wantErrContain: `resource "res-1" was not found`,
+		},
+		"update failed for its own reasons": {
+			gone:           false,
+			wantNotFound:   false,
+			wantExitCode:   cmdCmd.ExitCodeError,
+			wantErrContain: updateFailure,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var reads atomic.Int32
+			present := plugin.ReadResponse{ReadResult: plugin.ReadResult{
+				ID:      "res-1",
+				Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+				Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+			}}
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						if reads.Add(1) == 1 || !tt.gone {
+							return present, nil
+						}
+						// The post-failure re-read, after a concurrent delete: emptied state.
+						return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  resource.PropertyMap{},
+							Outputs: resource.PropertyMap{},
+						}}, nil
+					},
+					CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+						return plugin.CheckResponse{Properties: req.News}, nil
+					},
+					DiffF: func(_ context.Context, _ plugin.DiffRequest) (plugin.DiffResponse, error) {
+						return plugin.DiffResponse{Changes: plugin.DiffSome}, nil
+					},
+					UpdateF: func(_ context.Context, _ plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+						return plugin.UpdateResponse{}, errors.New(updateFailure)
+					},
+				},
+			})
+			inputFile := writeHCLFile(t, "patch.pcl", `enabled = true`)
+			cmd.SetArgs([]string{
+				"--stateless", "azure:index:myResource", "patch", "res-1", "--yes",
+				"--input", "pcl", "--input-file", inputFile,
+			})
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErrContain)
+			assert.Equal(t, tt.wantExitCode, cmdCmd.ExitCodeFor(err))
+			// Same structural bound as delete: pre-flight plus exactly one re-read, never a retry.
+			assert.Equal(t, int32(2), reads.Load(), "exactly one re-read, and no Update retry")
+		})
+	}
+}
+
+// TestDoCmdResourceUpsertKeepsFailureWhenDeletedMidFlight pins upsert's deliberate opt-out. Upsert
+// creates what it does not find, so "not found" is not one of its outcomes — answering with it
+// would tell a caller to stop reconciling when the correct response is to run again and create.
+func TestDoCmdResourceUpsertKeepsFailureWhenDeletedMidFlight(t *testing.T) {
+	t.Parallel()
+
+	const updateFailure = "api error ResourceNotFoundException: no such resource"
+
+	var reads atomic.Int32
+	cmd, _, _ := newDoResourceCommand(t, &testProvider{
+		spec: doResourceSpec(false),
+		MockProvider: plugin.MockProvider{
+			ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+				if reads.Add(1) == 1 {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+					}}, nil
+				}
+				return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+					ID:      req.ID,
+					Inputs:  resource.PropertyMap{},
+					Outputs: resource.PropertyMap{},
+				}}, nil
+			},
+			CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+				return plugin.CheckResponse{Properties: req.News}, nil
+			},
+			DiffF: func(_ context.Context, _ plugin.DiffRequest) (plugin.DiffResponse, error) {
+				return plugin.DiffResponse{Changes: plugin.DiffSome}, nil
+			},
+			UpdateF: func(_ context.Context, _ plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+				return plugin.UpdateResponse{}, errors.New(updateFailure)
+			},
+		},
+	})
+	inputFile := writeHCLFile(t, "upsert.pcl", `name = "new"`)
+	cmd.SetArgs([]string{
+		"--stateless", "azure:index:myResource", "upsert", "res-1", "--yes",
+		"--input", "pcl", "--input-file", inputFile,
+	})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, updateFailure)
+	assert.NotContains(t, strings.ToLower(err.Error()), "was not found")
+	assert.Equal(t, cmdCmd.ExitCodeError, cmdCmd.ExitCodeFor(err),
+		"upsert must stay retryable so the next run creates the resource")
+	// No re-read at all: upsert opts out, so the failure is reported as-is.
+	assert.Equal(t, int32(1), reads.Load())
+}
+
+// TestDoCmdResourceNotFoundExitCode pins the exit code contract for every operation that reports a
+// missing resource, including through the wrapping the CLI applies on the way out. A caller keying
+// off the code must not have to care which path produced it.
+func TestDoCmdResourceNotFoundExitCode(t *testing.T) {
+	t.Parallel()
+
+	// The emptied read that started all this: an echoed ID over no state.
+	emptiedRead := func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+		return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+			ID:      req.ID,
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{},
+		}}, nil
+	}
+
+	operations := map[string][]string{
+		"delete": {"--stateless", "azure:index:myResource", "delete", "res-gone", "--yes"},
+		"read":   {"azure:index:myResource", "read", "res-gone"},
+	}
+
+	for name, args := range operations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec:         doResourceSpec(false),
+				MockProvider: plugin.MockProvider{ReadF: emptiedRead},
+			})
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			// Message unchanged, so callers matching on text keep working.
+			assert.ErrorContains(t, err, `resource "res-gone" was not found`)
+			assert.Equal(t, cmdCmd.ExitResourceNotFound, cmdCmd.ExitCodeFor(err))
+
+			// The code has to survive wrapping: errors pick up context and a BailError envelope
+			// between RunE and the exit, and a bare type assertion would lose it there.
+			assert.Equal(t, cmdCmd.ExitResourceNotFound,
+				cmdCmd.ExitCodeFor(fmt.Errorf("delete failed: %w", err)),
+				"the exit code must survive error wrapping")
+		})
+	}
+
+	t.Run("a genuine failure stays a generic error", func(t *testing.T) {
+		t.Parallel()
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+					}}, nil
+				},
+				DeleteF: func(_ context.Context, _ plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					return plugin.DeleteResponse{}, errors.New("api error DependencyViolation: resource is in use")
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		assert.Equal(t, cmdCmd.ExitCodeError, cmdCmd.ExitCodeFor(err),
+			"a real failure must stay retryable, not be reported as already-gone")
+	})
+}
+
+// TestDoCmdResourceFailedDeleteKeepsOriginalError covers the other direction: the re-read must only
+// ever downgrade a delete failure to not-found on positive evidence of absence. Anything ambiguous
+// — state still present, or a re-read that itself fails — has to leave the original error intact,
+// or a genuine failure would be reported to the caller as a successful cleanup.
+func TestDoCmdResourceFailedDeleteKeepsOriginalError(t *testing.T) {
+	t.Parallel()
+
+	const deleteFailure = "api error DependencyViolation: resource is in use"
+
+	tests := map[string]struct {
+		// reread is the response to the Read issued after the failed Delete.
+		reread func() (plugin.ReadResponse, error)
+	}{
+		"resource is still there": {
+			reread: func() (plugin.ReadResponse, error) {
+				return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+					ID:      "res-1",
+					Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+					Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+				}}, nil
+			},
+		},
+		// An eventually-consistent backend part-way through settling. Ambiguous, so the original
+		// error stands and the caller's own retry picks up the clean answer next time round.
+		"resource reads back as partial state": {
+			reread: func() (plugin.ReadResponse, error) {
+				return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+					ID:      "res-1",
+					Inputs:  resource.PropertyMap{},
+					Outputs: resource.PropertyMap{"name": resource.NewProperty("half")},
+				}}, nil
+			},
+		},
+		"re-read itself fails": {
+			reread: func() (plugin.ReadResponse, error) {
+				return plugin.ReadResponse{}, errors.New("api error Throttling: rate exceeded")
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var reads atomic.Int32
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						if reads.Add(1) == 1 {
+							// Pre-flight: the resource is there, so we proceed to Delete.
+							return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+								ID:      req.ID,
+								Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+								Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+							}}, nil
+						}
+						return tt.reread()
+					},
+					DeleteF: func(_ context.Context, _ plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+						return plugin.DeleteResponse{}, errors.New(deleteFailure)
+					},
+				},
+			})
+			cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+			err := cmd.Execute()
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, deleteFailure, "the real failure must reach the caller")
+			assert.NotContains(t, strings.ToLower(err.Error()), "was not found",
+				"an ambiguous re-read must not be reported as a successful cleanup")
+			assert.Equal(t, int32(2), reads.Load(), "exactly one re-read, and no Delete retry")
+		})
+	}
+}

--- a/pkg/cmd/pulumi/do/do_resource_logging_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_logging_test.go
@@ -1,0 +1,313 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyRead(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		read plugin.ReadResponse
+		want readVerdict
+	}{
+		"blank id": {
+			read: plugin.ReadResponse{},
+			want: readBlankID,
+		},
+		"blank id wins over present state": {
+			read: plugin.ReadResponse{ReadResult: plugin.ReadResult{
+				Outputs: resource.PropertyMap{"name": resource.NewProperty("x")},
+			}},
+			want: readBlankID,
+		},
+		"nil outputs": {
+			read: plugin.ReadResponse{ReadResult: plugin.ReadResult{ID: "res-1"}},
+			want: readNilState,
+		},
+		"echoed id over empty bags": {
+			read: plugin.ReadResponse{ReadResult: plugin.ReadResult{
+				ID:      "res-1",
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{},
+			}},
+			want: readEmptyState,
+		},
+		"echoed id with only an id property": {
+			read: plugin.ReadResponse{ReadResult: plugin.ReadResult{
+				ID:      "res-1",
+				Inputs:  resource.PropertyMap{"id": resource.NewProperty("res-1")},
+				Outputs: resource.PropertyMap{"id": resource.NewProperty("res-1")},
+			}},
+			want: readEmptyState,
+		},
+		"state in outputs": {
+			read: plugin.ReadResponse{ReadResult: plugin.ReadResult{
+				ID:      "res-1",
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+			}},
+			want: readPresent,
+		},
+		"state in inputs only": {
+			read: plugin.ReadResponse{ReadResult: plugin.ReadResult{
+				ID:      "res-1",
+				Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+				Outputs: resource.PropertyMap{},
+			}},
+			want: readPresent,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyRead(tt.read)
+			assert.Equal(t, tt.want, got)
+			// readNotFound must stay a pure restatement of this, or the logs would describe a
+			// decision the CLI did not actually make.
+			assert.Equal(t, got.missing(), readNotFound(tt.read))
+		})
+	}
+}
+
+// captureHandler collects records so a test can assert on the structured attributes rather than on
+// rendered text.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []map[string]any
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := map[string]any{"msg": r.Message}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, attrs)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// matching returns records whose event and resourceId both match, so concurrent tests sharing the
+// default logger cannot contaminate the result.
+func (h *captureHandler) matching(event, resourceID string) []map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []map[string]any
+	for _, rec := range h.records {
+		if rec["event"] == event && rec["resourceId"] == resourceID {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+// captureLogs installs a capturing default logger for the duration of the test. Not parallel: it
+// swaps process-wide state.
+func captureLogs(t *testing.T) *captureHandler {
+	t.Helper()
+	h := &captureHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return h
+}
+
+// TestDoCmdResourceStructuredLogging pins the records an operator keys off in production. The
+// attribute names and the event identifiers are the contract here — not the messages.
+func TestDoCmdResourceStructuredLogging(t *testing.T) {
+	//nolint:paralleltest // installs a process-wide default logger
+	t.Run("emptied pre-flight read reports the echoed-id shape", func(t *testing.T) {
+		logs := captureLogs(t)
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{},
+						Outputs: resource.PropertyMap{},
+					}}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "log-gone", "--yes"})
+		require.Error(t, cmd.Execute())
+
+		verdicts := logs.matching(eventReadVerdict, "log-gone")
+		require.Len(t, verdicts, 1)
+		assert.Equal(t, "delete", verdicts[0]["operation"])
+		assert.Equal(t, "azure:index:myResource", verdicts[0]["resourceType"])
+		assert.Equal(t, string(readEmptyState), verdicts[0]["verdict"])
+		assert.Equal(t, true, verdicts[0]["missing"])
+
+		// No mutation was attempted, so the re-read path must be silent. Its absence is what makes
+		// the event usable as a signal that the race actually happened.
+		assert.Empty(t, logs.matching(eventRecheck, "log-gone"))
+	})
+
+	//nolint:paralleltest // installs a process-wide default logger
+	t.Run("delete losing the race emits a recheck with outcome gone", func(t *testing.T) {
+		logs := captureLogs(t)
+		var reads int
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					reads++
+					if reads == 1 {
+						return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+							Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+						}}, nil
+					}
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{},
+						Outputs: resource.PropertyMap{},
+					}}, nil
+				},
+				DeleteF: func(_ context.Context, _ plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					return plugin.DeleteResponse{}, errors.New("api error InvalidPermission.NotFound")
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "log-race", "--yes"})
+		require.Error(t, cmd.Execute())
+
+		verdicts := logs.matching(eventReadVerdict, "log-race")
+		require.Len(t, verdicts, 1)
+		assert.Equal(t, string(readPresent), verdicts[0]["verdict"])
+
+		rechecks := logs.matching(eventRecheck, "log-race")
+		require.Len(t, rechecks, 1, "the re-read path should record exactly once")
+		assert.Equal(t, "delete", rechecks[0]["operation"])
+		assert.Equal(t, "gone", rechecks[0]["outcome"])
+		assert.Equal(t, true, rechecks[0]["reclassified"])
+		assert.Equal(t, string(readEmptyState), rechecks[0]["verdict"])
+	})
+
+	//nolint:paralleltest // installs a process-wide default logger
+	t.Run("genuine failure records a recheck that did not reclassify", func(t *testing.T) {
+		logs := captureLogs(t)
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+					}}, nil
+				},
+				DeleteF: func(_ context.Context, _ plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					return plugin.DeleteResponse{}, errors.New("api error DependencyViolation")
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "log-fail", "--yes"})
+		require.Error(t, cmd.Execute())
+
+		rechecks := logs.matching(eventRecheck, "log-fail")
+		require.Len(t, rechecks, 1)
+		assert.Equal(t, "present", rechecks[0]["outcome"])
+		assert.Equal(t, false, rechecks[0]["reclassified"])
+	})
+
+	//nolint:paralleltest // installs a process-wide default logger and sets an env var
+	t.Run("PULUMI_DO_SKIP_RECHECK sheds the extra call but still records", func(t *testing.T) {
+		logs := captureLogs(t)
+		t.Setenv("PULUMI_DO_SKIP_RECHECK", "true")
+		var reads int
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					reads++
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+					}}, nil
+				},
+				DeleteF: func(_ context.Context, _ plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					return plugin.DeleteResponse{}, errors.New("api error ThrottlingException")
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "log-skip", "--yes"})
+		require.Error(t, cmd.Execute())
+
+		// The whole point of the switch: no second Read.
+		assert.Equal(t, 1, reads, "the re-read must not be issued when the switch is set")
+
+		rechecks := logs.matching(eventRecheck, "log-skip")
+		require.Len(t, rechecks, 1, "the decision is still recorded, so dashboards do not go quiet")
+		assert.Equal(t, "skipped", rechecks[0]["outcome"])
+		assert.Equal(t, false, rechecks[0]["reclassified"])
+	})
+
+	//nolint:paralleltest // installs a process-wide default logger
+	t.Run("a re-read that fails is recorded as such", func(t *testing.T) {
+		logs := captureLogs(t)
+		var reads int
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					reads++
+					if reads == 1 {
+						return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+							ID:      req.ID,
+							Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+							Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+						}}, nil
+					}
+					return plugin.ReadResponse{}, errors.New("api error Throttling: rate exceeded")
+				},
+				DeleteF: func(_ context.Context, _ plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					return plugin.DeleteResponse{}, errors.New("api error DependencyViolation")
+				},
+			},
+		})
+		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "log-throttle", "--yes"})
+		require.Error(t, cmd.Execute())
+
+		rechecks := logs.matching(eventRecheck, "log-throttle")
+		require.Len(t, rechecks, 1)
+		assert.Equal(t, "read-failed", rechecks[0]["outcome"])
+		assert.Equal(t, false, rechecks[0]["reclassified"])
+		assert.Contains(t, rechecks[0]["err"], "Throttling")
+	})
+}

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -522,30 +522,52 @@ enabled = true
 func TestDoCmdResourceMissingResourceNotFound(t *testing.T) {
 	t.Parallel()
 
-	t.Run("delete empty outputs with id", func(t *testing.T) {
-		t.Parallel()
-		var deleted bool
-		cmd, _, _ := newDoResourceCommand(t, &testProvider{
-			spec: doResourceSpec(false),
-			MockProvider: plugin.MockProvider{
-				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
-					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
-						ID:      req.ID,
-						Inputs:  resource.PropertyMap{},
-						Outputs: resource.PropertyMap{},
-					}}, nil
-				},
-				DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
-					assert.Equal(t, resource.ID("res-1"), req.ID)
-					deleted = true
-					return plugin.DeleteResponse{}, nil
-				},
+	// Any real state at all means the resource is there and we must still delete it — only a
+	// response with nothing to operate on counts as missing. Providers that return their state in
+	// just one of the two bags stay on the delete path.
+	foundResponses := map[string]plugin.ReadResponse{
+		"state in outputs only": {ReadResult: plugin.ReadResult{
+			ID:      "res-1",
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{"name": resource.NewProperty("out")},
+		}},
+		"state in inputs only": {ReadResult: plugin.ReadResult{
+			ID:      "res-1",
+			Inputs:  resource.PropertyMap{"name": resource.NewProperty("in")},
+			Outputs: resource.PropertyMap{},
+		}},
+		"id property alongside real state": {ReadResult: plugin.ReadResult{
+			ID:     "res-1",
+			Inputs: resource.PropertyMap{},
+			Outputs: resource.PropertyMap{
+				"id":   resource.NewProperty("res-1"),
+				"name": resource.NewProperty("out"),
 			},
+		}},
+	}
+
+	for shape, response := range foundResponses {
+		t.Run("delete "+shape, func(t *testing.T) {
+			t.Parallel()
+			var deleted bool
+			cmd, _, _ := newDoResourceCommand(t, &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+						return response, nil
+					},
+					DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+						assert.Equal(t, resource.ID("res-1"), req.ID)
+						deleted = true
+						return plugin.DeleteResponse{}, nil
+					},
+				},
+			})
+			cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
+			require.NoError(t, cmd.Execute())
+			assert.True(t, deleted)
 		})
-		cmd.SetArgs([]string{"--stateless", "azure:index:myResource", "delete", "res-1", "--yes"})
-		require.NoError(t, cmd.Execute())
-		assert.True(t, deleted)
-	})
+	}
 
 	notFoundResponses := map[string]plugin.ReadResponse{
 		"nil outputs": {},
@@ -556,6 +578,25 @@ func TestDoCmdResourceMissingResourceNotFound(t *testing.T) {
 		"blank id": {ReadResult: plugin.ReadResult{
 			Inputs:  resource.PropertyMap{"name": resource.NewProperty("stale")},
 			Outputs: resource.PropertyMap{"name": resource.NewProperty("stale")},
+		}},
+		// The shape bridged providers hand back when the refresh behind Read 404s: the requested
+		// import ID is echoed, but the state that Delete/Update actually need has been dropped.
+		// Acting on this is what made a repeated delete fail with a provider error instead of a
+		// not-found. See https://github.com/pulumi/pulumi/issues/23916.
+		"emptied state with id": {ReadResult: plugin.ReadResult{
+			ID:      "res-gone",
+			Inputs:  resource.PropertyMap{},
+			Outputs: resource.PropertyMap{},
+		}},
+		"nil inputs and empty outputs with id": {ReadResult: plugin.ReadResult{
+			ID:      "res-gone",
+			Outputs: resource.PropertyMap{},
+		}},
+		// An echoed ID is no more informative when it also shows up as a property.
+		"id-only state with id": {ReadResult: plugin.ReadResult{
+			ID:      "res-gone",
+			Inputs:  resource.PropertyMap{"id": resource.NewProperty("res-gone")},
+			Outputs: resource.PropertyMap{"id": resource.NewProperty("res-gone")},
 		}},
 	}
 

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -156,7 +156,9 @@ func (pc *packageCommand) newStatelessResourceUpsertCommand(res *schema.Resource
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
 			}
-			if readNotFound(read) {
+			verdict := classifyRead(read)
+			logReadVerdict(ctx, "upsert", res.Token, id, verdict)
+			if verdict.missing() {
 				return pc.runStatelessCreate(cmd, res, yes, func() (resource.PropertyMap, error) {
 					return inputs, nil
 				})
@@ -164,7 +166,7 @@ func (pc *packageCommand) newStatelessResourceUpsertCommand(res *schema.Resource
 			if read.ID != "" {
 				id = read.ID
 			}
-			return pc.runStatelessUpdate(cmd, res, id, read, inputs, "update", yes)
+			return pc.runStatelessUpdate(cmd, res, id, read, inputs, "update", keepFailure, yes)
 		},
 	}
 	cmd.Flags().StringVar(&inputFormat, "input", "yaml", "Format of the resource inputs file")

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -788,6 +788,52 @@ size = 2
 		assert.Equal(t, []string{"read", "check", "create"}, calls)
 		assert.JSONEq(t, `{"id":"res-2","name":"new"}`, stdout.String())
 	})
+
+	// Bridged providers echo the requested import ID back even when the refresh behind Read 404s,
+	// so an ID paired with emptied state still means the resource is gone and upsert must create.
+	t.Run("creates a missing resource read back as emptied state with an id", func(t *testing.T) {
+		t.Parallel()
+		var calls []string
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					calls = append(calls, "read")
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      req.ID,
+						Inputs:  resource.PropertyMap{},
+						Outputs: resource.PropertyMap{},
+					}}, nil
+				},
+				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					calls = append(calls, "check")
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					calls = append(calls, "create")
+					return plugin.CreateResponse{
+						ID: "res-2",
+						Properties: resource.PropertyMap{
+							"name": resource.NewProperty("new"),
+						},
+					}, nil
+				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					require.Fail(t, "Update should not be called for a missing resource")
+					return plugin.UpdateResponse{}, nil
+				},
+			},
+		})
+
+		inputFile := writeHCLFile(t, "upsert.pcl", `name = "new"`)
+		cmd.SetArgs([]string{
+			"--stateless", "azure:index:myResource", "upsert", "res-1", "--yes",
+			"--input", "pcl", "--input-file", inputFile, "--output", "json",
+		})
+		require.NoError(t, cmd.Execute())
+		assert.Equal(t, []string{"read", "check", "create"}, calls)
+		assert.JSONEq(t, `{"id":"res-2","name":"new"}`, stdout.String())
+	})
 }
 
 // TestDoCmdResourceStatefulCreateConstructsSnippet mirrors the upsert-constructs-snippet test but

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -208,6 +208,11 @@ removed and enforced to be validated.`)
 
 var DisableRegistryResolve = env.Bool("DISABLE_REGISTRY_RESOLVE", "Use the Pulumi Registry to resolve package names")
 
+var DoSkipRecheck = env.Bool("DO_SKIP_RECHECK", "Skip the single re-read `pulumi do` performs after "+
+	"a failed delete or patch. That re-read is what lets a resource deleted concurrently be reported "+
+	"as not found rather than as a provider error; disabling it trades that signal for one fewer API "+
+	"call per failing operation, which can be worth it while a provider is rate limiting.")
+
 // Environment variables that affect template discovery and caching
 var (
 	// TemplatePath is a path to the folder where templates are stored.


### PR DESCRIPTION
Issue #23916 

pulumi do --stateless delete only treated a nil Outputs bag or a
blank ID as "resource is gone" (readNotFound). Terraform-bridged
providers signal absence a third way: when the refresh behind Read
404s, they warn and drop state but still echo the requested import
ID back, leaving a non-blank ID paired with an empty property bag.
That shape passed readNotFound, so a retry-delete on an
already-gone resource (aws:vpc/securityGroupIngressRule,
securityGroupEgressRule, aws:appconfig/environment) went on to call
Delete with empty state and surfaced a raw provider error
(MissingParameter: groupName or groupId) instead of a clean
not-found — indistinguishable from a real failure to a caller
retrying on error, causing infinite reconcile loops.

- readNotFound now also checks hasResourceState on both Inputs and
  Outputs; a lone echoed "id" no longer counts as found. Native
  providers (nil-outputs path) are unaffected.
- goneAfterFailedDelete: on a failed Delete, re-read once and report
  not-found if the resource is now gone, closing the narrow
  TOCTOU window where two concurrent deletes race against a
  resource that still existed at read time. Bounded to a single
  re-read; verified no retry-loop regression via an executable
  read-count assertion.
- Added ExitResourceNotFound (10) so callers can branch on exit
  code instead of matching error text; fixed ExitCodeFor to use
  errors.As instead of a bare type assertion so the code survives
  error wrapping.
- Explicitly out of scope: aws:cloudwatch/eventTarget reporting a
  live resource as missing (dash- vs slash-form ID mismatch between
  create and read) — a provider-side bug, noted in code comments
  and changelog so it isn't assumed fixed here.

Tests: do_resource_test.go covers all not-found shapes (nil
outputs, emptied state with id, id-only state) plus a guard table
asserting partial state still deletes; do_resource_upsert_test.go
covers the upsert-creates case for the echoed-ID shape;
TestDoCmdResourceConcurrentDelete forces real goroutine interleaving
via a barrier and asserts an exact read count as the loop bound.
go test ./cmd/pulumi/do/... -race, gofmt, vet all clean.