### PR TITLE
Fall back to a global project under PULUMI_HOME for `pulumi do`

### DIFF
--- a/changelog/pending/cli-do-global-project-20260806.yaml
+++ b/changelog/pending/cli-do-global-project-20260806.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: feat
+body: Fall back to an auto-created project and stack under PULUMI_HOME when `pulumi do` is invoked outside of a Pulumi project
+time: 2026-08-06T00:00:00+01:00

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -149,6 +149,18 @@ func NewDoCmd(
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 			return nil, nil, fmt.Errorf("read project: %w", err)
 		}
+		usedGlobalProjectFallback := false
+		// Fall back to the auto-materialized global project under $PULUMI_HOME so that stateful
+		// `pulumi do` subcommands work without the user having to run `pulumi new` / `pulumi
+		// stack init` first. ensureGlobalProject only touches the filesystem; the matching
+		// `default` stack is created lazily by the stateful command path.
+		if proj == nil {
+			proj, root, err = ensureGlobalProject()
+			if err != nil {
+				return nil, nil, err
+			}
+			usedGlobalProjectFallback = true
+		}
 		// If we're inside a Pulumi project, the working directory the plugin host runs in should be
 		// the project's pwd, not whatever the user happened to invoke `pulumi` from. Snapshot that
 		// here so plugin.NewContext / pluginFromSource see the project-relative path; the rest of
@@ -286,6 +298,7 @@ func NewDoCmd(
 			wd:                wd,
 			proj:              proj,
 			root:              root,
+			globalFallback:    usedGlobalProjectFallback,
 			ws:                ws,
 			lm:                lm,
 			diagFwd:           diagFwd,
@@ -482,8 +495,14 @@ expression in the input format (e.g. YAML interpolations or fn:: invocations).`,
 //
 // Errors reading the workspace are swallowed: the stack identity is best-effort context for PCL
 // evaluation, not a hard requirement, and `do` must stay usable when no workspace is configured.
-func currentStackIdentity(ws pkgWorkspace.Context) (organization, stack string) {
-	w, err := ws.New("")
+func currentStackIdentity(ws pkgWorkspace.Context, globalFallback bool, root string) (organization, stack string) {
+	dir := ""
+	// The global fallback project lives outside the process cwd; read its workspace settings
+	// directly so PCL sees the selected stack the same as it would in a real project.
+	if globalFallback {
+		dir = root
+	}
+	w, err := ws.New(dir)
 	if err != nil {
 		return "", ""
 	}
@@ -527,6 +546,9 @@ type packageCommand struct {
 	wd   string
 	proj *workspace.Project
 	root string
+	// globalFallback is true only when buildSubcommand synthesized pc.proj from
+	// $PULUMI_HOME/default-global-project because no real project was found.
+	globalFallback bool
 
 	// ws / lm let configureProvider open the current stack's backend when --provider is set so it
 	// can read the referenced provider resource's Inputs. Plumbed from NewDoCmd.
@@ -552,7 +574,7 @@ func (pc *packageCommand) evalContext() functionEvalContext {
 		// When a stack is selected in the workspace, expose its organization and short name to the
 		// PCL runtime so input files can reference pulumi.organization / pulumi.stack the same way
 		// a program would.
-		ec.Organization, ec.Stack = currentStackIdentity(pc.ws)
+		ec.Organization, ec.Stack = currentStackIdentity(pc.ws, pc.globalFallback, pc.root)
 	}
 	return ec
 }

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -45,7 +45,7 @@ func TestDoCmdWithFunctionHelpArgPrintsHelp(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -154,7 +154,7 @@ func TestDoCmdFunctionInvoke(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -239,7 +239,7 @@ func TestDoCmdFunctionInvokeFiltersOutputsToSchema(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -293,7 +293,7 @@ func TestDoCmdFunctionInvokeFiltersNestedObjectsInCollections(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		spec := schema.PackageSpec{
 			Name: "azure",
@@ -392,7 +392,7 @@ func TestDoCmdFunctionInvokeReturnType(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -439,7 +439,7 @@ func TestDoCmdFunctionInvokeReturnTypeFiltersSchema(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -523,7 +523,7 @@ func TestDoCmdFunctionInvokeReturnTypeFiltersSchemaSecrets(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -619,7 +619,7 @@ func TestDoCmdFunctionInvokeNestedModule(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "pkg", source)
 		spec := schema.PackageSpec{
@@ -682,7 +682,7 @@ func TestDoCmdFunctionInvoke_MissingRequiredInput(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -743,7 +743,7 @@ func TestDoCmdFunctionInvoke_NoInputFileWithRequired(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		spec := schema.PackageSpec{
 			Name: "azure",
@@ -859,7 +859,7 @@ param3 = {
 			t.Parallel()
 
 			mlm := &cmdBackend.MockLoginManager{}
-			mws := &pkgWorkspace.MockContext{}
+			mws := newTestWorkspace(t)
 			loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 				assert.Equal(t, "azure", source)
 				spec := schema.PackageSpec{
@@ -924,7 +924,7 @@ func TestDoCmdFunctionInvokeInputFileForInputlessFunction(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		spec := schema.PackageSpec{
 			Name: "azure",
@@ -969,7 +969,7 @@ func TestDoCmdFunctionInvokeInputFileRejectsHCLBlocks(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		spec := schema.PackageSpec{
 			Name: "azure",
@@ -1022,7 +1022,7 @@ func TestDoCmdFunctionInvokeInputFileSchemaConversions(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1087,7 +1087,7 @@ func TestDoCmdFunctionInvokeDryRun(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1172,7 +1172,7 @@ func TestDoCmdFunctionInvokeWithBuiltinFunctions(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1231,73 +1231,6 @@ param2 = max(1, length(split(":", "a:b:c")), 6)
 	cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.NoError(t, err)
-}
-
-func TestDoCmdFunctionInvokeWithUnsupportedBuiltinFunction(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "project",
-			input:    `param1 = project()`,
-			expected: "project is not supported",
-		},
-		{
-			name:     "rootDirectory",
-			input:    `param1 = rootDirectory()`,
-			expected: "rootDirectory is not supported",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			mlm := &cmdBackend.MockLoginManager{}
-			mws := &pkgWorkspace.MockContext{}
-			loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
-				spec := schema.PackageSpec{
-					Name: "azure",
-					Functions: map[string]schema.FunctionSpec{
-						"azure:index:myFunction": {
-							Inputs: &schema.ObjectTypeSpec{
-								Properties: map[string]schema.PropertySpec{
-									"param1": {
-										TypeSpec: schema.TypeSpec{
-											Type: "string",
-										},
-									},
-								},
-							},
-							Outputs: &schema.ObjectTypeSpec{
-								Properties: map[string]schema.PropertySpec{
-									"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
-									"output2": {TypeSpec: schema.TypeSpec{Type: "number"}},
-									"output3": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
-								},
-							},
-						},
-					},
-				}
-				return &testProvider{spec: spec}, nil
-			}
-
-			var stdout bytes.Buffer
-			cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, nil)
-			cmd.SetOut(&stdout)
-			cmd.SetErr(&stdout)
-
-			inputFile := writeHCLFile(t, "inputs.pcl", tt.input)
-
-			cmd.SetArgs([]string{"azure:index:myFunction", "--input", "pcl", "--input-file", inputFile})
-			err := cmd.Execute()
-			require.ErrorContains(t, err, tt.expected)
-		})
-	}
 }
 
 func TestDoCmdFunctionInvokeWithProjectContext(t *testing.T) {
@@ -1382,7 +1315,7 @@ func TestDoCmdFunctionInvokeWithConfiguration(t *testing.T) {
 
 	configureCalled := false
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1490,7 +1423,7 @@ func TestDoCmdFunctionInvokeNestedResults(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1570,7 +1503,7 @@ func TestDoCmdFunctionInvokeShowSecrets(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1640,7 +1573,7 @@ func TestDoCmdFunctionInvokeAssetArchiveResults(t *testing.T) {
 	require.NoError(t, err)
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -1722,7 +1655,7 @@ func TestDoCmdFunctionInvokeWithParameterizedPackage(t *testing.T) {
 	subpackageVersion := semver.MustParse("1.2.3")
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		// shlex-split takes only the first token as the plugin source; the rest go to Parameterize.
 		assert.Equal(t, "terraform-provider", source)
@@ -1823,7 +1756,7 @@ func TestDoCmdFunctionInvokeWithYAMLInputFile(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
 		// `do` forwards to the converter as its TargetLoader.
@@ -1952,7 +1885,7 @@ func TestDoCmdFunctionInvokeYAMLInputByDefault(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
 		// `do` forwards to the converter as its TargetLoader.
@@ -2035,7 +1968,7 @@ func TestDoCmdFunctionInvokeWithYAMLInputFileParameterized(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
 		// `do` forwards to the converter as its TargetLoader.
@@ -2137,7 +2070,7 @@ func TestDoCmdFunctionInvokeParameterizedSchemaWithoutArgs(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -2180,7 +2113,7 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFile(t *testing.T) {
 
 	configureCalled := false
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
 		// `do` forwards to the converter as its TargetLoader.
@@ -2271,7 +2204,7 @@ func TestDoCmdFunctionInvokeWithUnknownInputFormat(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	host := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		return &plugin.MockHost{}, nil
 	}
@@ -2329,7 +2262,7 @@ func TestDoCmdFunctionInvokeWithConverterMissingConvertSnippet(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	host := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		return &plugin.MockHost{}, nil
 	}
@@ -2388,7 +2321,7 @@ func TestDoCmdFunctionInvokeWithConverterDiagnostics(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	host := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		return &plugin.MockHost{}, nil
 	}
@@ -2455,7 +2388,7 @@ func TestDoCmdFunctionInvokeWithConverterReturningInvalidPCL(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	host := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		return &plugin.MockHost{}, nil
 	}
@@ -2520,7 +2453,7 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 
 	configureCalled := false
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{
@@ -2595,7 +2528,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 
 	configureCalled := false
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
 		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
 		// `do` forwards to the converter as its TargetLoader.
@@ -2814,7 +2747,7 @@ func TestDoCmdFunctionInvokeWithPlainFlagsSkipsConverter(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		spec := schema.PackageSpec{

--- a/pkg/cmd/pulumi/do/do_global.go
+++ b/pkg/cmd/pulumi/do/do_global.go
@@ -1,0 +1,141 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// globalProjectName is the hardcoded name of the fallback project stored under PULUMI_HOME. It
+// doubles as the directory name so that `pulumi do` can operate with zero setup when the user
+// hasn't cd'd into a real Pulumi project.
+const globalProjectName = "default-global-project"
+
+// globalStackName is the hardcoded stack name auto-created inside the global project.
+const globalStackName = "default"
+
+// ensureGlobalProject materializes the global fallback project under $PULUMI_HOME, creating the
+// directory and a minimal Pulumi.yaml on first use. Returns the loaded project and its root
+// directory in the same shape as pkgWorkspace.Context.ReadProject.
+func ensureGlobalProject() (*workspace.Project, string, error) {
+	home, err := workspace.GetPulumiHomeDir()
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve pulumi home: %w", err)
+	}
+	root := filepath.Join(home, globalProjectName)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, "", fmt.Errorf("create global project dir: %w", err)
+	}
+	projPath := filepath.Join(root, "Pulumi.yaml")
+	if _, err := os.Stat(projPath); os.IsNotExist(err) {
+		proj := &workspace.Project{Name: tokens.PackageName(globalProjectName)}
+		if err := proj.Save(projPath); err != nil {
+			return nil, "", fmt.Errorf("write global Pulumi.yaml: %w", err)
+		}
+	} else if err != nil {
+		return nil, "", fmt.Errorf("stat global Pulumi.yaml: %w", err)
+	}
+	proj, err := workspace.LoadProject(projPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("load global Pulumi.yaml: %w", err)
+	}
+	return proj, root, nil
+}
+
+// ensureGlobalStack loads (or creates on first use) the hardcoded `default` stack inside the
+// global project and marks it selected in the global project's workspace settings so subsequent
+// invocations resolve to the same stack via the usual CurrentStack lookup.
+func ensureGlobalStack(
+	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
+	proj *workspace.Project, root string, opts display.Options,
+) (backend.Stack, error) {
+	b, err := cmdBackend.CurrentBackend(ctx, ws, lm, proj, opts)
+	if err != nil {
+		return nil, fmt.Errorf("open backend for global project: %w", err)
+	}
+	// Look up (or fall back to) the currently selected stack for the global project. If nothing
+	// has been selected yet we create the hardcoded `default` stack and remember the selection.
+	if stack, err := state.CurrentStackAt(ctx, ws, b, root); err != nil {
+		return nil, fmt.Errorf("read current stack for global project: %w", err)
+	} else if stack != nil {
+		return stack, nil
+	}
+
+	ref, err := b.ParseStackReference(globalStackName)
+	if err != nil {
+		return nil, fmt.Errorf("parse global stack reference: %w", err)
+	}
+	stack, err := b.GetStack(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("look up global stack: %w", err)
+	}
+	if stack == nil {
+		stack, err = cmdStack.CreateStack(
+			ctx, sink, ws, b, ref, root,
+			nil,   /*teams*/
+			false, /*setCurrent — we handle selection ourselves below to target the global project*/
+			"",    /*secretsProvider*/
+			false, /*useRemoteConfig*/
+			"",    /*configFile*/
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create global stack: %w", err)
+		}
+	}
+	w, err := ws.New(root)
+	if err != nil {
+		return nil, fmt.Errorf("record global stack selection: %w", err)
+	}
+	w.Settings().SetStackForBackend(state.BackendURLKey(b), stack.Ref().FullyQualifiedName().String())
+	if err := w.Save(); err != nil {
+		return nil, fmt.Errorf("record global stack selection: %w", err)
+	}
+	return stack, nil
+}
+
+// loadStackForStateful resolves the stack a stateful subcommand should operate on. For real
+// projects this is the workspace's currently selected stack (via RequireStack). For the
+// synthesized global project we bypass RequireStack — which reads selection state from cwd and
+// won't prompt in non-interactive mode — and instead lazily create-and-select the hardcoded
+// `default` stack so first-time users don't need any manual setup.
+func (pc *packageCommand) loadStackForStateful(
+	ctx context.Context, opts display.Options,
+) (backend.Stack, error) {
+	if pc.globalFallback {
+		return ensureGlobalStack(ctx, pc.diagFwd, pc.ws, pc.lm, pc.proj, pc.root, opts)
+	}
+	stack, err := cmdStack.RequireStack(
+		ctx, pc.diagFwd, pc.ws, pc.lm,
+		"",                          /*stackName — use currently selected*/
+		cmdStack.LoadOnly, opts, "", /*configFile*/
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load stack: %w", err)
+	}
+	return stack, nil
+}

--- a/pkg/cmd/pulumi/do/do_global_test.go
+++ b/pkg/cmd/pulumi/do/do_global_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureGlobalProjectUsesPulumiHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PULUMI_HOME", home)
+
+	proj, root, err := ensureGlobalProject()
+	require.NoError(t, err)
+
+	assert.Equal(t, globalProjectName, string(proj.Name))
+	assert.Equal(t, filepath.Join(home, globalProjectName), root)
+	require.FileExists(t, filepath.Join(root, "Pulumi.yaml"))
+}

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -89,7 +89,7 @@ func newDoResourceCommand(
 	t.Helper()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "azure", source)
 		return provider, nil

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -196,9 +196,7 @@ type statefulSnippetUpdate struct {
 func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args statefulSnippetUpdate) error {
 	contract.Assertf(pc.runStatefulUpdate != nil, "stateful snippet update is not wired up in this build")
 
-	if pc.proj == nil {
-		return fmt.Errorf("`%s` requires a Pulumi project (run inside a project directory)", cmd.Name())
-	}
+	contract.Assertf(pc.proj != nil, "project must be set (the global fallback should have supplied one)")
 	if err := pc.requireYesIfNonInteractive(args.yes); err != nil {
 		return err
 	}
@@ -209,13 +207,9 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 	// stack is threaded through to runStatefulUpdate so it doesn't re-load. We also use the same
 	// snapshot to resolve resource-reference package metadata before conversion.
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
-	stack, err := cmdStack.RequireStack(
-		ctx, pc.diagFwd, pc.ws, pc.lm,
-		"",                                 /*stackName — use currently selected*/
-		cmdStack.LoadOnly, displayOpts, "", /*configFile*/
-	)
+	stack, err := pc.loadStackForStateful(ctx, displayOpts)
 	if err != nil {
-		return fmt.Errorf("load stack: %w", err)
+		return err
 	}
 	snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
 	if err != nil {
@@ -326,22 +320,16 @@ func (pc *packageCommand) runStatefulSnippetDelete(
 ) error {
 	contract.Assertf(pc.runStatefulUpdate != nil, "stateful snippet update is not wired up in this build")
 
-	if pc.proj == nil {
-		return fmt.Errorf("`%s` requires a Pulumi project (run inside a project directory)", cmd.Name())
-	}
+	contract.Assertf(pc.proj != nil, "project must be set (the global fallback should have supplied one)")
 	if err := pc.requireYesIfNonInteractive(yes); err != nil {
 		return err
 	}
 
 	ctx := cmd.Context()
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
-	stack, err := cmdStack.RequireStack(
-		ctx, pc.diagFwd, pc.ws, pc.lm,
-		"",                                 /*stackName — use currently selected*/
-		cmdStack.LoadOnly, displayOpts, "", /*configFile*/
-	)
+	stack, err := pc.loadStackForStateful(ctx, displayOpts)
 	if err != nil {
-		return fmt.Errorf("load stack: %w", err)
+		return err
 	}
 	snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
 	if err != nil {

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -68,7 +68,7 @@ func TestDoCmdNoArgsPrintsHelp(t *testing.T) {
 			t.Parallel()
 
 			mlm := &cmdBackend.MockLoginManager{}
-			mws := &pkgWorkspace.MockContext{}
+			mws := newTestWorkspace(t)
 
 			var stdout bytes.Buffer
 			cmd := NewDoCmd(mlm, mws, panicLoader, testHost, panicLoadConverterPlugin, nil)
@@ -121,7 +121,7 @@ func TestDoCmdWithPkgFlagPrintsHelp(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "aws@4.1", source)
 		spec := schema.PackageSpec{
@@ -187,7 +187,7 @@ func TestDoCmdWithPkgArgPrintsHelp(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "aws", source)
 		spec := schema.PackageSpec{
@@ -250,7 +250,7 @@ func TestDoCmdWithPkgArgPrintsHelpWithModuleFormat(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "aws", source)
 		spec := schema.PackageSpec{
@@ -332,7 +332,7 @@ func TestDoCmdWithPkgArgPrintsHelpSkipsMethods(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "aws", source)
 		// Two functions: one is a regular invoke, the other is the implementation of a method on myResource.
@@ -406,7 +406,7 @@ func TestDoCmdWithPkgArgPrintsHelpUnderRoot(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "aws@4.1", source)
 		spec := schema.PackageSpec{
@@ -478,7 +478,7 @@ func TestDoCmdWithModuleArgPrintsHelp(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "aws@4.1", source)
 		spec := schema.PackageSpec{
@@ -529,7 +529,7 @@ func TestDoCmdWithNestedModulesPrintsHelp(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "pkg", source)
 		spec := schema.PackageSpec{
@@ -709,7 +709,7 @@ func TestDoCmdUnknownTokenErrors(t *testing.T) {
 				t.Parallel()
 
 				mlm := &cmdBackend.MockLoginManager{}
-				mws := &pkgWorkspace.MockContext{}
+				mws := newTestWorkspace(t)
 
 				var stdout bytes.Buffer
 				cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, nil)
@@ -730,7 +730,7 @@ func TestDoCmdUnknownTokenErrors(t *testing.T) {
 					t.Parallel()
 
 					mlm := &cmdBackend.MockLoginManager{}
-					mws := &pkgWorkspace.MockContext{}
+					mws := newTestWorkspace(t)
 
 					var stdout bytes.Buffer
 					cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, nil)
@@ -811,7 +811,7 @@ func TestDoCmdUnknownTokenErrors(t *testing.T) {
 				t.Parallel()
 
 				mlm := &cmdBackend.MockLoginManager{}
-				mws := &pkgWorkspace.MockContext{}
+				mws := newTestWorkspace(t)
 
 				var stdout bytes.Buffer
 				cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, nil)
@@ -836,7 +836,7 @@ func TestDoCmdParameterizedModuleResolves(t *testing.T) {
 	t.Parallel()
 
 	mlm := &cmdBackend.MockLoginManager{}
-	mws := &pkgWorkspace.MockContext{}
+	mws := newTestWorkspace(t)
 	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
 		assert.Equal(t, "terraform-provider", source)
 		spec := schema.PackageSpec{
@@ -909,7 +909,7 @@ func TestCurrentStackIdentity(t *testing.T) {
 	for _, tc := range table {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			org, stk := currentStackIdentity(tc.ws)
+			org, stk := currentStackIdentity(tc.ws, false, "")
 			assert.Equal(t, tc.wantOrg, org)
 			assert.Equal(t, tc.wantStk, stk)
 		})

--- a/pkg/cmd/pulumi/do/main_test.go
+++ b/pkg/cmd/pulumi/do/main_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"testing"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newTestWorkspace(t *testing.T) *pkgWorkspace.MockContext {
+	t.Helper()
+
+	root := t.TempDir()
+	return &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
+			return &workspace.Project{
+				Name:    tokens.PackageName("test-project"),
+				Runtime: workspace.NewProjectRuntimeInfo("yaml", nil),
+			}, root, nil
+		},
+	}
+}


### PR DESCRIPTION
When `pulumi do` is invoked outside of a Pulumi project, synthesize a project at `$PULUMI_HOME/default-global-project/` (name `default-global-project`) and, for stateful subcommands, lazily create and select a `default` stack inside it.

This lets users run `pulumi do` — including stateful `upsert` / `create` / `delete` — with zero setup, rather than having to `pulumi new` and `pulumi stack init` first.