### PR TITLE
Track plugin last-use with a marker file

### DIFF
--- a/changelog/pending/cli-plugin-fix-20260810-103349.yaml
+++ b/changelog/pending/cli-plugin-fix-20260810-103349.yaml
@@ -1,0 +1,5 @@
+component: cli/plugin
+kind: fix
+body: Track when a plugin was last run so `pulumi plugin ls` reports an accurate
+  last-used time on all platforms
+time: 2026-08-10T10:33:49.000000-04:00

--- a/changelog/pending/cli-plugin-fix-20260810-103349.yaml
+++ b/changelog/pending/cli-plugin-fix-20260810-103349.yaml
@@ -3,3 +3,5 @@ kind: fix
 body: Track when a plugin was last run so `pulumi plugin ls` reports an accurate
   last-used time on all platforms
 time: 2026-08-10T10:33:49.000000-04:00
+custom:
+  PR: "24251"

--- a/pkg/cmd/pulumi/plugin/plugin_list.go
+++ b/pkg/cmd/pulumi/plugin/plugin_list.go
@@ -114,6 +114,11 @@ func formatPluginsJSON(w io.Writer, plugins []workspace.PluginInfo) error {
 		if plugin.Version != nil {
 			version = plugin.Version.String()
 		}
+		// Read times before Size: computing the size walks the plugin directory, which
+		// updates the directory access time LastUsedTime may fall back to.
+		installTime := plugin.InstallTime()
+		lastUsedTime := plugin.LastUsedTime()
+
 		jsonPluginInfo[idx] = pluginInfoJSON{
 			Name:    plugin.Name,
 			Kind:    string(plugin.Kind),
@@ -121,12 +126,10 @@ func formatPluginsJSON(w io.Writer, plugins []workspace.PluginInfo) error {
 			Size:    plugin.Size(),
 		}
 
-		installTime := plugin.InstallTime()
 		if !installTime.IsZero() {
 			jsonPluginInfo[idx].InstallTime = makeStringRef(cmd.FormatTime(installTime.UTC()))
 		}
 
-		lastUsedTime := plugin.LastUsedTime()
 		if !lastUsedTime.IsZero() {
 			jsonPluginInfo[idx].LastUsedTime = makeStringRef(cmd.FormatTime(lastUsedTime.UTC()))
 		}
@@ -145,6 +148,11 @@ func formatPluginConsole(w io.Writer, plugins []workspace.PluginInfo) error {
 		if plugin.Version != nil {
 			version = plugin.Version.String()
 		}
+		// Read times before Size: computing the size walks the plugin directory, which
+		// updates the directory access time LastUsedTime may fall back to.
+		installTime := plugin.InstallTime()
+		lastUsedTime := plugin.LastUsedTime()
+
 		var bytes string
 		if plugin.Size() == 0 {
 			bytes = naString
@@ -152,14 +160,12 @@ func formatPluginConsole(w io.Writer, plugins []workspace.PluginInfo) error {
 			bytes = humanize.Bytes(plugin.Size())
 		}
 		var installTimeStr string
-		installTime := plugin.InstallTime()
 		if installTime.IsZero() {
 			installTimeStr = naString
 		} else {
 			installTimeStr = humanize.Time(installTime)
 		}
 		var lastUsedTimeStr string
-		lastUsedTime := plugin.LastUsedTime()
 		if lastUsedTime.IsZero() {
 			lastUsedTimeStr = humanNeverTime
 		} else {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1374,6 +1374,20 @@ func (spec PluginDescriptor) String() string {
 	return spec.Name + version
 }
 
+// pluginLastUsedSuffix is the suffix of the sidecar file, next to a cached plugin's
+// directory, whose mtime records the last time the plugin was resolved for execution.
+// The directory's access time can't serve this purpose: executing a file doesn't update
+// its parent directory's atime, and atime updates are disabled by default on Windows and
+// throttled on Linux (relatime). See https://github.com/pulumi/pulumi/issues/4404.
+const pluginLastUsedSuffix = ".lastused"
+
+// markPluginUsed records, best-effort, that the cached plugin at dir is about to be run.
+func markPluginUsed(dir string) {
+	if err := os.WriteFile(dir+pluginLastUsedSuffix, nil, 0o600); err != nil {
+		logging.V(6).Infof("failed to record last-use time for %s: %v", dir, err)
+	}
+}
+
 // PluginFS captures the filesystem operations used by PluginInfo (see Delete and
 // setFileMetadata). It exists so that plugin removal and metadata lookups can be exercised
 // without touching the real filesystem. A PluginInfo with a nil FS uses the real filesystem.
@@ -1483,10 +1497,11 @@ func (info *PluginInfo) Delete() error {
 	if err := fs.RemoveAll(dir); err != nil {
 		return err
 	}
-	// Attempt to delete any leftover .partial or .lock files.
+	// Attempt to delete any leftover .partial, .lock, or .lastused files.
 	// Don't fail the operation if we can't delete these.
 	contract.IgnoreError(fs.Remove(dir + ".partial"))
 	contract.IgnoreError(fs.Remove(dir + ".lock"))
+	contract.IgnoreError(fs.Remove(dir + pluginLastUsedSuffix))
 	return nil
 }
 
@@ -1511,7 +1526,13 @@ func (info *PluginInfo) setFileMetadata() error {
 		info.installTime = tinfo.ModTime()
 	}
 
-	info.lastUsedTime = tinfo.AccessTime()
+	// Prefer the last-used marker written by markPluginUsed; the directory's access time
+	// is only a fallback, since atime is unreliable on most platforms.
+	if marker, err := info.filesystem().Stat(info.Path + pluginLastUsedSuffix); err == nil {
+		info.lastUsedTime = marker.ModTime()
+	} else {
+		info.lastUsedTime = tinfo.AccessTime()
+	}
 
 	return nil
 }
@@ -2068,7 +2089,7 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 // possible to opt out of this behavior by setting PULUMI_IGNORE_AMBIENT_PLUGINS to any non-empty value.
 func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginDescriptor, projectPlugins []ProjectPlugin,
 ) (string, error) {
-	info, path, err := getPluginInfoAndPath(ctx, d, spec, projectPlugins)
+	info, path, err := getPluginInfoAndPath(ctx, d, spec, projectPlugins, true /*markUsed*/)
 	if err != nil {
 		return "", err
 	}
@@ -2080,7 +2101,7 @@ func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginDescriptor, proj
 
 func GetPluginInfo(ctx context.Context, d diag.Sink, spec PluginDescriptor, projectPlugins []ProjectPlugin,
 ) (*PluginInfo, error) {
-	info, path, err := getPluginInfoAndPath(ctx, d, spec, projectPlugins)
+	info, path, err := getPluginInfoAndPath(ctx, d, spec, projectPlugins, false /*markUsed*/)
 	if err != nil {
 		return nil, err
 	}
@@ -2111,11 +2132,15 @@ func getPluginPath(info *PluginInfo) string {
 //   - if found as an ambient plugin, nil and the path to the executable
 //   - if found in the pulumi dir's installed plugins, a PluginInfo and path to the executable
 //   - an error in all other cases.
+//
+// If markUsed is true and the plugin is resolved from the plugin cache, the plugin's
+// last-used time is recorded.
 func getPluginInfoAndPath(
 	ctx context.Context,
 	d diag.Sink,
 	spec PluginDescriptor,
 	projectPlugins []ProjectPlugin,
+	markUsed bool,
 ) (*PluginInfo, string, error) {
 	filename := spec.File()
 
@@ -2261,12 +2286,16 @@ func getPluginInfoAndPath(
 	}
 
 	_, subdir := spec.LocalName()
-	// If the plugin is located in a subdir, we need to fix up the path to include the subdir.
-	if subdir != "" && match != nil {
-		match.Path = filepath.Join(match.Path, subdir)
-	}
-
 	if match != nil {
+		if markUsed {
+			// Record last use against the plugin's root directory in the cache, before any
+			// subdir fixup, to match the paths reported by GetPlugins.
+			markPluginUsed(match.Path)
+		}
+		// If the plugin is located in a subdir, we need to fix up the path to include the subdir.
+		if subdir != "" {
+			match.Path = filepath.Join(match.Path, subdir)
+		}
 		matchPath := getPluginPath(match)
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): found in cache at %s",
 			spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL, matchPath)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1383,6 +1383,8 @@ const pluginLastUsedSuffix = ".lastused"
 
 // markPluginUsed records, best-effort, that the cached plugin at dir is about to be run.
 func markPluginUsed(dir string) {
+	contract.Requiref(strings.LastIndexByte(dir, filepath.Separator) != (len(dir)-1),
+		"dir", "%q must not end in / or be empty", dir)
 	if err := os.WriteFile(dir+pluginLastUsedSuffix, nil, 0o600); err != nil {
 		logging.V(6).Infof("failed to record last-use time for %s: %v", dir, err)
 	}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1822,6 +1822,60 @@ func TestProjectPluginsWithSymlink(t *testing.T) {
 	assert.Equal(t, filepath.Join(tempdir, "symlink", "pulumi-resource-aws"), path)
 }
 
+func TestLastUsedTimeFromMarker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "resource-mock-v1.0.0")
+	require.NoError(t, os.Mkdir(pluginDir, 0o700))
+
+	markPluginUsed(pluginDir)
+
+	stat, err := os.Stat(pluginDir + pluginLastUsedSuffix)
+	require.NoError(t, err)
+
+	version := semver.MustParse("1.0.0")
+	info := PluginInfo{
+		Name:    "mock",
+		Kind:    apitype.ResourcePlugin,
+		Version: &version,
+		Path:    pluginDir,
+	}
+	assert.Equal(t, stat.ModTime(), info.LastUsedTime())
+
+	require.NoError(t, info.Delete())
+	_, err = os.Stat(pluginDir + pluginLastUsedSuffix)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestGetPluginPathMarksLastUsed(t *testing.T) {
+	ctx := t.Context()
+	home := t.TempDir()
+	t.Setenv("PULUMI_HOME", home)
+	t.Setenv("PULUMI_IGNORE_AMBIENT_PLUGINS", "true")
+
+	pluginDir := filepath.Join(home, "plugins", "resource-mock-v1.0.0")
+	require.NoError(t, os.MkdirAll(pluginDir, 0o700))
+	err := os.WriteFile(filepath.Join(pluginDir, "pulumi-resource-mock"), []byte{}, 0o700) //nolint:gosec
+	require.NoError(t, err)
+
+	version := semver.MustParse("1.0.0")
+	spec := PluginDescriptor{Name: "mock", Kind: apitype.ResourcePlugin, Version: &version}
+
+	// Querying plugin info is not a use.
+	_, err = GetPluginInfo(ctx, diagtest.LogSink(t), spec, nil)
+	require.NoError(t, err)
+	_, err = os.Stat(pluginDir + pluginLastUsedSuffix)
+	assert.True(t, os.IsNotExist(err))
+
+	// Resolving the plugin's path for execution is.
+	path, err := GetPluginPath(ctx, diagtest.LogSink(t), spec, nil)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(pluginDir, "pulumi-resource-mock"), path)
+	_, err = os.Stat(pluginDir + pluginLastUsedSuffix)
+	require.NoError(t, err)
+}
+
 func TestNewPluginSpec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`pulumi plugin ls` derived LAST USED from the plugin directory's access time, which is wrong everywhere: executing a plugin binary never updates its parent directory's atime, atime updates are disabled by default on Windows and throttled on Linux (relatime), and the size calculation in `plugin ls` itself bumps the atime it is about to report.

Record last use explicitly instead: when `GetPluginPath` resolves a plugin from the cache for execution, touch a `<plugin-dir>.lastused` sidecar file. mtime updates are reliable on all platforms, so `LastUsedTime` now prefers the marker's mtime and only falls back to the directory atime for plugins installed before this change. `plugin rm` cleans up the marker, and `plugin ls` reads times before computing sizes so the fallback path is no longer self-polluting.

This is partially motivated by #23252, which requires an accurate signal to GC on.

Fixes #4404.