### PR TITLE
auto/go: match wrapped errors in the error predicates

### DIFF
--- a/changelog/pending/20260805--auto-go--wrapped-error-predicates.yaml
+++ b/changelog/pending/20260805--auto-go--wrapped-error-predicates.yaml
@@ -1,0 +1,7 @@
+component: auto/go
+kind: fix
+body: Match wrapped errors in the Automation API error predicates, and unwrap the underlying
+  cause
+time: 2026-08-05T10:38:51+02:00
+custom:
+  PR: "24197"

--- a/sdk/go/auto/errors.go
+++ b/sdk/go/auto/errors.go
@@ -15,6 +15,7 @@
 package auto
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -40,10 +41,14 @@ func (ae autoError) Error() string {
 	return fmt.Sprintf("%s\ncode: %d\nstdout: %s\nstderr: %s\n", ae.err, ae.code, ae.stdout, ae.stderr)
 }
 
+func (ae autoError) Unwrap() error {
+	return ae.err
+}
+
 // IsConcurrentUpdateError returns true if the error was a result of a conflicting update locking the stack.
 func IsConcurrentUpdateError(e error) bool {
-	ae, ok := e.(autoError)
-	if !ok {
+	var ae autoError
+	if !errors.As(e, &ae) {
 		return false
 	}
 
@@ -54,8 +59,8 @@ func IsConcurrentUpdateError(e error) bool {
 
 // IsSelectStack404Error returns true if the error was a result of selecting a stack that does not exist.
 func IsSelectStack404Error(e error) bool {
-	ae, ok := e.(autoError)
-	if !ok {
+	var ae autoError
+	if !errors.As(e, &ae) {
 		return false
 	}
 
@@ -65,8 +70,8 @@ func IsSelectStack404Error(e error) bool {
 
 // IsCreateStack409Error returns true if the error was a result of creating a stack that already exists.
 func IsCreateStack409Error(e error) bool {
-	ae, ok := e.(autoError)
-	if !ok {
+	var ae autoError
+	if !errors.As(e, &ae) {
 		return false
 	}
 
@@ -76,8 +81,8 @@ func IsCreateStack409Error(e error) bool {
 
 // IsCompilationError returns true if the program failed at the build/run step (only Typescript, Go, .NET)
 func IsCompilationError(e error) bool {
-	as, ok := e.(autoError)
-	if !ok {
+	var as autoError
+	if !errors.As(e, &as) {
 		return false
 	}
 
@@ -106,8 +111,8 @@ func IsCompilationError(e error) bool {
 
 // IsRuntimeError returns true if there was an error in the user program at during execution.
 func IsRuntimeError(e error) bool {
-	as, ok := e.(autoError)
-	if !ok {
+	var as autoError
+	if !errors.As(e, &as) {
 		return false
 	}
 
@@ -138,8 +143,8 @@ func IsRuntimeError(e error) bool {
 // IsUnexpectedEngineError returns true if the pulumi core engine encountered an error (most likely a bug).
 func IsUnexpectedEngineError(e error) bool {
 	// TODO: figure out how to write a test for this
-	as, ok := e.(autoError)
-	if !ok {
+	var as autoError
+	if !errors.As(e, &as) {
 		return false
 	}
 

--- a/sdk/go/auto/errors.go
+++ b/sdk/go/auto/errors.go
@@ -15,6 +15,7 @@
 package auto
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -40,9 +41,13 @@ func (ae autoError) Error() string {
 	return fmt.Sprintf("%s\ncode: %d\nstdout: %s\nstderr: %s\n", ae.err, ae.code, ae.stdout, ae.stderr)
 }
 
+func (ae autoError) Unwrap() error {
+	return ae.err
+}
+
 // IsConcurrentUpdateError returns true if the error was a result of a conflicting update locking the stack.
 func IsConcurrentUpdateError(e error) bool {
-	ae, ok := e.(autoError)
+	ae, ok := errors.AsType[autoError](e)
 	if !ok {
 		return false
 	}
@@ -54,7 +59,7 @@ func IsConcurrentUpdateError(e error) bool {
 
 // IsSelectStack404Error returns true if the error was a result of selecting a stack that does not exist.
 func IsSelectStack404Error(e error) bool {
-	ae, ok := e.(autoError)
+	ae, ok := errors.AsType[autoError](e)
 	if !ok {
 		return false
 	}
@@ -65,7 +70,7 @@ func IsSelectStack404Error(e error) bool {
 
 // IsCreateStack409Error returns true if the error was a result of creating a stack that already exists.
 func IsCreateStack409Error(e error) bool {
-	ae, ok := e.(autoError)
+	ae, ok := errors.AsType[autoError](e)
 	if !ok {
 		return false
 	}
@@ -76,7 +81,7 @@ func IsCreateStack409Error(e error) bool {
 
 // IsCompilationError returns true if the program failed at the build/run step (only Typescript, Go, .NET)
 func IsCompilationError(e error) bool {
-	as, ok := e.(autoError)
+	as, ok := errors.AsType[autoError](e)
 	if !ok {
 		return false
 	}
@@ -106,7 +111,7 @@ func IsCompilationError(e error) bool {
 
 // IsRuntimeError returns true if there was an error in the user program at during execution.
 func IsRuntimeError(e error) bool {
-	as, ok := e.(autoError)
+	as, ok := errors.AsType[autoError](e)
 	if !ok {
 		return false
 	}
@@ -138,7 +143,7 @@ func IsRuntimeError(e error) bool {
 // IsUnexpectedEngineError returns true if the pulumi core engine encountered an error (most likely a bug).
 func IsUnexpectedEngineError(e error) bool {
 	// TODO: figure out how to write a test for this
-	as, ok := e.(autoError)
+	as, ok := errors.AsType[autoError](e)
 	if !ok {
 		return false
 	}

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -15,6 +15,8 @@
 package auto
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -542,4 +544,110 @@ func TestRuntimeErrorDotnet(t *testing.T) {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()
 	}
+}
+
+// errPredicate pairs one of the exported error predicates with an autoError it is expected to match.
+type errPredicate struct {
+	name    string
+	matches func(error) bool
+	err     autoError
+}
+
+func errPredicates() []errPredicate {
+	cause := errors.New("exit status 255")
+	return []errPredicate{
+		{
+			name:    "IsConcurrentUpdateError",
+			matches: IsConcurrentUpdateError,
+			err: newAutoError(cause, "",
+				"error: [409] Conflict: Another update is currently in progress.", 255),
+		},
+		{
+			name:    "IsSelectStack404Error",
+			matches: IsSelectStack404Error,
+			err:     newAutoError(cause, "", "error: no stack named 'dev' found", 255),
+		},
+		{
+			name:    "IsCreateStack409Error",
+			matches: IsCreateStack409Error,
+			err:     newAutoError(cause, "", "error: stack 'dev' already exists", 255),
+		},
+		{
+			name:    "IsCompilationError",
+			matches: IsCompilationError,
+			err:     newAutoError(cause, "Build FAILED.", "", 255),
+		},
+		{
+			name:    "IsRuntimeError",
+			matches: IsRuntimeError,
+			err:     newAutoError(cause, "pulumi:pulumi:Stack failed with an unhandled exception:", "", 255),
+		},
+		{
+			name:    "IsUnexpectedEngineError",
+			matches: IsUnexpectedEngineError,
+			err: newAutoError(cause,
+				"The Pulumi CLI encountered a fatal error. This is a bug!", "", 255),
+		},
+	}
+}
+
+func TestErrorPredicatesMatchUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range errPredicates() {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, p.matches(p.err), "%s did not match its own autoError", p.name)
+		})
+	}
+}
+
+// Wrapping an error with fmt.Errorf("...: %w", err) is the standard Go idiom, and autoError is
+// unexported so callers cannot reach it with errors.As themselves. The predicates must therefore
+// look through wrapping.
+func TestErrorPredicatesMatchWrapped(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range errPredicates() {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+
+			wrapped := fmt.Errorf("stack operation failed: %w", p.err)
+			assert.True(t, p.matches(wrapped), "%s did not match a singly wrapped autoError", p.name)
+
+			doubleWrapped := fmt.Errorf("deploy: %w", wrapped)
+			assert.True(t, p.matches(doubleWrapped), "%s did not match a doubly wrapped autoError", p.name)
+		})
+	}
+}
+
+// autoError must unwrap to the error it was created from so that errors.Is and errors.As can reach
+// the underlying cause.
+func TestAutoErrorUnwrapsCause(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	var ae error = newAutoError(sentinel, "", "", 255)
+
+	assert.ErrorIs(t, ae, sentinel)
+	assert.ErrorIs(t, fmt.Errorf("stack operation failed: %w", ae), sentinel)
+}
+
+type causeError struct{ msg string }
+
+func (e *causeError) Error() string { return e.msg }
+
+func TestAutoErrorAsCause(t *testing.T) {
+	t.Parallel()
+
+	cause := &causeError{msg: "boom"}
+	var ae error = newAutoError(cause, "", "", 255)
+
+	var target *causeError
+	require.ErrorAs(t, ae, &target)
+	assert.Equal(t, cause, target)
+
+	target = nil
+	require.ErrorAs(t, fmt.Errorf("stack operation failed: %w", ae), &target)
+	assert.Equal(t, cause, target)
 }


### PR DESCRIPTION
> Written with AI assistance under human review.

## Summary

Closes #24196

The six exported error predicates in `sdk/go/auto/errors.go` detected `autoError` with a plain type
assertion, so a single `fmt.Errorf("...: %w", err)` — the standard way to add context in Go — made
every one of them silently return `false`. `autoError` is unexported, so callers had no way to work
around this with `errors.As` themselves. `autoError` also had no `Unwrap`, so `errors.Is`/`errors.As`
could not reach the cause it was built from.

- Use `errors.As` instead of a type assertion in `IsConcurrentUpdateError`, `IsSelectStack404Error`,
  `IsCreateStack409Error`, `IsCompilationError`, `IsRuntimeError` and `IsUnexpectedEngineError`.
- Add `func (ae autoError) Unwrap() error`.

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

New unit tests in `sdk/go/auto/errors_test.go`, written first and confirmed failing against the old
implementation:

- `TestErrorPredicatesMatchUnwrapped` — each predicate against a bare `autoError` (passed before and
  after; guards against regressing the existing behaviour).
- `TestErrorPredicatesMatchWrapped` — each predicate against a singly and doubly wrapped error.
- `TestAutoErrorUnwrapsCause` / `TestAutoErrorAsCause` — `errors.Is` and `errors.As` reaching the
  inner cause.

The last three failed for all six predicates before the change and pass after it.

## Validation

- [x] `make lint` — clean. Ran the repo's `bin/custom-gcl` with `.golangci.yml` over the `sdk` module
  (`0 issues`) plus `changie batch auto --dry-run`. Did not lint `pkg`/`tests` or `pulumi.json`,
  which this PR does not touch.
- [ ] `make test_fast` — not run. It covers the `pkg` module, which has no import of
  `sdk/v3/go/auto`.
- [x] `make tidy_fix` — clean (no `go.mod`/`go.sum` changes in this PR).
- [x] `make format` — clean (`gofmt` reports nothing; `make format` only rewrites `pulumi.json`,
  untouched here).
- [x] Relevant SDK tests pass (if SDK changes) — `cd sdk && go test ./go/...`. Everything passes
  except three packages that fail for environment reasons unrelated to this change: `go/auto`'s
  pre-existing integration tests (need a released `pulumi` CLI and credentials for the `moolumi`
  org), `common/workspace` (needs a writable `$HOME/.pulumi`; passes once it has one) and
  `common/util/gitutil` (needs to bind a unix socket). The new tests in `go/auto` are pure unit tests
  and pass.
- [ ] `make check_proto` — clean (if proto changes) — no proto changes.

## Changelog

- [x] Changelog entry added.

## Risk

Low. No exported API changes and no behaviour change for unwrapped errors — the added coverage is
strictly wrapped errors, which previously always returned `false`.

The one behavioural widening to be aware of: `autoError` now participates in `errors.Is`/`errors.As`
chains, so code doing `errors.Is(err, someTarget)` on an error returned by the Automation API may
now find a match where it previously could not see past `autoError`. That is the intended fix, but
it is the part worth a second look.
