### PR TITLE
Support requesting and waiting for open approval in `pulumi env open` and `pulumi env get`

### DIFF
--- a/changelog/pending/esc-env-request-approval.yaml
+++ b/changelog/pending/esc-env-request-approval.yaml
@@ -1,0 +1,6 @@
+component: cli/env
+kind: feat
+body: Add `--request-approval`, `--wait-for-approval`, `--wait-timeout`, `--access-duration`, and `--reason` flags to `pulumi env open` and `pulumi env get`, to submit an open request when the environment requires approval and wait for it to be approved
+time: 2026-08-09T00:00:00+00:00
+custom:
+    PR: "24244"

--- a/changelog/pending/esc-env-request-approval.yaml
+++ b/changelog/pending/esc-env-request-approval.yaml
@@ -1,6 +1,6 @@
 component: cli/env
 kind: feat
-body: Add `--request-approval`, `--wait-for-approval`, `--wait-timeout`, `--access-duration`, and `--reason` flags to `pulumi env open` and `pulumi env get`, to submit an open request when the environment requires approval and wait for it to be approved
+body: Add `--request-approval-if-needed`, `--wait-for-approval`, `--wait-for-approval-timeout`, `--approval-access-duration`, and `--approval-reason` flags to `pulumi env open` and `pulumi env get`, to submit an open request when the environment requires approval and wait for it to be approved
 time: 2026-08-09T00:00:00+00:00
 custom:
     PR: "24244"

--- a/pkg/cmd/esc/cli/cli_test.go
+++ b/pkg/cmd/esc/cli/cli_test.go
@@ -260,6 +260,8 @@ type testPulumiClient struct {
 	// submittedChangeRequests records submitted change requests in call order, so tests can assert
 	// that a command actually submits the change requests it creates.
 	submittedChangeRequests []submittedChangeRequest
+
+	accessDurationSeconds int
 }
 
 type submittedChangeRequest struct {
@@ -1539,6 +1541,8 @@ func (c *testPulumiClient) CreateEnvironmentOpenRequest(
 	grantExpirationSeconds int,
 	accessDurationSeconds int,
 ) (*client.CreateEnvironmentOpenRequestResponse, error) {
+	c.accessDurationSeconds = accessDurationSeconds
+
 	// Check if environment exists
 	key := fmt.Sprintf("%s/%s/%s", orgName, projectName, envName)
 	if _, exists := c.environments[key]; !exists {

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -51,7 +51,6 @@ type envCommand struct {
 
 	envNameFlag string
 
-	// Zero means approvalPollInterval.
 	pollInterval time.Duration
 }
 

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
@@ -49,6 +50,9 @@ type envCommand struct {
 	esc *escCommand
 
 	envNameFlag string
+
+	// Zero means approvalPollInterval.
+	pollInterval time.Duration
 }
 
 func newEnvCmd(esc *escCommand) *cobra.Command {

--- a/pkg/cmd/esc/cli/env_get.go
+++ b/pkg/cmd/esc/cli/env_get.go
@@ -42,6 +42,8 @@ import (
 
 type envGetCommand struct {
 	env *envCommand
+
+	approval openApprovalOptions
 }
 
 func newEnvGetCmd(env *envCommand) *cobra.Command {
@@ -148,6 +150,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")
+	addRequestApprovalFlags(cmd, &get.approval)
 
 	return cmd
 }
@@ -200,7 +203,9 @@ func (get *envGetCommand) showValue(
 	format string,
 	showSecrets bool,
 ) error {
-	return get.writeValue(ctx, get.env.esc.stdout, ref, path, format, showSecrets)
+	return get.env.withOpenApproval(ctx, ref, get.approval, func() error {
+		return get.writeValue(ctx, get.env.esc.stdout, ref, path, format, showSecrets)
+	})
 }
 
 func diff(oldName, old, newName, new string) string {
@@ -254,21 +259,27 @@ func (get *envGetCommand) getEnvironment(
 	path resource.PropertyPath,
 	showSecrets bool,
 ) (*envGetTemplateData, error) {
-	def, _, _, err := get.env.esc.client.GetEnvironment(
-		ctx,
-		ref.orgName,
-		ref.projectName,
-		ref.envName,
-		ref.version,
-		showSecrets,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("getting environment definition: %w", err)
-	}
-	if len(path) == 0 {
-		return get.getEntireEnvironment(ctx, ref.orgName, def, showSecrets)
-	}
-	return get.getEnvironmentMember(ctx, ref.orgName, ref.envName, def, path, showSecrets)
+	var data *envGetTemplateData
+	err := get.env.withOpenApproval(ctx, ref, get.approval, func() error {
+		def, _, _, err := get.env.esc.client.GetEnvironment(
+			ctx,
+			ref.orgName,
+			ref.projectName,
+			ref.envName,
+			ref.version,
+			showSecrets,
+		)
+		if err != nil {
+			return fmt.Errorf("getting environment definition: %w", err)
+		}
+		if len(path) == 0 {
+			data, err = get.getEntireEnvironment(ctx, ref.orgName, def, showSecrets)
+			return err
+		}
+		data, err = get.getEnvironmentMember(ctx, ref.orgName, ref.envName, def, path, showSecrets)
+		return err
+	})
+	return data, err
 }
 
 func (get *envGetCommand) getEntireEnvironment(

--- a/pkg/cmd/esc/cli/env_open.go
+++ b/pkg/cmd/esc/cli/env_open.go
@@ -34,6 +34,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	var duration time.Duration
 	var format string
 	var draft string
+	var approval openApprovalOptions
 
 	cmd := &cobra.Command{
 		Use:   "open [<org-name>/][<project-name>/]<environment-name>[@<version>] [property path]",
@@ -75,7 +76,13 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
+			var env *esc.Environment
+			var diags []client.EnvironmentDiagnostic
+			err = envcmd.withOpenApproval(ctx, ref, approval, func() error {
+				var err error
+				env, diags, err = envcmd.openEnvironment(ctx, ref, duration, draft)
+				return err
+			})
 			if err != nil {
 				return err
 			}
@@ -96,6 +103,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	cmd.Flags().StringVar(
 		&draft, "draft", "",
 		"open an environment draft with --draft=<change-request-id>")
+	addRequestApprovalFlags(cmd, &approval)
 
 	return cmd
 }

--- a/pkg/cmd/esc/cli/env_open_request.go
+++ b/pkg/cmd/esc/cli/env_open_request.go
@@ -131,8 +131,7 @@ func addRequestApprovalFlags(cmd *cobra.Command, opts *openApprovalOptions) {
 		"an optional reason explaining why the environment is being opened, shown to approvers")
 }
 
-// submitOpenRequest submits every change request the open request produces: one for the target
-// environment and one for each gated import.
+// submitOpenRequest submits a change request for the target environment and for each gated import.
 func (env *envCommand) submitOpenRequest(
 	ctx context.Context,
 	ref environmentRef,
@@ -177,9 +176,8 @@ type openApprovalOptions struct {
 	reason          string
 }
 
-// withOpenApproval runs attempt and, if it fails and an open request was asked for, submits one
-// and retries. A successful attempt is the only approval signal available: the service exposes no
-// change request status API.
+// withOpenApproval runs attempt and, if it fails and an open request was asked for, submits one.
+// If opts.waitForApproval is true, it then waits until request is approved.
 func (env *envCommand) withOpenApproval(
 	ctx context.Context,
 	ref environmentRef,

--- a/pkg/cmd/esc/cli/env_open_request.go
+++ b/pkg/cmd/esc/cli/env_open_request.go
@@ -115,20 +115,21 @@ func newEnvOpenRequestCmd(envcmd *envCommand) *cobra.Command {
 
 func addRequestApprovalFlags(cmd *cobra.Command, opts *openApprovalOptions) {
 	cmd.Flags().BoolVar(
-		&opts.requestApproval, "request-approval", false,
-		"if the environment requires approval to open, submit an open request")
+		&opts.requestApproval, "request-approval-if-needed", false,
+		"If the environment requires approval to open, submit an open request")
 	cmd.Flags().BoolVar(
 		&opts.waitForApproval, "wait-for-approval", false,
-		"wait for the submitted open request to be approved, then continue; implies --request-approval")
+		"Wait for the submitted open request to be approved, then continue; "+
+			"implies --request-approval-if-needed")
 	cmd.Flags().DurationVar(
-		&opts.waitTimeout, "wait-timeout", defaultWaitTimeout,
-		"how long --wait-for-approval waits before giving up (e.g. 30s, 5m)")
+		&opts.waitTimeout, "wait-for-approval-timeout", defaultWaitTimeout,
+		"How long --wait-for-approval waits before giving up (e.g. 30s, 5m)")
 	cmd.Flags().DurationVar(
-		&opts.accessDuration, "access-duration", defaultAccessDuration,
-		"how long access to the environment lasts once the request is approved (e.g. 5m, 2h)")
+		&opts.accessDuration, "approval-access-duration", defaultAccessDuration,
+		"How long access to the environment lasts once the request is approved (e.g. 5m, 2h)")
 	cmd.Flags().StringVar(
-		&opts.reason, "reason", "",
-		"an optional reason explaining why the environment is being opened, shown to approvers")
+		&opts.reason, "approval-reason", "",
+		"Reason explaining why the environment is being opened, shown to approvers")
 }
 
 // submitOpenRequest submits a change request for the target environment and for each gated import.

--- a/pkg/cmd/esc/cli/env_open_request.go
+++ b/pkg/cmd/esc/cli/env_open_request.go
@@ -15,11 +15,22 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/esc/cli/client"
+)
+
+const (
+	defaultGrantExpiration = 90000 * time.Second
+	defaultAccessDuration  = 259200 * time.Second
+
+	approvalPollInterval = 5 * time.Second
+	defaultWaitTimeout   = 5 * time.Minute
 )
 
 func newEnvOpenRequestCmd(envcmd *envCommand) *cobra.Command {
@@ -53,46 +64,19 @@ func newEnvOpenRequestCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			resp, err := envcmd.esc.client.CreateEnvironmentOpenRequest(
-				ctx,
-				ref.orgName,
-				ref.projectName,
-				ref.envName,
-				int(grantExpiration.Seconds()),
-				int(accessDuration.Seconds()),
-			)
+			changeRequests, err := envcmd.submitOpenRequest(ctx, ref, grantExpiration, accessDuration, reason)
 			if err != nil {
 				return err
-			}
-			if len(resp.ChangeRequests) == 0 {
-				return errors.New("no open request was created for this environment; " +
-					"check that an open approval rule applies to it")
-			}
-
-			var changeRequestDescription *string
-			if reason != "" {
-				changeRequestDescription = &reason
-			}
-
-			// An open request can span multiple change requests: one for the target environment
-			// and one for each gated import. Submit them all up front so the output paths below
-			// only differ in how they present the result.
-			for i := range resp.ChangeRequests {
-				if err := envcmd.esc.client.SubmitChangeRequest(
-					ctx, ref.orgName, resp.ChangeRequests[i].ChangeRequestID, changeRequestDescription,
-				); err != nil {
-					return fmt.Errorf("submitting change request: %w", err)
-				}
 			}
 
 			if format == outputJSON {
 				return writeJSON(envcmd.esc.stdout, struct {
 					ChangeRequestID string `json:"changeRequestId"`
-				}{resp.ChangeRequests[0].ChangeRequestID})
+				}{changeRequests[0].ChangeRequestID})
 			}
 
-			for i := range resp.ChangeRequests {
-				cr := resp.ChangeRequests[i]
+			for i := range changeRequests {
+				cr := changeRequests[i]
 				crRef := environmentRef{
 					orgName:     ref.orgName,
 					projectName: cr.ProjectName,
@@ -116,10 +100,10 @@ func newEnvOpenRequestCmd(envcmd *envCommand) *cobra.Command {
 	}
 
 	cmd.Flags().DurationVar(
-		&grantExpiration, "grant-expiration-seconds", 90000*time.Second,
+		&grantExpiration, "grant-expiration-seconds", defaultGrantExpiration,
 		"expiration time for the grant in seconds")
 	cmd.Flags().DurationVar(
-		&accessDuration, "access-duration-seconds", 259200*time.Second,
+		&accessDuration, "access-duration-seconds", defaultAccessDuration,
 		"duration of access in seconds")
 	cmd.Flags().StringVar(
 		&reason, "reason", "",
@@ -127,4 +111,117 @@ func newEnvOpenRequestCmd(envcmd *envCommand) *cobra.Command {
 	addOutputFlag(cmd, &output)
 
 	return cmd
+}
+
+func addRequestApprovalFlags(cmd *cobra.Command, opts *openApprovalOptions) {
+	cmd.Flags().BoolVar(
+		&opts.requestApproval, "request-approval", false,
+		"if the environment requires approval to open, submit an open request")
+	cmd.Flags().BoolVar(
+		&opts.waitForApproval, "wait-for-approval", false,
+		"wait for the submitted open request to be approved, then continue; implies --request-approval")
+	cmd.Flags().DurationVar(
+		&opts.waitTimeout, "wait-timeout", defaultWaitTimeout,
+		"how long --wait-for-approval waits before giving up (e.g. 30s, 5m)")
+	cmd.Flags().DurationVar(
+		&opts.accessDuration, "access-duration", defaultAccessDuration,
+		"how long access to the environment lasts once the request is approved (e.g. 5m, 2h)")
+	cmd.Flags().StringVar(
+		&opts.reason, "reason", "",
+		"an optional reason explaining why the environment is being opened, shown to approvers")
+}
+
+// submitOpenRequest submits every change request the open request produces: one for the target
+// environment and one for each gated import.
+func (env *envCommand) submitOpenRequest(
+	ctx context.Context,
+	ref environmentRef,
+	grantExpiration, accessDuration time.Duration,
+	reason string,
+) ([]client.EnvironmentOpenRequestChangeRequest, error) {
+	resp, err := env.esc.client.CreateEnvironmentOpenRequest(
+		ctx,
+		ref.orgName,
+		ref.projectName,
+		ref.envName,
+		int(grantExpiration.Seconds()),
+		int(accessDuration.Seconds()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.ChangeRequests) == 0 {
+		return nil, errors.New("no open request was created for this environment; " +
+			"check that an open approval rule applies to it")
+	}
+
+	var description *string
+	if reason != "" {
+		description = &reason
+	}
+	for i := range resp.ChangeRequests {
+		if err := env.esc.client.SubmitChangeRequest(
+			ctx, ref.orgName, resp.ChangeRequests[i].ChangeRequestID, description,
+		); err != nil {
+			return nil, fmt.Errorf("submitting change request: %w", err)
+		}
+	}
+	return resp.ChangeRequests, nil
+}
+
+type openApprovalOptions struct {
+	requestApproval bool
+	waitForApproval bool
+	accessDuration  time.Duration
+	waitTimeout     time.Duration
+	reason          string
+}
+
+// withOpenApproval runs attempt and, if it fails and an open request was asked for, submits one
+// and retries. A successful attempt is the only approval signal available: the service exposes no
+// change request status API.
+func (env *envCommand) withOpenApproval(
+	ctx context.Context,
+	ref environmentRef,
+	opts openApprovalOptions,
+	attempt func() error,
+) error {
+	err := attempt()
+	if err == nil || (!opts.requestApproval && !opts.waitForApproval) {
+		return err
+	}
+
+	accessDuration := valueOrDefault(opts.accessDuration, defaultAccessDuration)
+	interval := valueOrDefault(env.pollInterval, approvalPollInterval)
+	timeout := valueOrDefault(opts.waitTimeout, defaultWaitTimeout)
+
+	changeRequests, requestErr := env.submitOpenRequest(
+		ctx, ref, defaultGrantExpiration, accessDuration, opts.reason)
+	if requestErr != nil {
+		// attempt may have failed for a reason that has nothing to do with approvals.
+		return err
+	}
+
+	for i := range changeRequests {
+		cr := changeRequests[i]
+		crRef := environmentRef{orgName: ref.orgName, projectName: cr.ProjectName, envName: cr.EnvironmentName}
+		fmt.Fprintf(env.esc.stderr, "Submitted environment open request: %v\n",
+			env.esc.changeRequestURL(crRef, cr.ChangeRequestID))
+	}
+	if !opts.waitForApproval {
+		return err
+	}
+	fmt.Fprintf(env.esc.stderr, "Waiting up to %v for approval...\n", timeout)
+
+	for waited := time.Duration(0); waited < timeout; waited += interval {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+		if err = attempt(); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("timed out waiting for the open request to be approved: %w", err)
 }

--- a/pkg/cmd/esc/cli/env_open_request_test.go
+++ b/pkg/cmd/esc/cli/env_open_request_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
+)
+
+func testOpenApprovalCommand(t *testing.T) (*envCommand, *testPulumiClient, *bytes.Buffer) {
+	t.Helper()
+
+	client := &testPulumiClient{
+		user:         "test-user",
+		environments: map[string]*testEnvironment{"test-org/test-project/test-env": {}},
+		openEnvs:     map[string]*esc.Environment{},
+	}
+	var stderr bytes.Buffer
+	env := &envCommand{
+		esc:          &escCommand{client: client, stderr: &stderr},
+		pollInterval: time.Millisecond,
+	}
+	return env, client, &stderr
+}
+
+func TestWithOpenApproval(t *testing.T) {
+	t.Parallel()
+
+	ref := environmentRef{orgName: "test-org", projectName: "test-project", envName: "test-env"}
+	denied := errors.New("environment requires approval to open")
+
+	t.Run("no request without the flag", func(t *testing.T) {
+		t.Parallel()
+
+		env, client, _ := testOpenApprovalCommand(t)
+		err := env.withOpenApproval(t.Context(), ref, openApprovalOptions{}, func() error { return denied })
+		assert.ErrorIs(t, err, denied)
+		assert.Empty(t, client.submittedChangeRequests)
+	})
+
+	t.Run("retries until approved", func(t *testing.T) {
+		t.Parallel()
+
+		env, client, stderr := testOpenApprovalCommand(t)
+		attempts := 0
+		opts := openApprovalOptions{
+			waitForApproval: true,
+			reason:          "incident 1234",
+			accessDuration:  time.Hour,
+			waitTimeout:     10 * time.Millisecond,
+		}
+		err := env.withOpenApproval(t.Context(), ref, opts, func() error {
+			attempts++
+			if attempts < 3 {
+				return denied
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, attempts)
+		require.Len(t, client.submittedChangeRequests, 1)
+		assert.Equal(t, "incident 1234", *client.submittedChangeRequests[0].description)
+		assert.Equal(t, 3600, client.accessDurationSeconds)
+		assert.Contains(t, stderr.String(), "for approval")
+	})
+
+	t.Run("submits without waiting", func(t *testing.T) {
+		t.Parallel()
+
+		env, client, stderr := testOpenApprovalCommand(t)
+		attempts := 0
+		err := env.withOpenApproval(t.Context(), ref, openApprovalOptions{requestApproval: true}, func() error {
+			attempts++
+			return denied
+		})
+		assert.ErrorIs(t, err, denied)
+		assert.Equal(t, 1, attempts)
+		require.Len(t, client.submittedChangeRequests, 1)
+		assert.Equal(t, int(defaultAccessDuration.Seconds()), client.accessDurationSeconds)
+		assert.NotContains(t, stderr.String(), "Waiting")
+	})
+
+	t.Run("times out", func(t *testing.T) {
+		t.Parallel()
+
+		env, _, _ := testOpenApprovalCommand(t)
+		opts := openApprovalOptions{waitForApproval: true, waitTimeout: 10 * time.Millisecond}
+		err := env.withOpenApproval(t.Context(), ref, opts, func() error { return denied })
+		assert.ErrorIs(t, err, denied)
+		assert.ErrorContains(t, err, "timed out waiting for the open request to be approved")
+	})
+
+	t.Run("reports the original error when no approval rule applies", func(t *testing.T) {
+		t.Parallel()
+
+		env, _, _ := testOpenApprovalCommand(t)
+		missing := environmentRef{orgName: "test-org", projectName: "test-project", envName: "nope"}
+		opts := openApprovalOptions{waitForApproval: true, waitTimeout: 10 * time.Millisecond}
+		err := env.withOpenApproval(t.Context(), missing, opts, func() error { return denied })
+		assert.ErrorIs(t, err, denied)
+	})
+}


### PR DESCRIPTION
Adds `--request-approval-if-needed`, `--wait-for-approval`, `--wait-for-approval-timeout`, `--approval-access-duration`, and `--approval-reason` flags to `pulumi env open` and `pulumi env get`, to submit an open request when the environment requires approval and wait for it to be approved.