### PR TITLE
Collapse guided `pulumi new` prompts into a single confirmation

### DIFF
--- a/changelog/pending/20260806--cli-new--collapse-new-prompts.yaml
+++ b/changelog/pending/20260806--cli-new--collapse-new-prompts.yaml
@@ -1,0 +1,6 @@
+component: cli/new
+kind: feat
+body: Show a single confirmation of project, stack, and config defaults in interactive `pulumi new` instead of prompting for each value
+time: 2026-08-06T00:00:00+00:00
+custom:
+  PR: "24223"

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -367,6 +367,29 @@ func stackCrypters(
 	return sm.Encrypter(), sm.Decrypter(), nil
 }
 
+func saveTemplateConfig(
+	ctx context.Context, sink diag.Sink, ssml cmdStack.SecretsManagerLoader, ws pkgWorkspace.Context,
+	project *workspace.Project, s backend.Stack, values []templateConfigValue,
+	commandLineConfig config.Map, configFile string,
+) error {
+	if len(values) == 0 && len(commandLineConfig) == 0 {
+		return nil
+	}
+
+	encrypter, _, err := stackCrypters(ctx, sink, ssml, project, s, configFile)
+	if err != nil {
+		return err
+	}
+	c, err := encryptTemplateConfig(ctx, encrypter, values, commandLineConfig)
+	if err != nil {
+		return err
+	}
+	if len(c) == 0 {
+		return nil
+	}
+	return SaveConfig(ctx, sink, ws, s, c, configFile)
+}
+
 // ParseConfig parses the config values passed via command line flags.
 // These are passed as `-c aws:region=us-east-1 -c foo:bar=blah` and end up
 // in configArray as ["aws:region=us-east-1", "foo:bar=blah"].

--- a/pkg/cmd/pulumi/project/newcmd/confirm.go
+++ b/pkg/cmd/pulumi/project/newcmd/confirm.go
@@ -1,0 +1,360 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+)
+
+const (
+	confirmYes    = "Yes, create the project"
+	confirmChange = "Change these values"
+)
+
+var errConfirmationInterrupted = errors.New("no project created; please use `pulumi new` to start again")
+
+// A nil *confirmedNew means the guided path did not run and the sequential prompts own the flow.
+type confirmedNew struct {
+	name        string
+	description string
+	// Empty when the confirmation did not cover the stack.
+	stackName         string
+	config            []templateConfigValue
+	commandLineConfig config.Map
+}
+
+func (c *confirmedNew) createsStack() bool {
+	return c != nil && c.stackName != ""
+}
+
+// createStack creates the stack confirmed earlier, falling through to the sequential
+// prompt-and-create flow when the confirmation did not cover the stack.
+func (c *confirmedNew) createStack(
+	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b backend.Backend,
+	root string, args newArgs, opts display.Options,
+) (backend.Stack, string, error) {
+	if c.createsStack() {
+		// Quiet: the confirmation already showed the stack name, and the summary repeats it.
+		return createStackWithRetry(ctx, sink, args.stdout, ws, b, args.prompt, c.stackName, root, args.yes, opts,
+			cmdStack.CreateStackOptions{
+				SetCurrent:      true,
+				SecretsProvider: args.secretsProvider,
+				UseRemoteConfig: args.remoteStackConfig,
+				Quiet:           true,
+			})
+	}
+	s, err := PromptAndCreateStack(ctx, sink, ws, b, args.prompt,
+		args.stack, root, true /*setCurrent*/, args.yes, opts, args.secretsProvider,
+		args.remoteStackConfig, "")
+	if err != nil {
+		return nil, "", err
+	}
+	// cmdStack.CreateStack prints "Created stack '<stack>'" on success.
+	fmt.Fprintln(args.stdout)
+	return s, "", nil
+}
+
+// saveConfig saves the config gathered at confirmation, falling through to the sequential
+// prompt-and-save flow when the confirmation did not cover the stack.
+func (c *confirmedNew) saveConfig(
+	ctx context.Context, sink diag.Sink, ssml cmdStack.SecretsManagerLoader, ws pkgWorkspace.Context,
+	proj *workspace.Project, s backend.Stack, template cmdTemplates.ProjectTemplate,
+	args newArgs, opts display.Options,
+) error {
+	if c.createsStack() {
+		return saveTemplateConfig(ctx, sink, ssml, ws, proj, s, c.config, c.commandLineConfig, "")
+	}
+	return HandleConfig(ctx, sink, ssml, ws, args.prompt, proj, s,
+		args.templateNameOrURL, template, args.configArray, args.yes, args.configPath, opts, "")
+}
+
+func printPreamble(w io.Writer, opts display.Options) {
+	fmt.Fprintln(w, "This command will walk you through creating a new Pulumi project.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w,
+		opts.Color.Colorize(
+			colors.Highlight("Enter a value or leave blank to accept the (default), and press <ENTER>.",
+				"<ENTER>", colors.BrightCyan+colors.Bold),
+		))
+	fmt.Fprintln(w,
+		opts.Color.Colorize(
+			colors.Highlight("Press ^C at any time to quit.", "^C", colors.BrightCyan+colors.Bold),
+		))
+	fmt.Fprintln(w)
+}
+
+type projectDefaults struct {
+	name        string
+	description string
+	// Non-nil when args.name was empty and the default name failed validation.
+	nameErr error
+}
+
+func resolveProjectDefaults(
+	ctx context.Context, b backend.Backend, orgName string,
+	template cmdTemplates.ProjectTemplate, args newArgs, opts display.Options, cwd string,
+) projectDefaults {
+	d := projectDefaults{
+		name: pkgWorkspace.ValueOrSanitizedDefaultProjectName(
+			args.name, template.ProjectName, filepath.Base(cwd),
+		),
+		description: pkgWorkspace.ValueOrDefaultProjectDescription(
+			args.description, template.ProjectDescription, template.Description,
+		),
+	}
+	if args.name == "" {
+		d.nameErr = validateProjectName(ctx, b, orgName, d.name, args.generateOnly, opts.WithIsInteractive(false))
+	}
+	return d
+}
+
+func promptSequentialValues(
+	ctx context.Context, b backend.Backend, orgName string, defaults projectDefaults,
+	args newArgs, opts display.Options,
+) (string, string, error) {
+	// The guided flow's questions already set the tone, so no preamble when falling back from it.
+	hasAtLeastOnePrompt := (args.name == "") || (args.description == "") || (!args.generateOnly && args.stack == "")
+	if !args.yes && hasAtLeastOnePrompt && !args.useGuidedFlow() {
+		printPreamble(args.stdout, opts)
+	}
+
+	if defaults.nameErr != nil && args.yes {
+		// If --yes is given error out now that the default value is invalid. If we allow prompt to catch
+		// this case it can lead to a confusing error message.
+		// See https://github.com/pulumi/pulumi/issues/8747.
+		return "", "", fmt.Errorf("'%s' is not a valid project name. %w", defaults.name, defaults.nameErr)
+	}
+
+	return promptNameAndDescription(ctx, b, orgName, defaults.name, defaults.description, args, opts)
+}
+
+func promptNameAndDescription(
+	ctx context.Context, b backend.Backend, orgName, defaultName, defaultDescription string,
+	args newArgs, opts display.Options,
+) (string, string, error) {
+	name, description := args.name, args.description
+
+	var err error
+	if name == "" {
+		validate := func(s string) error {
+			return validateProjectName(ctx, b, orgName, s, args.generateOnly, opts)
+		}
+		if name, err = args.prompt(args.yes, "Project name", defaultName, false, validate, opts); err != nil {
+			return "", "", err
+		}
+	}
+
+	if description == "" {
+		if description, err = args.prompt(
+			args.yes, "Project description", defaultDescription, false, pkgWorkspace.ValidateProjectDescription, opts,
+		); err != nil {
+			return "", "", err
+		}
+	}
+
+	return name, description, nil
+}
+
+// A nil result means this run is not on the guided path, or that its defaults are unusable, and
+// the sequential prompts should run instead.
+func confirmGuidedValues(
+	ctx context.Context, b backend.Backend, orgName string, defaults projectDefaults,
+	template cmdTemplates.ProjectTemplate, args newArgs, opts display.Options,
+) (*confirmedNew, error) {
+	if !args.useGuidedFlow() {
+		return nil, nil
+	}
+	shows := struct{ name, description, stack bool }{
+		name:        args.name == "",
+		description: args.description == "",
+		stack:       !args.generateOnly && args.stack == "",
+	}
+	if !shows.name && !shows.description && !shows.stack {
+		return nil, nil
+	}
+	if shows.name && defaults.nameErr != nil {
+		// The sequential prompts already handle an unusable default coherently.
+		return nil, nil
+	}
+
+	c := &confirmedNew{name: defaults.name, description: defaults.description}
+
+	var err error
+	if shows.stack {
+		if c.stackName, err = buildStackName(ctx, b, defaultStackName); err != nil {
+			return nil, err
+		}
+		if err = c.promptUnsetConfig(template, args, opts); err != nil {
+			return nil, err
+		}
+	}
+
+	rows := make([]field, 0, 3)
+	if shows.name {
+		rows = append(rows, field{"Project name", c.name})
+	}
+	if shows.description {
+		rows = append(rows, field{"Description", c.description})
+	}
+	if shows.stack {
+		rows = append(rows, field{"Stack name", c.stackName})
+	}
+
+	accepted, err := askConfirmation(args.stdout, opts, args.selectOne, rows, c.configRows())
+	if err != nil {
+		return nil, friendlyInterrupt(err, errConfirmationInterrupted)
+	}
+	if accepted {
+		return c, nil
+	}
+
+	// Declined: every prompt, in today's order, pre-filled with the values just shown.
+	fmt.Fprintln(args.stdout)
+	if c.name, c.description, err = promptNameAndDescription(
+		ctx, b, orgName, c.name, c.description, args, opts,
+	); err != nil {
+		return nil, err
+	}
+	if shows.stack {
+		if c.stackName, err = promptStackName(args.stdout, b, args.prompt, c.stackName, false, opts); err != nil {
+			return nil, err
+		}
+		if err = c.repromptConfig(template, args, opts); err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+// resolveConfigDefaults resolves defaults under the project name chosen so far, including any key
+// declared without a namespace.
+func (c *confirmedNew) resolveConfigDefaults(
+	template cmdTemplates.ProjectTemplate, args newArgs,
+) ([]templateConfigValue, error) {
+	projectName := tokens.PackageName(c.name)
+
+	var err error
+	if c.commandLineConfig, err = ParseConfigForProject(
+		projectName, args.configArray, args.configPath,
+	); err != nil {
+		return nil, err
+	}
+	return resolveTemplateConfig(projectName, template.Config, c.commandLineConfig, nil, nil)
+}
+
+// promptUnsetConfig asks only for unset keys, so accepting the confirmation leaves nothing to ask.
+func (c *confirmedNew) promptUnsetConfig(
+	template cmdTemplates.ProjectTemplate, args newArgs, opts display.Options,
+) error {
+	values, err := c.resolveConfigDefaults(template, args)
+	if err != nil {
+		return err
+	}
+	if slices.ContainsFunc(values, templateConfigValue.unset) {
+		fmt.Fprintln(args.stdout)
+	}
+	if err = askTemplateConfig(values, args.prompt, args.yes, askUnset, opts); err != nil {
+		return err
+	}
+	c.config = values
+	return nil
+}
+
+// repromptConfig re-asks every key: the project name may have changed, re-resolving keys declared
+// without a namespace.
+func (c *confirmedNew) repromptConfig(
+	template cmdTemplates.ProjectTemplate, args newArgs, opts display.Options,
+) error {
+	prior := make(map[string]string, len(c.config))
+	for _, v := range c.config {
+		if !v.fromFlag {
+			prior[v.templateKey] = v.value
+		}
+	}
+	values, err := c.resolveConfigDefaults(template, args)
+	if err != nil {
+		return err
+	}
+	for i, v := range values {
+		if p, ok := prior[v.templateKey]; ok && p != "" && !v.fromFlag {
+			values[i].value = p
+		}
+	}
+	if slices.ContainsFunc(values, func(v templateConfigValue) bool { return !v.fromFlag }) {
+		fmt.Fprintln(args.stdout)
+	}
+	if err = askTemplateConfig(values, args.prompt, args.yes, askAll, opts); err != nil {
+		return err
+	}
+	c.config = values
+	return nil
+}
+
+func (c *confirmedNew) configRows() []field {
+	rows := make([]field, 0, len(c.config))
+	for _, v := range c.config {
+		value := v.value
+		if v.secret {
+			value = "[secret]"
+		}
+		rows = append(rows, field{cmdConfig.PrettyKeyForProject(v.key, tokens.PackageName(c.name)), value})
+	}
+	return rows
+}
+
+func askConfirmation(
+	w io.Writer, opts display.Options, sel selectFunc, rows, configRows []field,
+) (bool, error) {
+	fmt.Fprintln(w)
+	printFields(w, opts.Color, "", rows)
+	if len(configRows) > 0 {
+		fmt.Fprintln(w, opts.Color.Colorize(colors.SpecSubHeadline+"Config:"+colors.Reset))
+		printFields(w, opts.Color, "  ", configRows)
+	}
+	i, err := sel("Do these look good?", []string{confirmYes, confirmChange}, opts)
+	return i == 0, err
+}
+
+type field struct{ label, value string }
+
+func printFields(w io.Writer, color colors.Colorization, indent string, fields []field) {
+	width := 0
+	for _, f := range fields {
+		width = max(width, len(f.label))
+	}
+	for _, f := range fields {
+		label := f.label + ":" + strings.Repeat(" ", width-len(f.label))
+		fmt.Fprintln(w, indent+color.Colorize(colors.SpecSubHeadline+label+colors.Reset)+"  "+f.value)
+	}
+}

--- a/pkg/cmd/pulumi/project/newcmd/confirm.go
+++ b/pkg/cmd/pulumi/project/newcmd/confirm.go
@@ -105,11 +105,11 @@ func printPreamble(w io.Writer, opts display.Options) {
 	fmt.Fprintln(w,
 		opts.Color.Colorize(
 			colors.Highlight("Enter a value or leave blank to accept the (default), and press <ENTER>.",
-				"<ENTER>", colors.BrightCyan+colors.Bold),
+				"<ENTER>", colors.SpecPrompt),
 		))
 	fmt.Fprintln(w,
 		opts.Color.Colorize(
-			colors.Highlight("Press ^C at any time to quit.", "^C", colors.BrightCyan+colors.Bold),
+			colors.Highlight("Press ^C at any time to quit.", "^C", colors.SpecPrompt),
 		))
 	fmt.Fprintln(w)
 }
@@ -143,9 +143,8 @@ func promptSequentialValues(
 	ctx context.Context, b backend.Backend, orgName string, defaults projectDefaults,
 	args newArgs, opts display.Options,
 ) (string, string, error) {
-	// The guided flow's questions already set the tone, so no preamble when falling back from it.
 	hasAtLeastOnePrompt := (args.name == "") || (args.description == "") || (!args.generateOnly && args.stack == "")
-	if !args.yes && hasAtLeastOnePrompt && !args.useGuidedFlow() {
+	if !args.yes && hasAtLeastOnePrompt {
 		printPreamble(args.stdout, opts)
 	}
 
@@ -167,10 +166,7 @@ func promptNameAndDescription(
 
 	var err error
 	if name == "" {
-		validate := func(s string) error {
-			return validateProjectName(ctx, b, orgName, s, args.generateOnly, opts)
-		}
-		if name, err = args.prompt(args.yes, "Project name", defaultName, false, validate, opts); err != nil {
+		if name, err = promptProjectName(ctx, b, orgName, defaultName, args, opts); err != nil {
 			return "", "", err
 		}
 	}
@@ -186,8 +182,18 @@ func promptNameAndDescription(
 	return name, description, nil
 }
 
-// A nil result means this run is not on the guided path, or that its defaults are unusable, and
-// the sequential prompts should run instead.
+func promptProjectName(
+	ctx context.Context, b backend.Backend, orgName, defaultName string,
+	args newArgs, opts display.Options,
+) (string, error) {
+	validate := func(s string) error {
+		return validateProjectName(ctx, b, orgName, s, args.generateOnly, opts)
+	}
+	return args.prompt(args.yes, "Project name", defaultName, false, validate, opts)
+}
+
+// A nil result means this run is not on the guided path, and the sequential prompts should run
+// instead.
 func confirmGuidedValues(
 	ctx context.Context, b backend.Backend, orgName string, defaults projectDefaults,
 	template cmdTemplates.ProjectTemplate, args newArgs, opts display.Options,
@@ -203,17 +209,25 @@ func confirmGuidedValues(
 	if !shows.name && !shows.description && !shows.stack {
 		return nil, nil
 	}
-	if shows.name && defaults.nameErr != nil {
-		// The sequential prompts already handle an unusable default coherently.
-		return nil, nil
-	}
 
 	c := &confirmedNew{name: defaults.name, description: defaults.description}
 
 	var err error
+	projectIsNew := shows.name && defaults.nameErr == nil
+	if shows.name && defaults.nameErr != nil {
+		if c.name, err = promptProjectName(ctx, b, orgName, c.name, args, opts); err != nil {
+			return nil, err
+		}
+	}
 	if shows.stack {
 		if c.stackName, err = buildStackName(ctx, b, defaultStackName); err != nil {
 			return nil, err
+		}
+		// A project the backend has never heard of has no stacks to collide with.
+		if !projectIsNew {
+			if err = c.avoidExistingStack(ctx, b, args, opts); err != nil {
+				return nil, err
+			}
 		}
 		if err = c.promptUnsetConfig(template, args, opts); err != nil {
 			return nil, err
@@ -247,7 +261,9 @@ func confirmGuidedValues(
 		return nil, err
 	}
 	if shows.stack {
-		if c.stackName, err = promptStackName(args.stdout, b, args.prompt, c.stackName, false, opts); err != nil {
+		if c.stackName, err = promptStackName(
+			args.stdout, b, args.prompt, c.stackName, false, opts, b.ValidateStackName,
+		); err != nil {
 			return nil, err
 		}
 		if err = c.repromptConfig(template, args, opts); err != nil {
@@ -255,6 +271,68 @@ func confirmGuidedValues(
 		}
 	}
 	return c, nil
+}
+
+// avoidExistingStack asks for another stack name when the default is already taken. The answer
+// can still go stale before creation, which createStackWithRetry handles.
+func (c *confirmedNew) avoidExistingStack(
+	ctx context.Context, b backend.Backend, args newArgs, opts display.Options,
+) error {
+	org, stack := splitStackName(c.stackName)
+	taken, err := projectStackNames(ctx, b, org, c.name)
+	if err != nil || !taken[stack] {
+		// A backend that cannot list the project's stacks leaves the collision to creation time.
+		return nil
+	}
+
+	fmt.Fprintf(args.stdout, "\nStack '%s' already exists.\n", c.stackName)
+	validate := func(s string) error {
+		if err := b.ValidateStackName(s); err != nil {
+			return err
+		}
+		if _, name := splitStackName(s); taken[name] {
+			return errors.New("a stack with that name already exists in this project")
+		}
+		return nil
+	}
+	name, err := promptStackName(args.stdout, b, args.prompt, "", args.yes, opts, validate)
+	if err != nil {
+		return err
+	}
+	c.stackName, err = buildStackName(ctx, b, name)
+	return err
+}
+
+func projectStackNames(
+	ctx context.Context, b backend.Backend, orgName, projectName string,
+) (map[string]bool, error) {
+	filter := backend.ListStackNamesFilter{Project: &projectName}
+	if orgName != "" {
+		filter.Organization = &orgName
+	}
+
+	names := map[string]bool{}
+	var token backend.ContinuationToken
+	for {
+		refs, next, err := b.ListStackNames(ctx, filter, token)
+		if err != nil {
+			return nil, err
+		}
+		for _, ref := range refs {
+			names[ref.Name().String()] = true
+		}
+		if next == nil {
+			return names, nil
+		}
+		token = next
+	}
+}
+
+func splitStackName(stackName string) (string, string) {
+	if i := strings.LastIndex(stackName, "/"); i >= 0 {
+		return stackName[:i], stackName[i+1:]
+	}
+	return "", stackName
 }
 
 // resolveConfigDefaults resolves defaults under the project name chosen so far, including any key

--- a/pkg/cmd/pulumi/project/newcmd/confirm_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/confirm_test.go
@@ -168,6 +168,11 @@ func guidedNewTestBackend(t *testing.T) (b *backend.MockBackend, created *[]stri
 	b.GetStackF = func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
 		return nil, nil
 	}
+	b.ListStackNamesF = func(ctx context.Context, filter backend.ListStackNamesFilter,
+		token backend.ContinuationToken,
+	) ([]backend.StackReference, backend.ContinuationToken, error) {
+		return nil, nil, nil
+	}
 	b.GetLatestConfigurationF = func(ctx context.Context, s backend.Stack) (backend.LatestConfiguration, error) {
 		return backend.LatestConfiguration{}, backenderr.ErrNoPreviousDeployment
 	}
@@ -506,7 +511,7 @@ template:
 }
 
 //nolint:paralleltest // changes directory for process, mocks login manager
-func TestGuidedNewCollidingDefaultNameFallsThrough(t *testing.T) {
+func TestGuidedNewCollidingDefaultNameAsksThenConfirms(t *testing.T) {
 	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
 	tempdir := tempProjectDir(t)
 	t.Chdir(tempdir)
@@ -518,9 +523,7 @@ func TestGuidedNewCollidingDefaultNameFallsThrough(t *testing.T) {
 	}
 	mockCurrentBackend(t, b)
 
-	// selects: "AWS", "Python" — and nothing else: scriptedSelect fails the test on an
-	// unexpected confirmation select, proving the flow fell through to sequential prompts.
-	selectOne, _ := scriptedSelect(t, "AWS", "Python")
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", confirmYes)
 	var prompts []string
 	var out, errOut bytes.Buffer
 	args := newArgs{
@@ -537,11 +540,57 @@ func TestGuidedNewCollidingDefaultNameFallsThrough(t *testing.T) {
 	err := runNew(t.Context(), args)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, prompts)
-	assert.Equal(t, "Project name="+defaultName, prompts[0],
-		"the sequential prompts must run, starting with the project name")
-	assert.NotContains(t, out.String(), "Project name:  ")
+	assert.Equal(t, []string{"Project name=" + defaultName}, prompts,
+		"an unusable default name is the only thing asked before the block")
+	assert.Contains(t, out.String(), "Project name:  fresh-name",
+		"the block confirms the name that was just chosen")
+	assert.Contains(t, out.String(), "Stack name:    my-org/dev")
 	require.Equal(t, []string{"my-org/dev"}, *created)
-	assert.Contains(t, errOut.String(), "Created stack 'my-org/dev'",
-		"the sequential fallback announces the created stack")
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewExistingStackNameAsksBeforeBlock(t *testing.T) {
+	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	var listedProjects []string
+	b.ListStackNamesF = func(ctx context.Context, filter backend.ListStackNamesFilter,
+		token backend.ContinuationToken,
+	) ([]backend.StackReference, backend.ContinuationToken, error) {
+		require.NotNil(t, filter.Project)
+		listedProjects = append(listedProjects, *filter.Project)
+		return []backend.StackReference{
+			&backend.MockStackReference{NameV: tokens.MustParseStackName("dev")},
+		}, nil, nil
+	}
+	mockCurrentBackend(t, b)
+
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", confirmYes)
+	var prompts []string
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive: true,
+		// A name given up front can name a project that already has stacks, so the default
+		// stack name is checked before the block proposes it.
+		name:                 "my-project",
+		prompt:               countingPrompt(map[string]string{"Stack name": "prod"}, &prompts),
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"my-project"}, listedProjects)
+	assert.Equal(t, []string{"Stack name="}, prompts,
+		"a taken stack name is asked for before the block, with no default to accept")
+	assert.Contains(t, out.String(), "Stack 'my-org/dev' already exists.")
+	assert.Contains(t, out.String(), "Stack name:    my-org/prod")
+	require.Equal(t, []string{"my-org/prod"}, *created)
 }

--- a/pkg/cmd/pulumi/project/newcmd/confirm_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/confirm_test.go
@@ -1,0 +1,547 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"iter"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/registry"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func TestAskConfirmationRendersBlock(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	opts := display.Options{Color: colors.Never, Stdout: &out}
+	sel, offered := scriptedSelect(t, confirmYes)
+
+	ok, err := askConfirmation(&out, opts, sel, []field{
+		{"Project name", "my-project"},
+		{"Description", "A minimal AWS TypeScript Pulumi program"},
+		{"Stack name", "my-org/dev"},
+	}, []field{{"aws:region", "us-east-1"}})
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Equal(t,
+		"\n"+
+			"Project name:  my-project\n"+
+			"Description:   A minimal AWS TypeScript Pulumi program\n"+
+			"Stack name:    my-org/dev\n"+
+			"Config:\n"+
+			"  aws:region:  us-east-1\n",
+		out.String())
+	require.Len(t, *offered, 1)
+	assert.Equal(t, []string{confirmYes, confirmChange}, (*offered)[0])
+}
+
+func TestAskConfirmationOmitsEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	opts := display.Options{Color: colors.Never, Stdout: &out}
+	sel, _ := scriptedSelect(t, confirmChange)
+
+	ok, err := askConfirmation(&out, opts, sel, []field{{"Project name", "p"}}, nil)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.NotContains(t, out.String(), "Config:")
+}
+
+// runtimeOptionsNone is a promptRuntimeOptions that reports no additional runtime options,
+// hoisted so the guided confirmation flow tests below don't each redefine it.
+func runtimeOptionsNone(ctx *plugin.Context, language plugin.LanguageRuntime, info *workspace.ProjectRuntimeInfo,
+	main string, opts display.Options, yes, interactive bool, prompt promptForValueFunc,
+) (map[string]any, error) {
+	return nil, nil
+}
+
+// countingPrompt answers prompts from a map by valueType, falling back to the default,
+// and records every prompt it is asked.
+func countingPrompt(answers map[string]string, log *[]string) promptForValueFunc {
+	return func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		*log = append(*log, valueType+"="+defaultValue)
+		value, ok := answers[valueType]
+		if !ok {
+			value = defaultValue
+		}
+		if isValidFn != nil {
+			if err := isValidFn(value); err != nil {
+				return "", err
+			}
+		}
+		return value, nil
+	}
+}
+
+// guidedRepoTemplate points the template source at a local one-template repo whose Pulumi.yaml is
+// the given body, mirroring useLocalTemplateRepo but for a single template with a custom body (the
+// guided confirmation tests need a template that declares its own config block).
+func guidedRepoTemplate(t *testing.T, name, body string) {
+	t.Helper()
+
+	repo := t.TempDir()
+	writeLocalTemplate(t, repo, name, body)
+	git := func(cliArgs ...string) {
+		cmd := exec.Command("git", cliArgs...)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", cliArgs, out)
+	}
+	git("init", "--initial-branch=master")
+	git("add", ".")
+	git("-c", "user.name=test", "-c", "user.email=test@example.com", "-c", "commit.gpgsign=false",
+		"commit", "-m", "init")
+	t.Setenv(env.TemplateGitRepository.Var().Name(), repo)
+	t.Setenv(env.TemplateBranch.Var().Name(), "master")
+	t.Setenv(env.TemplatePath.Var().Name(), filepath.Join(t.TempDir(), "templates"))
+}
+
+// guidedConfigTemplateYAML is the template body shared by the guided confirmation flow tests: a
+// runtime with no install-time dependencies (so the full, non-generate-only flow stays offline),
+// and one config key with a default so the "accept" path never has to prompt for it.
+const guidedConfigTemplateYAML = `name: ${PROJECT}
+description: ${DESCRIPTION}
+runtime: yaml
+template:
+  description: A guided test template
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-east-1
+`
+
+// guidedNewTestBackend builds the mock backend the guided confirmation flow tests share: an
+// org-backed backend whose stack creation, secrets manager, and config-save calls all resolve
+// locally so the whole runNew flow runs offline. created records every stack name CreateStack saw.
+func guidedNewTestBackend(t *testing.T) (b *backend.MockBackend, created *[]string) {
+	t.Helper()
+
+	created = &[]string{}
+	b = stackCreationBackend(t, 0, created)
+	b.GetDefaultOrgF = func(ctx context.Context) (string, error) { return "my-org", nil }
+	b.SupportsOrganizationsF = func() bool { return true }
+	b.DoesProjectExistF = func(ctx context.Context, org, name string) (bool, error) { return false, nil }
+	b.NameF = func() string { return "mock" }
+	b.URLF = func() string { return "mock://guided" }
+	b.SetCurrentProjectF = func(proj *workspace.Project) {}
+	b.GetStackF = func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+		return nil, nil
+	}
+	b.GetLatestConfigurationF = func(ctx context.Context, s backend.Stack) (backend.LatestConfiguration, error) {
+		return backend.LatestConfiguration{}, backenderr.ErrNoPreviousDeployment
+	}
+	b.ParseStackReferenceF = func(s string) (backend.StackReference, error) {
+		parts := strings.Split(s, "/")
+		return &backend.MockStackReference{
+			NameV:               tokens.MustParseStackName(parts[len(parts)-1]),
+			StringV:             s,
+			FullyQualifiedNameV: tokens.QName(s),
+		}, nil
+	}
+	mockSecretsManager := func(ctx context.Context, ps *workspace.ProjectStack) (secrets.Manager, error) {
+		return &secrets.MockSecretsManager{
+			TypeF:  func() string { return "mock" },
+			StateF: func() json.RawMessage { return nil },
+			EncrypterF: func() config.Encrypter {
+				// A non-identity transform: tests that read the saved YAML back can tell a
+				// secure value apart from its plaintext (unlike an identity "encrypter", the
+				// ciphertext never contains the plaintext as a substring).
+				return &secrets.MockEncrypter{EncryptValueF: func(s string) string {
+					return base64.StdEncoding.EncodeToString([]byte(s))
+				}}
+			},
+			DecrypterF: func() config.Decrypter {
+				return &secrets.MockDecrypter{DecryptValueF: func(s string) string {
+					plain, err := base64.StdEncoding.DecodeString(s)
+					if err != nil {
+						return s
+					}
+					return string(plain)
+				}}
+			},
+		}, nil
+	}
+	b.CreateStackF = func(ctx context.Context, ref backend.StackReference, root string,
+		initialState *apitype.UntypedDeployment, opts *backend.CreateStackOptions,
+	) (backend.Stack, error) {
+		*created = append(*created, ref.String())
+		return &backend.MockStack{
+			RefF:                  func() backend.StackReference { return ref },
+			BackendF:              func() backend.Backend { return b },
+			SnapshotF:             func(ctx context.Context, sp secrets.Provider) (*deploy.Snapshot, error) { return nil, nil },
+			DefaultSecretManagerF: mockSecretsManager,
+		}, nil
+	}
+	b.GetReadOnlyCloudRegistryF = func() registry.Registry {
+		return &backend.MockCloudRegistry{Mock: registry.Mock{
+			ListTemplatesF: func(ctx context.Context, opts registry.ListTemplatesOptions,
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return singlePage()
+			},
+		}}
+	}
+	return b, created
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewAcceptSkipsAllPrompts(t *testing.T) {
+	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	mockCurrentBackend(t, b)
+
+	var prompts []string
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", confirmYes)
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive: true,
+		// aws:profile isn't declared by the template's config block at all: it must still
+		// reach the saved stack config, alongside the declared aws:region.
+		configArray:          []string{"aws:profile=work"},
+		prompt:               countingPrompt(nil, &prompts),
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	assert.Empty(t, prompts, "accepting the block must not prompt for anything")
+	require.Equal(t, []string{"my-org/dev"}, *created)
+	assert.NotContains(t, errOut.String(), "Created stack", "guided stack creation must run quiet")
+	assert.Contains(t, out.String(), "Stack name:    my-org/dev")
+	assert.Contains(t, out.String(), "aws:region:  us-east-1")
+	assert.NotContains(t, out.String(), "Created project")
+	assert.Contains(t, out.String(), "Project name:  "+filepath.Base(tempdir))
+	assert.Contains(t, out.String(), "Stack name:    my-org/dev")
+	proj := loadProject(t, tempdir)
+	assert.Equal(t, "A guided test template", *proj.Description)
+
+	projStack, err := workspace.LoadProjectStack(nil /*sink*/, proj, filepath.Join(tempdir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	region, ok := projStack.Config[config.MustMakeKey("aws", "region")]
+	require.True(t, ok, "the declared key with a default must still be saved")
+	regionValue, err := region.Value(config.NopDecrypter)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", regionValue)
+	profile, ok := projStack.Config[config.MustMakeKey("aws", "profile")]
+	require.True(t, ok, "a --config key the template doesn't declare must not be dropped")
+	profileValue, err := profile.Value(config.NopDecrypter)
+	require.NoError(t, err)
+	assert.Equal(t, "work", profileValue)
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewConfirmationInterruptIsFriendly(t *testing.T) {
+	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	mockCurrentBackend(t, b)
+
+	// selects: "AWS", "Python" — then Ctrl-C at the confirmation itself.
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", terminal.InterruptErr)
+	var out bytes.Buffer
+	args := newArgs{
+		interactive:          true,
+		prompt:               ui.PromptForValue,
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+	}
+
+	err := runNew(t.Context(), args)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errConfirmationInterrupted)
+	assert.Empty(t, *created, "Ctrl-C at the confirmation must not create a stack")
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewDeclineRepromptsPrefilled(t *testing.T) {
+	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	mockCurrentBackend(t, b)
+
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", confirmChange)
+	var prompts []string
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive:          true,
+		prompt:               countingPrompt(map[string]string{"Stack name": "prod"}, &prompts),
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"Project name=" + filepath.Base(tempdir),
+		"Project description=A guided test template",
+		"Stack name=my-org/dev",
+		"The AWS region to deploy into (aws:region)=us-east-1",
+	}, prompts, "every reprompt must be pre-filled with the value the block just showed")
+	assert.Equal(t, []string{"my-org/prod"}, *created, "a bare typed name still org-resolves")
+	assert.NotContains(t, errOut.String(), "Created stack", "guided stack creation must run quiet even after decline")
+
+	proj := loadProject(t, tempdir)
+	projStack, err := workspace.LoadProjectStack(nil /*sink*/, proj, filepath.Join(tempdir, "Pulumi.prod.yaml"))
+	require.NoError(t, err)
+	region, ok := projStack.Config[config.MustMakeKey("aws", "region")]
+	require.True(t, ok, "the pre-filled config value must still land once re-confirmed")
+	regionValue, err := region.Value(config.NopDecrypter)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", regionValue)
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewDeclineDoesNotReofferFlagConfig(t *testing.T) {
+	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	mockCurrentBackend(t, b)
+
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", confirmChange)
+	var prompts []string
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive: true,
+		// aws:region has a template default of us-east-1, but a --config value wins:
+		// it must show in the block and never be re-offered on decline.
+		configArray:          []string{"aws:region=eu-west-1"},
+		prompt:               countingPrompt(nil, &prompts),
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), "aws:region:  eu-west-1", "the block must show the flag value")
+	assert.Equal(t, []string{
+		"Project name=" + filepath.Base(tempdir),
+		"Project description=A guided test template",
+		"Stack name=my-org/dev",
+	}, prompts, "a key fixed by --config must never be re-prompted, on decline or otherwise")
+	require.Equal(t, []string{"my-org/dev"}, *created)
+	assert.NotContains(t, errOut.String(), "Created stack", "guided stack creation must run quiet")
+
+	proj := loadProject(t, tempdir)
+	projStack, err := workspace.LoadProjectStack(nil /*sink*/, proj, filepath.Join(tempdir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	region, ok := projStack.Config[config.MustMakeKey("aws", "region")]
+	require.True(t, ok)
+	regionValue, err := region.Value(config.NopDecrypter)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-west-1", regionValue)
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewNoDefaultConfigAskedBeforeBlock(t *testing.T) {
+	const noDefaultConfigTemplateYAML = `name: ${PROJECT}
+description: ${DESCRIPTION}
+runtime: yaml
+template:
+  description: A guided GCP test template
+  config:
+    gcp:project:
+      description: The Google Cloud project to deploy into
+`
+	guidedRepoTemplate(t, "gcp-python", noDefaultConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	mockCurrentBackend(t, b)
+
+	selectOne, _ := scriptedSelect(t, "Google Cloud", "Python", confirmYes)
+	var prompts []string
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive: true,
+		prompt: countingPrompt(map[string]string{
+			"The Google Cloud project to deploy into (gcp:project)": "proj-123",
+		}, &prompts),
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"The Google Cloud project to deploy into (gcp:project)="}, prompts,
+		"a key with no default must be prompted for with an empty default, before the block")
+	assert.Contains(t, out.String(), "gcp:project:  proj-123")
+	require.Equal(t, []string{"my-org/dev"}, *created)
+	assert.NotContains(t, errOut.String(), "Created stack", "guided stack creation must run quiet")
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewSecretConfigIsMaskedAndEncrypted(t *testing.T) {
+	const secretConfigTemplateYAML = `name: ${PROJECT}
+description: ${DESCRIPTION}
+runtime: yaml
+template:
+  description: A guided secret test template
+  config:
+    github:token:
+      description: The GitHub token to use
+      secret: true
+`
+	guidedRepoTemplate(t, "aws-python", secretConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	mockCurrentBackend(t, b)
+
+	selectOne, _ := scriptedSelect(t, "AWS", "Python", confirmYes)
+	var secretFlags []bool
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		secretFlags = append(secretFlags, secret)
+		if valueType == "The GitHub token to use (github:token)" {
+			return "tok_secret_value", nil
+		}
+		return defaultValue, nil
+	}
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive:          true,
+		prompt:               prompt,
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	require.Len(t, secretFlags, 1, "only the key with no default is prompted for, before the block")
+	assert.True(t, secretFlags[0], "the pre-block prompt for a secret key must be marked secret")
+	assert.Contains(t, out.String(), "github:token:  [secret]", "the block must mask the secret value, not show it")
+	assert.NotContains(t, out.String(), "tok_secret_value", "the plaintext secret must never reach the block")
+	require.Equal(t, []string{"my-org/dev"}, *created)
+	assert.NotContains(t, errOut.String(), "Created stack", "guided stack creation must run quiet")
+
+	rawYAML, err := os.ReadFile(filepath.Join(tempdir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(rawYAML), "tok_secret_value",
+		"the saved stack config must never store the secret in plaintext")
+	encrypted := base64.StdEncoding.EncodeToString([]byte("tok_secret_value"))
+	assert.Contains(t, string(rawYAML), "secure: "+encrypted,
+		"the saved stack config must mark the value secure (encrypted via the test secrets manager)")
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestGuidedNewCollidingDefaultNameFallsThrough(t *testing.T) {
+	guidedRepoTemplate(t, "aws-python", guidedConfigTemplateYAML)
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+	defaultName := filepath.Base(tempdir)
+
+	b, created := guidedNewTestBackend(t)
+	b.DoesProjectExistF = func(ctx context.Context, org, name string) (bool, error) {
+		return name == defaultName, nil
+	}
+	mockCurrentBackend(t, b)
+
+	// selects: "AWS", "Python" — and nothing else: scriptedSelect fails the test on an
+	// unexpected confirmation select, proving the flow fell through to sequential prompts.
+	selectOne, _ := scriptedSelect(t, "AWS", "Python")
+	var prompts []string
+	var out, errOut bytes.Buffer
+	args := newArgs{
+		interactive:          true,
+		prompt:               countingPrompt(map[string]string{"Project name": "fresh-name"}, &prompts),
+		promptRuntimeOptions: runtimeOptionsNone,
+		languageTemplate:     languageTemplateMock,
+		selectOne:            selectOne,
+		secretsProvider:      "default",
+		stdout:               &out,
+		stderr:               &errOut,
+	}
+
+	err := runNew(t.Context(), args)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, prompts)
+	assert.Equal(t, "Project name="+defaultName, prompts[0],
+		"the sequential prompts must run, starting with the project name")
+	assert.NotContains(t, out.String(), "Project name:  ")
+	require.Equal(t, []string{"my-org/dev"}, *created)
+	assert.Contains(t, errOut.String(), "Created stack 'my-org/dev'",
+		"the sequential fallback announces the created stack")
+}

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -48,6 +48,7 @@ import (
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -272,57 +273,17 @@ func runNew(ctx context.Context, args newArgs) error {
 		args.name = projectName
 	}
 
-	// Show instructions, if we're going to show at least one prompt.
-	hasAtLeastOnePrompt := (args.name == "") || (args.description == "") || (!args.generateOnly && args.stack == "")
-	if !args.yes && hasAtLeastOnePrompt {
-		fmt.Fprintln(args.stdout, "This command will walk you through creating a new Pulumi project.")
-		fmt.Fprintln(args.stdout)
-		fmt.Fprintln(args.stdout,
-			opts.Color.Colorize(
-				colors.Highlight("Enter a value or leave blank to accept the (default), and press <ENTER>.",
-					"<ENTER>", colors.BrightCyan+colors.Bold),
-			))
-		fmt.Fprintln(args.stdout,
-			opts.Color.Colorize(
-				colors.Highlight("Press ^C at any time to quit.", "^C", colors.BrightCyan+colors.Bold),
-			))
-		fmt.Fprintln(args.stdout)
+	defaults := resolveProjectDefaults(ctx, b, orgName, template, args, opts, cwd)
+	confirmed, err := confirmGuidedValues(ctx, b, orgName, defaults, template, args, opts)
+	if err != nil {
+		return err
 	}
-
-	// Prompt for the project name, if it wasn't already specified.
-	if args.name == "" {
-		defaultValue := pkgWorkspace.ValueOrSanitizedDefaultProjectName(args.name, template.ProjectName, filepath.Base(cwd))
-		err := validateProjectName(
-			ctx, b, orgName, defaultValue, args.generateOnly, opts.WithIsInteractive(false),
-		)
-		if err != nil {
-			// If --yes is given error out now that the default value is invalid. If we allow prompt to catch
-			// this case it can lead to a confusing error message because we set the defaultValue to "" below.
-			// See https://github.com/pulumi/pulumi/issues/8747.
-			if args.yes {
-				return fmt.Errorf("'%s' is not a valid project name. %w", defaultValue, err)
-			}
-		}
-		validate := func(s string) error {
-			return validateProjectName(ctx, b, orgName, s, args.generateOnly, opts)
-		}
-		args.name, err = args.prompt(args.yes, "Project name", defaultValue, false, validate, opts)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Prompt for the project description, if it wasn't already specified.
-	if args.description == "" {
-		defaultValue := pkgWorkspace.ValueOrDefaultProjectDescription(
-			args.description, template.ProjectDescription, template.Description,
-		)
-		args.description, err = args.prompt(
-			args.yes, "Project description", defaultValue, false, pkgWorkspace.ValidateProjectDescription, opts,
-		)
-		if err != nil {
-			return err
-		}
+	if confirmed != nil {
+		args.name, args.description = confirmed.name, confirmed.description
+	} else if args.name, args.description, err = promptSequentialValues(
+		ctx, b, orgName, defaults, args, opts,
+	); err != nil {
+		return err
 	}
 
 	// Actually copy the files.
@@ -333,8 +294,10 @@ func runNew(ctx context.Context, args newArgs) error {
 		return err
 	}
 
-	fmt.Fprintf(args.stdout, "Created project '%s'\n", args.name)
-	fmt.Fprintln(args.stdout)
+	if confirmed == nil {
+		fmt.Fprintf(args.stdout, "Created project '%s'\n", args.name)
+		fmt.Fprintln(args.stdout)
+	}
 
 	// Load the project, update the name & description, remove the template section, and save it.
 	proj, root, err := ws.ReadProject("")
@@ -381,14 +344,12 @@ func runNew(ctx context.Context, args newArgs) error {
 	}
 
 	// Create the stack, if needed.
+	var createdStackName string
 	if !args.generateOnly && s == nil {
-		if s, err = PromptAndCreateStack(ctx, cmdutil.Diag(), ws, b, args.prompt,
-			args.stack, root, true /*setCurrent*/, args.yes, opts, args.secretsProvider,
-			args.remoteStackConfig, ""); err != nil {
+		sink := diag.DefaultSink(args.stderr, args.stderr, diag.FormatOptions{Color: opts.Color})
+		if s, createdStackName, err = confirmed.createStack(ctx, sink, ws, b, root, args, opts); err != nil {
 			return err
 		}
-		// cmdStack.CreateStack prints "Created stack '<stack>'" on success.
-		fmt.Fprintln(args.stdout)
 	}
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
@@ -457,23 +418,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// Prompt for config values (if needed) and save.
 	if !args.generateOnly {
-		err = HandleConfig(
-			ctx,
-			cmdutil.Diag(),
-			ssml,
-			ws,
-			args.prompt,
-			proj,
-			s,
-			args.templateNameOrURL,
-			template,
-			args.configArray,
-			args.yes,
-			args.configPath,
-			opts,
-			"",
-		)
-		if err != nil {
+		if err = confirmed.saveConfig(ctx, cmdutil.Diag(), ssml, ws, proj, s, template, args, opts); err != nil {
 			return err
 		}
 	}
@@ -508,6 +453,16 @@ func runNew(ctx context.Context, args newArgs) error {
 		)+
 			" "+cmdutil.EmojiOr("✨", ""))
 	fmt.Fprintln(args.stdout)
+
+	if confirmed != nil {
+		// Any other stack announced itself as it was created, or already existed.
+		rows := []field{{"Project name", args.name}}
+		if createdStackName != "" {
+			rows = append(rows, field{"Stack name", createdStackName})
+		}
+		printFields(args.stdout, opts.Color, "    ", rows)
+		fmt.Fprintln(args.stdout)
+	}
 
 	// Print out next steps.
 	printNextSteps(args.stdout, proj, originalCwd, cwd, args.generateOnly, opts)

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -897,7 +897,7 @@ func TestPulumiNewSetsTemplateTag(t *testing.T) {
 			remote:   true,
 		},
 		{
-			answers:  []any{"Basic Pulumi Program", "Python"},
+			answers:  []any{"Basic Pulumi Program", "Python", confirmYes},
 			expected: "python",
 		},
 	}

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -77,7 +77,8 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		return createStack(ctx, sink, ws, b, stack, root, createOpts)
 	}
 
-	stackName, err := promptStackName(os.Stdout, b, prompt, defaultStackName, yes, opts) //nolint:forbidigo
+	stackName, err := promptStackName(os.Stdout, b, prompt, //nolint:forbidigo
+		defaultStackName, yes, opts, b.ValidateStackName)
 	if err != nil {
 		return nil, err
 	}
@@ -90,14 +91,14 @@ const defaultStackName = "dev"
 
 func promptStackName(
 	w io.Writer, b backend.Backend, prompt promptForValueFunc, defaultName string,
-	yes bool, opts display.Options,
+	yes bool, opts display.Options, validate func(string) error,
 ) (string, error) {
 	if b.SupportsOrganizations() {
 		fmt.Fprint(w, "Please enter your desired stack name.\n"+
 			"To create a stack in an organization, "+
 			"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
 	}
-	return prompt(yes, "Stack name", defaultName, false, b.ValidateStackName, opts)
+	return prompt(yes, "Stack name", defaultName, false, validate, opts)
 }
 
 func createStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b backend.Backend,

--- a/pkg/cmd/pulumi/project/newcmd/template.go
+++ b/pkg/cmd/pulumi/project/newcmd/template.go
@@ -71,10 +71,17 @@ func (args newArgs) useGuidedFlow() bool {
 func declinedToChoose(
 	template cmdTemplates.Template, err error,
 ) (cmdTemplates.Template, error) {
-	if errors.Is(err, terminal.InterruptErr) {
-		return nil, errNoTemplateSelected
+	if err := friendlyInterrupt(err, errNoTemplateSelected); err != nil {
+		return nil, err
 	}
-	return template, err
+	return template, nil
+}
+
+func friendlyInterrupt(err, friendly error) error {
+	if errors.Is(err, terminal.InterruptErr) {
+		return friendly
+	}
+	return err
 }
 
 func resolveTemplate(


### PR DESCRIPTION
## What

Guided interactive `pulumi new` shows the proposed project name, description, stack name, and resolved config in a single confirmation block and asks `Do these look good?`, instead of prompting for each value one question at a time.

https://github.com/user-attachments/assets/3a5c2226-96af-4526-a48f-2dac244e354a

## Why

Nearly every prompt in the guided flow has a sensible default, so the common path is pressing Enter repeatedly. One confirmation lets that path finish in a single keystroke while keeping every value editable for anyone who wants to change something.

## How

The flow lives in `confirm.go` as a `confirmedNew` value. Accepting creates the project immediately; choosing `Change these values` re-runs the familiar sequential prompts, pre-filled with the values just shown (config keys declared without a namespace are re-resolved if the project name changes). The guided path is gated on no template argument, no `--yes`, and an interactive terminal — outside that, and when the default project name is unusable, the sequential prompts own the run unchanged, so scripted and CI usage is untouched. Stack creation and config save go through the same code as the sequential flow, quieted only where the confirmation already showed the value, and Ctrl-C at the confirmation exits with a friendly message.

The `TestGuidedNew*` suite covers accepting (no further prompts), declining (pre-filled re-prompts), `--config`-fixed keys never re-asked, secret config masked and encrypted, no-default config asked before the block, friendly interrupt, and fall-through on a colliding default name.

## References

- Builds on #24320 (config-prompting and stack-creation refactor) and #24280 (`Quiet` stack creation), both merged



