### PR TITLE
parent analyzer spans correctly

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -418,6 +418,9 @@ func (deployment *deployment) run(cancelCtx *Context) (*deploy.Plan, display.Res
 	if deployment.Ctx.TracingSpan != nil {
 		ctx = opentracing.ContextWithSpan(ctx, deployment.Ctx.TracingSpan)
 	}
+	if deployment.Ctx.otelSpan != nil {
+		ctx = trace.ContextWithSpan(ctx, deployment.Ctx.otelSpan)
+	}
 
 	// Emit an appropriate prelude event.
 	deployment.Options.Events.preludeEvent(


### PR DESCRIPTION
The trace parent for otel is currently not passed through correctly through to the analyzers.  We already pass the tracing span through here, do the same for the otel tracing span as well.  Note that this passes this context through to the whole deployment, but it seems to only affect analyzer spans.
