### PR TITLE
Add securestore: OS-protected key storage core and envelope encryption

### DIFF
--- a/sdk/go/common/util/securestore/attended.go
+++ b/sdk/go/common/util/securestore/attended.go
@@ -1,0 +1,45 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/ciutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// Attended reports whether anyone can answer a dialog the credential provider
+// draws on the desktop session. Deliberately not a TTY test: `pulumi up | tee
+// log` is attended, `ssh host pulumi whoami` is not.
+func Attended() bool { return someoneCanAnswerAPasswordDialog() }
+
+func someoneCanAnswerAPasswordDialog() bool {
+	if cmdutil.DisableInteractive {
+		return false
+	}
+	if ciutil.IsCI() || os.Getenv("CI") != "" {
+		return false
+	}
+	return desktopSessionCanDrawDialogs()
+}
+
+func desktopSessionCanDrawDialogs() bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
+	return os.Getenv("WAYLAND_DISPLAY") != "" || os.Getenv("DISPLAY") != ""
+}

--- a/sdk/go/common/util/securestore/attended.go
+++ b/sdk/go/common/util/securestore/attended.go
@@ -22,24 +22,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// Attended reports whether anyone can answer a dialog the credential provider
-// draws on the desktop session. Deliberately not a TTY test: `pulumi up | tee
-// log` is attended, `ssh host pulumi whoami` is not.
-func Attended() bool { return someoneCanAnswerAPasswordDialog() }
-
-func someoneCanAnswerAPasswordDialog() bool {
+func Attended() bool {
 	if cmdutil.DisableInteractive {
 		return false
 	}
-	if ciutil.IsCI() || os.Getenv("CI") != "" {
-		return false
-	}
-	return desktopSessionCanDrawDialogs()
+	return !ciutil.IsCI()
+}
+
+func someoneCanAnswerAPasswordDialog() bool {
+	return Attended() && desktopSessionCanDrawDialogs()
 }
 
 func desktopSessionCanDrawDialogs() bool {
-	if runtime.GOOS != "linux" {
+	switch runtime.GOOS {
+	case "linux":
+		return os.Getenv("WAYLAND_DISPLAY") != "" || os.Getenv("DISPLAY") != ""
+	case "darwin":
+		return os.Getenv("SSH_CONNECTION") == "" && os.Getenv("SSH_TTY") == ""
+	default:
 		return true
 	}
-	return os.Getenv("WAYLAND_DISPLAY") != "" || os.Getenv("DISPLAY") != ""
 }

--- a/sdk/go/common/util/securestore/attended_test.go
+++ b/sdk/go/common/util/securestore/attended_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func disableInteractive(t *testing.T, disable bool) {
+	t.Helper()
+	prev := cmdutil.DisableInteractive
+	cmdutil.DisableInteractive = disable
+	t.Cleanup(func() { cmdutil.DisableInteractive = prev })
+}
+
+//nolint:paralleltest // mutates interactivity globals and the environment
+func TestNonInteractiveForbidsPrompting(t *testing.T) {
+	disableInteractive(t, true)
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "")
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
+	t.Setenv("DISPLAY", ":0")
+	assert.False(t, someoneCanAnswerAPasswordDialog())
+}
+
+//nolint:paralleltest // mutates interactivity globals and the environment
+func TestDetectionWithoutAStatedPreference(t *testing.T) {
+	disableInteractive(t, false)
+
+	t.Setenv("CI", "")
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("DISPLAY", ":0")
+	assert.False(t, someoneCanAnswerAPasswordDialog(), "CI has nobody to answer a dialog")
+
+	// The test host may itself be CI, so neutralise every detector before
+	// asserting on the display branch.
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "")
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "")
+	if runtime.GOOS == "linux" {
+		assert.False(t, someoneCanAnswerAPasswordDialog(), "no display means no dialog can be shown")
+		t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+		assert.True(t, someoneCanAnswerAPasswordDialog(), "a Wayland session can show one")
+		t.Setenv("WAYLAND_DISPLAY", "")
+		t.Setenv("DISPLAY", ":0")
+		assert.True(t, someoneCanAnswerAPasswordDialog(), "an X session can show one")
+	} else {
+		assert.True(t, someoneCanAnswerAPasswordDialog(),
+			"macOS and Windows refuse UI themselves rather than reading a display variable")
+	}
+}

--- a/sdk/go/common/util/securestore/attended_test.go
+++ b/sdk/go/common/util/securestore/attended_test.go
@@ -49,22 +49,46 @@ func TestDetectionWithoutAStatedPreference(t *testing.T) {
 	t.Setenv("DISPLAY", ":0")
 	assert.False(t, someoneCanAnswerAPasswordDialog(), "CI has nobody to answer a dialog")
 
-	// The test host may itself be CI, so neutralise every detector before
-	// asserting on the display branch.
+	// The test host may itself be CI or an SSH session, so neutralise every
+	// detector before asserting on the session branch.
 	t.Setenv("GITHUB_ACTIONS", "")
 	t.Setenv("CI", "")
 	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
 	t.Setenv("DISPLAY", "")
 	t.Setenv("WAYLAND_DISPLAY", "")
-	if runtime.GOOS == "linux" {
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_TTY", "")
+	switch runtime.GOOS {
+	case "linux":
 		assert.False(t, someoneCanAnswerAPasswordDialog(), "no display means no dialog can be shown")
 		t.Setenv("WAYLAND_DISPLAY", "wayland-0")
 		assert.True(t, someoneCanAnswerAPasswordDialog(), "a Wayland session can show one")
 		t.Setenv("WAYLAND_DISPLAY", "")
 		t.Setenv("DISPLAY", ":0")
 		assert.True(t, someoneCanAnswerAPasswordDialog(), "an X session can show one")
-	} else {
+	case "darwin":
+		assert.True(t, someoneCanAnswerAPasswordDialog(), "the console session can show a keychain dialog")
+		t.Setenv("SSH_CONNECTION", "10.0.0.1 50022 10.0.0.2 22")
+		assert.False(t, someoneCanAnswerAPasswordDialog(), "an SSH session cannot see a keychain dialog")
+	default:
 		assert.True(t, someoneCanAnswerAPasswordDialog(),
-			"macOS and Windows refuse UI themselves rather than reading a display variable")
+			"Windows never prompts, so any session may proceed")
+	}
+}
+
+//nolint:paralleltest // mutates interactivity globals and the environment
+func TestWarningsHaveAnAudienceWhenNoDialogCanBeShown(t *testing.T) {
+	disableInteractive(t, false)
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("CI", "")
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 50022 10.0.0.2 22")
+	t.Setenv("SSH_TTY", "/dev/ttys000")
+
+	assert.True(t, Attended(), "an SSH user reads stderr")
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		assert.False(t, someoneCanAnswerAPasswordDialog())
 	}
 }

--- a/sdk/go/common/util/securestore/envelope.go
+++ b/sdk/go/common/util/securestore/envelope.go
@@ -41,6 +41,10 @@ type envelope struct {
 	Data    string `json:"data"`
 }
 
+// aad is the "additional authenticated data" passed to the AEAD cipher: the
+// envelope metadata stays readable in the JSON, but it is bound into the
+// authentication tag, so tampering with the stored version, backend, or
+// algorithm makes decryption fail.
 func aad(version int, backend Backend, algo string) []byte {
 	return fmt.Appendf(nil, "%d|%s|%s", version, backend, algo)
 }

--- a/sdk/go/common/util/securestore/envelope.go
+++ b/sdk/go/common/util/securestore/envelope.go
@@ -1,0 +1,141 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const envelopeVersion = 1
+
+const envelopeAlgo = "aes-256-gcm"
+
+// IsEnvelope still detects these, so they are never overwritten as plaintext.
+var ErrUnsupportedVersion = errors.New("was encrypted by a newer version of the Pulumi CLI")
+
+// The marker distinguishes this from a legacy plaintext file, whose schema has
+// no "$"-prefixed key. Pointer so presence and supported version stay separate.
+type envelope struct {
+	Marker  *int   `json:"$pulumiSecureStore"`
+	Backend string `json:"backend"`
+	Algo    string `json:"algo"`
+	Nonce   string `json:"nonce"`
+	Data    string `json:"data"`
+}
+
+func aad(version int, backend Backend, algo string) []byte {
+	return fmt.Appendf(nil, "%d|%s|%s", version, backend, algo)
+}
+
+// Seal returns a versioned JSON envelope recording the protecting backend.
+func Seal(key []byte, backend Backend, plaintext []byte) ([]byte, error) {
+	aead, err := newAEAD(key)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	sealed := aead.Seal(nil, nonce, plaintext, aad(envelopeVersion, backend, envelopeAlgo))
+	version := envelopeVersion
+	return json.MarshalIndent(envelope{
+		Marker:  &version,
+		Backend: string(backend),
+		Algo:    envelopeAlgo,
+		Nonce:   base64.StdEncoding.EncodeToString(nonce),
+		Data:    base64.StdEncoding.EncodeToString(sealed),
+	}, "", "    ")
+}
+
+// Open decrypts an envelope produced by Seal.
+func Open(key, data []byte) ([]byte, error) {
+	env, err := parseEnvelope(data)
+	if err != nil {
+		return nil, err
+	}
+	if env.Algo != envelopeAlgo {
+		return nil, fmt.Errorf("unsupported secure-store envelope algorithm %q", env.Algo)
+	}
+	aead, err := newAEAD(key)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := base64.StdEncoding.DecodeString(env.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("parsing secure-store envelope nonce: %w", err)
+	}
+	sealed, err := base64.StdEncoding.DecodeString(env.Data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing secure-store envelope data: %w", err)
+	}
+	if len(nonce) != aead.NonceSize() {
+		return nil, fmt.Errorf("invalid secure-store envelope nonce length %d", len(nonce))
+	}
+	plaintext, err := aead.Open(nil, nonce, sealed, aad(*env.Marker, Backend(env.Backend), env.Algo))
+	if err != nil {
+		return nil, ErrWrongKey
+	}
+	return plaintext, nil
+}
+
+// Detection only: accepts versions this build cannot open, so an unreadable
+// envelope is never treated as plaintext.
+func IsEnvelope(data []byte) bool {
+	var probe struct {
+		Marker *int `json:"$pulumiSecureStore"`
+	}
+	return json.Unmarshal(data, &probe) == nil && probe.Marker != nil
+}
+
+// EnvelopeBackend returns the backend recorded in an envelope.
+func EnvelopeBackend(data []byte) (Backend, error) {
+	env, err := parseEnvelope(data)
+	if err != nil {
+		return "", err
+	}
+	return Backend(env.Backend), nil
+}
+
+func parseEnvelope(data []byte) (envelope, error) {
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return envelope{}, fmt.Errorf("parsing secure-store envelope: %w", err)
+	}
+	if env.Marker == nil {
+		return envelope{}, errors.New("not a secure-store envelope")
+	}
+	if *env.Marker != envelopeVersion {
+		return envelope{}, fmt.Errorf("%w (envelope version %d)", ErrUnsupportedVersion, *env.Marker)
+	}
+	return env, nil
+}
+
+func newAEAD(key []byte) (cipher.AEAD, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("secure-store key must be 32 bytes, got %d", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/sdk/go/common/util/securestore/item.go
+++ b/sdk/go/common/util/securestore/item.go
@@ -1,0 +1,61 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type wrapKind string
+
+const (
+	wrapRaw wrapKind = "raw"
+	wrapTPM wrapKind = "tpm"
+)
+
+// Stored as a base64 string: gnome-keyring drops the content type, KWallet
+// rejects non-UTF-8, and some Secret Service providers hard-fail on binary.
+const itemPrefix = "pulumi-securestore-v1"
+
+func formatItem(kind wrapKind, blob []byte) string {
+	return itemPrefix + ":" + string(kind) + ":" + base64.StdEncoding.EncodeToString(blob)
+}
+
+func parseItem(value string) (wrapKind, []byte, error) {
+	parts := strings.SplitN(value, ":", 3)
+	if len(parts) != 3 || parts[0] != itemPrefix {
+		return "", nil, errors.New("stored key has an unrecognized format")
+	}
+	kind := wrapKind(parts[1])
+	if kind != wrapRaw && kind != wrapTPM {
+		return "", nil, fmt.Errorf("stored key has unknown protection kind %q", parts[1])
+	}
+	blob, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return "", nil, fmt.Errorf("stored key is corrupt (not base64): %w", err)
+	}
+	return kind, blob, nil
+}
+
+// Identity wrapper: the store item holds the key itself.
+type rawWrapper struct{}
+
+func (rawWrapper) kind() wrapKind                     { return wrapRaw }
+func (rawWrapper) available() error                   { return nil }
+func (rawWrapper) wrap(key []byte) ([]byte, error)    { return key, nil }
+func (rawWrapper) unwrap(blob []byte) ([]byte, error) { return blob, nil }

--- a/sdk/go/common/util/securestore/mock_test.go
+++ b/sdk/go/common/util/securestore/mock_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type memStore struct {
+	mu    sync.Mutex
+	value string
+	set_  bool
+}
+
+func (m *memStore) available() (Outcome, error) { return Ready, nil }
+
+func (m *memStore) get() (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.set_ {
+		return "", ErrKeyNotFound
+	}
+	return m.value, nil
+}
+
+func (m *memStore) set(value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.value, m.set_ = value, true
+	return nil
+}
+
+func (m *memStore) delete() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.value, m.set_ = "", false
+	return nil
+}
+
+// Never resolves outside tests.
+const BackendMock Backend = "mock"
+
+const BackendMockStrong Backend = "mock-strong"
+
+// Toggleable availability, simulating a platform gaining a stronger tier.
+type gatedStore struct {
+	inner   itemStore
+	enabled *bool
+}
+
+func (g *gatedStore) available() (Outcome, error) {
+	if !*g.enabled {
+		return Absent, fmt.Errorf("%w: mock backend not yet enabled", ErrUnavailable)
+	}
+	return g.inner.available()
+}
+
+func (g *gatedStore) get() (string, error)   { return g.inner.get() }
+func (g *gatedStore) set(value string) error { return g.inner.set(value) }
+func (g *gatedStore) delete() error          { return g.inner.delete() }
+
+type refusingStore struct{ memStore }
+
+func (*refusingStore) available() (Outcome, error) { return Declined, ErrDeclined }
+
+func MockInit(t *testing.T) {
+	t.Helper()
+	mem := &memStore{}
+	prev := platformCandidatesHook
+	platformCandidatesHook = func(bool, string) []backendImpl {
+		return []backendImpl{{id: BackendMock, store: mem, wrap: rawWrapper{}}}
+	}
+	t.Cleanup(func() { platformCandidatesHook = prev })
+}
+
+// The preferred backend becomes available only once promote is called.
+func MockInitDual(t *testing.T) (promote func()) {
+	t.Helper()
+	enabled := false
+	weak, strong := &memStore{}, &memStore{}
+	prev := platformCandidatesHook
+	platformCandidatesHook = func(bool, string) []backendImpl {
+		return []backendImpl{
+			{id: BackendMockStrong, store: &gatedStore{inner: strong, enabled: &enabled}, wrap: rawWrapper{}},
+			{id: BackendMock, store: weak, wrap: rawWrapper{}},
+		}
+	}
+	t.Cleanup(func() { platformCandidatesHook = prev })
+	return func() { enabled = true }
+}

--- a/sdk/go/common/util/securestore/outcome.go
+++ b/sdk/go/common/util/securestore/outcome.go
@@ -1,0 +1,81 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"errors"
+	"sync"
+)
+
+// Outcome is the result of probing one backend. Only Absent and Locked permit
+// falling back to the next one.
+type Outcome int
+
+const (
+	Ready Outcome = iota
+	Absent
+	// Locked: exists, needs an unlock we were not permitted to ask for.
+	Locked
+	// Declined: we asked, the user said no.
+	Declined
+)
+
+func (o Outcome) String() string {
+	switch o {
+	case Ready:
+		return "ready"
+	case Absent:
+		return "absent"
+	case Locked:
+		return "locked"
+	case Declined:
+		return "declined"
+	default:
+		return "unknown"
+	}
+}
+
+// One command probes several times, so without memoizing, each probe of a
+// locked store raises its own dialog — re-asking after a decline.
+func memoizePrecheck(probe func(allowPrompt bool) (Outcome, error)) func(bool) (Outcome, error) {
+	var (
+		once [2]sync.Once
+		res  [2]struct {
+			outcome Outcome
+			err     error
+		}
+	)
+	return func(allowPrompt bool) (Outcome, error) {
+		i := 0
+		if allowPrompt {
+			i = 1
+		}
+		once[i].Do(func() { res[i].outcome, res[i].err = probe(allowPrompt) })
+		return res[i].outcome, res[i].err
+	}
+}
+
+func outcomeOf(err error) Outcome {
+	switch {
+	case err == nil:
+		return Ready
+	case errors.Is(err, ErrDeclined):
+		return Declined
+	case errors.Is(err, ErrLocked):
+		return Locked
+	default:
+		return Absent
+	}
+}

--- a/sdk/go/common/util/securestore/outcome.go
+++ b/sdk/go/common/util/securestore/outcome.go
@@ -50,20 +50,16 @@ func (o Outcome) String() string {
 // One command probes several times, so without memoizing, each probe of a
 // locked store raises its own dialog — re-asking after a decline.
 func memoizePrecheck(probe func(allowPrompt bool) (Outcome, error)) func(bool) (Outcome, error) {
-	var (
-		once [2]sync.Once
-		res  [2]struct {
-			outcome Outcome
-			err     error
-		}
-	)
+	type memo struct {
+		once    sync.Once
+		outcome Outcome
+		err     error
+	}
+	memos := map[bool]*memo{false: {}, true: {}}
 	return func(allowPrompt bool) (Outcome, error) {
-		i := 0
-		if allowPrompt {
-			i = 1
-		}
-		once[i].Do(func() { res[i].outcome, res[i].err = probe(allowPrompt) })
-		return res[i].outcome, res[i].err
+		m := memos[allowPrompt]
+		m.once.Do(func() { m.outcome, m.err = probe(allowPrompt) })
+		return m.outcome, m.err
 	}
 }
 

--- a/sdk/go/common/util/securestore/resolve.go
+++ b/sdk/go/common/util/securestore/resolve.go
@@ -1,0 +1,19 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+// Platform backends land in follow-up changes; until then every platform
+// resolves to plaintext.
+func platformCandidates(bool, string) []backendImpl { return nil }

--- a/sdk/go/common/util/securestore/securestore.go
+++ b/sdk/go/common/util/securestore/securestore.go
@@ -54,20 +54,21 @@ type Mode int
 const (
 	// No explicit choice: plaintext for writes until encryption is the default.
 	ModeDefault Mode = iota
-	// Best available backend, else plaintext.
+	// Best available secure backend, else plaintext.
 	ModeAuto
-	// Require a backend, error when none is usable.
+	// Require a secure backend, error when none is usable.
 	ModeOS
 	ModePlaintext
 )
 
 var (
 	ErrUnavailable = errors.New("no usable OS credential protection")
-	// Nothing the user does locally will read this data.
+	// The envelope names a credential store this platform does not have, so
+	// no local action (unlocking, retrying) can decrypt the data.
 	ErrBackendUnsupported = fmt.Errorf("%w: no such credential store on this platform", ErrUnavailable)
 	// Wraps ErrUnavailable: same effect, named cause.
 	ErrLocked = fmt.Errorf("%w: the OS credential store is locked", ErrUnavailable)
-	// Never a reason to fall back — that would contradict what the user said.
+	// Unlike ErrLocked this does not wrap ErrUnavailable; see Resolve.
 	ErrDeclined    = errors.New("the OS credential store was not unlocked")
 	ErrKeyNotFound = errors.New("no key stored in the OS credential store")
 	ErrWrongKey    = errors.New("data cannot be decrypted with the stored key")
@@ -148,6 +149,10 @@ func Resolve(mode Mode, pulumiHome string) (*Store, error) {
 		switch outcome {
 		case Ready:
 		case Declined:
+			// The user refused the unlock prompt: trying further backends or
+			// falling back to plaintext would contradict that, so this is an
+			// error even under ModeAuto (ErrDeclined does not wrap
+			// ErrUnavailable, the fall-back signal).
 			logging.V(7).Infof("secure store backend %q: %s", cand.id, outcome)
 			return nil, err
 		case Absent, Locked:
@@ -229,14 +234,12 @@ var createKeyMu sync.Mutex
 // cleanly reports none exists. Regenerating on a transient error would
 // permanently orphan the user's encrypted data.
 func (s *Store) GetOrCreateKey() ([]byte, error) {
-	key, err := s.GetKey()
-	if err == nil {
-		return key, nil
+	if s.b.id == BackendPlaintext {
+		return nil, ErrUnavailable
 	}
 	createKeyMu.Lock()
 	defer createKeyMu.Unlock()
-	// Re-check under the lock: a concurrent caller may have created the key.
-	key, err = s.GetKey()
+	key, err := s.GetKey()
 	switch {
 	case err == nil:
 		return key, nil

--- a/sdk/go/common/util/securestore/securestore.go
+++ b/sdk/go/common/util/securestore/securestore.go
@@ -1,0 +1,313 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package securestore keeps a per-user 32-byte encryption key in the most
+// protective mechanism the platform offers and encrypts local files with it.
+//
+// Operations are prompt-free and time-bounded, so the package is safe in CI.
+// The exception is unlocking a locked store when the user opted in and someone
+// can answer; that wait has no deadline, matching sudo and gpg.
+package securestore
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// Backend is recorded in the on-disk envelope so reads use the same mechanism.
+type Backend string
+
+const (
+	// ACL bound to our code-signing identity; signed builds only.
+	BackendMacOSACL      Backend = "macos-acl"
+	BackendMacOSSecurity Backend = "macos-security"
+
+	BackendWindowsCredMan        Backend = "windows-credman"
+	BackendWindowsCredManTPM     Backend = "windows-credman-tpm"
+	BackendLinuxSecretService    Backend = "linux-secretservice"
+	BackendLinuxSecretServiceTPM Backend = "linux-secretservice-tpm"
+	// TPM present but no usable OS store (headless servers).
+	BackendTPMFile Backend = "tpm-file"
+	// No protection available; callers keep plaintext behavior.
+	BackendPlaintext Backend = "plaintext"
+)
+
+// Mode mirrors PULUMI_CREDENTIAL_STORE.
+type Mode int
+
+const (
+	// No explicit choice: plaintext for writes until encryption is the default.
+	ModeDefault Mode = iota
+	// Best available backend, else plaintext.
+	ModeAuto
+	// Require a backend, error when none is usable.
+	ModeOS
+	ModePlaintext
+)
+
+var (
+	ErrUnavailable = errors.New("no usable OS credential protection")
+	// Nothing the user does locally will read this data.
+	ErrBackendUnsupported = fmt.Errorf("%w: no such credential store on this platform", ErrUnavailable)
+	// Wraps ErrUnavailable: same effect, named cause.
+	ErrLocked = fmt.Errorf("%w: the OS credential store is locked", ErrUnavailable)
+	// Never a reason to fall back — that would contradict what the user said.
+	ErrDeclined    = errors.New("the OS credential store was not unlocked")
+	ErrKeyNotFound = errors.New("no key stored in the OS credential store")
+	ErrWrongKey    = errors.New("data cannot be decrypted with the stored key")
+)
+
+// itemStore persists one opaque string item. Implementations must be
+// prompt-free and time-bounded.
+type itemStore interface {
+	available() (Outcome, error)
+	// get returns ErrKeyNotFound if absent.
+	get() (string, error)
+	set(value string) error
+	// delete of a missing item is not an error.
+	delete() error
+}
+
+// keyWrapper converts between the raw key and the persisted payload (identity
+// for "raw", TPM sealing for "tpm").
+type keyWrapper interface {
+	kind() wrapKind
+	available() error
+	wrap(key []byte) ([]byte, error)
+	unwrap(blob []byte) ([]byte, error)
+}
+
+type backendImpl struct {
+	id    Backend
+	store itemStore
+	wrap  keyWrapper
+}
+
+func (b backendImpl) available() (Outcome, error) {
+	outcome, err := b.store.available()
+	if outcome != Ready {
+		return outcome, err
+	}
+	if err := b.wrap.available(); err != nil {
+		return Absent, err
+	}
+	return Ready, nil
+}
+
+type Store struct {
+	b              backendImpl
+	fallbackReason error
+}
+
+func (s *Store) Backend() Backend { return s.b.id }
+
+// FallbackReason reports why a ModeAuto resolution fell back to plaintext.
+func (s *Store) FallbackReason() error { return s.fallbackReason }
+
+// Both callers have established the user opted in, so prompting is governed
+// by attendance alone.
+func candidates(pulumiHome string) []backendImpl {
+	return platformCandidatesHook(someoneCanAnswerAPasswordDialog(), pulumiHome)
+}
+
+var platformCandidatesHook = platformCandidates
+
+// Resolve picks the backend for writing. A plaintext resolution is not an
+// error: its key operations fail with ErrUnavailable, which callers take as
+// the signal to keep plaintext behavior.
+//
+// pulumiHome locates file-based key material; empty disables that backend.
+func Resolve(mode Mode, pulumiHome string) (*Store, error) {
+	switch mode {
+	case ModePlaintext, ModeDefault:
+		return &Store{b: backendImpl{id: BackendPlaintext}}, nil
+	case ModeAuto, ModeOS:
+	default:
+		return nil, fmt.Errorf("invalid secure store mode %d", mode)
+	}
+
+	var firstErr error
+	for _, cand := range candidates(pulumiHome) {
+		outcome, err := cand.available()
+		switch outcome {
+		case Ready:
+		case Declined:
+			logging.V(7).Infof("secure store backend %q: %s", cand.id, outcome)
+			return nil, err
+		case Absent, Locked:
+			logging.V(7).Infof("secure store backend %q: %s (%v)", cand.id, outcome, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		logging.V(7).Infof("secure store resolved to backend %q", cand.id)
+		return &Store{b: cand}, nil
+	}
+	logging.V(7).Infof("no secure store backend usable")
+	if firstErr == nil {
+		firstErr = ErrUnavailable
+	}
+	if mode == ModeOS {
+		return nil, fmt.Errorf("PULUMI_CREDENTIAL_STORE=os but %w "+
+			"(set PULUMI_CREDENTIAL_STORE=plaintext to override): %v",
+			ErrUnavailable, firstErr)
+	}
+	return &Store{b: backendImpl{id: BackendPlaintext}, fallbackReason: firstErr}, nil
+}
+
+// ForBackend returns a store for the backend that produced an existing
+// envelope, regardless of mode — reading data back must always be attempted.
+func ForBackend(id Backend, pulumiHome string) (*Store, error) {
+	if id == BackendPlaintext {
+		return &Store{b: backendImpl{id: BackendPlaintext}}, nil
+	}
+	for _, cand := range candidates(pulumiHome) {
+		if cand.id == id {
+			outcome, err := cand.available()
+			if outcome == Declined {
+				return nil, err
+			}
+			if err != nil {
+				return nil, fmt.Errorf("credential store backend %q is not usable here: %w", id, err)
+			}
+			return &Store{b: cand}, nil
+		}
+	}
+	return nil, fmt.Errorf("credential store backend %q is not available on this platform: %w",
+		id, ErrBackendUnsupported)
+}
+
+// GetKey never creates a key.
+func (s *Store) GetKey() ([]byte, error) {
+	if s.b.id == BackendPlaintext {
+		return nil, ErrUnavailable
+	}
+	value, err := s.b.store.get()
+	if err != nil {
+		return nil, err
+	}
+	kind, blob, err := parseItem(value)
+	if err != nil {
+		return nil, err
+	}
+	if kind != s.b.wrap.kind() {
+		return nil, fmt.Errorf("stored key was protected with %q but this backend uses %q: %w",
+			kind, s.b.wrap.kind(), ErrUnavailable)
+	}
+	key, err := s.b.wrap.unwrap(blob)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("stored key is corrupt (%d bytes, want 32)", len(key))
+	}
+	return key, nil
+}
+
+// createKeyMu serializes first-time key creation: OS store "add" is not
+// atomic (`security` returns "duplicate item" to the loser of a race).
+var createKeyMu sync.Mutex
+
+// GetOrCreateKey returns the stored key, creating one only when the backend
+// cleanly reports none exists. Regenerating on a transient error would
+// permanently orphan the user's encrypted data.
+func (s *Store) GetOrCreateKey() ([]byte, error) {
+	key, err := s.GetKey()
+	if err == nil {
+		return key, nil
+	}
+	createKeyMu.Lock()
+	defer createKeyMu.Unlock()
+	// Re-check under the lock: a concurrent caller may have created the key.
+	key, err = s.GetKey()
+	switch {
+	case err == nil:
+		return key, nil
+	case errors.Is(err, ErrKeyNotFound):
+	default:
+		// A raw-wrapped item under a TPM backend means the machine gained a
+		// TPM later. Re-wrap in place; failing would downgrade to plaintext.
+		if upgraded, upErr := s.upgradeKeyWrap(); upErr == nil && upgraded != nil {
+			return upgraded, nil
+		}
+		return nil, err
+	}
+
+	key = make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	blob, err := s.b.wrap.wrap(key)
+	if err != nil {
+		return nil, fmt.Errorf("protecting new key: %w", err)
+	}
+	if setErr := s.b.store.set(formatItem(s.b.wrap.kind(), blob)); setErr != nil {
+		// The add can lose a race, or hit store state a preceding lookup did
+		// not yet see (securityd settling after a delete). The persisted item
+		// wins.
+		if stored, getErr := s.GetKey(); getErr == nil {
+			return stored, nil
+		}
+		return nil, fmt.Errorf("storing key: %w", setErr)
+	}
+	// Writes have been observed to silently fail on some CI images; the
+	// persisted item wins.
+	stored, err := s.GetKey()
+	if err != nil {
+		return nil, fmt.Errorf("verifying stored key: %w", err)
+	}
+	if subtle.ConstantTimeCompare(key, stored) != 1 {
+		key = stored
+	}
+	return key, nil
+}
+
+// upgradeKeyWrap re-protects a raw-wrapped key with this backend's wrapper,
+// returning (nil, nil) when the item is not raw. Only that direction works:
+// a TPM-wrapped key cannot be unwrapped without its TPM.
+func (s *Store) upgradeKeyWrap() ([]byte, error) {
+	if s.b.wrap.kind() == wrapRaw {
+		return nil, nil
+	}
+	value, err := s.b.store.get()
+	if err != nil {
+		return nil, err
+	}
+	kind, blob, err := parseItem(value)
+	if err != nil || kind != wrapRaw || len(blob) != 32 {
+		return nil, nil
+	}
+	wrapped, err := s.b.wrap.wrap(blob)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.b.store.set(formatItem(s.b.wrap.kind(), wrapped)); err != nil {
+		return nil, err
+	}
+	return blob, nil
+}
+
+// Deleting a missing key is not an error.
+func (s *Store) DeleteKey() error {
+	if s.b.id == BackendPlaintext {
+		return nil
+	}
+	return s.b.store.delete()
+}

--- a/sdk/go/common/util/securestore/securestore_test.go
+++ b/sdk/go/common/util/securestore/securestore_test.go
@@ -188,6 +188,8 @@ func TestResolveModes(t *testing.T) {
 	assert.Equal(t, BackendPlaintext, st.Backend())
 	_, err = st.GetKey()
 	assert.True(t, errors.Is(err, ErrUnavailable))
+	_, err = st.GetOrCreateKey()
+	assert.True(t, errors.Is(err, ErrUnavailable))
 	require.NoError(t, st.DeleteKey())
 
 	st, err = Resolve(ModeDefault, "")
@@ -257,9 +259,6 @@ func (r *raceLosingStore) get() (string, error) {
 	if r.gets == 1 {
 		// Mirrors `security find-generic-password` reporting "not found" just
 		// before `add-generic-password` collides.
-		return "", ErrKeyNotFound
-	}
-	if r.gets == 2 {
 		return "", ErrKeyNotFound
 	}
 	return r.winner, nil

--- a/sdk/go/common/util/securestore/securestore_test.go
+++ b/sdk/go/common/util/securestore/securestore_test.go
@@ -1,0 +1,375 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securestore
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return key
+}
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	plaintext := []byte(`{"current":"https://api.pulumi.com"}`)
+
+	env, err := Seal(key, BackendMock, plaintext)
+	require.NoError(t, err)
+	assert.True(t, IsEnvelope(env))
+	assert.False(t, bytes.Contains(env, []byte("api.pulumi.com")))
+
+	backend, err := EnvelopeBackend(env)
+	require.NoError(t, err)
+	assert.Equal(t, BackendMock, backend)
+
+	got, err := Open(key, env)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, got)
+}
+
+func TestOpenWrongKey(t *testing.T) {
+	t.Parallel()
+	env, err := Seal(testKey(t), BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	_, err = Open(testKey(t), env)
+	assert.True(t, errors.Is(err, ErrWrongKey))
+}
+
+func TestOpenTamperedCiphertext(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	tampered := bytes.Replace(env, []byte(`"data": "`), []byte(`"data": "A`), 1)
+	_, err = Open(key, tampered)
+	assert.Error(t, err)
+}
+
+func TestIsEnvelopeRejectsLegacyCredentials(t *testing.T) {
+	t.Parallel()
+	assert.False(t, IsEnvelope([]byte(`{"current":"x","accessTokens":{"x":"tok"}}`)))
+	assert.False(t, IsEnvelope([]byte("")))
+	assert.False(t, IsEnvelope([]byte("not json")))
+}
+
+func TestUnsupportedEnvelopeVersion(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	future := bytes.Replace(env, []byte(`"$pulumiSecureStore": 1`), []byte(`"$pulumiSecureStore": 2`), 1)
+	require.NotEqual(t, env, future)
+
+	assert.True(t, IsEnvelope(future), "a future-version envelope must still be detected as an envelope")
+	_, err = EnvelopeBackend(future)
+	assert.True(t, errors.Is(err, ErrUnsupportedVersion))
+	_, err = Open(key, future)
+	assert.True(t, errors.Is(err, ErrUnsupportedVersion))
+}
+
+func TestOpenRejectsUnknownAlgo(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	tampered := bytes.Replace(env, []byte(`"algo": "aes-256-gcm"`), []byte(`"algo": "rot13"`), 1)
+	require.NotEqual(t, env, tampered)
+	_, err = Open(key, tampered)
+	assert.ErrorContains(t, err, "algorithm")
+}
+
+func TestOpenRejectsTamperedHeader(t *testing.T) {
+	t.Parallel()
+	key := testKey(t)
+	env, err := Seal(key, BackendMock, []byte("secret"))
+	require.NoError(t, err)
+	tampered := bytes.Replace(env, []byte(`"backend": "mock"`), []byte(`"backend": "mock-strong"`), 1)
+	require.NotEqual(t, env, tampered)
+	_, err = Open(key, tampered)
+	assert.True(t, errors.Is(err, ErrWrongKey), "header edits must fail authentication")
+}
+
+func TestSealRejectsBadKeyLength(t *testing.T) {
+	t.Parallel()
+	_, err := Seal([]byte("short"), BackendMock, []byte("x"))
+	assert.Error(t, err)
+}
+
+func TestItemFormatRoundTrip(t *testing.T) {
+	t.Parallel()
+	blob := []byte{0x00, 0x01, 0xFF, 0xFE}
+	kind, got, err := parseItem(formatItem(wrapTPM, blob))
+	require.NoError(t, err)
+	assert.Equal(t, wrapTPM, kind)
+	assert.Equal(t, blob, got)
+
+	_, _, err = parseItem("not-an-item")
+	assert.Error(t, err)
+	_, _, err = parseItem(itemPrefix + ":weird:AAAA")
+	assert.Error(t, err)
+}
+
+//nolint:paralleltest // MockInit swaps a package-global resolver
+func TestGetOrCreateKeyCreatesOnceAndIsStable(t *testing.T) {
+	MockInit(t)
+	st, err := Resolve(ModeAuto, "")
+	require.NoError(t, err)
+	require.Equal(t, BackendMock, st.Backend())
+
+	_, err = st.GetKey()
+	assert.True(t, errors.Is(err, ErrKeyNotFound), "GetKey must not create")
+
+	k1, err := st.GetOrCreateKey()
+	require.NoError(t, err)
+	require.Len(t, k1, 32)
+
+	k2, err := st.GetOrCreateKey()
+	require.NoError(t, err)
+	assert.Equal(t, k1, k2)
+
+	rd, err := ForBackend(BackendMock, "")
+	require.NoError(t, err)
+	k3, err := rd.GetKey()
+	require.NoError(t, err)
+	assert.Equal(t, k1, k3)
+
+	require.NoError(t, st.DeleteKey())
+	require.NoError(t, st.DeleteKey(), "delete is idempotent")
+	_, err = st.GetKey()
+	assert.True(t, errors.Is(err, ErrKeyNotFound))
+}
+
+//nolint:paralleltest // MockInit swaps a package-global resolver
+func TestCorruptStoredItemSurfacesErrorNotRegeneration(t *testing.T) {
+	MockInit(t)
+	st, err := Resolve(ModeAuto, "")
+	require.NoError(t, err)
+	require.NoError(t, st.b.store.set("garbage"))
+
+	_, err = st.GetOrCreateKey()
+	assert.Error(t, err, "corrupt stored key must surface an error, never be silently replaced")
+	value, err := st.b.store.get()
+	require.NoError(t, err)
+	assert.Equal(t, "garbage", value, "corrupt item must be left untouched")
+}
+
+//nolint:paralleltest // MockInit swaps a package-global resolver
+func TestResolveModes(t *testing.T) {
+	MockInit(t)
+
+	st, err := Resolve(ModePlaintext, "")
+	require.NoError(t, err)
+	assert.Equal(t, BackendPlaintext, st.Backend())
+	_, err = st.GetKey()
+	assert.True(t, errors.Is(err, ErrUnavailable))
+	require.NoError(t, st.DeleteKey())
+
+	st, err = Resolve(ModeDefault, "")
+	require.NoError(t, err)
+	assert.Equal(t, BackendPlaintext, st.Backend(), "default stays plaintext until the flip")
+
+	st, err = Resolve(ModeOS, "")
+	require.NoError(t, err)
+	assert.Equal(t, BackendMock, st.Backend())
+}
+
+func TestOutcomeClassification(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, Ready, outcomeOf(nil))
+	assert.Equal(t, Declined, outcomeOf(fmt.Errorf("wrapped: %w", ErrDeclined)))
+	assert.Equal(t, Locked, outcomeOf(fmt.Errorf("wrapped: %w", ErrLocked)))
+	assert.Equal(t, Absent, outcomeOf(ErrUnavailable))
+	assert.Equal(t, Absent, outcomeOf(errors.New("something else")))
+
+	assert.True(t, errors.Is(ErrLocked, ErrUnavailable), "locked still means unusable, so fallback keeps working")
+	assert.False(t, errors.Is(ErrDeclined, ErrUnavailable), "a refusal must never look like absence")
+}
+
+//nolint:paralleltest // mutates the package-global resolution hook
+func TestDeclinedStopsTheChain(t *testing.T) {
+	fallback := &memStore{}
+	prevHook := platformCandidatesHook
+	platformCandidatesHook = func(bool, string) []backendImpl {
+		return []backendImpl{
+			{id: BackendMockStrong, store: &refusingStore{}, wrap: rawWrapper{}},
+			{id: BackendMock, store: fallback, wrap: rawWrapper{}},
+		}
+	}
+	t.Cleanup(func() { platformCandidatesHook = prevHook })
+
+	for _, mode := range []Mode{ModeAuto, ModeOS} {
+		st, err := Resolve(mode, "")
+		require.Error(t, err, "a refusal must fail the resolution, not fall back")
+		assert.True(t, errors.Is(err, ErrDeclined))
+		assert.Nil(t, st)
+	}
+	_, err := fallback.get()
+	assert.True(t, errors.Is(err, ErrKeyNotFound), "the next backend must not have been used")
+}
+
+//nolint:paralleltest // MockInit swaps a package-global resolver
+func TestForBackendUnknown(t *testing.T) {
+	MockInit(t)
+	_, err := ForBackend(Backend("windows-credman"), "")
+	assert.Error(t, err)
+
+	st, err := ForBackend(BackendPlaintext, "")
+	require.NoError(t, err)
+	assert.Equal(t, BackendPlaintext, st.Backend())
+}
+
+// Loses a non-atomic create race: set fails, but a key is readable after.
+type raceLosingStore struct {
+	winner string
+	gets   int
+}
+
+func (r *raceLosingStore) available() (Outcome, error) { return Ready, nil }
+
+func (r *raceLosingStore) get() (string, error) {
+	r.gets++
+	if r.gets == 1 {
+		// Mirrors `security find-generic-password` reporting "not found" just
+		// before `add-generic-password` collides.
+		return "", ErrKeyNotFound
+	}
+	if r.gets == 2 {
+		return "", ErrKeyNotFound
+	}
+	return r.winner, nil
+}
+
+func (r *raceLosingStore) set(value string) error {
+	return errors.New("exit status 45")
+}
+
+func (r *raceLosingStore) delete() error { return nil }
+
+//nolint:paralleltest // mutates the package-global resolution hook
+func TestGetOrCreateKeyReconcilesWhenSetLosesRace(t *testing.T) {
+	winnerKey := testKey(t)
+	store := &raceLosingStore{winner: formatItem(wrapRaw, winnerKey)}
+	prevHook := platformCandidatesHook
+	platformCandidatesHook = func(bool, string) []backendImpl {
+		return []backendImpl{{id: BackendMock, store: store, wrap: rawWrapper{}}}
+	}
+	t.Cleanup(func() { platformCandidatesHook = prevHook })
+
+	st, err := Resolve(ModeAuto, "")
+	require.NoError(t, err)
+	key, err := st.GetOrCreateKey()
+	require.NoError(t, err, "losing the create race must reconcile silently, not fail")
+	assert.Equal(t, winnerKey, key, "the persisted (winning) key must be adopted")
+}
+
+//nolint:paralleltest // mutates the package-global resolution hook
+func TestGetOrCreateKeyConcurrent(t *testing.T) {
+	MockInit(t)
+	st, err := Resolve(ModeAuto, "")
+	require.NoError(t, err)
+
+	const n = 16
+	keys := make([][]byte, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			keys[i], errs[i] = st.GetOrCreateKey()
+		}(i)
+	}
+	wg.Wait()
+	for i := range n {
+		require.NoError(t, errs[i])
+		assert.Equal(t, keys[0], keys[i], "all concurrent callers must converge on one key")
+	}
+}
+
+// "Seals" by prefixing a marker, so wrapped and raw payloads differ.
+type fakeTPMWrapper struct{}
+
+func (fakeTPMWrapper) kind() wrapKind   { return wrapTPM }
+func (fakeTPMWrapper) available() error { return nil }
+func (fakeTPMWrapper) wrap(key []byte) ([]byte, error) {
+	return append([]byte("sealed:"), key...), nil
+}
+
+func (fakeTPMWrapper) unwrap(blob []byte) ([]byte, error) {
+	if !bytes.HasPrefix(blob, []byte("sealed:")) {
+		return nil, errors.New("not a sealed blob")
+	}
+	return bytes.TrimPrefix(blob, []byte("sealed:")), nil
+}
+
+//nolint:paralleltest // mutates the package-global resolution hook
+func TestGetOrCreateKeyUpgradesRawItemToTPM(t *testing.T) {
+	rawKey := testKey(t)
+	mem := &memStore{}
+	require.NoError(t, mem.set(formatItem(wrapRaw, rawKey)))
+	prevHook := platformCandidatesHook
+	platformCandidatesHook = func(bool, string) []backendImpl {
+		return []backendImpl{{id: BackendMock, store: mem, wrap: fakeTPMWrapper{}}}
+	}
+	t.Cleanup(func() { platformCandidatesHook = prevHook })
+
+	st, err := Resolve(ModeAuto, "")
+	require.NoError(t, err)
+	key, err := st.GetOrCreateKey()
+	require.NoError(t, err, "raw->tpm upgrade must succeed")
+	assert.Equal(t, rawKey, key, "the existing key must be preserved, not regenerated")
+
+	value, err := mem.get()
+	require.NoError(t, err)
+	kind, blob, err := parseItem(value)
+	require.NoError(t, err)
+	assert.Equal(t, wrapTPM, kind, "stored item must now be TPM-wrapped")
+	assert.Equal(t, append([]byte("sealed:"), rawKey...), blob)
+
+	got, err := st.GetKey()
+	require.NoError(t, err)
+	assert.Equal(t, rawKey, got)
+}
+
+func TestMemoizePrecheckAsksOncePerPolicy(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	precheck := memoizePrecheck(func(bool) (Outcome, error) {
+		calls++
+		return Ready, nil
+	})
+
+	for range 3 {
+		_, _ = precheck(true)
+	}
+	assert.Equal(t, 1, calls, "repeated probes must not re-ask, or a declined dialog would reappear")
+
+	_, _ = precheck(false)
+	assert.Equal(t, 2, calls, "the silent policy is a separate question")
+}


### PR DESCRIPTION
## Why

The CLI stores Pulumi access tokens in plaintext in `~/.pulumi/credentials.json`. The goal of this work is to encrypt that file with AES-256-GCM under a 32-byte key held by the most protective backend each platform offers — macOS keychain, Windows Credential Manager, Linux Secret Service, TPM-sealed where available.

What that defends against: offline/at-rest theft (the file copied off the box, committed to git, synced, or captured in a backup), other local users on shared machines, and commodity infostealers that harvest known artifacts. Explicitly conceded: a targeted attacker running as the same user who injects into or ptraces the running process (we could further protect against this as discussed in #24207).

We do not prompt for keystore access by default even across cli updates. Still in some cases the keystore might be locked. Here we ask the user to unlock it by presenting a system prompt in attended (system can draw a dialog) sessions and error out in unattended sessions. 

Users can enforce plaintext at any time skipping keystore usage. An existing credentials file always takes precedence when choosing the backend (keystore or plaintext) on the read path though. 

Automations using the cli must never block. We ensure that by time-bound access to the keystore.

## What this PR adds

The platform-independent core of the `securestore` package. No platform backends yet.

**Envelope** (`Seal`/`Open`): versioned AES-256-GCM. The envelope records version, backend, and algorithm, and binds all three as GCM additional authenticated data — so reads always know which mechanism protects the key, a backend change is detected rather than misread, and a tampered or downgraded header fails authentication with a clear error.

**Key lifecycle** (`GetKey`/`GetOrCreateKey`/`DeleteKey`): prompt-free and time-bounded as described above. The key is never regenerated after a store *error* — only after a clean not-found — because regenerating over a transient failure would permanently orphan the encrypted data. Stored items carry a versioned `pulumi-securestore-v1:raw|tpm:` prefix so the wrap kind is self-describing; later PRs use that to upgrade a raw key to TPM wrapping in place.

**Resolution** (`Resolve(mode)`): picks the best backend for writes under `PULUMI_CREDENTIAL_STORE` (`auto` = best available else plaintext, `os` = required else error, `plaintext` = opt-out, unset = plaintext until this feature is not opt-in anymore). Probing a candidate has four outcomes: `ready`, `absent`, `locked`, `declined`. Fallback is about availability, not the user's answer: `absent` tries the next candidate, but `declined` — a dismissed unlock dialog — stops the chain.

**Attended policy** (`attended.go`): whether a locked store may draw an unlock dialog is a session question. The dialog is drawn by the credential provider on the desktop session the cli runs, not on our stdout, so the two answers differ: `pulumi up | tee log` is attended (piped stdout, but the user can click the dialog), `ssh host pulumi whoami` is not (a terminal, but no dialog can reach anyone). This means a desktop session that can draw dialogs (a display on Linux, not an SSH session on macOS), excluding detected CIs. `--non-interactive` forces unattended. Agent sessions are not special-cased — an agent in the user's terminal is attended (the human is watching and can answer). The Automation API passes `--non-interactive` on every invocation. A permitted unlock wait has no deadline, matching `sudo` and `gpg`; everything else is time-bounded.

## Testing

Envelope round-trip, tamper, and AAD tests; resolution-semantics tests for all modes and outcomes against mock backends; attended-policy tests (`securestore_test.go`, `mock_test.go`, `attended_test.go`).

Manual testing as outlined here: https://github.com/pulumi/pulumi/pull/24150#issuecomment-5142751832

🤖 Generated with [Claude Code](https://claude.com/claude-code)