### PR TITLE
ask agents to be a bit more careful about commenting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,11 @@ All commands assume you're at the repo root.
   - Use `mise exec -- make work` to create a `go.work` file for cross-module development.
 - Proto-generated files must stay in sync with `proto/*.proto`. CI enforces via `mise exec -- make check_proto`.
 - `pkg/codegen/schema/pulumi.json` is the metaschema. It must be valid JSON Schema and pass biome formatting.
-- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. Try to keep changelog entries to one sentence and focus on user-visible changes. Do not include implementation details. Do not end changelog entries with punctuation. Once the PR exists, add its number to the entry's `custom.PR` field so the changelog links back to it.
+- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. Try to keep changelog entries to one sentence and focus on user-visible changes. Do not include implementation details. Do not end changelog entries with punctuation.
 - PRs are squash-merged — the PR description becomes the commit message.
 - Integration tests need the CLI and SDKs built first. `bin/` must be on `PATH`.
 - Copyright headers for new files should always be stamped with the current year.
+- Use comments judiciously, only add them where they are necessary to explain why something is happening, and for exported methods.
 
 ## Forbidden actions
 


### PR DESCRIPTION
Agents tend to comment anything and everything, even though that is very often not necessary, and makes later reading of the code harder instead of easier.  Tell them to be a bit more careful about it.

Also while there, don't tell them to add the PR number to changelog entries anymore, since that is no longer necessary.
