### PR TITLE
Switch diy deprecation warning to an error

### DIFF
--- a/changelog/pending/backend-diy-chore-20260805-215942.yaml
+++ b/changelog/pending/backend-diy-chore-20260805-215942.yaml
@@ -1,0 +1,4 @@
+component: backend/diy
+kind: chore
+body: The deprecation warning is now an error. PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_WARNING is now PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR.
+time: 2026-08-05T21:59:42.752778+01:00

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -345,8 +345,8 @@ func newDIYBackend(
 
 	// If we're not in project mode and the user hasn't disabled the warning, warn that legacy mode is deprecated and
 	// due to be removed.
-	if !projectMode && !opts.Env.GetBool(env.DIYBackendIgnoreDeprecationWarning) {
-		d.Warningf(diag.Message("", `
+	if !projectMode && !opts.Env.GetBool(env.DIYBackendIgnoreDeprecationError) {
+		return nil, errors.New(`
 ================================================================================
 Legacy DIY state is deprecated, please upgrade your state to project mode using:
 'pulumi state upgrade'
@@ -354,8 +354,8 @@ Legacy DIY state is deprecated, please upgrade your state to project mode using:
 It is due to be removed in a future release before the end of this year (2026).
 If you have any feedback or concerns, please let us know by commenting on the
 issue at https://github.com/pulumi/pulumi/issues/19566.
-Set PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_WARNING=1 to disable this warning.
-================================================================================`))
+Set PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR=1 to disable this error.
+================================================================================`)
 	}
 
 	// If we're not in project mode, or we've disabled the warning, we're done.

--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -43,6 +43,8 @@ import (
 // validating that the legacy behavior is preserved.
 
 func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
+
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())
 	ctx := t.Context()
@@ -101,7 +103,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 }
 
 func TestDrillError_legacy(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())
@@ -119,7 +121,7 @@ func TestDrillError_legacy(t *testing.T) {
 }
 
 func TestCancel_legacy(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())
@@ -180,7 +182,7 @@ func TestCancel_legacy(t *testing.T) {
 }
 
 func TestRemoveMakesBackups_legacy(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())
@@ -223,7 +225,7 @@ func TestRemoveMakesBackups_legacy(t *testing.T) {
 }
 
 func TestRenameWorks_legacy(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Login to a temp dir diy backend
 	tmpDir := markLegacyStore(t, t.TempDir())
@@ -294,7 +296,7 @@ func TestRenameWorks_legacy(t *testing.T) {
 
 // Regression test for https://github.com/pulumi/pulumi/issues/10439
 func TestHtmlEscaping_legacy(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	sm := b64.NewBase64SecretsManager()
 	resources := []*pkgresource.State{
@@ -348,7 +350,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 }
 
 func TestDIYBackendRejectsStackInitOptions_legacy(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Here, we provide options that illegally specify a team on a
 	// backend that does not support teams. We expect this to create
@@ -390,7 +392,8 @@ func TestParallelStackFetch_legacy(t *testing.T) {
 
 	// Create a custom environment with DIYBackendParallel set
 	s := make(declared.MapStore)
-	s[env.DIYBackendParallel.Var().Name()] = "5" // Set parallel to 5
+	s[env.DIYBackendParallel.Var().Name()] = "5"                  // Set parallel to 5
+	s[env.DIYBackendIgnoreDeprecationError.Var().Name()] = "true" // Ignore deprecation error
 
 	b, err := newDIYBackend(
 		ctx,

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -850,7 +850,7 @@ func TestDIYBackendRejectsStackInitOptions(t *testing.T) {
 }
 
 func TestLegacyFolderStructure(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Make a dummy stack file in the legacy location
 	tmpDir := t.TempDir()
@@ -924,6 +924,7 @@ func TestOptIntoLegacyFolderStructure(t *testing.T) {
 	ctx := t.Context()
 	s := make(env.MapStore)
 	s[env.DIYBackendLegacyLayout.Var().Name()] = "true"
+	s[env.DIYBackendIgnoreDeprecationError.Var().Name()] = "true"
 	b, err := newDIYBackend(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(tmpDir), nil,
 		&diyBackendOptions{Env: env.NewEnv(s)},
 	)
@@ -1189,7 +1190,7 @@ func TestNew_legacyFileWarning(t *testing.T) {
 }
 
 func TestLegacyUpgrade(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Make a dummy stack file in the legacy location
 	tmpDir := t.TempDir()
@@ -1258,7 +1259,7 @@ func TestLegacyUpgrade(t *testing.T) {
 }
 
 func TestLegacyUpgrade_partial(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	// Verifies that we can upgrade a subset of stacks.
 
@@ -1303,7 +1304,7 @@ func TestLegacyUpgrade_partial(t *testing.T) {
 // When a stack project could not be determined,
 // we should fill it in with ProjectsForDetachedStacks.
 func TestLegacyUpgrade_ProjectsForDetachedStacks(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	stateDir := t.TempDir()
 	bucket, err := fileblob.OpenBucket(stateDir, nil)
@@ -1372,7 +1373,7 @@ func TestLegacyUpgrade_ProjectsForDetachedStacks(t *testing.T) {
 // and ProjectsForDetachedStacks returns an error,
 // the upgrade should fail.
 func TestLegacyUpgrade_ProjectsForDetachedStacks_error(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	stateDir := t.TempDir()
 	bucket, err := fileblob.OpenBucket(stateDir, nil)
@@ -1428,7 +1429,7 @@ func TestLegacyUpgrade_ProjectsForDetachedStacks_error(t *testing.T) {
 // If an upgrade failed because we couldn't write the meta.yaml,
 // the stacks should be left in legacy mode.
 func TestLegacyUpgrade_writeMetaError(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	stateDir := t.TempDir()
 	bucket, err := fileblob.OpenBucket(stateDir, nil)
@@ -1505,7 +1506,7 @@ func TestSerializeTimestampRFC3339(t *testing.T) {
 }
 
 func TestUpgrade_manyFailures(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	const (
 		numStacks    = 100

--- a/pkg/backend/diy/meta_test.go
+++ b/pkg/backend/diy/meta_test.go
@@ -211,7 +211,7 @@ func TestMeta_WriteTo_zero(t *testing.T) {
 // Verify that we don't create a metadata file with version 0 in buckets
 // that have other files.
 func TestNew_noMetaOnInit(t *testing.T) {
-	t.Parallel()
+	t.Setenv("PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR", "true")
 
 	tmpDir := t.TempDir()
 	bucket, err := fileblob.OpenBucket(tmpDir, nil)

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -168,8 +168,8 @@ var (
 		"Disables the warning about legacy stack files mixed with project-scoped stack files.",
 		env.Alternative("SELF_MANAGED_STATE_NO_LEGACY_WARNING"))
 
-	DIYBackendIgnoreDeprecationWarning = env.Bool("DIY_BACKEND_IGNORE_DEPRECATION_WARNING",
-		"Disables the warning about legacy stack mode being deprecated.")
+	DIYBackendIgnoreDeprecationError = env.Bool("DIY_BACKEND_IGNORE_DEPRECATION_ERROR",
+		"Disables the error about legacy stack mode being deprecated.")
 
 	DIYBackendLegacyLayout = env.Bool("DIY_BACKEND_LEGACY_LAYOUT",
 		"Uses the legacy layout for new buckets, which currently default to project-scoped stacks.",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -262,7 +262,10 @@ func TestDestroyStackRef_LocalNonProject_NewEnv(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
-	e.Env = []string{"PULUMI_DIY_BACKEND_LEGACY_LAYOUT=true"}
+	e.Env = []string{
+		"PULUMI_DIY_BACKEND_LEGACY_LAYOUT=true",
+		"DIY_BACKEND_IGNORE_DEPRECATION_ERROR=true",
+	}
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	testDestroyStackRef(e, "")
 }
@@ -273,7 +276,10 @@ func TestDestroyStackRef_LocalNonProject_OldEnv(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
-	e.Env = []string{"PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT=true"}
+	e.Env = []string{
+		"PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT=true",
+		"DIY_BACKEND_IGNORE_DEPRECATION_ERROR=true",
+	}
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	testDestroyStackRef(e, "")
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -264,7 +264,7 @@ func TestDestroyStackRef_LocalNonProject_NewEnv(t *testing.T) {
 
 	e.Env = []string{
 		"PULUMI_DIY_BACKEND_LEGACY_LAYOUT=true",
-		"DIY_BACKEND_IGNORE_DEPRECATION_ERROR=true",
+		"PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR=true",
 	}
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	testDestroyStackRef(e, "")
@@ -278,7 +278,7 @@ func TestDestroyStackRef_LocalNonProject_OldEnv(t *testing.T) {
 
 	e.Env = []string{
 		"PULUMI_SELF_MANAGED_STATE_LEGACY_LAYOUT=true",
-		"DIY_BACKEND_IGNORE_DEPRECATION_ERROR=true",
+		"PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR=true",
 	}
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	testDestroyStackRef(e, "")


### PR DESCRIPTION
Next part of https://github.com/pulumi/pulumi/issues/19566, make the warning a (skippable) error. The envvar is renamed from `PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_WARNING` to `PULUMI_DIY_BACKEND_IGNORE_DEPRECATION_ERROR`.