### PR TITLE
Clean up PULUMI_ERROR_ON_DEPENDENCY_CYCLES properly

### DIFF
--- a/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
@@ -19,11 +19,13 @@ from ..util import LanghostTest
 class ComponentDependenciesTest(LanghostTest):
     def test_component_dependencies(self):
         environ["PULUMI_ERROR_ON_DEPENDENCY_CYCLES"] = "false"
-        self.run_test(
-            program=path.join(self.base_path(), "component_dependencies"),
-            expected_resource_count=16,
-        )
-        del environ["PULUMI_ERROR_ON_DEPENDENCY_CYCLES"]
+        try:
+            self.run_test(
+                program=path.join(self.base_path(), "component_dependencies"),
+                expected_resource_count=16,
+            )
+        finally:
+            del environ["PULUMI_ERROR_ON_DEPENDENCY_CYCLES"]
 
     def register_resource(
         self,

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -16,6 +16,7 @@ from typing import Optional, TypeVar, Awaitable, List, Any
 import asyncio
 import os
 import unittest
+from unittest import mock
 import pytest
 import pytest_asyncio
 
@@ -40,10 +41,9 @@ async def test_get_package():
 
 @pytest.fixture(autouse=True)
 def clean_up_env_vars():
-    try:
-        del os.environ[ERROR_ON_DEPENDENCY_CYCLES_VAR]
-    except KeyError:
-        pass
+    with mock.patch.dict(os.environ):
+        os.environ.pop(ERROR_ON_DEPENDENCY_CYCLES_VAR, None)
+        yield
 
 
 @pulumi.runtime.test


### PR DESCRIPTION
Noticed during #24230 - we don't clean up the variable correctly if a test fails, this PR makes sure we do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)