### PR TITLE
tracing: use fallback parents for grpc otel traces

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	slicesfx "github.com/pgavlin/fx/v2/slices"
+	"go.opentelemetry.io/otel"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -62,6 +63,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -149,6 +151,10 @@ type evalSource struct {
 
 	// the function to run the evaluation with.
 	runner func(resourceMonitorTarget string) *promise.Promise[struct{}]
+
+	// the span covering the currently-running program evaluation, if any. The resource monitor uses it as the
+	// fallback parent for incoming calls that carry no trace context of their own.
+	runSpan atomic.Pointer[oteltrace.Span]
 }
 
 func (src *evalSource) Close() error {
@@ -349,11 +355,18 @@ func (iter *evalSourceIterator) forkRun(
 	// Fire up the goroutine to make the RPC invocation against the language runtime.  As this executes, calls
 	// to queue things up in the resource channel will occur, and we will serve them concurrently.
 	go PanicRecovery(iter.panicErrs, func() {
+		_, runSpan := cmdutil.StartSpan(iter.src.plugctx.Base(), otel.Tracer("pulumi-cli"), "run-program")
+		iter.src.runSpan.Store(&runSpan)
+
 		// Next, launch the language plugin.
 		run := iter.src.runner(iter.mon.Address())
 
 		// Communicate the error, if it exists, or nil if the program exited cleanly.
 		_, err := run.Result(context.TODO())
+
+		iter.src.runSpan.Store(nil)
+		runSpan.End()
+
 		if err != nil {
 			logging.V(5).Infof("Program exited with error: %s", err)
 		} else {
@@ -546,6 +559,13 @@ func newResourceMonitor(
 		componentAliases:        map[resource.URN][]resource.URN{},
 	}
 
+	otelParent := func() oteltrace.Span {
+		if s := src.runSpan.Load(); s != nil {
+			return *s
+		}
+		return oteltrace.SpanFromContext(src.plugctx.Base())
+	}
+
 	// Fire up a gRPC server and start listening for incomings.
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: resmon.cancel,
@@ -553,7 +573,7 @@ func newResourceMonitor(
 			pulumirpc.RegisterResourceMonitorServer(srv, resmon)
 			return nil
 		},
-		Options: sourceEvalServeOptions(src.plugctx, tracingSpan, env.DebugGRPC.Value()),
+		Options: sourceEvalServeOptions(src.plugctx, tracingSpan, otelParent, env.DebugGRPC.Value()),
 	})
 	if err != nil {
 		return nil, err
@@ -638,11 +658,9 @@ func (rm *resmon) Cancel(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-func sourceEvalServeOptions(ctx *plugin.Context, tracingSpan opentracing.Span, logFile string) []grpc.ServerOption {
-	var otelParent oteltrace.Span
-	if ctx != nil {
-		otelParent = oteltrace.SpanFromContext(ctx.Base())
-	}
+func sourceEvalServeOptions(
+	ctx *plugin.Context, tracingSpan opentracing.Span, otelParent func() oteltrace.Span, logFile string,
+) []grpc.ServerOption {
 	serveOpts := rpcutil.TracingServerInterceptorOptionsWithOTelParent(
 		tracingSpan,
 		otelParent,

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	slicesfx "github.com/pgavlin/fx/v2/slices"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -638,8 +639,13 @@ func (rm *resmon) Cancel(ctx context.Context) error {
 }
 
 func sourceEvalServeOptions(ctx *plugin.Context, tracingSpan opentracing.Span, logFile string) []grpc.ServerOption {
-	serveOpts := rpcutil.TracingServerInterceptorOptions(
+	var otelParent oteltrace.Span
+	if ctx != nil {
+		otelParent = oteltrace.SpanFromContext(ctx.Base())
+	}
+	serveOpts := rpcutil.TracingServerInterceptorOptionsWithOTelParent(
 		tracingSpan,
+		otelParent,
 		otgrpc.SpanDecorator(decorateResourceSpans),
 	)
 	if logFile != "" {

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2821,7 +2821,7 @@ func TestSourceEvalServeOptions(t *testing.T) {
 	t.Parallel()
 	require.Len(
 		t,
-		sourceEvalServeOptions(nil, opentracing.SpanFromContext(t.Context()), "" /* logFile */),
+		sourceEvalServeOptions(nil, opentracing.SpanFromContext(t.Context()), nil, "" /* logFile */),
 		2,
 	)
 
@@ -2829,7 +2829,7 @@ func TestSourceEvalServeOptions(t *testing.T) {
 		t,
 		sourceEvalServeOptions(&plugin.Context{
 			DebugTraceMutex: &sync.Mutex{},
-		}, opentracing.SpanFromContext(t.Context()), "logFile.log"),
+		}, opentracing.SpanFromContext(t.Context()), nil, "logFile.log"),
 		4,
 	)
 }

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -48,14 +48,20 @@ func OpenTracingServerInterceptorOptions(parentSpan opentracing.Span, options ..
 // Configures interceptors to propagate OpenTracing and OpenTelemetry metadata through headers.
 // If parentSpan is non-nil, it becomes the default parent for orphan spans.
 func TracingServerInterceptorOptions(parentSpan opentracing.Span, options ...otgrpc.Option) []grpc.ServerOption {
+	return TracingServerInterceptorOptionsWithOTelParent(parentSpan, nil, options...)
+}
+
+func TracingServerInterceptorOptionsWithOTelParent(
+	parentSpan opentracing.Span, otelParent trace.Span, options ...otgrpc.Option,
+) []grpc.ServerOption {
 	return []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
-			otelUnaryServerInterceptor(),
+			otelUnaryServerInterceptor(otelParent),
 			OpenTracingServerInterceptor(parentSpan, options...),
 			stackTraceUnaryServerInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
-			otelStreamServerInterceptor(),
+			otelStreamServerInterceptor(otelParent),
 			OpenTracingStreamServerInterceptor(parentSpan, options...),
 			stackTraceStreamServerInterceptor(),
 		),
@@ -66,11 +72,11 @@ func TracingServerInterceptorOptions(parentSpan opentracing.Span, options ...otg
 func OTelServerInterceptorOptions() []grpc.ServerOption {
 	return []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
-			otelUnaryServerInterceptor(),
+			otelUnaryServerInterceptor(nil),
 			stackTraceUnaryServerInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
-			otelStreamServerInterceptor(),
+			otelStreamServerInterceptor(nil),
 			stackTraceStreamServerInterceptor(),
 		),
 	}
@@ -214,7 +220,7 @@ func captureStackTrace(skip int) string {
 	return stackBuilder.String()
 }
 
-func otelUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+func otelUnaryServerInterceptor(fallbackParent trace.Span) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req any,
@@ -222,6 +228,7 @@ func otelUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		handler grpc.UnaryHandler,
 	) (any, error) {
 		ctx = extractOTelContext(ctx)
+		ctx = withFallbackParent(ctx, fallbackParent)
 		ctx, span := startServerSpan(ctx, info.FullMethod)
 		defer span.End()
 
@@ -231,7 +238,7 @@ func otelUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-func otelStreamServerInterceptor() grpc.StreamServerInterceptor {
+func otelStreamServerInterceptor(fallbackParent trace.Span) grpc.StreamServerInterceptor {
 	return func(
 		srv any,
 		ss grpc.ServerStream,
@@ -239,6 +246,7 @@ func otelStreamServerInterceptor() grpc.StreamServerInterceptor {
 		handler grpc.StreamHandler,
 	) error {
 		ctx := extractOTelContext(ss.Context())
+		ctx = withFallbackParent(ctx, fallbackParent)
 		ctx, span := startServerSpan(ctx, info.FullMethod)
 		defer span.End()
 
@@ -247,6 +255,16 @@ func otelStreamServerInterceptor() grpc.StreamServerInterceptor {
 		setSpanStatus(span, err)
 		return err
 	}
+}
+
+func withFallbackParent(ctx context.Context, fallbackParent trace.Span) context.Context {
+	if fallbackParent == nil || !fallbackParent.SpanContext().IsValid() {
+		return ctx
+	}
+	if trace.SpanContextFromContext(ctx).IsValid() {
+		return ctx
+	}
+	return trace.ContextWithSpan(ctx, fallbackParent)
 }
 
 // serverStreamWithContext wraps a grpc.ServerStream to provide a custom context.

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -52,7 +52,7 @@ func TracingServerInterceptorOptions(parentSpan opentracing.Span, options ...otg
 }
 
 func TracingServerInterceptorOptionsWithOTelParent(
-	parentSpan opentracing.Span, otelParent trace.Span, options ...otgrpc.Option,
+	parentSpan opentracing.Span, otelParent func() trace.Span, options ...otgrpc.Option,
 ) []grpc.ServerOption {
 	return []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
@@ -220,7 +220,7 @@ func captureStackTrace(skip int) string {
 	return stackBuilder.String()
 }
 
-func otelUnaryServerInterceptor(fallbackParent trace.Span) grpc.UnaryServerInterceptor {
+func otelUnaryServerInterceptor(fallbackParent func() trace.Span) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req any,
@@ -238,7 +238,7 @@ func otelUnaryServerInterceptor(fallbackParent trace.Span) grpc.UnaryServerInter
 	}
 }
 
-func otelStreamServerInterceptor(fallbackParent trace.Span) grpc.StreamServerInterceptor {
+func otelStreamServerInterceptor(fallbackParent func() trace.Span) grpc.StreamServerInterceptor {
 	return func(
 		srv any,
 		ss grpc.ServerStream,
@@ -257,14 +257,15 @@ func otelStreamServerInterceptor(fallbackParent trace.Span) grpc.StreamServerInt
 	}
 }
 
-func withFallbackParent(ctx context.Context, fallbackParent trace.Span) context.Context {
-	if fallbackParent == nil || !fallbackParent.SpanContext().IsValid() {
+func withFallbackParent(ctx context.Context, fallbackParent func() trace.Span) context.Context {
+	if fallbackParent == nil || trace.SpanContextFromContext(ctx).IsValid() {
 		return ctx
 	}
-	if trace.SpanContextFromContext(ctx).IsValid() {
+	parent := fallbackParent()
+	if parent == nil || !parent.SpanContext().IsValid() {
 		return ctx
 	}
-	return trace.ContextWithSpan(ctx, fallbackParent)
+	return trace.ContextWithSpan(ctx, parent)
 }
 
 // serverStreamWithContext wraps a grpc.ServerStream to provide a custom context.

--- a/sdk/go/common/util/rpcutil/interceptor_test.go
+++ b/sdk/go/common/util/rpcutil/interceptor_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcutil
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestOTelServerInterceptorFallbackParent(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	prevProvider := otel.GetTracerProvider()
+	prevPropagator := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevProvider)
+		otel.SetTextMapPropagator(prevPropagator)
+	})
+
+	var fallback atomic.Pointer[trace.Span]
+	provider := func() trace.Span {
+		if s := fallback.Load(); s != nil {
+			return *s
+		}
+		return nil
+	}
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(TracingServerInterceptorOptionsWithOTelParent(nil, provider)...)
+	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	check := func(ctx context.Context) sdktrace.ReadOnlySpan {
+		before := len(recorder.Ended())
+		_, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+		spans := recorder.Ended()
+		require.Greater(t, len(spans), before)
+		for _, span := range spans[before:] {
+			if span.SpanKind() == trace.SpanKindServer {
+				return span
+			}
+		}
+		require.FailNow(t, "no server span recorded")
+		return nil
+	}
+
+	tracer := tp.Tracer("test")
+
+	_, spanA := tracer.Start(t.Context(), "parent-a")
+	fallback.Store(&spanA)
+	serverSpan := check(t.Context())
+	require.Equal(t, spanA.SpanContext().SpanID(), serverSpan.Parent().SpanID())
+	require.Equal(t, spanA.SpanContext().TraceID(), serverSpan.SpanContext().TraceID())
+
+	_, spanB := tracer.Start(t.Context(), "parent-b")
+	fallback.Store(&spanB)
+	serverSpan = check(t.Context())
+	require.Equal(t, spanB.SpanContext().SpanID(), serverSpan.Parent().SpanID())
+
+	propagatedCtx, clientSpan := tracer.Start(t.Context(), "propagated-client")
+	md := metadata.MD{}
+	otel.GetTextMapPropagator().Inject(propagatedCtx, propagationCarrier(md))
+	serverSpan = check(metadata.NewOutgoingContext(t.Context(), md))
+	require.Equal(t, clientSpan.SpanContext().SpanID(), serverSpan.Parent().SpanID())
+	require.Equal(t, clientSpan.SpanContext().TraceID(), serverSpan.SpanContext().TraceID())
+
+	fallback.Store(nil)
+	serverSpan = check(t.Context())
+	require.False(t, serverSpan.Parent().IsValid())
+}


### PR DESCRIPTION
Not all SDKs necessarily implement otel parenting correctly, which means we end up with orphaned spans.  Add a fallback parent to otel, so we at least have the span parented under the whole pulumi process instead of just having it loose, which somewhat improves readability.

Ideally we'll fix all the SDKs, but older SDKs will always have this issue, so having a fallback makes this better generally.
