### PR TITLE
Preserve explicit package plugin download URLs

### DIFF
--- a/changelog/pending/cli-package-fix-20260804-230326.yaml
+++ b/changelog/pending/cli-package-fix-20260804-230326.yaml
@@ -1,4 +1,4 @@
 component: cli/package
 kind: fix
-body: --server is maintained when adding to the packages section of Pulumi.yaml
+body: Maintain `--server` when adding to the packages section of Pulumi.yaml
 time: 2026-08-04T23:03:26.506575+01:00

--- a/changelog/pending/cli-package-fix-20260804-230326.yaml
+++ b/changelog/pending/cli-package-fix-20260804-230326.yaml
@@ -1,0 +1,4 @@
+component: cli/package
+kind: fix
+body: --server is maintained when adding to the packages section of Pulumi.yaml
+time: 2026-08-04T23:03:26.506575+01:00

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -360,6 +360,13 @@ func Resolve(
 		return remoteResolution()
 	}
 
+	// If this used to work (like "aws") or if the user has specified a
+	// pluginDownloadURL themselves, then pass it through.
+	if registry.IsPreRegistryPackage(spec.Source) || spec.PluginDownloadURL != "" ||
+		util.SetKnownPluginDownloadURL(&naivePackageDescriptor.PluginDescriptor) {
+		return remoteResolution()
+	}
+
 	var registryNotFoundErr error
 	var registryQueryErr error
 
@@ -418,13 +425,6 @@ func Resolve(
 		} else {
 			registryQueryErr = fmt.Errorf("%w: %w", ErrRegistryQuery, err)
 		}
-	}
-
-	// If this used to work (like "aws") or if the user has specified a
-	// pluginDownloadURL themselves, then pass it through.
-	if registry.IsPreRegistryPackage(spec.Source) || spec.PluginDownloadURL != "" ||
-		util.SetKnownPluginDownloadURL(&naivePackageDescriptor.PluginDescriptor) {
-		return remoteResolution()
 	}
 
 	if registryQueryErr != nil {

--- a/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
@@ -771,6 +771,37 @@ func TestResolvePackage(t *testing.T) {
 			},
 		},
 		{
+			name: "pluginDownloadURL bypasses registry resolution",
+			options: &Options{
+				ResolveWithRegistry: true,
+			},
+			workspace: pluginstorage.MockContext{},
+			registryResponse: func() (registry.Registry, error) {
+				return registry.Mock{
+					ListPackagesF: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+						return func(yield func(apitype.PackageMetadata, error) bool) {
+							yield(apitype.PackageMetadata{}, errors.New("registry should not be called"))
+						}
+					},
+				}, nil
+			},
+			pluginSpec: workspace.PackageSpec{
+				Source:            "found-pkg",
+				PluginDownloadURL: "https://www.example.com/custom-found-pkg.tar.gz",
+			},
+			expected: PackageResolution{
+				Spec: workspace.PackageSpec{
+					Source:            "found-pkg",
+					PluginDownloadURL: "https://www.example.com/custom-found-pkg.tar.gz",
+				},
+				Pkg: workspace.PackageDescriptor{PluginDescriptor: workspace.PluginDescriptor{
+					Name:              "found-pkg",
+					Kind:              apitype.ResourcePlugin,
+					PluginDownloadURL: "https://www.example.com/custom-found-pkg.tar.gz",
+				}},
+			},
+		},
+		{
 			name:      "handle pulumiverse packages",
 			workspace: pluginstorage.MockContext{},
 			pluginSpec: workspace.PackageSpec{


### PR DESCRIPTION
If explicit plugin package download urls are given then don't attempt to do a registry resolution, just take the server url given as is.