### PR TITLE
securestore: add macOS keychain backends

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -186,6 +186,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
+	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -186,7 +186,6 @@ require (
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
-	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -208,8 +208,6 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
-github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -208,6 +208,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
+github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/ebitengine/purego v0.10.2
 	github.com/git-pkgs/manifests v0.4.1
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4
 	github.com/godbus/dbus/v5 v5.2.2

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -62,6 +62,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
+github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
+github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/sdk/go/common/util/securestore/acl_darwin.go
+++ b/sdk/go/common/util/securestore/acl_darwin.go
@@ -1,0 +1,221 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package securestore
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// Never change: encrypted files reference this exact item. The account
+	// differs from keyringAccount so the two macOS backends never collide —
+	// this item's ACL is ours alone, the fallback must stay readable by
+	// /usr/bin/security.
+	aclService = "Pulumi CLI"
+	aclAccount = "credentials-key-acl"
+	aclLabel   = "Pulumi CLI credentials key"
+)
+
+// The per-app ACL comes from SecItemAdd itself, which binds access to the
+// creating app's code-signing identity.
+func aclKeychainBackend(allowPrompt bool) backendImpl {
+	return backendImpl{
+		id: BackendMacOSACL,
+		store: &aclStore{
+			service:     aclService,
+			account:     aclAccount,
+			label:       aclLabel,
+			allowPrompt: allowPrompt,
+		},
+		wrap: rawWrapper{},
+	}
+}
+
+// Deliberately minimal: no synchronizable attribute (never iCloud-synced) and
+// no explicit access attributes — SecItemAdd's default ACL is what we want,
+// and setting access attributes prompts.
+type aclStore struct {
+	service, account, label string
+	allowPrompt             bool
+}
+
+// Silent ops suppress dialogs even though the precheck just read the lock
+// state: the keychain can lock in between (sleep, inactivity, screen lock).
+// Prompt-permitted ops run untimed, since the user may be typing a password.
+func runACLOp[T any](s *aclStore, op func() (T, error)) (T, error) {
+	if _, err := keychainPrecheck(s.allowPrompt); err != nil {
+		var zero T
+		return zero, err
+	}
+	if s.allowPrompt {
+		return op()
+	}
+	return withTimeout(keyringOpTimeout, func() (T, error) {
+		return withoutKeychainUI(op)
+	})
+}
+
+func (s *aclStore) available() (Outcome, error) {
+	if _, err := withTimeout(keyringOpTimeout, func() (struct{}, error) {
+		return struct{}{}, aclSelfCheck()
+	}); err != nil {
+		if errors.Is(err, ErrUnavailable) {
+			return Absent, err
+		}
+		return Absent, fmt.Errorf("%w: the keychain ACL requires a signed binary: %v",
+			ErrUnavailable, err)
+	}
+	// Deliberately outside the deadline: a permitted unlock waits on the user.
+	if outcome, err := keychainPrecheck(s.allowPrompt); outcome != Ready {
+		return outcome, err
+	}
+	outcome, err := withTimeout(keyringOpTimeout, func() (Outcome, error) {
+		return s.probe()
+	})
+	if err != nil && outcome == Ready {
+		// withTimeout's zero value for Outcome is Ready; a timeout is Absent.
+		outcome = Absent
+	}
+	return outcome, err
+}
+
+// Suppresses UI whatever the prompt policy: deciding usability must never
+// itself draw a dialog.
+func (s *aclStore) probe() (Outcome, error) {
+	if err := loadDarwinAPI(); err != nil {
+		return Absent, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	status, err := withoutKeychainUI(func() (int32, error) {
+		var result uintptr
+		status := s.copyMatching(&result)
+		if result != 0 {
+			cf.release(result)
+		}
+		return status, nil
+	})
+	if err != nil {
+		return Absent, err
+	}
+	if status == errSecSuccess || status == errSecItemNotFound {
+		return Ready, nil
+	}
+	statusErr := osStatusError(status)
+	if outcome := outcomeOf(statusErr); outcome != Absent {
+		return outcome, statusErr
+	}
+	if errors.Is(statusErr, ErrUnavailable) {
+		return Absent, statusErr
+	}
+	return Absent, fmt.Errorf("%w: %v", ErrUnavailable, statusErr)
+}
+
+// Requests the data, not just attributes: attributes stay readable on a
+// locked keychain, so only a data read exposes the lock.
+func (s *aclStore) copyMatching(result *uintptr) int32 {
+	service := cf.newString(s.service)
+	defer cf.release(service)
+	account := cf.newString(s.account)
+	defer cf.release(account)
+	query := cf.newDict(
+		[]uintptr{sec.class, sec.attrService, sec.attrAccount, sec.returnData, sec.matchLimit},
+		[]uintptr{sec.classGenericPassword, service, account, cf.booleanTrue, sec.matchLimitOne},
+	)
+	defer cf.release(query)
+	return sec.itemCopyMatching(query, result)
+}
+
+func (s *aclStore) get() (string, error) {
+	return runACLOp(s, func() (string, error) {
+		if err := loadDarwinAPI(); err != nil {
+			return "", fmt.Errorf("%w: %v", ErrUnavailable, err)
+		}
+		var result uintptr
+		if status := s.copyMatching(&result); status != errSecSuccess {
+			return "", osStatusError(status)
+		}
+		if result == 0 {
+			return "", errors.New("keychain returned no data for the stored item")
+		}
+		defer cf.release(result)
+		return string(cf.dataBytes(result)), nil
+	})
+}
+
+func (s *aclStore) set(value string) error {
+	_, err := runACLOp(s, func() (struct{}, error) {
+		if err := loadDarwinAPI(); err != nil {
+			return struct{}{}, fmt.Errorf("%w: %v", ErrUnavailable, err)
+		}
+		service := cf.newString(s.service)
+		defer cf.release(service)
+		account := cf.newString(s.account)
+		defer cf.release(account)
+		label := cf.newString(s.label)
+		defer cf.release(label)
+		data := cf.newData([]byte(value))
+		defer cf.release(data)
+
+		attrs := cf.newDict(
+			[]uintptr{sec.class, sec.attrService, sec.attrAccount, sec.attrLabel, sec.valueData},
+			[]uintptr{sec.classGenericPassword, service, account, label, data},
+		)
+		defer cf.release(attrs)
+
+		status := sec.itemAdd(attrs, nil)
+		if status == errSecDuplicateItem {
+			// Data only — re-setting access attributes on an existing item prompts.
+			query := cf.newDict(
+				[]uintptr{sec.class, sec.attrService, sec.attrAccount},
+				[]uintptr{sec.classGenericPassword, service, account},
+			)
+			defer cf.release(query)
+			update := cf.newDict([]uintptr{sec.valueData}, []uintptr{data})
+			defer cf.release(update)
+			status = sec.itemUpdate(query, update)
+		}
+		if status != errSecSuccess {
+			return struct{}{}, osStatusError(status)
+		}
+		return struct{}{}, nil
+	})
+	return err
+}
+
+func (s *aclStore) delete() error {
+	_, err := runACLOp(s, func() (struct{}, error) {
+		if err := loadDarwinAPI(); err != nil {
+			return struct{}{}, fmt.Errorf("%w: %v", ErrUnavailable, err)
+		}
+		service := cf.newString(s.service)
+		defer cf.release(service)
+		account := cf.newString(s.account)
+		defer cf.release(account)
+		query := cf.newDict(
+			[]uintptr{sec.class, sec.attrService, sec.attrAccount},
+			[]uintptr{sec.classGenericPassword, service, account},
+		)
+		defer cf.release(query)
+
+		status := sec.itemDelete(query)
+		if status == errSecSuccess || status == errSecItemNotFound {
+			return struct{}{}, nil
+		}
+		return struct{}{}, osStatusError(status)
+	})
+	return err
+}

--- a/sdk/go/common/util/securestore/acl_darwin_test.go
+++ b/sdk/go/common/util/securestore/acl_darwin_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package securestore
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withSelfCheckOverride(t *testing.T, fn func() error) {
+	t.Helper()
+	prev := aclSelfCheckOverride
+	aclSelfCheckOverride = fn
+	t.Cleanup(func() { aclSelfCheckOverride = prev })
+}
+
+// A throwaway item, so tests never touch the real one.
+func testACLStore(t *testing.T) *aclStore {
+	t.Helper()
+	suffix := make([]byte, 8)
+	_, err := rand.Read(suffix)
+	require.NoError(t, err)
+	store := &aclStore{
+		service: "Pulumi CLI Test " + hex.EncodeToString(suffix),
+		account: "credentials-key-acl-test",
+		label:   "Pulumi CLI test item (safe to delete)",
+	}
+	t.Cleanup(func() {
+		// The body skips when the keychain is unusable; nothing to clean up.
+		if err := store.delete(); err != nil && !errors.Is(err, ErrUnavailable) {
+			t.Errorf("cleaning up test keychain item: %v", err)
+		}
+	})
+	return store
+}
+
+func TestACLBackendShape(t *testing.T) {
+	t.Parallel()
+	b := aclKeychainBackend(true)
+	assert.Equal(t, BackendMacOSACL, b.id)
+	assert.Equal(t, rawWrapper{}, b.wrap)
+	store, ok := b.store.(*aclStore)
+	require.True(t, ok)
+	assert.Equal(t, "Pulumi CLI", store.service)
+	assert.Equal(t, "credentials-key-acl", store.account,
+		"must differ from the fallback backend's account to avoid item collisions")
+	assert.NotEmpty(t, store.label)
+	assert.True(t, store.allowPrompt, "the prompt policy must reach the store")
+	silent, ok := aclKeychainBackend(false).store.(*aclStore)
+	require.True(t, ok)
+	assert.False(t, silent.allowPrompt)
+}
+
+//nolint:paralleltest // must not overlap tests that set aclSelfCheckOverride
+func TestACLSelfCheckRejectsTestBinary(t *testing.T) {
+	require.Nil(t, aclSelfCheckOverride)
+
+	err := aclSelfCheck()
+	require.Error(t, err, "an ad-hoc-signed test binary must not pass the self-check")
+
+	outcome, availErr := aclKeychainBackend(false).available()
+	require.Error(t, availErr)
+	assert.Equal(t, Absent, outcome)
+	assert.True(t, errors.Is(availErr, ErrUnavailable), "available() = %v, want ErrUnavailable", availErr)
+}
+
+//nolint:paralleltest // mutates package-global aclSelfCheckOverride
+func TestACLStoreRoundTrip(t *testing.T) {
+	withSelfCheckOverride(t, func() error { return nil })
+	store := testACLStore(t)
+
+	if _, err := store.available(); err != nil {
+		if errors.Is(err, ErrUnavailable) {
+			t.Skipf("keychain not usable in this environment: %v", err)
+		}
+		t.Fatalf("available() = %v", err)
+	}
+
+	_, err := store.get()
+	assert.True(t, errors.Is(err, ErrKeyNotFound), "get on missing item = %v, want ErrKeyNotFound", err)
+	require.NoError(t, store.delete(), "deleting a missing item is not an error")
+
+	first := formatItem(wrapRaw, []byte("first value \x00\xff with bytes ✓"))
+	require.NoError(t, store.set(first))
+	got, err := store.get()
+	require.NoError(t, err)
+	assert.Equal(t, first, got)
+
+	second := formatItem(wrapRaw, []byte("second value"))
+	require.NoError(t, store.set(second))
+	got, err = store.get()
+	require.NoError(t, err)
+	assert.Equal(t, second, got)
+
+	_, availableErr := store.available()
+	require.NoError(t, availableErr)
+
+	require.NoError(t, store.delete())
+	_, err = store.get()
+	assert.True(t, errors.Is(err, ErrKeyNotFound), "get after delete = %v, want ErrKeyNotFound", err)
+	require.NoError(t, store.delete())
+}
+
+//nolint:paralleltest // mutates package-global aclSelfCheckOverride
+func TestACLAvailableUsesSelfCheckError(t *testing.T) {
+	boom := errors.New("not signed enough")
+	withSelfCheckOverride(t, func() error { return boom })
+	_, err := (&aclStore{service: "unused", account: "unused"}).available()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnavailable))
+	assert.Contains(t, err.Error(), "not signed enough")
+}
+
+func TestOSStatusErrorMapping(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, osStatusError(errSecSuccess))
+
+	assert.True(t, errors.Is(osStatusError(errSecItemNotFound), ErrKeyNotFound))
+
+	for _, status := range []int32{errSecInteractionNotAllowed, errSecInteractionRequired} {
+		err := osStatusError(status)
+		assert.True(t, errors.Is(err, ErrLocked), "status %d must map to ErrLocked", status)
+		assert.True(t, errors.Is(err, ErrUnavailable), "ErrLocked wraps ErrUnavailable")
+		assert.Equal(t, Locked, outcomeOf(err), "a locked keychain must classify as Locked, not Absent")
+		assert.Contains(t, err.Error(), fmt.Sprintf("keychain error %d", status))
+		assert.Contains(t, err.Error(), "locked")
+	}
+
+	err := osStatusError(errSecUserCanceled)
+	assert.True(t, errors.Is(err, ErrDeclined), "a canceled prompt is a refusal, never a fallback")
+	assert.Equal(t, Declined, outcomeOf(err))
+
+	err = osStatusError(errSecNotAvailable)
+	assert.True(t, errors.Is(err, ErrUnavailable))
+	assert.Contains(t, err.Error(), "keychain error -25291")
+
+	err = osStatusError(errSecAuthFailed) // not a special case
+	assert.False(t, errors.Is(err, ErrUnavailable))
+	assert.False(t, errors.Is(err, ErrKeyNotFound))
+	assert.Contains(t, err.Error(), "keychain error -25293")
+}
+
+// With UI suppressed a locked keychain reports errSecAuthFailed, which would
+// classify as Absent. Verified interactively on macOS 26.5.
+//
+//nolint:paralleltest // mutates the package-global lock-state hook
+func TestSilentOpsOnLockedKeychainReportLocked(t *testing.T) {
+	fakeKeychainLock(t, true)
+
+	store := &aclStore{service: "unused", account: "unused", allowPrompt: false}
+
+	_, err := store.get()
+	assert.True(t, errors.Is(err, ErrLocked), "get on a locked keychain = %v, want ErrLocked", err)
+	assert.Equal(t, Locked, outcomeOf(err))
+
+	assert.True(t, errors.Is(store.set("value"), ErrLocked))
+	assert.True(t, errors.Is(store.delete(), ErrLocked))
+}
+
+// Re-arms the memoized precheck, which would otherwise carry a cached answer
+// between tests.
+func fakeKeychainLock(t *testing.T, locked bool) {
+	t.Helper()
+	prev := defaultKeychainLockedHook
+	defaultKeychainLockedHook = func() (bool, bool) { return locked, true }
+	keychainPrecheck = memoizePrecheck(probeKeychain)
+	t.Cleanup(func() {
+		defaultKeychainLockedHook = prev
+		keychainPrecheck = memoizePrecheck(probeKeychain)
+	})
+}
+
+//nolint:paralleltest // mutates package-global hooks
+func TestSilentPathNeverAnnouncesAWait(t *testing.T) {
+	fakeKeychainLock(t, true)
+
+	notified := 0
+	prevNotify := notifyWaitingForKeychainUnlock
+	notifyWaitingForKeychainUnlock = func() { notified++ }
+	t.Cleanup(func() { notifyWaitingForKeychainUnlock = prevNotify })
+
+	store := &aclStore{service: "unused", account: "unused", allowPrompt: false}
+	_, _ = store.get()
+	_ = store.set("value")
+	assert.Zero(t, notified, "a silent operation announces nothing because it never waits")
+}
+
+// Losing UI suppression means silence cannot be promised, so the tier must
+// step aside rather than risk a dialog.
+//
+//nolint:paralleltest // mutates the package-global bindings
+func TestMissingUISuppressionDisablesSilentOps(t *testing.T) {
+	require.NoError(t, loadDarwinAPI())
+	prev := sec.keychainSetUserInteractionOK
+	sec.keychainSetUserInteractionOK = nil
+	t.Cleanup(func() { sec.keychainSetUserInteractionOK = prev })
+
+	store := &aclStore{service: "unused", account: "unused", allowPrompt: false}
+	_, err := store.get()
+	assert.ErrorIs(t, err, ErrUnavailable)
+	assert.Contains(t, err.Error(), "suppress")
+
+	outcome, probeErr := store.probe()
+	assert.Equal(t, Absent, outcome, "the tier must step aside, not claim to be usable")
+	assert.ErrorIs(t, probeErr, ErrUnavailable)
+}
+
+//nolint:paralleltest // mutates the package-global bindings
+func TestMissingLockLookupReadsAsUnknown(t *testing.T) {
+	require.NoError(t, loadDarwinAPI())
+	prev := sec.keychainGetStatus
+	sec.keychainGetStatus = nil
+	t.Cleanup(func() { sec.keychainGetStatus = prev })
+
+	locked, ok := realDefaultKeychainLocked()
+	assert.False(t, ok, "an absent lookup is unknown state, not a false answer")
+	assert.False(t, locked)
+}

--- a/sdk/go/common/util/securestore/cf_darwin.go
+++ b/sdk/go/common/util/securestore/cf_darwin.go
@@ -1,0 +1,224 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package securestore
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+// CoreFoundation bindings via purego (no cgo); CFTypeRefs are carried as
+// uintptr. CF Create Rule: refs from Create/Copy functions must be released
+// exactly once; Get-style refs are borrowed and must not be.
+
+const (
+	coreFoundationPath = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+	securityPath       = "/System/Library/Frameworks/Security.framework/Security"
+
+	// kCFStringEncodingUTF8 from CoreFoundation/CFString.h.
+	kCFStringEncodingUTF8 = 0x08000100
+	// kCFNumberSInt64Type from CoreFoundation/CFNumber.h.
+	kCFNumberSInt64Type = 4
+)
+
+// Accumulates the first symbol-resolution error, so call sites can bind many
+// symbols without per-symbol error handling.
+type lib struct {
+	path   string
+	handle uintptr
+	err    error
+}
+
+func openLib(path string) *lib {
+	l := &lib{path: path}
+	handle, err := purego.Dlopen(path, purego.RTLD_LAZY|purego.RTLD_GLOBAL)
+	if err != nil {
+		l.err = fmt.Errorf("loading %s: %w", path, err)
+		return l
+	}
+	l.handle = handle
+	return l
+}
+
+func (l *lib) fn(fptr any, name string) {
+	if l.err != nil {
+		return
+	}
+	sym, err := purego.Dlsym(l.handle, name)
+	if err != nil {
+		l.err = fmt.Errorf("resolving %s in %s: %w", name, l.path, err)
+		return
+	}
+	purego.RegisterFunc(fptr, sym)
+}
+
+// Binds a symbol that may not exist, leaving the variable nil. For the
+// deprecated SecKeychain family: its removal should disable only the features
+// needing it, not every Security binding. Callers must nil-check.
+func (l *lib) optionalFn(fptr any, name string) {
+	if l.err != nil {
+		return
+	}
+	if sym, err := purego.Dlsym(l.handle, name); err == nil {
+		purego.RegisterFunc(fptr, sym)
+	}
+}
+
+// For struct-typed symbols (e.g. kCFTypeDictionaryKeyCallBacks) that C passes
+// by address.
+func (l *lib) addr(name string) uintptr {
+	if l.err != nil {
+		return 0
+	}
+	sym, err := purego.Dlsym(l.handle, name)
+	if err != nil {
+		l.err = fmt.Errorf("resolving %s in %s: %w", name, l.path, err)
+		return 0
+	}
+	return sym
+}
+
+// For pointer-typed symbols like `const CFStringRef kSecClass`: Dlsym yields
+// the variable's address, so one dereference gives the value.
+func (l *lib) constant(name string) uintptr {
+	addr := l.addr(name)
+	if addr == 0 {
+		return 0
+	}
+	// Double-indirect through &addr so go vet does not flag a plain
+	// uintptr-to-unsafe.Pointer conversion; addr points at immortal dyld data.
+	return **(**uintptr)(unsafe.Pointer(&addr))
+}
+
+type cfAPI struct {
+	release            func(ref uintptr)
+	stringCreate       func(alloc uintptr, cstr string, encoding uint32) uintptr
+	stringGetLength    func(s uintptr) int
+	stringGetCString   func(s uintptr, buf []byte, size int, encoding uint32) bool
+	stringGetTypeID    func() uintptr
+	dataCreate         func(alloc uintptr, bytes []byte, length int) uintptr
+	dataGetLength      func(data uintptr) int
+	dataGetBytePtr     func(data uintptr) *byte
+	dictionaryCreate   func(alloc uintptr, keys, values *uintptr, count int, keyCB, valueCB uintptr) uintptr
+	dictionaryGetValue func(dict, key uintptr) uintptr
+	numberGetValue     func(num uintptr, numType int, out *int64) bool
+	getTypeID          func(ref uintptr) uintptr
+
+	typeDictKeyCallBacks   uintptr
+	typeDictValueCallBacks uintptr
+	booleanTrue            uintptr
+}
+
+func newCFAPI(l *lib) *cfAPI {
+	c := &cfAPI{}
+	l.fn(&c.release, "CFRelease")
+	l.fn(&c.stringCreate, "CFStringCreateWithCString")
+	l.fn(&c.stringGetLength, "CFStringGetLength")
+	l.fn(&c.stringGetCString, "CFStringGetCString")
+	l.fn(&c.stringGetTypeID, "CFStringGetTypeID")
+	l.fn(&c.dataCreate, "CFDataCreate")
+	l.fn(&c.dataGetLength, "CFDataGetLength")
+	l.fn(&c.dataGetBytePtr, "CFDataGetBytePtr")
+	l.fn(&c.dictionaryCreate, "CFDictionaryCreate")
+	l.fn(&c.dictionaryGetValue, "CFDictionaryGetValue")
+	l.fn(&c.numberGetValue, "CFNumberGetValue")
+	l.fn(&c.getTypeID, "CFGetTypeID")
+	c.typeDictKeyCallBacks = l.addr("kCFTypeDictionaryKeyCallBacks")
+	c.typeDictValueCallBacks = l.addr("kCFTypeDictionaryValueCallBacks")
+	c.booleanTrue = l.constant("kCFBooleanTrue")
+	return c
+}
+
+// Caller releases.
+func (c *cfAPI) newString(s string) uintptr {
+	return c.stringCreate(0, s, kCFStringEncodingUTF8)
+}
+
+// Borrowed ref.
+func (c *cfAPI) goString(s uintptr) string {
+	n := c.stringGetLength(s) // length in UTF-16 code units
+	if n <= 0 {
+		return ""
+	}
+	buf := make([]byte, n*4+1) // worst-case UTF-8 expansion plus NUL
+	if !c.stringGetCString(s, buf, len(buf), kCFStringEncodingUTF8) {
+		return ""
+	}
+	for i, b := range buf {
+		if b == 0 {
+			return string(buf[:i])
+		}
+	}
+	return string(buf)
+}
+
+// Caller releases.
+func (c *cfAPI) newData(b []byte) uintptr {
+	return c.dataCreate(0, b, len(b))
+}
+
+func (c *cfAPI) dataBytes(data uintptr) []byte {
+	n := c.dataGetLength(data)
+	if n <= 0 {
+		return nil
+	}
+	ptr := c.dataGetBytePtr(data)
+	if ptr == nil {
+		return nil
+	}
+	out := make([]byte, n)
+	copy(out, unsafe.Slice(ptr, n))
+	return out
+}
+
+// Caller releases. Retains its keys and values, so caller-created refs may be
+// released immediately after.
+func (c *cfAPI) newDict(keys, values []uintptr) uintptr {
+	return c.dictionaryCreate(0, &keys[0], &values[0], len(keys),
+		c.typeDictKeyCallBacks, c.typeDictValueCallBacks)
+}
+
+var (
+	darwinAPIOnce sync.Once
+	darwinAPIErr  error
+	// cf and sec are non-nil iff loadDarwinAPI returned nil.
+	cf  *cfAPI
+	sec *secAPI
+)
+
+// Failure is an error, not a panic, so probing can fall back.
+func loadDarwinAPI() error {
+	darwinAPIOnce.Do(func() {
+		cfLib := openLib(coreFoundationPath)
+		secLib := openLib(securityPath)
+		cfBound := newCFAPI(cfLib)
+		secBound := newSecAPI(secLib)
+		if cfLib.err != nil {
+			darwinAPIErr = cfLib.err
+			return
+		}
+		if secLib.err != nil {
+			darwinAPIErr = secLib.err
+			return
+		}
+		cf, sec = cfBound, secBound
+	})
+	return darwinAPIErr
+}

--- a/sdk/go/common/util/securestore/codesign_darwin.go
+++ b/sdk/go/common/util/securestore/codesign_darwin.go
@@ -1,0 +1,79 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package securestore
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The ACL binds to a real (Developer ID / App Store) signature; an ad-hoc
+// binary gets a new identity every rebuild, re-prompting each time. Uses
+// SecCodeCopySelf, not csops, which misreports on macOS 26/arm64.
+
+// Constants from Security/CSCommon.h and Security/SecCode.h.
+const (
+	kSecCSDefaultFlags       = 0
+	kSecCSSigningInformation = 1 << 1
+	kSecCodeSignatureAdhoc   = 0x0002
+)
+
+// Test binaries are at best ad-hoc signed, so the real check always rejects them.
+var aclSelfCheckOverride func() error
+
+func aclSelfCheck() error {
+	if aclSelfCheckOverride != nil {
+		return aclSelfCheckOverride()
+	}
+	if err := loadDarwinAPI(); err != nil {
+		return err
+	}
+
+	var self uintptr
+	if status := sec.codeCopySelf(kSecCSDefaultFlags, &self); status != errSecSuccess {
+		return fmt.Errorf("determining own code identity: code signing error %d", status)
+	}
+	defer cf.release(self)
+
+	var info uintptr
+	if status := sec.codeCopySigningInformation(self, kSecCSSigningInformation, &info); status != errSecSuccess {
+		return fmt.Errorf("reading own code signature: code signing error %d", status)
+	}
+	defer cf.release(info)
+
+	// Per SecCode.h, kSecCodeInfoIdentifier is present iff the code is
+	// signed. Dictionary values are borrowed (Get rule): do not release.
+	if cf.dictionaryGetValue(info, sec.codeInfoIdentifier) == 0 {
+		return errors.New("binary is not code-signed")
+	}
+
+	// TODO(secure-credentials): pin to Pulumi's Team ID + identifier via
+	// SecRequirement once Apple enrollment completes. Until then any real
+	// (non-ad-hoc, team-identified) signature is accepted.
+	team := cf.dictionaryGetValue(info, sec.codeInfoTeamIdentifier)
+	if team == 0 || cf.getTypeID(team) != cf.stringGetTypeID() || cf.goString(team) == "" {
+		return errors.New("binary's code signature has no Team ID (ad-hoc or unsigned build)")
+	}
+
+	if flagsRef := cf.dictionaryGetValue(info, sec.codeInfoFlags); flagsRef != 0 {
+		var flags int64
+		if cf.numberGetValue(flagsRef, kCFNumberSInt64Type, &flags) && flags&kSecCodeSignatureAdhoc != 0 {
+			return errors.New("binary is ad-hoc signed")
+		}
+	}
+	return nil
+}

--- a/sdk/go/common/util/securestore/keychainstatus_darwin.go
+++ b/sdk/go/common/util/securestore/keychainstatus_darwin.go
@@ -1,0 +1,115 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package securestore
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// The login keychain is genuinely lockable: lock-keychain, lock-on-sleep,
+// key-authenticated SSH (no PAM unlock), or a diverged keychain password.
+
+// Caller releases the ref. Not ok also means the deprecated lookup is gone,
+// which reads as "lock state unknown" rather than failing the tier.
+func copyDefaultKeychain() (kc uintptr, ok bool) {
+	if loadDarwinAPI() != nil || sec.keychainCopyDefault == nil || sec.keychainGetStatus == nil {
+		return 0, false
+	}
+	if status := sec.keychainCopyDefault(&kc); status != errSecSuccess || kc == 0 {
+		return 0, false
+	}
+	return kc, true
+}
+
+// Hooked so tests need not lock the developer's own keychain.
+var defaultKeychainLockedHook = realDefaultKeychainLocked
+
+func defaultKeychainLocked() (locked, ok bool) { return defaultKeychainLockedHook() }
+
+func realDefaultKeychainLocked() (locked, ok bool) {
+	kc, ok := copyDefaultKeychain()
+	if !ok {
+		return false, false
+	}
+	defer cf.release(kc)
+	var status uint32
+	if s := sec.keychainGetStatus(kc, &status); s != errSecSuccess {
+		return false, false
+	}
+	return status&kSecUnlockStateStatus == 0, true
+}
+
+// Printed before blocking, so a dialog on another space is not seen as a hang.
+var notifyWaitingForKeychainUnlock = func() {
+	fmt.Fprintln(os.Stderr,
+		"Pulumi needs the key protecting your credentials: answer the keychain password prompt to continue.")
+}
+
+var interactionMu sync.Mutex
+
+// Deprecated, but the modern replacement (kSecUseAuthenticationContext +
+// LAContext) was measured inert for legacy keychain items — it drew the very
+// dialog it should suppress.
+func withoutKeychainUI[T any](fn func() (T, error)) (T, error) {
+	if err := loadDarwinAPI(); err != nil {
+		var zero T
+		return zero, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	if sec.keychainSetUserInteractionOK == nil {
+		// Silence cannot be promised, so decline rather than risk a dialog.
+		var zero T
+		return zero, fmt.Errorf("%w: cannot suppress keychain dialogs", ErrUnavailable)
+	}
+	interactionMu.Lock()
+	defer interactionMu.Unlock()
+	if status := sec.keychainSetUserInteractionOK(false); status != errSecSuccess {
+		var zero T
+		return zero, fmt.Errorf("%w: could not disable keychain dialogs: %v",
+			ErrUnavailable, osStatusError(status))
+	}
+	// Leaving interaction disabled would break every later keychain user.
+	defer sec.keychainSetUserInteractionOK(true) //nolint:errcheck // best effort restore
+	return fn()
+}
+
+// Both macOS tiers go through this before anything that could draw a dialog.
+// Locked gets one unlock attempt when permitted, and is reported untouched
+// when not; unknown state is left to the operation.
+var keychainPrecheck = memoizePrecheck(probeKeychain)
+
+func probeKeychain(allowPrompt bool) (Outcome, error) {
+	locked, ok := defaultKeychainLocked()
+	if !ok || !locked {
+		return Ready, nil
+	}
+	if !allowPrompt {
+		return Locked, fmt.Errorf("%w: unlock it or set PULUMI_CREDENTIAL_STORE=plaintext", ErrLocked)
+	}
+	kc, ok := copyDefaultKeychain()
+	if !ok || sec.keychainUnlock == nil {
+		return Locked, fmt.Errorf("%w: it cannot be unlocked from here", ErrLocked)
+	}
+	defer cf.release(kc)
+	notifyWaitingForKeychainUnlock()
+	err := osStatusError(sec.keychainUnlock(kc, 0, 0, false))
+	if err != nil {
+		return outcomeOf(err), err
+	}
+	return Ready, nil
+}

--- a/sdk/go/common/util/securestore/keyring.go
+++ b/sdk/go/common/util/securestore/keyring.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux || windows
-
 package securestore
 
 import (

--- a/sdk/go/common/util/securestore/keyring_test.go
+++ b/sdk/go/common/util/securestore/keyring_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux || windows
-
 package securestore
 
 import (

--- a/sdk/go/common/util/securestore/resolve_darwin.go
+++ b/sdk/go/common/util/securestore/resolve_darwin.go
@@ -12,30 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin
+
 package securestore
 
-import (
-	"fmt"
-	"time"
-)
-
-// On timeout the goroutine is abandoned; the buffered channel lets it exit
-// once fn returns. Only a permanently hung fn leaks it, acceptable in a CLI.
-func withTimeout[T any](timeout time.Duration, fn func() (T, error)) (T, error) {
-	type result struct {
-		v   T
-		err error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		v, err := fn()
-		ch <- result{v, err}
-	}()
-	select {
-	case r := <-ch:
-		return r.v, r.err
-	case <-time.After(timeout):
-		var zero T
-		return zero, fmt.Errorf("%w: operation timed out after %s", ErrUnavailable, timeout)
+// SecItem (per-app ACL, signed builds only) first, then the /usr/bin/security
+// fallback that works for any binary.
+func platformCandidates(allowPrompt bool, _ string) []backendImpl {
+	return []backendImpl{
+		aclKeychainBackend(allowPrompt),
+		{
+			id:    BackendMacOSSecurity,
+			store: newKeyringStore(func() (Outcome, error) { return keychainPrecheck(allowPrompt) }),
+			wrap:  rawWrapper{},
+		},
 	}
 }

--- a/sdk/go/common/util/securestore/resolve_other.go
+++ b/sdk/go/common/util/securestore/resolve_other.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !linux && !windows
+//go:build !darwin && !linux && !windows
 
 package securestore
 

--- a/sdk/go/common/util/securestore/security_darwin.go
+++ b/sdk/go/common/util/securestore/security_darwin.go
@@ -1,0 +1,118 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package securestore
+
+import "fmt"
+
+// Security framework bindings via purego. A plain SecItemAdd already yields a
+// per-app ACL bound to the creating app's signing identity, so no SecAccess or
+// SecTrustedApplication is needed.
+
+// OSStatus codes from Security/SecBase.h.
+const (
+	errSecSuccess               = 0
+	errSecUserCanceled          = -128 // the user canceled an authorization dialog
+	errSecNotAvailable          = -25291
+	errSecAuthFailed            = -25293
+	errSecDuplicateItem         = -25299
+	errSecItemNotFound          = -25300
+	errSecInteractionNotAllowed = -25308
+	errSecInteractionRequired   = -25315
+)
+
+// kSecUnlockStateStatus from Security/SecKeychain.h: set in the
+// SecKeychainGetStatus mask when the keychain is unlocked.
+const kSecUnlockStateStatus = 1
+
+// osStatusError maps an OSStatus to a package error, keeping the numeric code.
+func osStatusError(status int32) error {
+	switch status {
+	case errSecSuccess:
+		return nil
+	case errSecItemNotFound:
+		return ErrKeyNotFound
+	case errSecUserCanceled:
+		return fmt.Errorf("%w: keychain error %d: the keychain prompt was canceled", ErrDeclined, status)
+	case errSecInteractionNotAllowed, errSecInteractionRequired:
+		return fmt.Errorf("%w: keychain error %d: user interaction required; "+
+			"the keychain may be locked (e.g. in an SSH session)", ErrLocked, status)
+	case errSecNotAvailable:
+		return fmt.Errorf("%w: keychain error %d: no keychain is available", ErrUnavailable, status)
+	default:
+		return fmt.Errorf("keychain error %d", status)
+	}
+}
+
+type secAPI struct {
+	itemAdd          func(attrs uintptr, result *uintptr) int32
+	itemCopyMatching func(query uintptr, result *uintptr) int32
+	itemUpdate       func(query, attrs uintptr) int32
+	itemDelete       func(query uintptr) int32
+
+	codeCopySelf               func(flags uint32, self *uintptr) int32
+	codeCopySigningInformation func(code uintptr, flags uint32, info *uintptr) int32
+
+	// Deprecated, with no modern replacement for what we need; see
+	// withoutKeychainUI.
+	keychainCopyDefault          func(keychain *uintptr) int32
+	keychainGetStatus            func(keychain uintptr, status *uint32) int32
+	keychainUnlock               func(keychain uintptr, passwordLength uint32, password uintptr, usePassword bool) int32
+	keychainSetUserInteractionOK func(allowed bool) int32
+
+	// SecItem attribute/value CFStringRef constants.
+	class                uintptr
+	classGenericPassword uintptr
+	attrService          uintptr
+	attrAccount          uintptr
+	attrLabel            uintptr
+	valueData            uintptr
+	returnData           uintptr
+	matchLimit           uintptr
+	matchLimitOne        uintptr
+
+	// SecCodeCopySigningInformation dictionary keys.
+	codeInfoIdentifier     uintptr
+	codeInfoTeamIdentifier uintptr
+	codeInfoFlags          uintptr
+}
+
+func newSecAPI(l *lib) *secAPI {
+	s := &secAPI{}
+	l.fn(&s.itemAdd, "SecItemAdd")
+	l.fn(&s.itemCopyMatching, "SecItemCopyMatching")
+	l.fn(&s.itemUpdate, "SecItemUpdate")
+	l.fn(&s.itemDelete, "SecItemDelete")
+	l.fn(&s.codeCopySelf, "SecCodeCopySelf")
+	l.fn(&s.codeCopySigningInformation, "SecCodeCopySigningInformation")
+	l.optionalFn(&s.keychainCopyDefault, "SecKeychainCopyDefault")
+	l.optionalFn(&s.keychainGetStatus, "SecKeychainGetStatus")
+	l.optionalFn(&s.keychainUnlock, "SecKeychainUnlock")
+	l.optionalFn(&s.keychainSetUserInteractionOK, "SecKeychainSetUserInteractionAllowed")
+	s.class = l.constant("kSecClass")
+	s.classGenericPassword = l.constant("kSecClassGenericPassword")
+	s.attrService = l.constant("kSecAttrService")
+	s.attrAccount = l.constant("kSecAttrAccount")
+	s.attrLabel = l.constant("kSecAttrLabel")
+	s.valueData = l.constant("kSecValueData")
+	s.returnData = l.constant("kSecReturnData")
+	s.matchLimit = l.constant("kSecMatchLimit")
+	s.matchLimitOne = l.constant("kSecMatchLimitOne")
+	s.codeInfoIdentifier = l.constant("kSecCodeInfoIdentifier")
+	s.codeInfoTeamIdentifier = l.constant("kSecCodeInfoTeamIdentifier")
+	s.codeInfoFlags = l.constant("kSecCodeInfoFlags")
+	return s
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -3109,8 +3109,8 @@ github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+m
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
-github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
+github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=


### PR DESCRIPTION
## Summary

PR stack: #24208 ← #24209 ← #24210 ← **this** ← #24212.

macOS gets two keychain tiers, resolved at runtime by a code-signature self-check:

1. **`BackendMacOSACL`** — a native `SecItem` generic secret whose ACL is bound to the creating app's code-signing identity. Only our binary reads it silently; every other same-user process - including `/usr/bin/security` - is denied or prompted. This is real per-app protection, which the `security`-exec model fundamentally can't give (any process can run `security` and read such an item). This tier requires a real (Team-ID) signature, so it stays dormant until we sign release binaries with our Developer-ID. This is a follow up task. The security->acl upgrade self-activates then with no code change.
2. **`BackendMacOSSecurity`** — the keyring store from #24209 via `zalando/go-keyring`: works for any publish pipeline including ad-hoc/homebrew-core/dev builds, still prompt-free as described in #24208 across rebuilds and cli updates.

The two tiers use distinct keychain accounts (`credentials-key-acl` vs `credentials-key`) so they never collide on one item.

Security.framework and CoreFoundation are reached through **purego** (`Dlopen`/`Dlsym`), so `CGO_ENABLED=0` and the Linux-runner cross-compile pipeline are unchanged.

### The native tier (`acl_darwin.go`)

- The per-app ACL comes from a plain `SecItemAdd`. The default ACL binds the item to the creating app's signing identity. The item is deliberately minimal: no synchronizable attribute (never iCloud-synced), no explicit access attributes (setting them prompts).
- The ACL stores a code-signing *requirement* (identifier + Team ID). Future releases signed by the same team keep silent access across upgrades and certificate renewals.
- The runtime self-check (`codesign_darwin.go`) uses `SecCodeCopySelf` + `SecCodeCopySigningInformation` and rejects unsigned, ad-hoc, or team-less binaries. A TODO records the follow-up of pinning to Pulumi's Team ID + identifier via `SecRequirement` once Apple enrollment completes.

### The lock-state precheck (`keychainstatus_darwin.go`, both tiers)

Same policy as the Linux Secret Service path in #24209. There is no prompt object to dismiss on macOS, so the choice must be made *before* the call:

- Ask the keychain's lock state first (`SecKeychainGetStatus`) and answer from it. Asking directly instead of inferring from an operation's status is important as in unattended sessions a locked keychain returns `errSecAuthFailed` (-25293), indistinguishable from a real authorization failure.
- Locked and prompting forbidden (unattended) → `Locked`, with an actionable error. Locked and prompting permitted (attended) → a notice on stderr, then one `SecKeychainUnlock` attempt. A system dialog shows up asking to unlock the keychain. Cancelling it maps `errSecUserCanceled` (-128) to `Declined`, which stops the chain rather than silently falling back to a weaker tier or plaintext.
- Unattended sessions additionally run inside `SecKeychainSetUserInteractionAllowed(false)`. The modern replacement (`kSecUseAuthenticationContext` with `LAContext.interactionNotAllowed`) still let the system render a dialog. So the deprecated lever is the only one that works. Suppression also covers the race where the keychain locks between precheck and operation (sleep, inactivity, screen lock) and any prompt source we haven't enumerated, such as the ACL-mismatch dialog.

The deprecated `SecKeychain*` symbols - used to check lock status basically - are bound optionally and nil-checked, so if Apple ever removes them (which is unlikely due to their broad usage) the degradation only affects this feature instead of crashing the cli. Losing the lock lookup reads as "state unknown" leaving handling to the actual operation. Everything else — `SecItem*`, `SecCode*` — is current, non-deprecated API.

### purego bindings (`cf_darwin.go`, `security_darwin.go`)

Thin explicit bindings: per-library error accumulation so one load failure surfaces as an error (letting resolution/keystore selection fall back to the next tier) instead of a panic. `withTimeout`/`opTimeout` move from `keyring.go` to `item.go` since darwin now shares them, and `keyring.go` drops its `linux || windows` build tag because the fallback tier reuses the keyring store.

### Dependencies

- `ebitengine/purego` v0.10.2 — new direct dependency in the sdk module. The `tests/go.sum` change is just the existing indirect bumping 0.10.0 → 0.10.2.

## Testing

`acl_darwin_test.go` (runs on macOS CI):

- The self-check rejects the test binary itself — test binaries are at best ad-hoc signed, so the real check is exercised, not mocked.
- A full round trip against a real throwaway keychain item (randomized service name, cleaned up), enabled by a self-check override; skips where the keychain is unusable.
- The `OSStatus` → typed-error mapping: not-found → `ErrKeyNotFound`, interaction-required → `ErrLocked`, canceled → `ErrDeclined`, and crucially `errSecAuthFailed` mapping to *none* of them.
- Locked-keychain behavior via a lock-state hook (tests never lock the developer's real keychain): silent ops report `Locked`, never announce a wait; a missing UI-suppression symbol (Apple removed deprecated symbols) makes the tier step aside; a missing lock lookup reads as unknown state, not a false answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)