### PR TITLE
fix(sdk/python): don't hang on a resource that depends on its parent

### DIFF
--- a/changelog/pending/sdk-python-fix-20260807-120814.yaml
+++ b/changelog/pending/sdk-python-fix-20260807-120814.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: fix
+body: Report an error instead of hanging when a Python resource depends on its own parent
+time: 2026-08-07T12:08:14.854357+02:00

--- a/changelog/pending/sdk-python-fix-20260807-120814.yaml
+++ b/changelog/pending/sdk-python-fix-20260807-120814.yaml
@@ -2,3 +2,5 @@ component: sdk/python
 kind: fix
 body: Report an error instead of hanging when a Python resource depends on its own parent
 time: 2026-08-07T12:08:14.854357+02:00
+custom:
+  PR: "24230"

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -325,10 +325,6 @@ async def _add_dependency(
         # Rather than adding the component resource itself, each child resource
         # is added as a dependency.
         if isinstance(res, ComponentResource) and not res._remote:
-            # Copy the set before iterating so that any concurrent child additions during
-            # the dependency computation (which is async, so can be interleaved with other
-            # operations including child resource construction which adds children to this
-            # resource) do not trigger modification during iteration errors.
             child_resources = res._childResources.copy()
             for child in child_resources:
                 res_list.append((child, from_resource))

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -292,7 +292,11 @@ async def _add_dependency(
 
     # Note that a recursive algorithm here would be cleaner, but that results in a
     # RecursionError with deeply nested hierarchies of ComponentResources.
+    # The traversal below must not await: awaiting a URN part way through can
+    # deadlock against a cycle that has not been walked yet. Collect the
+    # resources to await and await them once the whole graph has been checked.
     res_list = [(res, from_resource)]
+    awaitable: list[Resource] = []
     while len(res_list) > 0:
         res, from_resource = res_list.pop(0)
         if not isinstance(res, Resource):
@@ -329,9 +333,12 @@ async def _add_dependency(
             for child in child_resources:
                 res_list.append((child, from_resource))
         else:
-            urn = await res.urn.future()
-            if urn:
-                deps[urn] = res
+            awaitable.append(res)
+
+    for res in awaitable:
+        urn = await res.urn.future()
+        if urn:
+            deps[urn] = res
 
 
 async def _expand_dependencies(

--- a/sdk/python/lib/test/test_rpc.py
+++ b/sdk/python/lib/test/test_rpc.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import asyncio
+import os
 import unittest
+from unittest import mock
 
 from pulumi.output import Unknown, UNKNOWN
 from pulumi.resource import ComponentResource, CustomResource
@@ -213,7 +215,8 @@ class TestAddDependency(unittest.IsolatedAsyncioTestCase):
         sibling = _FakeCustomResource("sibling")
         parent = _FakeComponentResource("parent", [sibling, cyclic_child])
 
-        with self.assertRaises(RuntimeError):
+        env = {rpc.ERROR_ON_DEPENDENCY_CYCLES_VAR: "true"}
+        with mock.patch.dict(os.environ, env), self.assertRaises(RuntimeError):
             await asyncio.wait_for(
                 rpc._add_dependency({}, parent, cyclic_child), timeout=30
             )

--- a/sdk/python/lib/test/test_rpc.py
+++ b/sdk/python/lib/test/test_rpc.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import unittest
 
 from pulumi.output import Unknown, UNKNOWN
+from pulumi.resource import ComponentResource, CustomResource
 from pulumi.runtime import rpc
 
 
@@ -180,3 +182,40 @@ class TestContainsUnknowns(unittest.TestCase):
         resource_props_preview = resource_props.copy()
         resource_props_preview["arn"] = UNKNOWN
         self.assertTrue(rpc.contains_unknowns(resource_props_preview))
+
+
+class _NeverResolvingUrn:
+    def future(self):
+        return asyncio.get_event_loop().create_future()
+
+
+class _FakeCustomResource(CustomResource):
+    def __init__(self, name: str):
+        self.__dict__["_type"] = "test:index:custom"
+        self.__dict__["_name"] = name
+        self.__dict__["urn"] = _NeverResolvingUrn()
+
+
+class _FakeComponentResource(ComponentResource):
+    def __init__(self, name: str, children: list):
+        self.__dict__["_type"] = "test:index:component"
+        self.__dict__["_name"] = name
+        self.__dict__["_remote"] = False
+        self.__dict__["_childResources"] = children
+        self.__dict__["urn"] = _NeverResolvingUrn()
+
+
+class TestAddDependency(unittest.IsolatedAsyncioTestCase):
+    """Regression test for https://github.com/pulumi/pulumi/issues/13551"""
+
+    async def test_cycle_through_parent_is_reported(self):
+        cyclic_child = _FakeCustomResource("cyclic-child")
+        sibling = _FakeCustomResource("sibling")
+        # `sibling` is listed first so that the traversal reaches it, and would
+        # await its URN, before it walks as far as the cycle.
+        parent = _FakeComponentResource("parent", [sibling, cyclic_child])
+
+        with self.assertRaises(RuntimeError):
+            await asyncio.wait_for(
+                rpc._add_dependency({}, parent, cyclic_child), timeout=30
+            )

--- a/sdk/python/lib/test/test_rpc.py
+++ b/sdk/python/lib/test/test_rpc.py
@@ -211,8 +211,6 @@ class TestAddDependency(unittest.IsolatedAsyncioTestCase):
     async def test_cycle_through_parent_is_reported(self):
         cyclic_child = _FakeCustomResource("cyclic-child")
         sibling = _FakeCustomResource("sibling")
-        # `sibling` is listed first so that the traversal reaches it, and would
-        # await its URN, before it walks as far as the cycle.
         parent = _FakeComponentResource("parent", [sibling, cyclic_child])
 
         with self.assertRaises(RuntimeError):

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-04T13:43:16.388842Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -449,7 +449,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-04T13:43:16.388842Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -449,7 +449,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1394,8 +1394,6 @@ func TestConstructProviderExplicitPython(t *testing.T) {
 //
 //nolint:paralleltest // ProgramTestManualLifeCycle calls t.Parallel()
 func TestFailsOnImplicitDependencyCyclesPython(t *testing.T) {
-	t.Skip("Temporarily skipping flakey test - pulumi/pulumi#14708")
-
 	stdout := &bytes.Buffer{}
 	pt := integration.ProgramTestManualLifeCycle(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join("python", "implicit-dependency-cycles"),


### PR DESCRIPTION
Accidentally ran the daily bug-basher twice today.

The point here is that we don't want to start `await`ing things until we've checked whether a deadlock can happen. If `Parent` depends on `Child` and `Child` depends on `Parent`, but `OtherChild` ends up running before `Child`, then it's stuck waiting for `Parent`, `Parent` is waiting for `Child`, and `Child` never gets run.

Fixes #13551.