### PR TITLE
Validate resource/function/property names

### DIFF
--- a/changelog/pending/20260806--sdkgen--reject-leading-underscore-names.yaml
+++ b/changelog/pending/20260806--sdkgen--reject-leading-underscore-names.yaml
@@ -1,0 +1,3 @@
+component: sdkgen
+kind: fix
+body: Reject schema resource, function, and property names that start with underscores

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -108,6 +108,13 @@ func validatePrintableName(path, kind, name string) *hcl.Diagnostic {
 	return nil
 }
 
+func validateName(path, kind, name string) *hcl.Diagnostic {
+	if strings.HasPrefix(name, "_") {
+		return errorf(path, "%s must not start with an underscore", kind)
+	}
+	return nil
+}
+
 func validateSpec(spec PackageSpec) (hcl.Diagnostics, error) {
 	bytes, err := json.Marshal(spec)
 	if err != nil {
@@ -1393,6 +1400,11 @@ func (t *types) bindProperties(path string, properties map[string]PropertySpec, 
 		if diag := validatePrintableName(propertyPath, "property name", name); diag != nil {
 			diags = diags.Append(diag)
 		}
+		if name != "__self__" {
+			if diag := validateName(propertyPath, "property name", name); diag != nil {
+				diags = diags.Append(diag)
+			}
+		}
 		if isReservedKeyword(name) {
 			diags = diags.Append(errorf(propertyPath, "%s", name+" is a reserved property name"))
 		}
@@ -2168,6 +2180,9 @@ func (t *types) bindResourceDef(
 		parts := strings.Split(token, ":")
 		if len(parts) == 3 {
 			name := parts[2]
+			if diag := validateName(path, "resource name", name); diag != nil {
+				diags = diags.Append(diag)
+			}
 			if isReservedKeyword(name) {
 				diags = diags.Append(errorf(path, "%s", name+" is a reserved name, cannot name resource"))
 			}
@@ -2403,6 +2418,9 @@ func (t *types) bindFunctionDef(token string, options ValidationOptions) (*Funct
 	parts := strings.Split(token, ":")
 	if len(parts) == 3 {
 		name := parts[2]
+		if diag := validateName(path, "function name", name); diag != nil {
+			diags = diags.Append(diag)
+		}
 		if isReservedKeyword(name) {
 			diags = diags.Append(errorf(path, "%s", name+" is a reserved name, cannot name function"))
 			return nil, diags, errors.New(name + " is a reserved name, cannot name function")

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1243,6 +1243,23 @@ func TestBindSpecPrintableNames(t *testing.T) {
 				"property name must contain only printable, non-whitespace characters",
 		},
 		{
+			name: "resource output property leading underscore",
+			spec: PackageSpec{
+				Name: "test",
+				Resources: map[string]ResourceSpec{
+					"test:index:TestResource": {
+						ObjectTypeSpec: ObjectTypeSpec{
+							Properties: map[string]PropertySpec{
+								"_badProperty": stringProperty,
+							},
+						},
+					},
+				},
+			},
+			wantSummary: "#/resources/test:index:TestResource/properties/_badProperty: " +
+				"property name must not start with an underscore",
+		},
+		{
 			name: "resource input property",
 			spec: PackageSpec{
 				Name: "test",
@@ -1285,6 +1302,16 @@ func TestBindSpecPrintableNames(t *testing.T) {
 			},
 			wantSummary: "#/resources/test:index:Bad%09Resource: " +
 				"resource name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "resource name leading underscore",
+			spec: PackageSpec{
+				Name: "test",
+				Resources: map[string]ResourceSpec{
+					"test:index:_BadResource": {},
+				},
+			},
+			wantSummary: "#/resources/test:index:_BadResource: resource name must not start with an underscore",
 		},
 		{
 			name: "resource name space",
@@ -1337,6 +1364,16 @@ func TestBindSpecPrintableNames(t *testing.T) {
 			},
 			wantSummary: "#/functions/test:index:bad%7Ffunction: " +
 				"function name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "function name leading underscore",
+			spec: PackageSpec{
+				Name: "test",
+				Functions: map[string]FunctionSpec{
+					"test:index:_badFunction": {},
+				},
+			},
+			wantSummary: "#/functions/test:index:_badFunction: function name must not start with an underscore",
 		},
 		{
 			name: "function name space",


### PR DESCRIPTION
Validate that resource/function/property names do not start with underscores. Codegen can't deal with these and it's unclear how Go or Python in particular could ever nicely support underscore leading names.