### PR TITLE
Split template fetching into speed tiers, one owning its own state

### DIFF
--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1210,7 +1210,7 @@ func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
 					ListTemplatesF: func(
 						ctx context.Context, opts registry.ListTemplatesOptions,
 					) iter.Seq2[apitype.ListTemplatesResponse, error] {
-						assert.Equal(t, registry.ListTemplatesOptions{}, opts)
+						require.Len(t, opts.Backing, 1, "browsing splits the listing, one backing per fetch")
 						return singlePage()
 					},
 				},

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -118,23 +118,17 @@ func NewTemplateMatcher(urlInfo *registry.URLInfo, templateName string) func(Tem
 	}
 }
 
-// defaultRegistry is the registry the cloud fetches share. It resolves its backend lazily and
-// only once, so fetches that list concurrently pay for a single backend lookup.
+// Sharing one registry across fetches costs one backend lookup, not one per fetch.
 func defaultRegistry(ctx context.Context, e env.Env) registry.Registry {
 	return cmdCmd.NewDefaultRegistry(ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), e)
 }
 
-// listRegistry runs one registry listing with the options its scheduler chose; which fetch asks
-// for what lives in [newImpl].
 func (f *fetch) listRegistry(
 	ctx context.Context, r registry.Registry, opts registry.ListTemplatesOptions, c *cleanup,
 ) {
 	f.listRegistryMatching(ctx, r, opts, func(TemplateMatchable) bool { return true }, c)
 }
 
-// resolveRegistryName resolves a template name, URL, or partial URL against the registry. A name
-// pinned to a version is looked up directly; anything else runs an unfiltered listing and keeps
-// the matches.
 func (f *fetch) resolveRegistryName(
 	ctx context.Context, r registry.Registry, templateName string, c *cleanup,
 ) {
@@ -160,8 +154,6 @@ func (f *fetch) listRegistryMatching(
 			return
 		}
 
-		// The totals describe every organization the caller belongs to, not the page, so every
-		// page carries the same answer. Recording into this fetch keeps listings from contending.
 		f.addVcsOrgs(page.VcsTemplateSourceTotals)
 
 		for _, template := range page.Templates {

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
@@ -119,63 +118,74 @@ func NewTemplateMatcher(urlInfo *registry.URLInfo, templateName string) func(Tem
 	}
 }
 
-func (s *Source) getCloudTemplates(
-	ctx context.Context, templateName string,
-	wg *sync.WaitGroup, e env.Env,
-) {
-	if !e.GetBool(env.DisableRegistryResolve) {
-		s.getRegistryTemplates(ctx, e, templateName)
-		return
-	}
-
-	// Use the old org templates based API.
-	//
-	// This path can be removed when we are confident in registry resolution. We will
-	// always need to maintain a way to access templates without the service, but we
-	// should only need to maintain one way to access templates through the service.
-	s.getOrgTemplates(ctx, templateName, wg, e)
+// defaultRegistry is the registry the cloud fetches share. It resolves its backend lazily and
+// only once, so fetches that list concurrently pay for a single backend lookup.
+func defaultRegistry(ctx context.Context, e env.Env) registry.Registry {
+	return cmdCmd.NewDefaultRegistry(ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), e)
 }
 
-func (s *Source) getRegistryTemplates(ctx context.Context, e env.Env, templateName string) {
-	r := cmdCmd.NewDefaultRegistry(ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), e)
+// listRegistry runs one registry listing with the options its scheduler chose; which fetch asks
+// for what lives in [newImpl].
+func (f *fetch) listRegistry(
+	ctx context.Context, r registry.Registry, opts registry.ListTemplatesOptions, c *cleanup,
+) {
+	f.listRegistryMatching(ctx, r, opts, func(TemplateMatchable) bool { return true }, c)
+}
 
+// resolveRegistryName resolves a template name, URL, or partial URL against the registry. A name
+// pinned to a version is looked up directly; anything else runs an unfiltered listing and keeps
+// the matches.
+func (f *fetch) resolveRegistryName(
+	ctx context.Context, r registry.Registry, templateName string, c *cleanup,
+) {
 	urlInfo, err := parseTemplateURL(templateName)
 	if err != nil {
-		s.addError(err)
+		f.addError(err)
 		return
 	}
-
 	if urlInfo != nil && urlInfo.Version() != nil {
-		s.getRegistryTemplateByVersion(ctx, r, urlInfo)
+		f.resolveRegistryVersion(ctx, r, urlInfo, c)
 		return
 	}
+	f.listRegistryMatching(ctx, r, registry.ListTemplatesOptions{}, NewTemplateMatcher(urlInfo, templateName), c)
+}
 
-	matches := NewTemplateMatcher(urlInfo, templateName)
-	for template, err := range registry.Templates(r.ListTemplates(ctx, registry.ListTemplatesOptions{})) {
+func (f *fetch) listRegistryMatching(
+	ctx context.Context, r registry.Registry, opts registry.ListTemplatesOptions,
+	matches func(TemplateMatchable) bool, c *cleanup,
+) {
+	for page, err := range r.ListTemplates(ctx, opts) {
 		if err != nil {
-			s.addError(fmt.Errorf("could not get template: %w", err))
+			f.addError(fmt.Errorf("could not get template: %w", err))
 			return
 		}
 
-		if template.Source == "github" && strings.HasPrefix(template.Name, "pulumi/templates/") {
-			// These templates are maintained using https://github.com/pulumi/templates, and are
-			// ingested without going through the Pulumi Cloud.
-			continue
-		}
+		// The totals describe every organization the caller belongs to, not the page, so every
+		// page carries the same answer. Recording into this fetch keeps listings from contending.
+		f.addVcsOrgs(page.VcsTemplateSourceTotals)
 
-		t := registryTemplate{template, r, s}
-		if !matches(t) {
-			continue
-		}
+		for _, template := range page.Templates {
+			if template.Source == "github" && strings.HasPrefix(template.Name, "pulumi/templates/") {
+				// These templates are maintained using https://github.com/pulumi/templates, and are
+				// ingested without going through the Pulumi Cloud.
+				continue
+			}
 
-		s.addTemplate(t)
+			t := registryTemplate{template, r, c}
+			if !matches(t) {
+				continue
+			}
+
+			f.addTemplate(t)
+		}
 	}
 }
 
-func (s *Source) getRegistryTemplateByVersion(
+func (f *fetch) resolveRegistryVersion(
 	ctx context.Context,
 	r registry.Registry,
 	urlInfo *registry.URLInfo,
+	c *cleanup,
 ) {
 	version := urlInfo.Version()
 	displayName := buildResolveName(urlInfo)
@@ -192,23 +202,23 @@ func (s *Source) getRegistryTemplateByVersion(
 
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
-			s.addError(fmt.Errorf("template '%s' version '%s' not found",
+			f.addError(fmt.Errorf("template '%s' version '%s' not found",
 				displayName, version.String()))
 			return
 		}
-		s.addError(fmt.Errorf("could not resolve template: %w", err))
+		f.addError(fmt.Errorf("could not resolve template: %w", err))
 		return
 	}
 
 	if template.Source == "github" && strings.HasPrefix(template.Name, "pulumi/templates/") {
-		s.addError(fmt.Errorf(
+		f.addError(fmt.Errorf(
 			"template '%s' is VCS-backed and does not support specific versions",
 			displayName,
 		))
 		return
 	}
 
-	s.addTemplate(registryTemplate{template, r, s})
+	f.addTemplate(registryTemplate{template, r, c})
 }
 
 func buildResolveName(u *registry.URLInfo) string {
@@ -226,7 +236,7 @@ func buildResolveName(u *registry.URLInfo) string {
 type registryTemplate struct {
 	t        apitype.TemplateMetadata
 	registry registry.Registry
-	source   *Source
+	cleanup  *cleanup
 }
 
 var _ Template = registryTemplate{}
@@ -272,6 +282,8 @@ func (r registryTemplate) Description() string {
 
 func (r registryTemplate) Error() error { return nil }
 
+func (r registryTemplate) Publisher() string { return r.GetPublisher() }
+
 func (r registryTemplate) Download(ctx context.Context) (ProjectTemplate, error) {
 	templateBytes, err := r.registry.DownloadTemplate(ctx, r.t.DownloadURL)
 	if err != nil {
@@ -283,7 +295,7 @@ func (r registryTemplate) Download(ctx context.Context) (ProjectTemplate, error)
 		return ProjectTemplate{}, fmt.Errorf("failed to make temporary directory: %w", err)
 	}
 	// Having created a template directory, we now add it to the list of directories to close.
-	r.source.addCloser(func() error { return os.RemoveAll(templateDir) })
+	r.cleanup.add(func() error { return os.RemoveAll(templateDir) })
 	tarReader, err := createTarReader(templateBytes)
 	if err != nil {
 		return ProjectTemplate{}, fmt.Errorf("failed to create tar reader: %w", err)
@@ -303,33 +315,30 @@ func (r registryTemplate) GetTemplateName() string { return r.Name() }
 func (r registryTemplate) GetSource() string       { return r.t.Source }
 func (r registryTemplate) GetPublisher() string    { return r.t.Publisher }
 
-func (s *Source) getOrgTemplates(
-	ctx context.Context, templateName string,
-	wg *sync.WaitGroup, e env.Env,
-) {
+func (f *fetch) listOrgTemplates(ctx context.Context, templateName string, e env.Env, c *cleanup) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		s.addError(fmt.Errorf("getting current working directory: %w", err))
+		f.addError(fmt.Errorf("getting current working directory: %w", err))
 		return
 	}
 
 	ws := pkgWorkspace.Instance
 	project, _, err := ws.ReadProject(cwd)
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
-		s.addError(fmt.Errorf("could not read the current project: %w", err))
+		f.addError(fmt.Errorf("could not read the current project: %w", err))
 		return
 	}
 
 	url, err := pkgWorkspace.GetCurrentCloudURL(ws, e, project)
 	if err != nil {
-		s.addError(fmt.Errorf("could not get current cloud url: %w", err))
+		f.addError(fmt.Errorf("could not get current cloud url: %w", err))
 		return
 	}
 
 	b, err := cmdBackend.DefaultLoginManager.Current(ctx, ws, cmdutil.Diag(), url, project, false)
 	if err != nil {
 		if !errors.Is(err, backenderr.MissingEnvVarForNonInteractiveError{}) {
-			s.addError(fmt.Errorf("could not get the current backend: %w", err))
+			f.addError(fmt.Errorf("could not get the current backend: %w", err))
 		}
 		slog.InfoContext(ctx, "could not get a backend for org templates")
 		return
@@ -344,7 +353,7 @@ func (s *Source) getOrgTemplates(
 			slog.InfoContext(ctx, "user is not logged in")
 			return // No current user - so don't proceed
 		}
-		s.addError(fmt.Errorf("could not get the current user for %s: %s", url, err))
+		f.addError(fmt.Errorf("could not get the current user for %s: %s", url, err))
 		return
 	}
 
@@ -356,7 +365,7 @@ func (s *Source) getOrgTemplates(
 	slog.InfoContext(ctx, "Listing Org Templates from the cloud")
 	user, orgs, _, err := b.CurrentUser()
 	if err != nil {
-		s.addError(fmt.Errorf("could not get the current user: %w", err))
+		f.addError(fmt.Errorf("could not get the current user: %w", err))
 		return
 	} else if user == "" {
 		return // No current user - so don't proceed.
@@ -365,7 +374,6 @@ func (s *Source) getOrgTemplates(
 	alreadySeenSourceURLs := map[string]struct{}{}
 
 	handleOrg := func(org string) {
-		defer wg.Done()
 		slog.InfoContext(ctx, "Checking for templates", "org", org)
 		orgTemplates, err := b.ListTemplates(ctx, org)
 		if apiError := new(apitype.ErrorResponse); errors.As(err, &apiError) {
@@ -375,7 +383,7 @@ func (s *Source) getOrgTemplates(
 				return
 			}
 		} else if err != nil {
-			s.addError(fmt.Errorf("list templates: %w", err))
+			f.addError(fmt.Errorf("list templates: %w", err))
 			slog.WarnContext(ctx, "Failed to get templates", "org", org, "err", err.Error())
 			return
 		} else if orgTemplates.HasAccessError {
@@ -417,10 +425,10 @@ func (s *Source) getOrgTemplates(
 				}
 
 				slog.DebugContext(ctx, "adding template", "template", template.Name)
-				s.addTemplate(orgTemplate{
+				f.addTemplate(orgTemplate{
 					t:       template,
 					org:     org,
-					source:  s,
+					cleanup: c,
 					backend: b,
 				})
 			}
@@ -428,15 +436,14 @@ func (s *Source) getOrgTemplates(
 	}
 
 	for _, org := range orgs {
-		wg.Add(1)
-		go handleOrg(org)
+		f.wg.Go(func() { handleOrg(org) })
 	}
 }
 
 type orgTemplate struct {
 	t       *apitype.PulumiTemplateRemote
 	org     string
-	source  *Source
+	cleanup *cleanup
 	backend backend.Backend
 }
 
@@ -446,13 +453,14 @@ func (t orgTemplate) Name() string        { return t.t.Name }
 func (t orgTemplate) DisplayName() string { return t.t.Name }
 func (t orgTemplate) Description() string { return t.t.Description }
 func (t orgTemplate) Error() error        { return nil }
+func (t orgTemplate) Publisher() string   { return t.org }
 func (t orgTemplate) Download(ctx context.Context) (ProjectTemplate, error) {
 	templateDir, err := os.MkdirTemp("", "pulumi-template-")
 	if err != nil {
 		return ProjectTemplate{}, err
 	}
 	// Having created a template directory, we now add it to the list of directories to close.
-	t.source.addCloser(func() error { return os.RemoveAll(templateDir) })
+	t.cleanup.add(func() error { return os.RemoveAll(templateDir) })
 
 	tarReader, err := t.backend.DownloadTemplate(ctx, t.org, t.t.TemplateURL)
 	if err != nil {

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -25,12 +25,122 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
+	"github.com/pulumi/pulumi/pkg/v3/registry"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
+
+// fetch is one independent template fetch. Each fetch owns everything it produced — templates,
+// errors, and whatever the listing reported on the side — so that a caller can join one fetch
+// without waiting on the others, and so that no two fetches share a field to race over.
+type fetch struct {
+	wg sync.WaitGroup
+
+	// m guards everything below: a fetch may fan out into goroutines of its own that report
+	// results concurrently.
+	m         sync.Mutex
+	templates []Template
+	errs      []error
+
+	// errsOnEmpty are reported only if the [Source] as a whole found nothing. A fetch that came
+	// up empty is not itself an error; another may still have found something.
+	errsOnEmpty []error
+
+	// vcsOrgs names organizations the service reported as having VCS-backed template
+	// collections. Only a listing that asks the service for them fills this in.
+	vcsOrgs []string
+}
+
+func (f *fetch) addTemplate(t Template) {
+	contract.Assertf(t != nil, "We should never return nil templates")
+	f.m.Lock()
+	f.templates = append(f.templates, t)
+	f.m.Unlock()
+}
+
+func (f *fetch) addError(err error) {
+	f.m.Lock()
+	f.errs = append(f.errs, err)
+	f.m.Unlock()
+}
+
+func (f *fetch) addErrorOnEmpty(err error) {
+	f.m.Lock()
+	f.errsOnEmpty = append(f.errsOnEmpty, err)
+	f.m.Unlock()
+}
+
+func (f *fetch) addVcsOrgs(totals []apitype.OrgVcsTemplateSourceTotal) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	for _, total := range totals {
+		if !slices.Contains(f.vcsOrgs, total.OrgLogin) {
+			f.vcsOrgs = append(f.vcsOrgs, total.OrgLogin)
+		}
+	}
+}
+
+// join waits for the fetch to finish, then returns its templates, or its errors if it produced
+// any.
+func (f *fetch) join() ([]Template, error) {
+	f.wg.Wait()
+
+	f.m.Lock()
+	defer f.m.Unlock()
+	if err := errors.Join(f.errs...); err != nil {
+		return nil, err
+	}
+	return slices.Clone(f.templates), nil
+}
+
+// joinVcsOrgs waits for the fetch to finish, then returns the organizations it observed.
+func (f *fetch) joinVcsOrgs() []string {
+	f.wg.Wait()
+
+	f.m.Lock()
+	defer f.m.Unlock()
+	return slices.Clone(f.vcsOrgs)
+}
+
+// cleanup collects the deletions a [Source] owes when it closes. Templates hold this rather than
+// the whole Source: downloading one registers a temp directory, which should not also hand it
+// access to the fetches.
+type cleanup struct {
+	m       sync.Mutex
+	closed  bool
+	closers []func() error
+}
+
+func (c *cleanup) add(f func() error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	contract.Assertf(!c.closed, "Attempted to add a closer to a closed source")
+	c.closers = append(c.closers, f)
+}
+
+// assertOpen panics if the source has already been closed, which would mean the templates it
+// handed out have been deleted from disk.
+func (c *cleanup) assertOpen(action string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	contract.Assertf(!c.closed, "%s", "Attempted to act on closed source: "+action)
+}
+
+func (c *cleanup) run() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.closed = true
+	errs := make([]error, len(c.closers))
+	for i, f := range c.closers {
+		errs[i] = f()
+	}
+	return errors.Join(errs...)
+}
 
 // Source provides access to a set of project templates, any set of which may be present on
 // disk.
@@ -38,67 +148,120 @@ import (
 // Source is responsible for cleaning up old templates, and should always be [Close]d when
 // created.
 type Source struct {
-	templates    []Template
-	errorOnEmpty []error
-	errors       []error
+	// The fetches, fastest first. They are speed tiers, not categories: project is the local disk
+	// and curated template set, database is what the service answers from its own tables without
+	// leaving the building, and upstream is what it must fetch from a version control provider on
+	// every request. Tracking them apart lets a caller join one without waiting on the rest.
+	//
+	// Each fetch owns its own results, so Source holds no state they could race over; it only
+	// composes them.
+	project  fetch
+	database fetch
+	upstream fetch
+
+	// cleanup is shared with the templates the fetches hand out, so a downloaded template can
+	// register its temp directory for deletion.
+	cleanup cleanup
 
 	// cancel holds the function to cancel the context passed into the [New] that created the source.
 	cancel context.CancelFunc
-	// closers holds a list of functions to be invoked when the Source is closed.
-	closers []func() error
-	closed  bool
+}
 
-	// m should be held whenever Source is mutated.
-	m  sync.Mutex
-	wg sync.WaitGroup
+// fetches lists the fetches, fastest first. Anything that spans all of them — waiting, joining
+// errors — should range over this so a new fetch only needs to be added here.
+func (s *Source) fetches() []*fetch {
+	return []*fetch{&s.project, &s.database, &s.upstream}
+}
+
+// waitAll blocks until every fetch has finished.
+func (s *Source) waitAll() {
+	for _, w := range s.fetches() {
+		w.wg.Wait()
+	}
 }
 
 // Templates lists the templates available to the [Source].
 //
-// Templates *does not* produce a sorted list. If templates need to be sorted, then the
-// caller is responsible for sorting them.
+// Templates *does not* produce a sorted list; it groups the fetches in the order they are declared
+// on [Source]. If templates need to be sorted, then the caller is responsible for sorting them.
 func (s *Source) Templates() ([]Template, error) {
-	s.wg.Wait() // Wait to ensure that all templates have been fetched before returning the template list.
+	// Wait to ensure that all templates have been fetched before returning the template list.
+	s.waitAll()
+	s.cleanup.assertOpen("read templates")
 
-	s.lockOpen("read templates")
-	defer s.m.Unlock()
-	if err := errors.Join(s.errors...); err != nil {
+	var errs []error
+	for _, w := range s.fetches() {
+		errs = append(errs, w.errs...)
+	}
+	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
-	if len(s.templates) == 0 {
-		return nil, errors.Join(s.errorOnEmpty...)
+
+	// A registry template already produced by an earlier fetch is dropped. A service that does
+	// not honor the backing filter answers each fetch with everything it has, which would
+	// otherwise list every cloud template twice.
+	seen := map[string]bool{}
+	var all []Template
+	for _, w := range s.fetches() {
+		for _, t := range w.templates {
+			if m, ok := t.(TemplateMatchable); ok {
+				id := registryIdentity(m)
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+			}
+			all = append(all, t)
+		}
 	}
-	return s.templates, nil
+	if len(all) == 0 {
+		var onEmpty []error
+		for _, w := range s.fetches() {
+			onEmpty = append(onEmpty, w.errsOnEmpty...)
+		}
+		return nil, errors.Join(onEmpty...)
+	}
+	return all, nil
 }
 
-func (s *Source) addTemplate(t Template) {
-	contract.Assertf(t != nil, "We should never return nil templates")
-	s.lockOpen("add template")
-	s.templates = append(s.templates, t)
-	s.m.Unlock()
+// registryIdentity is the source/publisher/name triple that names a template in the registry.
+func registryIdentity(t TemplateMatchable) string {
+	return t.GetSource() + "/" + t.GetPublisher() + "/" + t.GetRegistryName()
 }
 
-func (s *Source) addCloser(f func() error) {
-	s.lockOpen("add closer")
-	s.closers = append(s.closers, f)
-	s.m.Unlock()
+// ProjectTemplates lists only the templates found by the project fetcher (local disk and the
+// curated template set), without waiting for the slower cloud fetches, which keep running in the
+// background. Use [Source.Templates] for the complete set.
+//
+// Unlike [Source.Templates], an empty result is not an error here: a fetch that is still running
+// may yet produce templates, so only the complete set can conclude that there are none.
+func (s *Source) ProjectTemplates() ([]Template, error) {
+	return s.project.join()
 }
 
-func (s *Source) addError(err error) {
-	s.lockOpen("add error")
-	s.errors = append(s.errors, err)
-	s.m.Unlock()
+// DatabaseTemplates lists the cloud templates the service answers from its own tables, without
+// waiting on the collections it would have to fetch upstream. As with [Source.ProjectTemplates],
+// an empty result is not an error.
+//
+// Only a [Source] created to browse — one given no template name — splits the cloud listing far
+// enough for this tier to hold anything; every other path runs one unfiltered listing as the
+// upstream fetch and answers here with nothing. Callers that need the complete set must use
+// [Source.Templates] and pay the upstream cost.
+func (s *Source) DatabaseTemplates() ([]Template, error) {
+	return s.database.join()
 }
 
-func (s *Source) addErrorOnEmpty(err error) {
-	s.lockOpen("add error on empty")
-	s.errorOnEmpty = append(s.errorOnEmpty, err)
-	s.m.Unlock()
-}
-
-func (s *Source) lockOpen(action string) {
-	s.m.Lock()
-	contract.Assertf(!s.closed, "%s", "Attempted to act on closed source: "+action)
+// VcsTemplateSourceOrgs names organizations that have VCS-backed template collections configured.
+// Their templates are only in [Source.Templates], never in [Source.DatabaseTemplates].
+//
+// The result is best-effort in both directions: an organization listed here has at least one
+// collection, but one absent from here may still have them — because the service did not report
+// it, or because this [Source] did not run the listing that reports it.
+// Every listing records what the service reported, but only the database fetch's answer is
+// read, so the two cloud listings never contend and the result does not depend on which of
+// them finished first.
+func (s *Source) VcsTemplateSourceOrgs() []string {
+	return s.database.joinVcsOrgs()
 }
 
 // Close cleans up the [Source] and any associated templates.
@@ -107,16 +270,10 @@ func (s *Source) lockOpen(action string) {
 func (s *Source) Close() error {
 	s.cancel()
 
-	s.wg.Wait() // Wait to ensure that all templates have been fetched so all closers are visible.
+	// Wait to ensure that all templates have been fetched so all closers are visible.
+	s.waitAll()
 
-	s.lockOpen("close")
-	defer s.m.Unlock()
-	s.closed = true
-	errs := make([]error, len(s.closers))
-	for i, f := range s.closers {
-		errs[i] = f()
-	}
-	return errors.Join(errs...)
+	return s.cleanup.run()
 }
 
 // A template entry to show in the chooser.
@@ -125,6 +282,9 @@ type Template interface {
 	DisplayName() string
 	Description() string
 	Error() error
+	// Publisher returns the organization that published this template to the registry. It is
+	// empty for templates without one, such as the curated pulumi/templates set.
+	Publisher() string
 	// Download the template and return an instantiable [ProjectTemplate] for this template.
 	Download(ctx context.Context) (ProjectTemplate, error)
 }
@@ -166,15 +326,53 @@ func newImpl(
 	source.cancel = cancel
 
 	if scope == ScopeAll || scope == ScopeLocal {
-		source.wg.Go(func() {
-			source.getProjectTemplates(ctx, templateNamePathOrURL, scope, templateKind, getProjectTemplates)
+		source.project.wg.Go(func() {
+			source.project.listProjectTemplates(
+				ctx, templateNamePathOrURL, scope, templateKind, getProjectTemplates, &source.cleanup,
+			)
 		})
 	}
 
 	if scope == ScopeAll && templateKind == TemplateKindPulumiProject && isTemplateName(templateNamePathOrURL) {
-		source.wg.Go(func() {
-			source.getCloudTemplates(ctx, templateNamePathOrURL, &source.wg, e)
-		})
+		switch {
+		case e.GetBool(env.DisableRegistryResolve):
+			// Use the old org templates based API.
+			//
+			// This path can be removed when we are confident in registry resolution. We will
+			// always need to maintain a way to access templates without the service, but we
+			// should only need to maintain one way to access templates through the service.
+			//
+			// It has no notion of a backing and fetches every org's collections upstream, so it
+			// runs wholly as the upstream fetch.
+			source.upstream.wg.Go(func() {
+				source.upstream.listOrgTemplates(ctx, templateNamePathOrURL, e, &source.cleanup)
+			})
+		case templateNamePathOrURL == "":
+			// Browsing splits the cloud listing in two so that the database half can be joined
+			// without waiting on the upstream half. Neither asks for
+			// [apitype.TemplateBackingPulumi]: those are the curated templates, which the
+			// project fetch already has from its own checkout.
+			r := defaultRegistry(ctx, e)
+			source.database.wg.Go(func() {
+				source.database.listRegistry(ctx, r, registry.ListTemplatesOptions{
+					Backing: []apitype.TemplateBacking{apitype.TemplateBackingRegistry},
+				}, &source.cleanup)
+			})
+			source.upstream.wg.Go(func() {
+				source.upstream.listRegistry(ctx, r, registry.ListTemplatesOptions{
+					Backing: []apitype.TemplateBacking{apitype.TemplateBackingVcs},
+				}, &source.cleanup)
+			})
+		default:
+			// Resolving a name has no prompt to render early, so it takes one unfiltered
+			// lookup rather than paying for two. That lookup pays the upstream fan-out, so it
+			// runs wholly as the upstream fetch.
+			source.upstream.wg.Go(func() {
+				source.upstream.resolveRegistryName(
+					ctx, defaultRegistry(ctx, e), templateNamePathOrURL, &source.cleanup,
+				)
+			})
+		}
 	}
 
 	return &source

--- a/pkg/cmd/pulumi/templates/templates.go
+++ b/pkg/cmd/pulumi/templates/templates.go
@@ -35,24 +35,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// fetch is one independent template fetch. Each fetch owns everything it produced — templates,
-// errors, and whatever the listing reported on the side — so that a caller can join one fetch
-// without waiting on the others, and so that no two fetches share a field to race over.
 type fetch struct {
 	wg sync.WaitGroup
 
-	// m guards everything below: a fetch may fan out into goroutines of its own that report
-	// results concurrently.
 	m         sync.Mutex
 	templates []Template
 	errs      []error
 
-	// errsOnEmpty are reported only if the [Source] as a whole found nothing. A fetch that came
-	// up empty is not itself an error; another may still have found something.
+	// errsOnEmpty are reported only if the [Source] as a whole found nothing.
 	errsOnEmpty []error
 
-	// vcsOrgs names organizations the service reported as having VCS-backed template
-	// collections. Only a listing that asks the service for them fills this in.
 	vcsOrgs []string
 }
 
@@ -85,8 +77,6 @@ func (f *fetch) addVcsOrgs(totals []apitype.OrgVcsTemplateSourceTotal) {
 	}
 }
 
-// join waits for the fetch to finish, then returns its templates, or its errors if it produced
-// any.
 func (f *fetch) join() ([]Template, error) {
 	f.wg.Wait()
 
@@ -98,7 +88,6 @@ func (f *fetch) join() ([]Template, error) {
 	return slices.Clone(f.templates), nil
 }
 
-// joinVcsOrgs waits for the fetch to finish, then returns the organizations it observed.
 func (f *fetch) joinVcsOrgs() []string {
 	f.wg.Wait()
 
@@ -107,9 +96,6 @@ func (f *fetch) joinVcsOrgs() []string {
 	return slices.Clone(f.vcsOrgs)
 }
 
-// cleanup collects the deletions a [Source] owes when it closes. Templates hold this rather than
-// the whole Source: downloading one registers a temp directory, which should not also hand it
-// access to the fetches.
 type cleanup struct {
 	m       sync.Mutex
 	closed  bool
@@ -123,8 +109,6 @@ func (c *cleanup) add(f func() error) {
 	c.closers = append(c.closers, f)
 }
 
-// assertOpen panics if the source has already been closed, which would mean the templates it
-// handed out have been deleted from disk.
 func (c *cleanup) assertOpen(action string) {
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -148,32 +132,20 @@ func (c *cleanup) run() error {
 // Source is responsible for cleaning up old templates, and should always be [Close]d when
 // created.
 type Source struct {
-	// The fetches, fastest first. They are speed tiers, not categories: project is the local disk
-	// and curated template set, database is what the service answers from its own tables without
-	// leaving the building, and upstream is what it must fetch from a version control provider on
-	// every request. Tracking them apart lets a caller join one without waiting on the rest.
-	//
-	// Each fetch owns its own results, so Source holds no state they could race over; it only
-	// composes them.
 	project  fetch
 	database fetch
 	upstream fetch
 
-	// cleanup is shared with the templates the fetches hand out, so a downloaded template can
-	// register its temp directory for deletion.
 	cleanup cleanup
 
 	// cancel holds the function to cancel the context passed into the [New] that created the source.
 	cancel context.CancelFunc
 }
 
-// fetches lists the fetches, fastest first. Anything that spans all of them — waiting, joining
-// errors — should range over this so a new fetch only needs to be added here.
 func (s *Source) fetches() []*fetch {
 	return []*fetch{&s.project, &s.database, &s.upstream}
 }
 
-// waitAll blocks until every fetch has finished.
 func (s *Source) waitAll() {
 	for _, w := range s.fetches() {
 		w.wg.Wait()
@@ -182,10 +154,9 @@ func (s *Source) waitAll() {
 
 // Templates lists the templates available to the [Source].
 //
-// Templates *does not* produce a sorted list; it groups the fetches in the order they are declared
-// on [Source]. If templates need to be sorted, then the caller is responsible for sorting them.
+// Templates *does not* produce a sorted list. If templates need to be sorted, then the
+// caller is responsible for sorting them.
 func (s *Source) Templates() ([]Template, error) {
-	// Wait to ensure that all templates have been fetched before returning the template list.
 	s.waitAll()
 	s.cleanup.assertOpen("read templates")
 
@@ -197,9 +168,7 @@ func (s *Source) Templates() ([]Template, error) {
 		return nil, err
 	}
 
-	// A registry template already produced by an earlier fetch is dropped. A service that does
-	// not honor the backing filter answers each fetch with everything it has, which would
-	// otherwise list every cloud template twice.
+	// A service that does not honor the backing filter answers each fetch with everything it has.
 	seen := map[string]bool{}
 	var all []Template
 	for _, w := range s.fetches() {
@@ -224,42 +193,18 @@ func (s *Source) Templates() ([]Template, error) {
 	return all, nil
 }
 
-// registryIdentity is the source/publisher/name triple that names a template in the registry.
 func registryIdentity(t TemplateMatchable) string {
 	return t.GetSource() + "/" + t.GetPublisher() + "/" + t.GetRegistryName()
 }
 
-// ProjectTemplates lists only the templates found by the project fetcher (local disk and the
-// curated template set), without waiting for the slower cloud fetches, which keep running in the
-// background. Use [Source.Templates] for the complete set.
-//
-// Unlike [Source.Templates], an empty result is not an error here: a fetch that is still running
-// may yet produce templates, so only the complete set can conclude that there are none.
 func (s *Source) ProjectTemplates() ([]Template, error) {
 	return s.project.join()
 }
 
-// DatabaseTemplates lists the cloud templates the service answers from its own tables, without
-// waiting on the collections it would have to fetch upstream. As with [Source.ProjectTemplates],
-// an empty result is not an error.
-//
-// Only a [Source] created to browse — one given no template name — splits the cloud listing far
-// enough for this tier to hold anything; every other path runs one unfiltered listing as the
-// upstream fetch and answers here with nothing. Callers that need the complete set must use
-// [Source.Templates] and pay the upstream cost.
 func (s *Source) DatabaseTemplates() ([]Template, error) {
 	return s.database.join()
 }
 
-// VcsTemplateSourceOrgs names organizations that have VCS-backed template collections configured.
-// Their templates are only in [Source.Templates], never in [Source.DatabaseTemplates].
-//
-// The result is best-effort in both directions: an organization listed here has at least one
-// collection, but one absent from here may still have them — because the service did not report
-// it, or because this [Source] did not run the listing that reports it.
-// Every listing records what the service reported, but only the database fetch's answer is
-// read, so the two cloud listings never contend and the result does not depend on which of
-// them finished first.
 func (s *Source) VcsTemplateSourceOrgs() []string {
 	return s.database.joinVcsOrgs()
 }
@@ -282,8 +227,6 @@ type Template interface {
 	DisplayName() string
 	Description() string
 	Error() error
-	// Publisher returns the organization that published this template to the registry. It is
-	// empty for templates without one, such as the curated pulumi/templates set.
 	Publisher() string
 	// Download the template and return an instantiable [ProjectTemplate] for this template.
 	Download(ctx context.Context) (ProjectTemplate, error)
@@ -336,22 +279,14 @@ func newImpl(
 	if scope == ScopeAll && templateKind == TemplateKindPulumiProject && isTemplateName(templateNamePathOrURL) {
 		switch {
 		case e.GetBool(env.DisableRegistryResolve):
-			// Use the old org templates based API.
-			//
-			// This path can be removed when we are confident in registry resolution. We will
-			// always need to maintain a way to access templates without the service, but we
-			// should only need to maintain one way to access templates through the service.
-			//
-			// It has no notion of a backing and fetches every org's collections upstream, so it
-			// runs wholly as the upstream fetch.
+			// TODO[pulumi/pulumi#24250]: remove the org templates API once we're confident in
+			// registry resolution.
 			source.upstream.wg.Go(func() {
 				source.upstream.listOrgTemplates(ctx, templateNamePathOrURL, e, &source.cleanup)
 			})
 		case templateNamePathOrURL == "":
-			// Browsing splits the cloud listing in two so that the database half can be joined
-			// without waiting on the upstream half. Neither asks for
-			// [apitype.TemplateBackingPulumi]: those are the curated templates, which the
-			// project fetch already has from its own checkout.
+			// Split so the database half can be joined without waiting on the upstream half.
+			// Neither asks for [apitype.TemplateBackingPulumi]: the project fetch has those.
 			r := defaultRegistry(ctx, e)
 			source.database.wg.Go(func() {
 				source.database.listRegistry(ctx, r, registry.ListTemplatesOptions{
@@ -364,9 +299,6 @@ func newImpl(
 				}, &source.cleanup)
 			})
 		default:
-			// Resolving a name has no prompt to render early, so it takes one unfiltered
-			// lookup rather than paying for two. That lookup pays the upstream fan-out, so it
-			// runs wholly as the upstream fetch.
 			source.upstream.wg.Go(func() {
 				source.upstream.resolveRegistryName(
 					ctx, defaultRegistry(ctx, e), templateNamePathOrURL, &source.cleanup,

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -651,8 +651,6 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				// Browsing splits the listing, so each fetch names one backing and the service
-				// answers with the templates that have it.
 				byBacking := map[apitype.TemplateBacking][]apitype.TemplateMetadata{
 					apitype.TemplateBackingRegistry: {{
 						Name:      "just/has/slashes",
@@ -703,8 +701,6 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, templates, 3)
 
-	// The fetches are concatenated in the order they are declared, so the registry-backed template
-	// leads.
 	assert.Equal(t, "just/has/slashes", templates[0].Name())
 	assert.Equal(t, "just/has/slashes [pulumi-org]", templates[0].DisplayName())
 	assert.Equal(t, "name", templates[1].Name())
@@ -713,7 +709,6 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 	assert.Equal(t, "name [gl-org/repo]", templates[2].DisplayName())
 }
 
-// mockRegistrySource wires a ListTemplates implementation into a source that browses.
 func mockRegistrySource(
 	t *testing.T,
 	list func(context.Context, registry.ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error],
@@ -743,8 +738,7 @@ func mockRegistrySource(
 
 //nolint:paralleltest // replaces global backend instance
 func TestVcsTemplateSourceOrgsAreReadOffTheListing(t *testing.T) {
-	// The totals ride on every page of every listing, so both browse fetches report the same
-	// organizations; observing them twice must not double-count.
+	// Both browse fetches see the same totals; observing them twice must not double-count.
 	source := mockRegistrySource(t, func(
 		ctx context.Context, opts registry.ListTemplatesOptions,
 	) iter.Seq2[apitype.ListTemplatesResponse, error] {
@@ -764,8 +758,6 @@ func TestVcsTemplateSourceOrgsAreReadOffTheListing(t *testing.T) {
 
 //nolint:paralleltest // replaces global backend instance
 func TestBothFetchesListingEverythingIsNotDuplicated(t *testing.T) {
-	// A service that predates the backing filter ignores it and answers every fetch with
-	// everything it has.
 	source := mockRegistrySource(t, func(
 		ctx context.Context, opts registry.ListTemplatesOptions,
 	) iter.Seq2[apitype.ListTemplatesResponse, error] {
@@ -863,7 +855,6 @@ func testContext(t *testing.T) context.Context {
 
 func ptr[T any](v T) *T { return &v }
 
-// singlePage answers a template listing with one page holding the given templates.
 func singlePage(templates ...apitype.TemplateMetadata) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
 		yield(apitype.ListTemplatesResponse{Templates: templates}, nil)

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -46,24 +46,6 @@ import (
 const expectedRegistryFormatError = "Expected: registry://templates/source/publisher/name[@version], " +
 	"source/publisher/name[@version], publisher/name[@version], or name[@version]"
 
-// asPages presents a stream of templates as the pages a registry listing yields, one template per
-// page.
-func asPages(s iter.Seq2[apitype.TemplateMetadata, error]) iter.Seq2[apitype.ListTemplatesResponse, error] {
-	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
-		for t, err := range s {
-			if err != nil {
-				if !yield(apitype.ListTemplatesResponse{}, err) {
-					return
-				}
-				continue
-			}
-			if !yield(apitype.ListTemplatesResponse{Templates: []apitype.TemplateMetadata{t}}, nil) {
-				return
-			}
-		}
-	}
-}
-
 //nolint:paralleltest // replaces global backend instance
 func TestFilterOnName(t *testing.T) {
 	template1 := &apitype.PulumiTemplateRemote{
@@ -144,21 +126,14 @@ func TestFilterOnName(t *testing.T) {
 			ctx context.Context, opts registry.ListTemplatesOptions,
 		) iter.Seq2[apitype.ListTemplatesResponse, error] {
 			assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-			return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-				if !yield(apitype.TemplateMetadata{
-					Name:      "name1",
-					Publisher: "publisher1",
-					Source:    "source1",
-				}, nil) {
-					return
-				}
-				if !yield(apitype.TemplateMetadata{
-					Name:      "name2",
-					Publisher: "publisher2",
-					Source:    "source2",
-				}, nil) {
-					return
-				}
+			return singlePage(apitype.TemplateMetadata{
+				Name:      "name1",
+				Publisher: "publisher1",
+				Source:    "source1",
+			}, apitype.TemplateMetadata{
+				Name:      "name2",
+				Publisher: "publisher2",
+				Source:    "source2",
 			})
 		}
 		mockBackend := &backend.MockBackend{
@@ -265,8 +240,8 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 				ProjectName:        "template3",
 				ProjectDescription: "An ASP.NET application running a simple container in a EKS Cluster",
 			}},
-			orgTemplate{t: template1, org: "org1", source: source, backend: mockBackend},
-			orgTemplate{t: template2, org: "org1", source: source, backend: mockBackend},
+			orgTemplate{t: template1, org: "org1", cleanup: &source.cleanup, backend: mockBackend},
+			orgTemplate{t: template2, org: "org1", cleanup: &source.cleanup, backend: mockBackend},
 		},
 		template)
 }
@@ -322,9 +297,9 @@ func TestSurfaceListTemplateErrors_RegistryTemplates(t *testing.T) {
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{}, somethingWentWrong)
-				})
+				return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+					yield(apitype.ListTemplatesResponse{}, somethingWentWrong)
+				}
 			},
 		},
 	}
@@ -397,7 +372,7 @@ func TestSurfaceOnEmptyError_OrgTemplates(t *testing.T) {
 
 	_, err := source.Templates()
 	var expected TemplateNotFoundError
-	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.errorOnEmpty)
+	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.project.errsOnEmpty)
 }
 
 //nolint:paralleltest // replaces global backend instance
@@ -409,7 +384,7 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 			ListTemplatesF: func(
 				_ context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				return asPages(func(func(apitype.TemplateMetadata, error) bool) {})
+				return singlePage()
 			},
 		},
 	}
@@ -443,7 +418,7 @@ func TestSurfaceOnEmptyError_RegistryTemplates(t *testing.T) {
 
 	_, err := source.Templates()
 	var expected TemplateNotFoundError
-	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.errorOnEmpty)
+	assert.ErrorAsf(t, err, &expected, "what's in %#v", source.project.errsOnEmpty)
 }
 
 //nolint:paralleltest // replaces global backend instance
@@ -513,7 +488,7 @@ description: An ASP.NET application running a simple container in a EKS Cluster
 	template, err := source.Templates()
 	require.NoError(t, err)
 	assert.Equal(t,
-		[]Template{orgTemplate{t: template1, org: "org1", source: source, backend: mockBackend}},
+		[]Template{orgTemplate{t: template1, org: "org1", cleanup: &source.cleanup, backend: mockBackend}},
 		template)
 	t.Cleanup(func() {
 		require.NoError(t, source.Close())
@@ -580,11 +555,9 @@ func createMockRegistrySource(
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Name:        "name1",
-						DownloadURL: "example.com/download/name",
-					}, nil)
+				return singlePage(apitype.TemplateMetadata{
+					Name:        "name1",
+					DownloadURL: "example.com/download/name",
 				})
 			},
 			DownloadTemplateF: downloadFunc,
@@ -678,32 +651,28 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-					if !yield(apitype.TemplateMetadata{
+				// Browsing splits the listing, so each fetch names one backing and the service
+				// answers with the templates that have it.
+				byBacking := map[apitype.TemplateBacking][]apitype.TemplateMetadata{
+					apitype.TemplateBackingRegistry: {{
+						Name:      "just/has/slashes",
+						Source:    "private",
+						Publisher: "pulumi-org",
+					}},
+					apitype.TemplateBackingVcs: {{
 						Name:      "gh-org/repo/name",
 						Source:    "github",
 						Publisher: "pulumi-org",
 						RepoSlug:  ptr("gh-org/repo"),
-					}, nil) {
-						return
-					}
-					if !yield(apitype.TemplateMetadata{
+					}, {
 						Name:      "gl-org/repo/name",
 						Source:    "gitlab",
 						Publisher: "pulumi-org",
 						RepoSlug:  ptr("gl-org/repo"),
-					}, nil) {
-						return
-					}
-					if !yield(apitype.TemplateMetadata{
-						Name:      "just/has/slashes",
-						Source:    "private",
-						Publisher: "pulumi-org",
-					}, nil) {
-						return
-					}
-				})
+					}},
+				}
+				require.Len(t, opts.Backing, 1)
+				return singlePage(byBacking[opts.Backing[0]]...)
 			},
 		},
 	}
@@ -734,12 +703,83 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, templates, 3)
 
-	assert.Equal(t, "name", templates[0].Name())
-	assert.Equal(t, "name [gh-org/repo]", templates[0].DisplayName())
+	// The fetches are concatenated in the order they are declared, so the registry-backed template
+	// leads.
+	assert.Equal(t, "just/has/slashes", templates[0].Name())
+	assert.Equal(t, "just/has/slashes [pulumi-org]", templates[0].DisplayName())
 	assert.Equal(t, "name", templates[1].Name())
-	assert.Equal(t, "name [gl-org/repo]", templates[1].DisplayName())
-	assert.Equal(t, "just/has/slashes", templates[2].Name())
-	assert.Equal(t, "just/has/slashes [pulumi-org]", templates[2].DisplayName())
+	assert.Equal(t, "name [gh-org/repo]", templates[1].DisplayName())
+	assert.Equal(t, "name", templates[2].Name())
+	assert.Equal(t, "name [gl-org/repo]", templates[2].DisplayName())
+}
+
+// mockRegistrySource wires a ListTemplates implementation into a source that browses.
+func mockRegistrySource(
+	t *testing.T,
+	list func(context.Context, registry.ListTemplatesOptions) iter.Seq2[apitype.ListTemplatesResponse, error],
+) *Source {
+	t.Helper()
+	mockBackend := &backend.MockBackend{
+		GetReadOnlyCloudRegistryF: func() registry.Registry {
+			return &backend.MockCloudRegistry{Mock: registry.Mock{ListTemplatesF: list}}
+		},
+	}
+	testutil.MockLoginManager(t, &cmdBackend.MockLoginManager{
+		CurrentF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	})
+	return newImpl(testContext(t), "", ScopeAll, TemplateKindPulumiProject,
+		templateRepository(TemplateRepository{}, TemplateNotFoundError{}),
+		env.NewEnv(env.MapStore{"PULUMI_DISABLE_REGISTRY_RESOLVE": "false"}))
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestVcsTemplateSourceOrgsAreReadOffTheListing(t *testing.T) {
+	// The totals ride on every page of every listing, so both browse fetches report the same
+	// organizations; observing them twice must not double-count.
+	source := mockRegistrySource(t, func(
+		ctx context.Context, opts registry.ListTemplatesOptions,
+	) iter.Seq2[apitype.ListTemplatesResponse, error] {
+		return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+			yield(apitype.ListTemplatesResponse{
+				VcsTemplateSourceTotals: []apitype.OrgVcsTemplateSourceTotal{
+					{OrgLogin: "acme", Total: 2},
+					{OrgLogin: "globex", Total: 1},
+				},
+			}, nil)
+		}
+	})
+
+	assert.Equal(t, []string{"acme", "globex"}, source.VcsTemplateSourceOrgs(),
+		"an org with collections is named even though no fetch carries its templates")
+}
+
+//nolint:paralleltest // replaces global backend instance
+func TestBothFetchesListingEverythingIsNotDuplicated(t *testing.T) {
+	// A service that predates the backing filter ignores it and answers every fetch with
+	// everything it has.
+	source := mockRegistrySource(t, func(
+		ctx context.Context, opts registry.ListTemplatesOptions,
+	) iter.Seq2[apitype.ListTemplatesResponse, error] {
+		return singlePage(
+			apitype.TemplateMetadata{Name: "vpc", Source: "private", Publisher: "acme"},
+			apitype.TemplateMetadata{Name: "org/repo/eks", Source: "github", Publisher: "acme", RepoSlug: ptr("org/repo")},
+		)
+	})
+
+	templates, err := source.Templates()
+	require.NoError(t, err)
+	require.Len(t, templates, 2, "each template is listed once even when both fetches return it")
+	assert.Equal(t, "vpc", templates[0].Name())
+	assert.Equal(t, "eks", templates[1].Name())
 }
 
 //nolint:paralleltest // replaces global backend instance
@@ -751,32 +791,22 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
 				assert.Equal(t, registry.ListTemplatesOptions{}, opts)
-				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-					if !yield(apitype.TemplateMetadata{
-						Name:        "gh-org/repo/target",
-						Source:      "github",
-						Description: ptr("This is from GH"),
-						Publisher:   "pulumi-org",
-						RepoSlug:    ptr("gh-org/repo"),
-					}, nil) {
-						return
-					}
-					if !yield(apitype.TemplateMetadata{
-						Name:      "gl-org/repo/name",
-						Source:    "gitlab",
-						Publisher: "pulumi-org",
-						RepoSlug:  ptr("gl-org/repo"),
-					}, nil) {
-						return
-					}
-					if !yield(apitype.TemplateMetadata{
-						Name:        "target",
-						Source:      "private",
-						Description: ptr("This is from the registry"),
-						Publisher:   "pulumi-org",
-					}, nil) {
-						return
-					}
+				return singlePage(apitype.TemplateMetadata{
+					Name:        "gh-org/repo/target",
+					Source:      "github",
+					Description: ptr("This is from GH"),
+					Publisher:   "pulumi-org",
+					RepoSlug:    ptr("gh-org/repo"),
+				}, apitype.TemplateMetadata{
+					Name:      "gl-org/repo/name",
+					Source:    "gitlab",
+					Publisher: "pulumi-org",
+					RepoSlug:  ptr("gl-org/repo"),
+				}, apitype.TemplateMetadata{
+					Name:        "target",
+					Source:      "private",
+					Description: ptr("This is from the registry"),
+					Publisher:   "pulumi-org",
 				})
 			},
 		},
@@ -833,6 +863,13 @@ func testContext(t *testing.T) context.Context {
 
 func ptr[T any](v T) *T { return &v }
 
+// singlePage answers a template listing with one page holding the given templates.
+func singlePage(templates ...apitype.TemplateMetadata) iter.Seq2[apitype.ListTemplatesResponse, error] {
+	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
+		yield(apitype.ListTemplatesResponse{Templates: templates}, nil)
+	}
+}
+
 //nolint:paralleltest // replaces global backend instance
 func TestRegistryTemplateResolution(t *testing.T) {
 	ctx := testContext(t)
@@ -842,31 +879,26 @@ func TestRegistryTemplateResolution(t *testing.T) {
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Name:        "csharp-documented",
-						Source:      "private",
-						Publisher:   "pulumi_local",
-						Description: ptr("A C# template"),
-					}, nil)
-					yield(apitype.TemplateMetadata{
-						Name:      "csharp-documented",
-						Source:    "github",
-						Publisher: "different-org",
-					}, nil)
-					yield(apitype.TemplateMetadata{
-						Name:        "gh-org/repo/target",
-						Source:      "github",
-						Publisher:   "pulumi-org",
-						RepoSlug:    ptr("gh-org/repo"),
-						Description: ptr("A template from VCS"),
-					}, nil)
-					yield(apitype.TemplateMetadata{
-						Name:        "whatever-template",
-						Source:      "private",
-						Publisher:   "test-org",
-						Description: ptr("A template with special chars"),
-					}, nil)
+				return singlePage(apitype.TemplateMetadata{
+					Name:        "csharp-documented",
+					Source:      "private",
+					Publisher:   "pulumi_local",
+					Description: ptr("A C# template"),
+				}, apitype.TemplateMetadata{
+					Name:      "csharp-documented",
+					Source:    "github",
+					Publisher: "different-org",
+				}, apitype.TemplateMetadata{
+					Name:        "gh-org/repo/target",
+					Source:      "github",
+					Publisher:   "pulumi-org",
+					RepoSlug:    ptr("gh-org/repo"),
+					Description: ptr("A template from VCS"),
+				}, apitype.TemplateMetadata{
+					Name:        "whatever-template",
+					Source:      "private",
+					Publisher:   "test-org",
+					Description: ptr("A template with special chars"),
 				})
 			},
 		},
@@ -1066,13 +1098,11 @@ func TestVersionedTemplateResolution(t *testing.T) {
 			ListTemplatesF: func(
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
-				return asPages(func(yield func(apitype.TemplateMetadata, error) bool) {
-					yield(apitype.TemplateMetadata{
-						Name:        "my-template",
-						Source:      "private",
-						Publisher:   "my-org",
-						Description: ptr("Latest version"),
-					}, nil)
+				return singlePage(apitype.TemplateMetadata{
+					Name:        "my-template",
+					Source:      "private",
+					Publisher:   "my-org",
+					Description: ptr("Latest version"),
 				})
 			},
 		},

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -28,19 +28,19 @@ type getProjectTemplateFunc = func(ctx context.Context, templateNamePathOrURL st
 	templateKind TemplateKind,
 ) (TemplateRepository, error)
 
-func (s *Source) getProjectTemplates(
-	ctx context.Context, templateNamePathOrURL string, scope SearchScope, templateKind TemplateKind,
-	get getProjectTemplateFunc,
+func (f *fetch) listProjectTemplates(
+	ctx context.Context, templateNamePathOrURL string, scope SearchScope,
+	templateKind TemplateKind, get getProjectTemplateFunc, c *cleanup,
 ) {
 	repo, err := get(ctx, templateNamePathOrURL, scope == ScopeLocal, templateKind)
 	if err != nil {
 		if notFound := (TemplateNotFoundError{}); errors.As(err, &notFound) {
-			s.addErrorOnEmpty(notFound)
+			f.addErrorOnEmpty(notFound)
 			return
 		}
 		// Bail on all errors unless its a 401 from a Pulumi Cloud backend...
 		if !errors.Is(err, ErrPulumiCloudUnauthorized) {
-			s.addError(err)
+			f.addError(err)
 			return
 		}
 
@@ -48,18 +48,18 @@ func (s *Source) getProjectTemplates(
 		// attempt to retrieve the template using the user's Pulumi Cloud credentials.
 		repo, err = retrievePrivatePulumiCloudTemplate(templateNamePathOrURL)
 		if err != nil {
-			s.addError(err)
+			f.addError(err)
 			return
 		}
 	}
-	s.addCloser(repo.Delete)
+	c.add(repo.Delete)
 	projectTemplates, err := repo.Templates()
 	if err != nil {
-		s.addError(fmt.Errorf("could not get template from workspace: %w", err))
+		f.addError(fmt.Errorf("could not get template from workspace: %w", err))
 		return
 	}
 
-	s.addDownloadedTemplates(projectTemplates)
+	f.addDownloadedTemplates(projectTemplates)
 }
 
 // Retrieve a Private template from the given Pulumi Cloud URL **including an auth token for Pulumi Cloud**.
@@ -100,9 +100,9 @@ func retrievePrivatePulumiCloudTemplate(templateURL string) (TemplateRepository,
 	return templateRepository, err
 }
 
-func (s *Source) addDownloadedTemplates(src []ProjectTemplate) {
+func (f *fetch) addDownloadedTemplates(src []ProjectTemplate) {
 	for _, t := range src {
-		s.addTemplate(projectTemplate{t})
+		f.addTemplate(projectTemplate{t})
 	}
 }
 
@@ -116,6 +116,7 @@ func (t projectTemplate) Name() string        { return t.t.Name }
 func (t projectTemplate) DisplayName() string { return t.t.Name }
 func (t projectTemplate) Description() string { return t.t.Description }
 func (t projectTemplate) Error() error        { return t.t.Error }
+func (t projectTemplate) Publisher() string   { return "" }
 func (t projectTemplate) Download(ctx context.Context) (ProjectTemplate, error) {
 	return t.t, nil
 }


### PR DESCRIPTION
> **Stack** (merge bottom-up)
> 1. #24224 — Yield template listings by page and let callers filter by backing
> 2. **#24225 — Split template fetching into speed tiers** ← you are here
> 3. #24226 — Add a guided cloud and language flow to interactive `pulumi new`
>
> Based on #24224. Review that first, or read [this PR's own diff](https://github.com/pulumi/pulumi/pull/24225/files).

## Why

A `Source` ran every listing into one shared set of templates behind one mutex, so a caller could only ever wait for all of them. The listing that has to reach a version control provider is far slower than the rest, so a prompt built from the complete set waits on the slowest fetch before rendering anything — even though the templates it needs first are already in hand.

Splitting the fetches by how long they take is what lets #24226 render its first prompt immediately. That's the motivation, but the restructuring stands on its own and is easier to review apart from the feature that consumes it.

## What

`Source` now holds three fetches — project, database and upstream — named for how long they take rather than for what they hold. Each fetch owns the templates, errors and side observations it produced, under its own mutex.

- `ProjectTemplates` and `DatabaseTemplates` join one fetch without waiting on the rest.
- `Templates` still joins all three, dropping a registry template an earlier fetch already produced.
- `VcsTemplateSourceOrgs` reports the organizations the service named as having collections it did not fetch, read from a single fetch so the answer does not depend on which listing finished first.

## How

Browsing splits the cloud listing into a registry fetch and a vcs fetch, so the database tier holds something to prompt from. Resolving a name still runs one unfiltered lookup, since it has no prompt to render early. `listRegistry` and `resolveRegistryName` become separate entry points over a shared paging loop, rather than one entry point whose branches were inert in one mode or the other.

The closers move to a `cleanup` type that templates hold, instead of a `*Source` back-pointer, so downloading a template can register its temp directory without also gaining access to the fetches. `Template` gains `Publisher`, which the guided prompts need to attribute a template to an organization.

## Reviewer notes

The new tier accessors have **no caller in this PR** — #24226 is the first. Every existing caller still uses `Templates()` and keeps its current semantics:

| Caller | API |
| --- | --- |
| `up.go:330` | `Templates()` |
| `new.go` (`--list-templates`) | `Templates()` |
| `package new`, `policy new` | `Templates()` |

The one behavior change for them: browsing now issues two registry calls instead of one, concurrently — one per backing. Same wall clock, one more request.

## Testing

`make lint` is clean across all seven modules.

