### PR TITLE
Show the value being added when a detailed diff reports an add

### DIFF
--- a/changelog/pending/cli-display-fix-20260810-141438.yaml
+++ b/changelog/pending/cli-display-fix-20260810-141438.yaml
@@ -1,0 +1,4 @@
+component: cli/display
+kind: fix
+body: Show the value being added when a refresh or provider diff reports an added property
+time: 2026-08-10T14:14:38.519316+02:00

--- a/changelog/pending/cli-display-fix-20260810-141438.yaml
+++ b/changelog/pending/cli-display-fix-20260810-141438.yaml
@@ -2,3 +2,5 @@ component: cli/display
 kind: fix
 body: Show the value being added when a refresh or provider diff reports an added property
 time: 2026-08-10T14:14:38.519316+02:00
+custom:
+  PR: "24245"

--- a/pkg/engine/detailedDiff.go
+++ b/pkg/engine/detailedDiff.go
@@ -49,9 +49,7 @@ func getProperty(key any, v resource.PropertyValue) (resource.PropertyValue, boo
 	}
 }
 
-// valueOrUnknown returns v if the property it came from exists, and an unknown value otherwise. A detailed diff may
-// name a property that the engine has no value for -- e.g. a default that the provider only applies while planning
-// -- and rendering the absent value as `<null>` misreports what is being added or removed.
+// valueOrUnknown returns v if the property it came from exists, and an unknown value otherwise.
 func valueOrUnknown(v resource.PropertyValue, exists bool) resource.PropertyValue {
 	if exists {
 		return v

--- a/pkg/engine/detailedDiff.go
+++ b/pkg/engine/detailedDiff.go
@@ -23,29 +23,40 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// getProperty fetches the child property with the indicated key from the given property value. If the key does not
-// exist, it returns an empty `PropertyValue`.
-func getProperty(key any, v resource.PropertyValue) resource.PropertyValue {
+// getProperty fetches the child property with the indicated key from the given property value. The second result
+// reports whether the key exists; if it does not, an empty `PropertyValue` is returned.
+func getProperty(key any, v resource.PropertyValue) (resource.PropertyValue, bool) {
 	switch {
 	case v.IsArray():
 		index, ok := key.(int)
 		if !ok || index < 0 || index >= len(v.ArrayValue()) {
-			return resource.PropertyValue{}
+			return resource.PropertyValue{}, false
 		}
-		return v.ArrayValue()[index]
+		return v.ArrayValue()[index], true
 	case v.IsObject():
 		k, ok := key.(string)
 		if !ok {
-			return resource.PropertyValue{}
+			return resource.PropertyValue{}, false
 		}
-		return v.ObjectValue()[resource.PropertyKey(k)]
+		pv, has := v.ObjectValue()[resource.PropertyKey(k)]
+		return pv, has
 	case v.IsComputed() || v.IsOutput() || v.IsSecret():
 		// We consider the contents of these values opaque and return them as-is, as we cannot know whether or not the
 		// value will or does contain an element with the given key.
-		return v
+		return v, true
 	default:
-		return resource.PropertyValue{}
+		return resource.PropertyValue{}, false
 	}
+}
+
+// valueOrUnknown returns v if the property it came from exists, and an unknown value otherwise. A detailed diff may
+// name a property that the engine has no value for -- e.g. a default that the provider only applies while planning
+// -- and rendering the absent value as `<null>` misreports what is being added or removed.
+func valueOrUnknown(v resource.PropertyValue, exists bool) resource.PropertyValue {
+	if exists {
+		return v
+	}
+	return resource.MakeComputed(resource.NewProperty(""))
 }
 
 // addDiff inserts a diff of the given kind at the given path into the parent ValueDiff.
@@ -61,7 +72,8 @@ func addDiff(path resource.PropertyPath, kind plugin.DiffKind, parent *resource.
 
 	element := path[0]
 
-	old, new := getProperty(element, oldParent), getProperty(element, newParent)
+	old, hasOld := getProperty(element, oldParent)
+	new, hasNew := getProperty(element, newParent)
 
 	switch element := element.(type) {
 	case int:
@@ -79,9 +91,9 @@ func addDiff(path resource.PropertyPath, kind plugin.DiffKind, parent *resource.
 		if len(path) == 1 {
 			switch kind {
 			case plugin.DiffAdd, plugin.DiffAddReplace:
-				parent.Array.Adds[element] = new
+				parent.Array.Adds[element] = valueOrUnknown(new, hasNew)
 			case plugin.DiffDelete, plugin.DiffDeleteReplace:
-				parent.Array.Deletes[element] = old
+				parent.Array.Deletes[element] = valueOrUnknown(old, hasOld)
 			case plugin.DiffUpdate, plugin.DiffUpdateReplace:
 				valueDiff := resource.ValueDiff{Old: old, New: new}
 				if d := old.Diff(new); d != nil {
@@ -117,9 +129,9 @@ func addDiff(path resource.PropertyPath, kind plugin.DiffKind, parent *resource.
 		if len(path) == 1 {
 			switch kind {
 			case plugin.DiffAdd, plugin.DiffAddReplace:
-				parent.Object.Adds[e] = new
+				parent.Object.Adds[e] = valueOrUnknown(new, hasNew)
 			case plugin.DiffDelete, plugin.DiffDeleteReplace:
-				parent.Object.Deletes[e] = old
+				parent.Object.Deletes[e] = valueOrUnknown(old, hasOld)
 			case plugin.DiffUpdate, plugin.DiffUpdateReplace:
 				valueDiff := resource.ValueDiff{Old: old, New: new}
 				if d := old.Diff(new); d != nil {
@@ -186,7 +198,7 @@ diffs:
 		}
 
 		news := resource.NewProperty(step.New.Inputs)
-		if refresh {
+		if refresh && !pdiff.InputDiff {
 			news = resource.NewProperty(step.New.Outputs)
 		}
 

--- a/pkg/engine/detailedDiff_test.go
+++ b/pkg/engine/detailedDiff_test.go
@@ -801,3 +801,39 @@ func TestTranslateDetailedDiff(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/23067: a detailed diff may name a property that the
+// engine has no value for, and rendering the missing value as a null misreports what is being added.
+func TestTranslateDetailedDiffAbsentValue(t *testing.T) {
+	t.Parallel()
+
+	oldOutputs := resource.PropertyMap{"forceDestroy": resource.NewNullProperty()}
+	newInputs := resource.PropertyMap{}
+
+	diff, _ := TranslateDetailedDiff(&StepEventMetadata{
+		Old:          &StepEventStateMetadata{Inputs: resource.PropertyMap{}, Outputs: oldOutputs},
+		New:          &StepEventStateMetadata{Inputs: newInputs},
+		DetailedDiff: map[string]plugin.PropertyDiff{"forceDestroy": {Kind: plugin.DiffAdd}},
+	}, false)
+
+	assert.Equal(t, resource.PropertyMap{
+		"forceDestroy": resource.MakeComputed(resource.NewProperty("")),
+	}, diff.Adds)
+}
+
+// Refresh diffs are computed over inputs, so the new value must be read from the new inputs rather than the new
+// outputs.
+func TestTranslateDetailedDiffRefreshInputDiff(t *testing.T) {
+	t.Parallel()
+
+	diff, _ := TranslateDetailedDiff(&StepEventMetadata{
+		Old: &StepEventStateMetadata{Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
+		New: &StepEventStateMetadata{
+			Inputs:  resource.PropertyMap{"oof": resource.NewProperty("rab")},
+			Outputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		},
+		DetailedDiff: map[string]plugin.PropertyDiff{"oof": {Kind: plugin.DiffAdd, InputDiff: true}},
+	}, true /* refresh */)
+
+	assert.Equal(t, resource.PropertyMap{"oof": resource.NewProperty("rab")}, diff.Adds)
+}

--- a/pkg/engine/lifecycletest/testdata/output/TestCanceledRefresh/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestCanceledRefresh/diff.stdout.txt
@@ -1,7 +1,7 @@
 <{%fg 3%}>~ pkgA:m:typA: (update)
 <{%reset%}>    [id=2]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
-<{%reset%}><{%fg 2%}>  + oof: <{%reset%}><{%fg 2%}><null><{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>  + oof: <{%reset%}><{%fg 2%}>"rab"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%fg 13%}><{%bold%}>Resources:<{%reset%}>
     <{%fg 3%}>~ 1 updated<{%reset%}>
 

--- a/pkg/engine/lifecycletest/testdata/output/TestCanceledRefresh/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestCanceledRefresh/urns-diff.stdout.txt
@@ -1,6 +1,6 @@
 <{%fg 3%}>~ urn:pulumi:test::test::pkgA:m:typA::resA: (update)
 <{%reset%}>    [id=2]
-<{%reset%}><{%fg 2%}>  + oof: <{%reset%}><{%fg 2%}><null><{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>  + oof: <{%reset%}><{%fg 2%}>"rab"<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%fg 13%}><{%bold%}>Resources:<{%reset%}>
     <{%fg 3%}>~ 1 updated<{%reset%}>
 

--- a/pkg/engine/lifecycletest/testdata/output/TestDetailedDiffReplace/1/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestDetailedDiffReplace/1/diff.stdout.txt
@@ -1,11 +1,11 @@
 <{%fg 10%}>++pkgA:m:typA: (create-replacement)
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
-<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}><null><{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}>[unknown]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%fg 13%}>+-pkgA:m:typA: (replace)
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]
-<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}><null><{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}>[unknown]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%fg 9%}>--pkgA:m:typA: (delete-replaced)
 <{%fg 9%}>    [id=3]
 <{%reset%}><{%fg 9%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]

--- a/pkg/engine/lifecycletest/testdata/output/TestDetailedDiffReplace/1/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestDetailedDiffReplace/1/urns-diff.stdout.txt
@@ -1,9 +1,9 @@
 <{%fg 10%}>++urn:pulumi:test::test::pkgA:m:typA::resA: (create-replacement)
 <{%reset%}>    [id=3]
-<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}><null><{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}>[unknown]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%fg 13%}>+-urn:pulumi:test::test::pkgA:m:typA::resA: (replace)
 <{%reset%}>    [id=3]
-<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}><null><{%reset%}><{%fg 2%}>
+<{%reset%}><{%fg 2%}>  + prop: <{%reset%}><{%fg 2%}>[unknown]<{%reset%}><{%fg 2%}>
 <{%reset%}><{%reset%}><{%fg 9%}>--urn:pulumi:test::test::pkgA:m:typA::resA: (delete-replaced)
 <{%fg 9%}>    [id=3]
 <{%reset%}><{%reset%}><{%fg 13%}><{%bold%}>Resources:<{%reset%}>


### PR DESCRIPTION
Two things to fix here - first is that we couldn't tell the difference between "null" and "I don't know what this is" in the detailed diff, now we track the difference. Second is that refresh diffs were looking in the outputs for new inputs.

Fixes #23067.
