### PR TITLE
Omit unused value variable in Go codegen numeric-range loops

### DIFF
--- a/changelog/pending/programgen-go-fix-20260807-104719.yaml
+++ b/changelog/pending/programgen-go-fix-20260807-104719.yaml
@@ -1,4 +1,6 @@
 component: programgen/go
 kind: fix
 body: Fix invalid `_ := index` statement emitted for resources with a numeric `range` whose value variable is unused
-time: 2026-08-07T10:47:19.590973+02:00
+time: 2026-08-07T10:47:19.000000+01:00
+custom:
+  PR: "24227"

--- a/changelog/pending/programgen-go-fix-20260807-104719.yaml
+++ b/changelog/pending/programgen-go-fix-20260807-104719.yaml
@@ -1,0 +1,4 @@
+component: programgen/go
+kind: fix
+body: Fix invalid `_ := index` statement emitted for resources with a numeric `range` whose value variable is unused
+time: 2026-08-07T10:47:19.590973+02:00

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -1728,7 +1728,9 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 			g.Fgenf(w, "for index := 0; index < %.v; index++ {\n", rangeExpr)
 			g.Indented(func() {
 				g.Fgenf(w, "%skey0 := index\n", g.Indent)
-				g.Fgenf(w, "%s%s := index\n", g.Indent, valVar)
+				if isValUsed {
+					g.Fgenf(w, "%sval0 := index\n", g.Indent)
+				}
 			})
 		} else {
 			g.Fgenf(w, "for key0, %s := range %.v {\n", valVar, rangeExpr)
@@ -1863,7 +1865,9 @@ func (g *generator) genReadResource(w io.Writer, r *pcl.ReadResource) {
 			g.Fgenf(w, "for index := 0; index < %.v; index++ {\n", rangeExpr)
 			g.Indented(func() {
 				g.Fgenf(w, "%skey0 := index\n", g.Indent)
-				g.Fgenf(w, "%s%s := index\n", g.Indent, valVar)
+				if isValUsed {
+					g.Fgenf(w, "%sval0 := index\n", g.Indent)
+				}
 			})
 		} else {
 			g.Fgenf(w, "for key0, %s := range %.v {\n", valVar, rangeExpr)
@@ -2172,7 +2176,9 @@ func (g *generator) genComponent(w io.Writer, r *pcl.Component) {
 			g.Fgenf(w, "for index := 0; index < %.v; index++ {\n", rangeExpr)
 			g.Indented(func() {
 				g.Fgenf(w, "%skey0 := index\n", g.Indent)
-				g.Fgenf(w, "%s%s := index\n", g.Indent, valVar)
+				if isValUsed {
+					g.Fgenf(w, "%sval0 := index\n", g.Indent)
+				}
 			})
 		} else {
 			g.Fgenf(w, "for key0, %s := range %.v {\n", valVar, rangeExpr)

--- a/tests/testdata/codegen/components-pp/go/components.go
+++ b/tests/testdata/codegen/components-pp/go/components.go
@@ -13,7 +13,6 @@ func main() {
 		var multipleSimpleComponents []*SimpleComponent
 		for index := 0; index < 10; index++ {
 			key0 := index
-			_ := index
 			__res, err := NewSimpleComponent(ctx, fmt.Sprintf("multipleSimpleComponents-%v", key0), nil)
 			if err != nil {
 				return err

--- a/tests/testdata/codegen/unknown-resource-pp/go/unknown-resource.go
+++ b/tests/testdata/codegen/unknown-resource-pp/go/unknown-resource.go
@@ -26,7 +26,6 @@ func main() {
 		var fromModule []*eks.Example
 		for index := 0; index < 10; index++ {
 			key0 := index
-			_ := index
 			__res, err := eks.NewExample(ctx, fmt.Sprintf("fromModule-%v", key0), &eks.ExampleArgs{
 				AssociatedMain: main.Id,
 			})


### PR DESCRIPTION
Accidental find as a side-effect of my daily "try to find a random issue and fix it" Claude job. The codegen tests aren't valid programs because we write `_ :=`, which leads to a "no unused vars on the left side" issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)