### PR TITLE
securestore: add Linux Secret Service and Windows Credential Manager backends

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4
 	github.com/go-test/deep v1.1.1
-	github.com/godbus/dbus/v5 v5.1.0
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v55 v55.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -185,6 +185,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
@@ -272,6 +273,7 @@ require (
 	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelslog v0.20.0 // indirect

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -185,7 +185,6 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
-	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
@@ -273,7 +272,6 @@ require (
 	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelslog v0.20.0 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -195,6 +195,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -258,8 +260,8 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -574,6 +576,8 @@ github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18W
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
 github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -195,8 +195,6 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
-github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -576,8 +574,6 @@ github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18W
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
-github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
 github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/git-pkgs/manifests v0.4.1
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/golang/glog v1.2.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl/v2 v2.22.0
@@ -55,6 +56,7 @@ require (
 	github.com/pkg/term v1.1.0
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
+	github.com/zalando/go-keyring v0.2.8
 	go.opentelemetry.io/collector/pdata v1.53.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
 	go.opentelemetry.io/otel v1.44.0
@@ -86,6 +88,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/git-pkgs/packageurl-go v0.3.1 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -55,6 +55,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -94,6 +96,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -246,6 +250,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/sdk/go/common/util/securestore/keyring.go
+++ b/sdk/go/common/util/securestore/keyring.go
@@ -34,7 +34,7 @@ const (
 // Secret Service calls can hang on D-Bus activation or invisible prompts.
 // Bounds only calls that never wait on the user — the interactive unlock has
 // no deadline — and failures still return immediately.
-const opTimeout = 3 * time.Second
+const opTimeout = 1 * time.Second
 
 // On timeout the goroutine is abandoned; the buffered channel lets it exit
 // once fn returns. Only a permanently hung fn leaks it, acceptable in a CLI.

--- a/sdk/go/common/util/securestore/keyring.go
+++ b/sdk/go/common/util/securestore/keyring.go
@@ -32,9 +32,12 @@ const (
 )
 
 // Secret Service calls can hang on D-Bus activation or invisible prompts.
+// Bounds only calls that never wait on the user — the interactive unlock has
+// no deadline — and failures still return immediately.
 const opTimeout = 3 * time.Second
 
-// The abandoned goroutine may leak for the process lifetime, acceptable in a CLI.
+// On timeout the goroutine is abandoned; the buffered channel lets it exit
+// once fn returns. Only a permanently hung fn leaks it, acceptable in a CLI.
 func withTimeout[T any](fn func() (T, error)) (T, error) {
 	type result struct {
 		v   T

--- a/sdk/go/common/util/securestore/keyring.go
+++ b/sdk/go/common/util/securestore/keyring.go
@@ -1,0 +1,145 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || windows
+
+package securestore
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+const (
+	// Never change: encrypted files reference this exact item.
+	keyringService = "Pulumi CLI"
+	keyringAccount = "credentials-key"
+)
+
+// Secret Service calls can hang on D-Bus activation or invisible prompts.
+const opTimeout = 3 * time.Second
+
+// The abandoned goroutine may leak for the process lifetime, acceptable in a CLI.
+func withTimeout[T any](fn func() (T, error)) (T, error) {
+	type result struct {
+		v   T
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		v, err := fn()
+		ch <- result{v, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.v, r.err
+	case <-time.After(opTimeout):
+		var zero T
+		return zero, fmt.Errorf("%w: operation timed out after %s", ErrUnavailable, opTimeout)
+	}
+}
+
+type getCache struct {
+	mu    sync.Mutex
+	valid bool
+	value string
+	err   error
+}
+
+// go-keyring picks the platform mechanism itself. preCheck lets platforms fail
+// fast before the store is touched.
+type keyringStore struct {
+	preCheck func() (Outcome, error)
+	cache    *getCache
+}
+
+func newKeyringStore(preCheck func() (Outcome, error)) keyringStore {
+	return keyringStore{preCheck: preCheck, cache: &getCache{}}
+}
+
+func (s keyringStore) available() (Outcome, error) {
+	if s.preCheck != nil {
+		if outcome, err := s.preCheck(); outcome != Ready {
+			return outcome, err
+		}
+	}
+	value, err := s.fetch()
+	if s.cache != nil {
+		s.cache.mu.Lock()
+		s.cache.valid, s.cache.value, s.cache.err = true, value, err
+		s.cache.mu.Unlock()
+	}
+	if err == nil || errors.Is(err, ErrKeyNotFound) {
+		return Ready, nil
+	}
+	if errors.Is(err, ErrUnavailable) {
+		return Absent, err
+	}
+	return Absent, fmt.Errorf("%w: %v", ErrUnavailable, err)
+}
+
+func (s keyringStore) get() (string, error) {
+	if s.cache != nil {
+		s.cache.mu.Lock()
+		if s.cache.valid {
+			value, err := s.cache.value, s.cache.err
+			s.cache.valid = false
+			s.cache.mu.Unlock()
+			return value, err
+		}
+		s.cache.mu.Unlock()
+	}
+	return s.fetch()
+}
+
+func (s keyringStore) fetch() (string, error) {
+	value, err := withTimeout(func() (string, error) {
+		return keyring.Get(keyringService, keyringAccount)
+	})
+	if errors.Is(err, keyring.ErrNotFound) {
+		return "", ErrKeyNotFound
+	}
+	return value, err
+}
+
+func (s keyringStore) invalidate() {
+	if s.cache != nil {
+		s.cache.mu.Lock()
+		s.cache.valid = false
+		s.cache.mu.Unlock()
+	}
+}
+
+func (s keyringStore) set(value string) error {
+	s.invalidate()
+	_, err := withTimeout(func() (struct{}, error) {
+		return struct{}{}, keyring.Set(keyringService, keyringAccount, value)
+	})
+	return err
+}
+
+func (s keyringStore) delete() error {
+	s.invalidate()
+	_, err := withTimeout(func() (struct{}, error) {
+		return struct{}{}, keyring.Delete(keyringService, keyringAccount)
+	})
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil
+	}
+	return err
+}

--- a/sdk/go/common/util/securestore/keyring_test.go
+++ b/sdk/go/common/util/securestore/keyring_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || windows
+
+package securestore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCacheServesTheProbeFetchExactlyOnce(t *testing.T) {
+	t.Parallel()
+	cache := &getCache{}
+	cache.mu.Lock()
+	cache.valid, cache.value = true, "from-the-probe"
+	cache.mu.Unlock()
+	store := keyringStore{cache: cache}
+
+	value, err := store.get()
+	require.NoError(t, err)
+	assert.Equal(t, "from-the-probe", value)
+
+	cache.mu.Lock()
+	valid := cache.valid
+	cache.mu.Unlock()
+	assert.False(t, valid, "the cached fetch must not be served twice")
+}
+
+func TestWritesInvalidateTheCachedFetch(t *testing.T) {
+	t.Parallel()
+	for _, write := range []struct {
+		name string
+		do   func(keyringStore) error
+	}{
+		{"set", func(s keyringStore) error { _ = s.set("x"); return nil }},
+		{"delete", func(s keyringStore) error { _ = s.delete(); return nil }},
+	} {
+		cache := &getCache{}
+		cache.mu.Lock()
+		cache.valid, cache.value = true, "stale"
+		cache.mu.Unlock()
+		store := keyringStore{cache: cache}
+
+		require.NoError(t, write.do(store))
+
+		cache.mu.Lock()
+		valid := cache.valid
+		cache.mu.Unlock()
+		assert.False(t, valid, "%s must invalidate the cached fetch", write.name)
+	}
+}

--- a/sdk/go/common/util/securestore/keyring_test.go
+++ b/sdk/go/common/util/securestore/keyring_test.go
@@ -21,10 +21,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
 )
 
+//nolint:paralleltest // keyring.MockInit swaps go-keyring's global provider
 func TestGetCacheServesTheProbeFetchExactlyOnce(t *testing.T) {
-	t.Parallel()
+	keyring.MockInit()
 	cache := &getCache{}
 	cache.mu.Lock()
 	cache.valid, cache.value = true, "from-the-probe"
@@ -41,8 +43,9 @@ func TestGetCacheServesTheProbeFetchExactlyOnce(t *testing.T) {
 	assert.False(t, valid, "the cached fetch must not be served twice")
 }
 
+//nolint:paralleltest // keyring.MockInit swaps go-keyring's global provider
 func TestWritesInvalidateTheCachedFetch(t *testing.T) {
-	t.Parallel()
+	keyring.MockInit()
 	for _, write := range []struct {
 		name string
 		do   func(keyringStore) error

--- a/sdk/go/common/util/securestore/probe_linux.go
+++ b/sdk/go/common/util/securestore/probe_linux.go
@@ -144,7 +144,7 @@ func unlockWithoutDrawingUI(conn *dbus.Conn) error {
 	if promptPath != "" && promptPath != "/" {
 		_ = conn.Object(secretServiceBusName, promptPath).Call("org.freedesktop.Secret.Prompt.Dismiss", 0).Err
 	}
-	return errors.New("it needs a password prompt, and none can be shown here")
+	return errors.New("unlocking the credential store needs a password prompt, and none can be shown here")
 }
 
 func confirmUnlocked(conn *dbus.Conn) error {
@@ -204,7 +204,8 @@ func unlockAndWaitForUser(conn *dbus.Conn) error {
 	// take down is one we are abandoning ourselves.
 	defer func() { _ = prompt.Call("org.freedesktop.Secret.Prompt.Dismiss", 0).Err }()
 	shown := showDialogNonBlocking(prompt)
-	notifyWaitingForUnlock()
+	fmt.Fprintln(os.Stderr,
+		"Pulumi needs the key protecting your credentials: answer your keyring's password prompt to continue.")
 
 	for {
 		select {
@@ -250,11 +251,6 @@ func providerVanished(sig *dbus.Signal) bool {
 	name, _ := sig.Body[0].(string)
 	newOwner, _ := sig.Body[2].(string)
 	return name == secretServiceBusName && newOwner == ""
-}
-
-var notifyWaitingForUnlock = func() {
-	fmt.Fprintln(os.Stderr,
-		"Pulumi needs the key protecting your credentials: answer your keyring's password prompt to continue.")
 }
 
 func nameOwnerProcess(conn *dbus.Conn, owner string) string {

--- a/sdk/go/common/util/securestore/probe_linux.go
+++ b/sdk/go/common/util/securestore/probe_linux.go
@@ -1,0 +1,271 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package securestore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	// secretServiceBusName is the well-known D-Bus name of the Secret
+	// Service (gnome-keyring, KWallet 5.97+, KeePassXC, ...).
+	secretServiceBusName = "org.freedesktop.secrets"
+	// defaultCollectionPath is the alias object for the user's default
+	// secret collection.
+	defaultCollectionPath = dbus.ObjectPath("/org/freedesktop/secrets/aliases/default")
+	// collectionLockedProperty is the standard Locked property on a
+	// collection.
+	collectionLockedProperty = "org.freedesktop.Secret.Collection.Locked"
+	secretServicePath        = dbus.ObjectPath("/org/freedesktop/secrets")
+)
+
+// secretServicePrecheck fast-fails before go-keyring ever touches the Secret
+// Service: it verifies a session bus exists, that a provider is actually
+// running, and that the default collection is unlocked. A locked collection
+// gets one unlock attempt, which only draws a dialog when allowPrompt says
+// someone is there to answer it.
+var secretServicePrecheck = memoizePrecheck(probeSecretService)
+
+func probeSecretService(allowPrompt bool) (Outcome, error) {
+	// Cheap environment check first: no session bus address and no
+	// user-runtime bus socket means connecting is pointless.
+	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+		if runtimeDir == "" {
+			return Absent, fmt.Errorf("%w: no D-Bus session bus", ErrUnavailable)
+		}
+		if _, err := os.Stat(filepath.Join(runtimeDir, "bus")); err != nil {
+			return Absent, fmt.Errorf("%w: no D-Bus session bus", ErrUnavailable)
+		}
+	}
+
+	_, err := withTimeout(func() (struct{}, error) {
+		conn, err := dbus.ConnectSessionBus()
+		if err != nil {
+			return struct{}{}, fmt.Errorf("%w: cannot connect to the D-Bus session bus: %v", ErrUnavailable, err)
+		}
+		defer conn.Close()
+
+		// GetNameOwner detects a *running* provider without triggering
+		// D-Bus service activation (which could start an agent and prompt).
+		var owner string
+		err = conn.BusObject().Call("org.freedesktop.DBus.GetNameOwner", 0, secretServiceBusName).Store(&owner)
+		if err != nil || owner == "" {
+			return struct{}{}, fmt.Errorf("%w: no Secret Service provider is running", ErrUnavailable)
+		}
+		provider := nameOwnerProcess(conn, owner)
+
+		// Reading the Locked property is side-effect free; anything but an
+		// unlocked default collection means using the store would prompt.
+		locked, err := conn.Object(secretServiceBusName, defaultCollectionPath).GetProperty(collectionLockedProperty)
+		if err != nil {
+			return struct{}{}, fmt.Errorf("%w: cannot read the default secret collection%s: %v",
+				ErrUnavailable, provider, err)
+		}
+		isLocked, ok := locked.Value().(bool)
+		if !ok {
+			return struct{}{}, fmt.Errorf("%w: cannot read the default secret collection%s: "+
+				"unexpected Locked property type %T", ErrUnavailable, provider, locked.Value())
+		}
+		if isLocked {
+			return struct{}{}, lockedCollectionError{provider: provider}
+		}
+		return struct{}{}, nil
+	})
+	var locked lockedCollectionError
+	if errors.As(err, &locked) {
+		unlockErr := unlockDefaultCollection(allowPrompt)
+		switch {
+		case unlockErr == nil:
+			return Ready, nil
+		case errors.Is(unlockErr, ErrDeclined):
+			return Declined, unlockErr
+		default:
+			return Locked, fmt.Errorf("%w%s: %v", ErrLocked, locked.provider, unlockErr)
+		}
+	}
+	if err != nil {
+		return Absent, err
+	}
+	return Ready, nil
+}
+
+type lockedCollectionError struct{ provider string }
+
+func (lockedCollectionError) Error() string { return "the default secret collection is locked" }
+
+func unlockDefaultCollection(mayAskUser bool) error {
+	if mayAskUser {
+		return onSessionBus(unlockAndWaitForUser)
+	}
+	_, err := withTimeout(func() (struct{}, error) {
+		return struct{}{}, onSessionBus(unlockWithoutDrawingUI)
+	})
+	return err
+}
+
+func onSessionBus(do func(*dbus.Conn) error) error {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return do(conn)
+}
+
+func unlockWithoutDrawingUI(conn *dbus.Conn) error {
+	unlocked, promptPath, err := requestUnlock(conn)
+	if err != nil {
+		return err
+	}
+	if len(unlocked) > 0 {
+		return nil
+	}
+	if promptPath != "" && promptPath != "/" {
+		_ = conn.Object(secretServiceBusName, promptPath).Call("org.freedesktop.Secret.Prompt.Dismiss", 0).Err
+	}
+	return errors.New("it needs a password prompt, and none can be shown here")
+}
+
+func confirmUnlocked(conn *dbus.Conn) error {
+	locked, err := conn.Object(secretServiceBusName, defaultCollectionPath).GetProperty(collectionLockedProperty)
+	if err != nil {
+		return err
+	}
+	if isLocked, ok := locked.Value().(bool); !ok || isLocked {
+		return errors.New("the collection is still locked after the unlock attempt")
+	}
+	return nil
+}
+
+func requestUnlock(conn *dbus.Conn) (unlocked []dbus.ObjectPath, prompt dbus.ObjectPath, err error) {
+	err = conn.Object(secretServiceBusName, secretServicePath).
+		Call("org.freedesktop.Secret.Service.Unlock", 0, []dbus.ObjectPath{defaultCollectionPath}).
+		Store(&unlocked, &prompt)
+	return unlocked, prompt, err
+}
+
+func unlockAndWaitForUser(conn *dbus.Conn) error {
+	unlocked, promptPath, err := requestUnlock(conn)
+	if err != nil {
+		return err
+	}
+	if len(unlocked) > 0 {
+		return nil
+	}
+	if promptPath == "" || promptPath == "/" {
+		return errors.New("unlock returned neither an unlocked collection nor a prompt")
+	}
+
+	matchOpts := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(promptPath),
+		dbus.WithMatchInterface("org.freedesktop.Secret.Prompt"),
+		dbus.WithMatchMember("Completed"),
+	}
+	if err := conn.AddMatchSignal(matchOpts...); err != nil {
+		return err
+	}
+	defer func() { _ = conn.RemoveMatchSignal(matchOpts...) }()
+	ownerOpts := []dbus.MatchOption{
+		dbus.WithMatchInterface("org.freedesktop.DBus"),
+		dbus.WithMatchMember("NameOwnerChanged"),
+		dbus.WithMatchArg(0, secretServiceBusName),
+	}
+	if err := conn.AddMatchSignal(ownerOpts...); err != nil {
+		return err
+	}
+	defer func() { _ = conn.RemoveMatchSignal(ownerOpts...) }()
+	signals := make(chan *dbus.Signal, 8)
+	conn.Signal(signals)
+	defer conn.RemoveSignal(signals)
+
+	prompt := conn.Object(secretServiceBusName, promptPath)
+	// The command ends when the user answers, so the only prompt we ever
+	// take down is one we are abandoning ourselves.
+	defer func() { _ = prompt.Call("org.freedesktop.Secret.Prompt.Dismiss", 0).Err }()
+	shown := showDialogNonBlocking(prompt)
+	notifyWaitingForUnlock()
+
+	for {
+		select {
+		case call := <-shown:
+			// The method reply says only whether the dialog was raised. A
+			// failure here means no Completed signal is ever coming, so the
+			// wait must end rather than hang on a dialog nobody can see.
+			if call.Err != nil {
+				return call.Err
+			}
+			shown = nil
+		case sig, ok := <-signals:
+			if !ok {
+				return errors.New("the session bus closed before the unlock prompt completed")
+			}
+			switch {
+			case sig.Name == "org.freedesktop.DBus.NameOwnerChanged" && providerVanished(sig):
+				return errors.New("the credential store stopped while its password prompt was open")
+			case sig.Path == promptPath && sig.Name == "org.freedesktop.Secret.Prompt.Completed":
+				if len(sig.Body) > 0 {
+					if dismissed, isBool := sig.Body[0].(bool); isBool && !dismissed {
+						return confirmUnlocked(conn)
+					}
+				}
+				// Providers also report "dismissed" when no prompter could be
+				// reached at all, so do not claim the user did it.
+				return fmt.Errorf("%w: its password prompt was dismissed or could not be shown", ErrDeclined)
+			}
+		}
+	}
+}
+
+func showDialogNonBlocking(prompt dbus.BusObject) <-chan *dbus.Call {
+	done := make(chan *dbus.Call, 1)
+	prompt.Go("org.freedesktop.Secret.Prompt.Prompt", 0, done, "")
+	return done
+}
+
+func providerVanished(sig *dbus.Signal) bool {
+	if len(sig.Body) < 3 {
+		return false
+	}
+	name, _ := sig.Body[0].(string)
+	newOwner, _ := sig.Body[2].(string)
+	return name == secretServiceBusName && newOwner == ""
+}
+
+var notifyWaitingForUnlock = func() {
+	fmt.Fprintln(os.Stderr,
+		"Pulumi needs the key protecting your credentials: answer your keyring's password prompt to continue.")
+}
+
+func nameOwnerProcess(conn *dbus.Conn, owner string) string {
+	var pid uint32
+	err := conn.BusObject().Call("org.freedesktop.DBus.GetConnectionUnixProcessID", 0, owner).Store(&pid)
+	if err != nil {
+		return ""
+	}
+	comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf(" (provider %q)", strings.TrimSpace(string(comm)))
+}

--- a/sdk/go/common/util/securestore/probe_linux_test.go
+++ b/sdk/go/common/util/securestore/probe_linux_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package securestore
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretServicePrecheckNoSessionBus(t *testing.T) {
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir()) // exists, but has no "bus" socket
+
+	outcome, err := secretServicePrecheck(false)
+	assert.Equal(t, Absent, outcome)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnavailable)
+	assert.Contains(t, err.Error(), "no D-Bus session bus")
+}
+
+func statePrompting(t *testing.T, attended bool) *[]bool {
+	t.Helper()
+	var granted []bool
+	restore := platformCandidatesHook
+	platformCandidatesHook = func(allowPrompt bool, _ string) []backendImpl {
+		granted = append(granted, allowPrompt)
+		return nil
+	}
+	t.Cleanup(func() { platformCandidatesHook = restore })
+
+	prevDisable := cmdutil.DisableInteractive
+	cmdutil.DisableInteractive = !attended
+	t.Cleanup(func() { cmdutil.DisableInteractive = prevDisable })
+	if attended {
+		// Neutralise the detectors so an attended run stays attended on a CI
+		// host or a headless machine.
+		t.Setenv("CI", "")
+		t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
+		t.Setenv("DISPLAY", ":0")
+	}
+	return &granted
+}
+
+//nolint:paralleltest // swaps package-global resolution and interactivity state
+func TestPromptPolicy(t *testing.T) {
+	granted := statePrompting(t, true)
+
+	_, _ = Resolve(ModeAuto, "")
+	assert.True(t, (*granted)[0], "auto opted in, so it may ask rather than downgrade")
+
+	*granted = nil
+	_, _ = Resolve(ModeOS, "")
+	assert.True(t, (*granted)[0], "os may ask")
+
+	*granted = nil
+	_, _ = ForBackend(BackendLinuxSecretService, "")
+	assert.True(t, (*granted)[0], "reading an encrypted file may ask")
+
+	*granted = nil
+	_, _ = Resolve(ModeDefault, "")
+	assert.Empty(t, *granted, "the default mode never reaches a backend")
+}
+
+//nolint:paralleltest // swaps package-global resolution and interactivity state
+func TestPromptPolicyUnattended(t *testing.T) {
+	granted := statePrompting(t, false)
+
+	_, _ = Resolve(ModeOS, "")
+	assert.False(t, (*granted)[0], "--non-interactive forbids prompting even in os mode")
+
+	*granted = nil
+	_, _ = ForBackend(BackendLinuxSecretService, "")
+	assert.False(t, (*granted)[0], "reads must not ask when nobody can answer")
+}
+
+func TestSecretServicePrecheckNoRuntimeDir(t *testing.T) {
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	outcome, err := secretServicePrecheck(false)
+	assert.Equal(t, Absent, outcome)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnavailable)
+}

--- a/sdk/go/common/util/securestore/resolve_linux.go
+++ b/sdk/go/common/util/securestore/resolve_linux.go
@@ -1,0 +1,26 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package securestore
+
+// platformCandidates returns Linux backends: the Secret Service holding the
+// raw key. TPM-sealed tiers follow in a separate change.
+func platformCandidates(allowPrompt bool, _ string) []backendImpl {
+	ss := newKeyringStore(func() (Outcome, error) { return secretServicePrecheck(allowPrompt) })
+	return []backendImpl{
+		{id: BackendLinuxSecretService, store: ss, wrap: rawWrapper{}},
+	}
+}

--- a/sdk/go/common/util/securestore/resolve_other.go
+++ b/sdk/go/common/util/securestore/resolve_other.go
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !linux && !windows
+
 package securestore
 
-// Platform backends land in follow-up changes; until then every platform
-// resolves to plaintext.
+// platformCandidates: no protective backends on this platform; callers fall
+// back to plaintext.
 func platformCandidates(bool, string) []backendImpl { return nil }

--- a/sdk/go/common/util/securestore/resolve_windows.go
+++ b/sdk/go/common/util/securestore/resolve_windows.go
@@ -1,0 +1,25 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package securestore
+
+// platformCandidates returns Windows backends: the Credential Manager holding
+// the raw key. TPM-wrapped tiers follow in a separate change.
+func platformCandidates(_ bool, _ string) []backendImpl {
+	return []backendImpl{
+		{id: BackendWindowsCredMan, store: newKeyringStore(nil), wrap: rawWrapper{}},
+	}
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-test/deep v1.1.1 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2997,6 +2997,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -3191,8 +3192,8 @@ github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXK
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -3973,6 +3974,7 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=


### PR DESCRIPTION
## Summary

PR stack: #24208 ← **this** ← #24210 ← #24211 ← #24212.

This PR gives `securestore` its first two real backends: the **Linux Secret Service** (gnome-keyring, KWallet, KeePassXC, …) and the **Windows Credential Manager**, both reached through `zalando/go-keyring`. On these platforms the 32-byte file-encryption key introduced by the core PR can now live in the OS credential store instead of falling through to plaintext. TPM-wrapped tiers (#24210) and the macOS backends (#24211) follow; nothing reads or writes `credentials.json` differently until the final integration PR (#24212).

### The keyring store (`keyring.go`, linux+windows)

- Every go-keyring call is wrapped in a 3-second timeout: Secret Service calls can hang on D-Bus service activation or on unlock prompts nobody can see.
- `keyring.ErrNotFound` maps to the typed `ErrKeyNotFound`; anything else is wrapped as `ErrUnavailable`.
- The availability probe is to `Get` the item. So the probe caches its result and the next `get()` consumes it exactly once: the common probe-then-read sequence costs one store round trip instead of two. `set`/`delete` invalidate the cache so it can never serve a stale value.
- The item identity (service `"Pulumi CLI"`, account `"credentials-key"`) must never change: encrypted files reference exactly this item.

### Linux: prompt-free probing, attendance aware unlocking (`probe_linux.go`)

Talking to the Secret Service naively can block for minutes or throw dialogs at users. The precheck (memoized per process) distinguishes the store's states before go-keyring ever touches it:

1. No `DBUS_SESSION_BUS_ADDRESS` and no `$XDG_RUNTIME_DIR/bus` socket → `Absent` without connecting at all (avoids D-Bus's 25 s default timeout).
2. `GetNameOwner` on `org.freedesktop.secrets` → detects a *running* provider without triggering D-Bus service activation, which could start an agent and prompt. No owner → `Absent`.
3. Read the default collection's `Locked` property. Unlocked → `Ready`.

A locked collection gets exactly one unlock attempt, and what that attempt may do is decided by the session policy from the core PR (attended desktop vs. CI / no display / `--non-interactive`):

- **Silent path** (unattended): call `Unlock`, but accept only a prompt-free unlock. KDE's ksecretd reports the collection locked after every daemon start even though completing the unlock is instant and draws nothing. If the provider instead returns a prompt object, it is dismissed - means no dialog shows up - and the outcome is `Locked`.
- **Prompt path** (attended): raise the prompt, printing a notice to stderr first so a dialog on another workspace doesn't look like a hang (https://github.com/pulumi/pulumi/pull/24208#discussion_r3734917115), then wait for the `Completed` signal with no deadline. That's the same contract as sudo, git, and gpg. The wait aborts if the provider leaves the bus mid-prompt (`NameOwnerChanged`), and the prompt is dismissed whenever we abandon it. A dismissed prompt yields `Declined`, which deliberately fails resolution rather than falling back: writing plaintext because someone cancelled a dialog is prohibited.

### Windows

No precheck: Credential Manager reads and writes go through DPAPI with no UI in any session type, so attempting the operation is itself the cheap, prompt-free probe.

### Wiring

`resolve_linux.go` / `resolve_windows.go` register the backends holding the raw key (the TPM wrap upgrade lands in #24210); the previous all-platform `resolve.go` becomes `resolve_other.go` (`!linux && !windows`), keeping every other GOOS on the plaintext fallback.

### Dependencies

- `zalando/go-keyring` v0.2.8 — new direct dependency (pure Go)
- `godbus/dbus/v5` v5.1.0 → v5.2.2 — existing dependency, bumped for `ConnectSessionBus` and the match-signal helpers
- `danieljoos/wincred` — indirect, via go-keyring

## Testing

- `keyring_test.go` (runs on Linux and Windows CI): the single-use probe cache — served exactly once, invalidated by `set`/`delete`.
- `probe_linux_test.go` (Linux CI): the precheck fast-fails without a session bus, and the prompt policy matrix — `ModeAuto`, `ModeOS`, and `ForBackend` (reading an existing envelope) may prompt when attended; nothing may prompt under `--non-interactive`; `ModeDefault` never reaches a backend.
- The unlock flow was exercised end-to-end (locked/unlocked collections, accepted and dismissed prompts) on the reference implementation this stack splits, #24076.
- Manual testing as outlined here: https://github.com/pulumi/pulumi/pull/24150#issuecomment-5142751832

🤖 Generated with [Claude Code](https://claude.com/claude-code)