### PR TITLE
Yield template listings by page and let callers filter by backing

### DIFF
--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -58,7 +58,7 @@ func (r registryClient) GetPackage(
 
 func (r registryClient) ListTemplates(
 	ctx context.Context, opts registry.ListTemplatesOptions,
-) iter.Seq2[apitype.TemplateMetadata, error] {
+) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	return r.c.ListTemplates(ctx, opts)
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -3435,7 +3435,7 @@ func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apit
 
 func (pc *Client) ListTemplates(
 	ctx context.Context, opts registry.ListTemplatesOptions,
-) iter.Seq2[apitype.TemplateMetadata, error] {
+) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	query := url.Values{}
 	query.Set("limit", "499")
 	if opts.Name != "" {
@@ -3447,9 +3447,12 @@ func (pc *Client) ListTemplates(
 	if opts.Search != "" {
 		query.Set("search", opts.Search)
 	}
+	for _, backing := range opts.Backing {
+		query.Add("backing", string(backing))
+	}
 
 	var continuationToken *string
-	return func(f func(apitype.TemplateMetadata, error) bool) {
+	return func(f func(apitype.ListTemplatesResponse, error) bool) {
 		for {
 			pageQuery := query
 			if continuationToken != nil {
@@ -3461,13 +3464,11 @@ func (pc *Client) ListTemplates(
 			var resp apitype.ListTemplatesResponse
 			err := pc.restCall(ctx, "GET", "/api/registry/templates?"+pageQuery.Encode(), nil, nil, &resp)
 			if err != nil {
-				f(apitype.TemplateMetadata{}, err)
+				f(apitype.ListTemplatesResponse{}, err)
 				return
 			}
-			for _, v := range resp.Templates {
-				if !f(v, nil) {
-					return
-				}
+			if !f(resp, nil) {
+				return
 			}
 			continuationToken = resp.ContinuationToken
 			if continuationToken == nil {

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -691,9 +691,9 @@ func TestListTemplates(t *testing.T) {
 		// Call ListTemplates and collect results
 		//nolint:prealloc // capacity unknown ahead of time
 		searchResults := []apitype.TemplateMetadata{}
-		for tmpl, err := range mockClient.ListTemplates(
+		for tmpl, err := range registry.Templates(mockClient.ListTemplates(
 			t.Context(), registry.ListTemplatesOptions{Name: "my-template"},
-		) {
+		)) {
 			require.NoError(t, err)
 			searchResults = append(searchResults, tmpl)
 		}
@@ -790,9 +790,9 @@ func TestListTemplates(t *testing.T) {
 
 		//nolint:prealloc // capacity unknown ahead of time
 		searchResults := []apitype.TemplateMetadata{}
-		for tmpl, err := range mockClient.ListTemplates(
+		for tmpl, err := range registry.Templates(mockClient.ListTemplates(
 			t.Context(), registry.ListTemplatesOptions{Name: "my-template"},
-		) {
+		)) {
 			require.NoError(t, err)
 			searchResults = append(searchResults, tmpl)
 		}

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -64,7 +64,7 @@ func (r *cloudRegistry) GetPackage(
 
 func (r *cloudRegistry) ListTemplates(
 	ctx ctx.Context, opts registry.ListTemplatesOptions,
-) iter.Seq2[apitype.TemplateMetadata, error] {
+) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	return r.cl.ListTemplates(ctx, opts)
 }
 

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -471,8 +471,8 @@ func TestInvalidTemplateName(t *testing.T) {
 					Mock: registry.Mock{
 						ListTemplatesF: func(
 							ctx context.Context, opts registry.ListTemplatesOptions,
-						) iter.Seq2[apitype.TemplateMetadata, error] {
-							return func(yield func(apitype.TemplateMetadata, error) bool) {}
+						) iter.Seq2[apitype.ListTemplatesResponse, error] {
+							return singlePage()
 						},
 					},
 				}
@@ -620,8 +620,8 @@ func TestValidateStackRefAndProjectName(t *testing.T) {
 				Mock: registry.Mock{
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
-					) iter.Seq2[apitype.TemplateMetadata, error] {
-						return func(yield func(apitype.TemplateMetadata, error) bool) {}
+					) iter.Seq2[apitype.ListTemplatesResponse, error] {
+						return singlePage()
 					},
 				},
 			}
@@ -698,8 +698,8 @@ func TestProjectExists(t *testing.T) {
 				Mock: registry.Mock{
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
-					) iter.Seq2[apitype.TemplateMetadata, error] {
-						return func(yield func(apitype.TemplateMetadata, error) bool) {}
+					) iter.Seq2[apitype.ListTemplatesResponse, error] {
+						return singlePage()
 					},
 				},
 			}
@@ -850,8 +850,8 @@ func TestPulumiNewConflictingProject(t *testing.T) {
 				Mock: registry.Mock{
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
-					) iter.Seq2[apitype.TemplateMetadata, error] {
-						return func(yield func(apitype.TemplateMetadata, error) bool) {}
+					) iter.Seq2[apitype.ListTemplatesResponse, error] {
+						return singlePage()
 					},
 				},
 			}
@@ -918,8 +918,8 @@ func TestPulumiNewSetsTemplateTag(t *testing.T) {
 							Mock: registry.Mock{
 								ListTemplatesF: func(
 									ctx context.Context, opts registry.ListTemplatesOptions,
-								) iter.Seq2[apitype.TemplateMetadata, error] {
-									return func(yield func(apitype.TemplateMetadata, error) bool) {}
+								) iter.Seq2[apitype.ListTemplatesResponse, error] {
+									return singlePage()
 								},
 							},
 						}
@@ -1060,8 +1060,8 @@ func TestPulumiNewWithOrgTemplates(t *testing.T) {
 				Mock: registry.Mock{
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
-					) iter.Seq2[apitype.TemplateMetadata, error] {
-						return func(yield func(apitype.TemplateMetadata, error) bool) {}
+					) iter.Seq2[apitype.ListTemplatesResponse, error] {
+						return singlePage()
 					},
 				},
 			}
@@ -1104,6 +1104,13 @@ Available Templates:
 
 func ptr[T any](v T) *T { return &v }
 
+// singlePage answers a template listing with one page holding the given templates.
+func singlePage(templates ...apitype.TemplateMetadata) iter.Seq2[apitype.ListTemplatesResponse, error] {
+	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+		yield(apitype.ListTemplatesResponse{Templates: templates}, nil)
+	}
+}
+
 //nolint:paralleltest // Sets a mock login manager
 func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_REGISTRY_RESOLVE", "false")
@@ -1112,19 +1119,12 @@ func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
-					if !yield(apitype.TemplateMetadata{
-						Name: "template-1", Description: ptr("Describe 1"), Publisher: "Some org",
-					}, nil) {
-						return
-					}
-					if !yield(apitype.TemplateMetadata{
-						Name: "template-2", Description: ptr("Describe 2"), RepoSlug: ptr("some-org/repo"), Source: "github",
-					}, nil) {
-						return
-					}
-				}
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return singlePage(apitype.TemplateMetadata{
+					Name: "template-1", Description: ptr("Describe 1"), Publisher: "Some org",
+				}, apitype.TemplateMetadata{
+					Name: "template-2", Description: ptr("Describe 2"), RepoSlug: ptr("some-org/repo"), Source: "github",
+				})
 			},
 		},
 	}
@@ -1209,9 +1209,9 @@ func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
 				Mock: registry.Mock{
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
-					) iter.Seq2[apitype.TemplateMetadata, error] {
+					) iter.Seq2[apitype.ListTemplatesResponse, error] {
 						assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-						return func(yield func(apitype.TemplateMetadata, error) bool) {}
+						return singlePage()
 					},
 				},
 			}
@@ -1296,8 +1296,8 @@ resources:
 				Mock: registry.Mock{
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
-					) iter.Seq2[apitype.TemplateMetadata, error] {
-						return func(yield func(apitype.TemplateMetadata, error) bool) {}
+					) iter.Seq2[apitype.ListTemplatesResponse, error] {
+						return singlePage()
 					},
 				},
 			}

--- a/pkg/cmd/pulumi/templatecmd/template_list.go
+++ b/pkg/cmd/pulumi/templatecmd/template_list.go
@@ -114,11 +114,11 @@ func (c *templateListCmd) Run(ctx context.Context, out io.Writer, args templateL
 	// Pagination is handled inside the registry iterator; we collect into a slice
 	// so both renderers can take a stable, deterministic view.
 	templates := []apitype.TemplateMetadata{}
-	for tmpl, err := range reg.ListTemplates(ctx, registry.ListTemplatesOptions{
+	for tmpl, err := range registry.Templates(reg.ListTemplates(ctx, registry.ListTemplatesOptions{
 		Name:   args.name,
 		Org:    args.org,
 		Search: args.search,
-	}) {
+	})) {
 		if err != nil {
 			return fmt.Errorf("listing templates: %w", err)
 		}

--- a/pkg/cmd/pulumi/templatecmd/template_list_test.go
+++ b/pkg/cmd/pulumi/templatecmd/template_list_test.go
@@ -29,17 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// templatesFromIterable yields the given templates as a registry list iterator.
-func templatesFromIterable(templates []apitype.TemplateMetadata) iter.Seq2[apitype.TemplateMetadata, error] {
-	return func(yield func(apitype.TemplateMetadata, error) bool) {
-		for _, tmpl := range templates {
-			if !yield(tmpl, nil) {
-				return
-			}
-		}
-	}
-}
-
 // mockListRegistry stubs registry.Registry's ListTemplates and panics on every
 // other method. The test only needs ListTemplates wired up.
 type mockListRegistry struct {
@@ -53,16 +42,17 @@ func newMockListRegistry(
 	r := &mockListRegistry{}
 	r.ListTemplatesF = func(
 		_ context.Context, opts registry.ListTemplatesOptions,
-	) iter.Seq2[apitype.TemplateMetadata, error] {
+	) iter.Seq2[apitype.ListTemplatesResponse, error] {
 		if captured != nil {
 			*captured = opts
 		}
-		if err != nil {
-			return func(yield func(apitype.TemplateMetadata, error) bool) {
-				yield(apitype.TemplateMetadata{}, err)
+		return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+			if err != nil {
+				yield(apitype.ListTemplatesResponse{}, err)
+				return
 			}
+			yield(apitype.ListTemplatesResponse{Templates: templates}, nil)
 		}
-		return templatesFromIterable(templates)
 	}
 	return r
 }

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -151,7 +151,7 @@ func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateNa
 	}
 
 	matches := NewTemplateMatcher(urlInfo, templateName)
-	for template, err := range r.ListTemplates(ctx, registry.ListTemplatesOptions{}) {
+	for template, err := range registry.Templates(r.ListTemplates(ctx, registry.ListTemplatesOptions{})) {
 		if err != nil {
 			s.addError(fmt.Errorf("could not get template: %w", err))
 			return

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -46,6 +46,24 @@ import (
 const expectedRegistryFormatError = "Expected: registry://templates/source/publisher/name[@version], " +
 	"source/publisher/name[@version], publisher/name[@version], or name[@version]"
 
+// asPages presents a stream of templates as the pages a registry listing yields, one template per
+// page.
+func asPages(s iter.Seq2[apitype.TemplateMetadata, error]) iter.Seq2[apitype.ListTemplatesResponse, error] {
+	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+		for t, err := range s {
+			if err != nil {
+				if !yield(apitype.ListTemplatesResponse{}, err) {
+					return
+				}
+				continue
+			}
+			if !yield(apitype.ListTemplatesResponse{Templates: []apitype.TemplateMetadata{t}}, nil) {
+				return
+			}
+		}
+	}
+}
+
 //nolint:paralleltest // replaces global backend instance
 func TestFilterOnName(t *testing.T) {
 	template1 := &apitype.PulumiTemplateRemote{
@@ -124,9 +142,9 @@ func TestFilterOnName(t *testing.T) {
 	t.Run("org-backed-templates - disable registry resolve = false", func(t *testing.T) {
 		listTemplates := func(
 			ctx context.Context, opts registry.ListTemplatesOptions,
-		) iter.Seq2[apitype.TemplateMetadata, error] {
+		) iter.Seq2[apitype.ListTemplatesResponse, error] {
 			assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-			return func(yield func(apitype.TemplateMetadata, error) bool) {
+			return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 				if !yield(apitype.TemplateMetadata{
 					Name:      "name1",
 					Publisher: "publisher1",
@@ -141,7 +159,7 @@ func TestFilterOnName(t *testing.T) {
 				}, nil) {
 					return
 				}
-			}
+			})
 		}
 		mockBackend := &backend.MockBackend{
 			GetReadOnlyCloudRegistryF: func() registry.Registry {
@@ -303,10 +321,10 @@ func TestSurfaceListTemplateErrors_RegistryTemplates(t *testing.T) {
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 					yield(apitype.TemplateMetadata{}, somethingWentWrong)
-				}
+				})
 			},
 		},
 	}
@@ -390,8 +408,8 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				_ context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(func(apitype.TemplateMetadata, error) bool) {}
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return asPages(func(func(apitype.TemplateMetadata, error) bool) {})
 			},
 		},
 	}
@@ -561,13 +579,13 @@ func createMockRegistrySource(
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 					yield(apitype.TemplateMetadata{
 						Name:        "name1",
 						DownloadURL: "example.com/download/name",
 					}, nil)
-				}
+				})
 			},
 			DownloadTemplateF: downloadFunc,
 		},
@@ -659,9 +677,9 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
 				assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
+				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 					if !yield(apitype.TemplateMetadata{
 						Name:      "gh-org/repo/name",
 						Source:    "github",
@@ -685,7 +703,7 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 					}, nil) {
 						return
 					}
-				}
+				})
 			},
 		},
 	}
@@ -731,9 +749,9 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
 				assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
+				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 					if !yield(apitype.TemplateMetadata{
 						Name:        "gh-org/repo/target",
 						Source:      "github",
@@ -759,7 +777,7 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 					}, nil) {
 						return
 					}
-				}
+				})
 			},
 		},
 	}
@@ -823,8 +841,8 @@ func TestRegistryTemplateResolution(t *testing.T) {
 		Mock: registry.Mock{
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 					yield(apitype.TemplateMetadata{
 						Name:        "csharp-documented",
 						Source:      "private",
@@ -849,7 +867,7 @@ func TestRegistryTemplateResolution(t *testing.T) {
 						Publisher:   "test-org",
 						Description: ptr("A template with special chars"),
 					}, nil)
-				}
+				})
 			},
 		},
 	}
@@ -1047,15 +1065,15 @@ func TestVersionedTemplateResolution(t *testing.T) {
 			},
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
-			) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
+			) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
 					yield(apitype.TemplateMetadata{
 						Name:        "my-template",
 						Source:      "private",
 						Publisher:   "my-org",
 						Description: ptr("Latest version"),
 					}, nil)
-				}
+				})
 			},
 		},
 	}

--- a/pkg/registry/mock.go
+++ b/pkg/registry/mock.go
@@ -37,7 +37,7 @@ type Mock struct {
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.TemplateMetadata, error)
 
-	ListTemplatesF func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error]
+	ListTemplatesF func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error]
 
 	DownloadTemplateF func(ctx context.Context, downloadURL string) (io.ReadCloser, error)
 }
@@ -69,7 +69,7 @@ func (m Mock) GetTemplate(
 
 func (m Mock) ListTemplates(
 	ctx context.Context, opts ListTemplatesOptions,
-) iter.Seq2[apitype.TemplateMetadata, error] {
+) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	if m.ListTemplatesF == nil {
 		panic("registry.Mock.ListTemplatesF not implemented")
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -56,14 +56,17 @@ type Registry interface {
 
 	// ListTemplates retrieves registry-backed templates matching the given options.
 	//
-	// Pagination is handled by the iterator: implementations follow continuation
-	// tokens internally so callers see a single flat stream.
+	// The iterator yields one [apitype.ListTemplatesResponse] per service page:
+	// implementations follow continuation tokens internally, so callers iterate pages
+	// without managing pagination themselves. Fields that describe the request as a
+	// whole, such as [apitype.ListTemplatesResponse.VcsTemplateSourceTotals], are
+	// repeated on every page. Use [Templates] to iterate the individual templates.
 	//
 	// VCS-backed templates (those sourced from GitHub or GitLab repositories) are
 	// not returned by this method.
 	ListTemplates(
 		ctx context.Context, opts ListTemplatesOptions,
-	) iter.Seq2[apitype.TemplateMetadata, error]
+	) iter.Seq2[apitype.ListTemplatesResponse, error]
 
 	// DownloadTemplate downloads a template given the value of
 	// [apitype.TemplateMetadata].DownloadURL.
@@ -80,6 +83,32 @@ type ListTemplatesOptions struct {
 	// Search performs a case-insensitive partial match against the template
 	// name, display name, description, metadata values, and runtime language.
 	Search string
+	// Backing restricts results to the given backings. Listing
+	// [apitype.TemplateBackingVcs] makes the service fetch from the upstream provider, which
+	// is far slower than the other backings.
+	Backing []apitype.TemplateBacking
+}
+
+// Templates flattens the pages of a [Registry.ListTemplates] listing into the individual
+// templates they carry.
+func Templates(
+	pages iter.Seq2[apitype.ListTemplatesResponse, error],
+) iter.Seq2[apitype.TemplateMetadata, error] {
+	return func(yield func(apitype.TemplateMetadata, error) bool) {
+		for page, err := range pages {
+			if err != nil {
+				if !yield(apitype.TemplateMetadata{}, err) {
+					return
+				}
+				continue
+			}
+			for _, t := range page.Templates {
+				if !yield(t, nil) {
+					return
+				}
+			}
+		}
+	}
 }
 
 type registryKey struct{}
@@ -139,11 +168,11 @@ func (r *onDemandRegistry) GetTemplate(
 
 func (r *onDemandRegistry) ListTemplates(
 	ctx context.Context, opts ListTemplatesOptions,
-) iter.Seq2[apitype.TemplateMetadata, error] {
+) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	impl, err := r.factory()
 	if err != nil {
-		return func(consumer func(apitype.TemplateMetadata, error) bool) {
-			consumer(apitype.TemplateMetadata{}, err)
+		return func(consumer func(apitype.ListTemplatesResponse, error) bool) {
+			consumer(apitype.ListTemplatesResponse{}, err)
 		}
 	}
 	return impl.ListTemplates(ctx, opts)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -28,6 +28,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
+// singlePage answers a template listing with one page holding the given templates.
+func singlePage(templates ...apitype.TemplateMetadata) iter.Seq2[apitype.ListTemplatesResponse, error] {
+	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+		yield(apitype.ListTemplatesResponse{Templates: templates}, nil)
+	}
+}
+
 type mockRegistry struct {
 	getPackage func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
@@ -37,7 +44,7 @@ type mockRegistry struct {
 	getTemplate func(
 		ctx context.Context, source, publisher, name string, version *semver.Version,
 	) (apitype.TemplateMetadata, error)
-	listTemplates func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error]
+	listTemplates func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error]
 
 	downloadTemplate func(ctx context.Context, downloadURL string) (io.ReadCloser, error)
 }
@@ -60,7 +67,7 @@ func (r mockRegistry) GetTemplate(
 
 func (r mockRegistry) ListTemplates(
 	ctx context.Context, opts ListTemplatesOptions,
-) iter.Seq2[apitype.TemplateMetadata, error] {
+) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	return r.listTemplates(ctx, opts)
 }
 

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -239,7 +239,7 @@ func ResolveTemplateFromName(
 		var pulumiTemplateMetadata *apitype.TemplateMetadata
 		var privateTemplateMetadata []apitype.TemplateMetadata
 		var suggested []apitype.TemplateMetadata
-		for meta, err := range registry.ListTemplates(ctx, ListTemplatesOptions{Name: name}) {
+		for meta, err := range Templates(registry.ListTemplates(ctx, ListTemplatesOptions{Name: name})) {
 			if err != nil {
 				return apitype.TemplateMetadata{}, err
 			}

--- a/pkg/registry/resolve_test.go
+++ b/pkg/registry/resolve_test.go
@@ -836,15 +836,13 @@ func TestResolveTemplateFromName(t *testing.T) {
 	t.Run("single/private-match", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error] {
+			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error] {
 				assert.Equal(t, "my-template", opts.Name)
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Source:    "private",
-						Publisher: "my-org",
-						Name:      "my-template",
-					}, nil)
-				}
+				return singlePage(apitype.TemplateMetadata{
+					Source:    "private",
+					Publisher: "my-org",
+					Name:      "my-template",
+				})
 			},
 		}
 
@@ -857,14 +855,12 @@ func TestResolveTemplateFromName(t *testing.T) {
 	t.Run("single/pulumi-match", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Source:    "pulumi",
-						Publisher: "pulumi",
-						Name:      "aws",
-					}, nil)
-				}
+			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return singlePage(apitype.TemplateMetadata{
+					Source:    "pulumi",
+					Publisher: "pulumi",
+					Name:      "aws",
+				})
 			},
 		}
 
@@ -878,14 +874,12 @@ func TestResolveTemplateFromName(t *testing.T) {
 		t.Parallel()
 		desiredVersion := semver.MustParse("1.5.0")
 		mockReg := mockRegistry{
-			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Source:    "private",
-						Publisher: "my-org",
-						Name:      "my-template",
-					}, nil)
-				}
+			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return singlePage(apitype.TemplateMetadata{
+					Source:    "private",
+					Publisher: "my-org",
+					Name:      "my-template",
+				})
 			},
 			getTemplate: func(
 				ctx context.Context, source, publisher, name string, version *semver.Version,
@@ -911,14 +905,12 @@ func TestResolveTemplateFromName(t *testing.T) {
 		t.Parallel()
 		desiredVersion := semver.MustParse("99.0.0")
 		mockReg := mockRegistry{
-			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Source:    "private",
-						Publisher: "my-org",
-						Name:      "my-template",
-					}, nil)
-				}
+			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return singlePage(apitype.TemplateMetadata{
+					Source:    "private",
+					Publisher: "my-org",
+					Name:      "my-template",
+				})
 			},
 			getTemplate: func(
 				ctx context.Context, source, publisher, name string, version *semver.Version,
@@ -936,10 +928,8 @@ func TestResolveTemplateFromName(t *testing.T) {
 	t.Run("single/not-found", func(t *testing.T) {
 		t.Parallel()
 		mockReg := mockRegistry{
-			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.TemplateMetadata, error] {
-				return func(yield func(apitype.TemplateMetadata, error) bool) {
-					// No matches
-				}
+			listTemplates: func(ctx context.Context, opts ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error] {
+				return singlePage()
 			},
 		}
 

--- a/sdk/go/common/apitype/templates.go
+++ b/sdk/go/common/apitype/templates.go
@@ -47,9 +47,40 @@ type TemplateMetadata struct {
 	Metadata   map[string]string `json:"metadata,omitempty"`
 }
 
+// TemplateBacking is where a template's contents come from. The service fetches VCS-backed
+// templates from the provider on every request, so a listing that includes them is considerably
+// slower than one that does not.
+type TemplateBacking string
+
+const (
+	// TemplateBackingPulumi is Pulumi's own getting-started templates.
+	TemplateBackingPulumi TemplateBacking = "pulumi"
+	// TemplateBackingRegistry is templates published to the Pulumi Registry.
+	TemplateBackingRegistry TemplateBacking = "registry"
+	// TemplateBackingVcs is templates in a collection an organization configured against a
+	// version control provider.
+	TemplateBackingVcs TemplateBacking = "vcs"
+)
+
 type ListTemplatesResponse struct {
 	Templates         []TemplateMetadata `json:"templates"`
 	ContinuationToken *string            `json:"continuationToken,omitempty"`
+	// Diagnostics reports collections that could not be read. Such a collection is skipped
+	// rather than failing the request.
+	Diagnostics []string `json:"diagnostics,omitempty"`
+	// VcsTemplateSourceTotals counts the VCS-backed template collections each of the caller's
+	// organizations has configured. It is unaffected by the request's filters and pagination,
+	// so it describes organizations whose templates the response itself does not carry.
+	VcsTemplateSourceTotals []OrgVcsTemplateSourceTotal `json:"vcsTemplateSourceTotals,omitempty"`
+}
+
+// OrgVcsTemplateSourceTotal reports how many VCS-backed template collections an organization has
+// configured. Organizations with none are omitted from a listing, as is Pulumi's own collection,
+// so an entry means the organization has at least one collection of its own. A collection may
+// hold any number of templates, including none.
+type OrgVcsTemplateSourceTotal struct {
+	OrgLogin string `json:"orgLogin"`
+	Total    int    `json:"total"`
 }
 
 // A pulumi template remote where the source URL contains


### PR DESCRIPTION
> **Stack** (merge bottom-up)
> 1. **#24224 — Yield template listings by page and let callers filter by backing** ← you are here
> 2. #24225 — Split template fetching into speed tiers
> 3. #24226 — Add a guided cloud and language flow to interactive `pulumi new`

## Why

Interactive `pulumi new` cannot render a prompt until it has a template list, and one part of that list is far slower to produce than the rest: templates backed by a version control provider, which the service has to fetch from the provider itself. Everything else the service answers from its own tables.

Two things in the current API make it impossible to render early. `ListTemplates` flattens the service's pages into a stream of individual templates, which discards everything the response says about the request as a whole — including the VCS collection totals, which name the organizations whose templates the listing did not itself fetch. And there is no way to ask for a subset, so a caller that wants only the fast part still waits for the slow part.

This PR changes only what the service can be asked for. #24225, stacked on top, is the first caller to use it.

## What

- The `ListTemplates` iterator yields one `apitype.ListTemplatesResponse` per service response instead of one template at a time. `registry.Templates` flattens it for callers that only want the templates, so existing call sites are unaffected.
- `ListTemplatesOptions` gains `Backing`, letting a caller ask for the backings the service answers from its own tables and leave out the version control fetch.

## How

`apitype.ListTemplatesResponse` and `apitype.TemplateBacking` are additive. The iterator change is mechanical at every existing call site — each one wraps in `registry.Templates` and keeps its current behavior. No caller passes `Backing` in this PR.

## Testing

`make lint` is clean across all seven modules. 
