### PR TITLE
Pass the invoked CLI command to browser-based login for signup attribution

### DIFF
--- a/changelog/pending/20260804--cli--track-login-command.yaml
+++ b/changelog/pending/20260804--cli--track-login-command.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Pass the invoked command (e.g. `pulumi new`) to the browser-based login/signup flow so Pulumi Cloud can attribute signups to the command that triggered them
+time: 2026-08-04T00:00:00+00:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -99,6 +99,19 @@ func agentCredentialUseFromContext(ctx context.Context) *agentCredentialUse {
 	return use
 }
 
+type commandNameContextKey struct{}
+
+// ContextWithCommandName returns a context carrying the full invoked CLI command path
+// (e.g. "pulumi new"), for use in login/signup analytics.
+func ContextWithCommandName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, commandNameContextKey{}, name)
+}
+
+func commandNameFromContext(ctx context.Context) (string, bool) {
+	name, ok := ctx.Value(commandNameContextKey{}).(string)
+	return name, ok
+}
+
 // MarkAgentCredentialsUsed records that this CLI command selected shared
 // temporary agent credentials for the given cloud URL.
 func MarkAgentCredentialsUsed(ctx context.Context, cloudURL string) {
@@ -372,8 +385,11 @@ func loginWithBrowser(
 	q.Add("cliSessionPort", port)
 	q.Add("cliSessionNonce", nonce)
 	q.Add("cliSessionDescription", tokenDescription)
-	if command != "pulumi" {
-		q.Add("cliCommand", command)
+	// The invoked command path (e.g. "pulumi new"), independent of the "pulumi" literal
+	// above, so the login/signup destination can attribute the visit to the command
+	// that triggered it.
+	if name, ok := commandNameFromContext(ctx); ok && name != "" && name != "pulumi" {
+		q.Add("cliCommand", name)
 	}
 	u.RawQuery = q.Encode()
 

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -30,6 +30,9 @@ import (
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -52,14 +55,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // testJWT is a test JWT token used in tests.
 //
 //nolint:lll // JWT token is long
 const testJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+func TestCommandNameContext(t *testing.T) {
+	t.Parallel()
+
+	_, ok := commandNameFromContext(t.Context())
+	assert.False(t, ok)
+
+	ctx := ContextWithCommandName(t.Context(), "pulumi new")
+	name, ok := commandNameFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "pulumi new", name)
+}
 
 //nolint:paralleltest // mutates global configuration
 func TestEnabledFullyQualifiedStackNames(t *testing.T) {

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -381,6 +381,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			}
 			ctx = cmdutil.ContextWithProcessStartTime(ctx, processStartTime)
 			ctx = httpstate.ContextWithAgentCredentialUse(ctx)
+			ctx = httpstate.ContextWithCommandName(ctx, cmd.CommandPath())
 			cmd.SetContext(ctx)
 
 			cmdutil.InitPprofServer(ctx)


### PR DESCRIPTION
## Summary

`loginWithBrowser` has sent a `cliCommand` query param to `/cli-login` since 2023 (#14153), intended to tell Pulumi Cloud which CLI command triggered a browser-based login/signup (`pulumi login`, `pulumi new`, ...). In practice it never fires: the only call site that reaches it always passes the literal string `"pulumi"` as its `command` argument, and the guard is `if command != "pulumi"`. The intention of the existing `command` arg is meant to be the binary, so the current value is correct, but can't be used to identify the subcommand.

- Add `httpstate.ContextWithCommandName`/`commandNameFromContext`, mirroring the existing `ContextWithAgentCredentialUse` context-key pattern in the same file.
- Wire it once in the root `PersistentPreRunE` (`pkg/cmd/pulumi/pulumi.go`) using `cmd.CommandPath()` — safe for this purpose since cobra's `CommandPath()` only ever concatenates `Use` names from root to the invoked (sub)command, never flags or positional argument values.
- `loginWithBrowser` now reads the real invoked command from context to populate `cliCommand`, leaving the existing `command` parameter (still always `"pulumi"`) untouched for its other uses — the token description and the "Run `pulumi login --help`" help text, both of which specifically need the program name, not the invoking subcommand.
