### PR TITLE
Remove pluginDownloadURL from pulumi-language-hcl downloads

### DIFF
--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -24,29 +24,17 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// knownLanguageRuntime describes a language runtime that is no longer bundled with the
-// `pulumi` binary and must be downloaded on demand. The URL points at the release source
-// (typically a GitHub repository) and Version pins the release the CLI is built against.
-type knownLanguageRuntime struct {
-	PluginDownloadURL string
-	Version           semver.Version
-}
-
-// knownLanguageRuntimes is the set of language runtimes that the CLI knows how to fetch
-// without being told a download URL by the user or a project file. As we migrate
-// previously-bundled language runtimes off the CLI release tarball, they are added here so
-// the CLI continues to know where to find them.
-var knownLanguageRuntimes = map[string]knownLanguageRuntime{
-	"hcl": {
-		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-hcl",
-		// renovate: datasource=github-releases depName=pulumi/pulumi-hcl extractVersion=^v(?<version>.+)$
-		Version: semver.MustParse("0.13.0"),
-	},
+// knownLanguageRuntimes pins the release of each language runtime that is no longer
+// bundled with the `pulumi` binary and must be downloaded on demand.
+var knownLanguageRuntimes = map[string]semver.Version{
+	// renovate: datasource=github-releases depName=pulumi/pulumi-hcl extractVersion=^v(?<version>.+)$
+	"hcl": semver.MustParse("0.13.0"),
 }
 
 // SetKnownPluginDownloadURL fills in metadata on the given PluginDescriptor that the CLI
-// knows about for well-known plugins: a PluginDownloadURL, and for unbundled language
-// runtimes, a pinned Version. Returns true if it filled in anything.
+// knows about for well-known plugins: a PluginDownloadURL for plugins hosted outside the
+// default locations, and a pinned Version for unbundled language runtimes. Returns true
+// if the descriptor names a plugin the CLI knows how to fetch.
 func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 	// If the download url is already set don't touch it
 	if spec.PluginDownloadURL != "" {
@@ -60,22 +48,9 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 		}
 	}
 
-	if spec.Kind == apitype.ConverterPlugin && spec.Name == "hcl" {
-		// The HCL converter lives in the pulumi-labs org rather than pulumi, and at a repository
-		// name (pulumi-hcl) that doesn't match the default pulumi-converter-<name> convention. We
-		// encode both pieces of information here so the auto-install machinery resolves the right
-		// release artifact.
-		spec.PluginDownloadURL = "github://api.github.com/pulumi/pulumi-hcl"
-		return true
-	}
-
 	if spec.Kind == apitype.LanguagePlugin {
-		if known, ok := knownLanguageRuntimes[spec.Name]; ok {
-			spec.PluginDownloadURL = known.PluginDownloadURL
-			if spec.Version == nil {
-				v := known.Version
-				spec.Version = &v
-			}
+		if version, ok := knownLanguageRuntimes[spec.Name]; ok && spec.Version == nil {
+			spec.Version = &version
 			return true
 		}
 	}

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -67,9 +67,8 @@ func TestKnownLanguageRuntimeHCL(t *testing.T) {
 	spec.Version = nil
 
 	assert.Equal(t, workspace.PluginDescriptor{
-		Name:              "hcl",
-		Kind:              apitype.LanguagePlugin,
-		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-hcl",
+		Name: "hcl",
+		Kind: apitype.LanguagePlugin,
 	}, spec)
 }
 
@@ -85,9 +84,8 @@ func TestKnownLanguageRuntimePreservesExplicitVersion(t *testing.T) {
 	res := SetKnownPluginDownloadURL(&spec)
 	assert.True(t, res)
 	assert.Equal(t, workspace.PluginDescriptor{
-		Name:              "hcl",
-		Kind:              apitype.LanguagePlugin,
-		PluginDownloadURL: "github://api.github.com/pulumi/pulumi-hcl",
-		Version:           &explicit,
+		Name:    "hcl",
+		Kind:    apitype.LanguagePlugin,
+		Version: &explicit,
 	}, spec)
 }

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -82,7 +82,7 @@ func TestKnownLanguageRuntimePreservesExplicitVersion(t *testing.T) {
 		Version: &explicit,
 	}
 	res := SetKnownPluginDownloadURL(&spec)
-	assert.True(t, res)
+	assert.False(t, res)
 	assert.Equal(t, workspace.PluginDescriptor{
 		Name:    "hcl",
 		Kind:    apitype.LanguagePlugin,

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,7 +44,7 @@
         '/^pkg/util/plugin\\.go$/',
       ],
       matchStrings: [
-        '// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+Version:\\s+semver\\.MustParse\\("(?<currentValue>[^"]+)"\\)',
+        '// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+"[^"]+":\\s+semver\\.MustParse\\("(?<currentValue>[^"]+)"\\)',
       ],
     },
   ],

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -506,11 +506,11 @@ func newGithubSource(url *url.URL, name string, kind apitype.PluginKind) (*githu
 		// github.com/pulumi/pulumi-converter-aws rather than github.com/pulumi/pulumi-aws which would clash
 		// with the providers of the same name.
 		repository = "pulumi-converter-" + name
-		if name == "yaml" {
-			// We special case the yaml converter plugin to be in the pulumi-yaml repo. It's not ideal but its
-			// to have this hardcoded here than having to deal with two repos for YAML, and long term this
-			// should go away and be replaced with a registry lookup.
-			repository = "pulumi-yaml"
+		switch name {
+		case "yaml", "hcl":
+			// We special case the yaml & hcl converter plugin to be in their language repos repo. Long term
+			// this should go away and be replaced with a registry lookup.
+			repository = "pulumi-" + name
 		}
 	}
 


### PR DESCRIPTION
This PR removes the now unneeded addition of `PluginDownloadURL` from Pulumi HCL. This allows the CLI to hit `get.pulumi.com` for rate-limmited GH downloads, which is the user facing win here.

We also fix the converter default install repo for `pulumi-converter-hcl`.