### PR TITLE
show secrets in printPropertyValueDiff when showSecrets is set

### DIFF
--- a/changelog/pending/engine-fix-20260810-174751.yaml
+++ b/changelog/pending/engine-fix-20260810-174751.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Show secrets in diff display when `--show-secrets` is passed
+time: 2026-08-10T17:47:51.923659813+02:00

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -886,6 +886,20 @@ func (p *propertyPrinter) printPropertyValueDiff(titleFunc func(*propertyPrinter
 	p = p.withOp(deploy.OpUpdate).withPrefix(true)
 	contract.Assertf(p.indent > 0, "indentation must be > 0 to print property value diffs")
 
+	if p.showSecrets && (diff.Old.IsSecret() || diff.New.IsSecret()) {
+		old, new := diff.Old, diff.New
+		if old.IsSecret() {
+			old = old.SecretValue().Element
+		}
+		if new.IsSecret() {
+			new = new.SecretValue().Element
+		}
+		if elemDiff := old.Diff(new); elemDiff != nil {
+			p.printPropertyValueDiff(titleFunc, *elemDiff)
+			return
+		}
+	}
+
 	if diff.Array != nil {
 		titleFunc(p)
 		p.writeVerbatim("[\n")

--- a/pkg/backend/display/object_diff_test.go
+++ b/pkg/backend/display/object_diff_test.go
@@ -367,6 +367,107 @@ func TestGetResourceOutputsPropertiesString(t *testing.T) {
 				"<{%fg 2%}>\n<{%reset%}>",
 		},
 		{
+			name: "stack output secret changed with showSecrets = true",
+			oldState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.MakeSecret(resource.NewProperty("initial")),
+				}),
+			},
+			newState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.MakeSecret(resource.NewProperty("changed")),
+				}),
+			},
+			showSecrets: true,
+			expected: "<{%fg 3%}>  ~ secret: <{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 1%}>initial<{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 3%}> => <{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 2%}>changed<{%reset%}>" +
+				"<{%fg 3%}>\"\n<{%reset%}>",
+		},
+		{
+			name: "stack output secret changed with showSecrets = false",
+			oldState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.MakeSecret(resource.NewProperty("initial")),
+				}),
+			},
+			newState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.MakeSecret(resource.NewProperty("changed")),
+				}),
+			},
+			showSecrets: false,
+			expected: "<{%fg 3%}>  ~ secret: <{%reset%}>" +
+				"<{%fg 1%}>[secret]<{%reset%}>" +
+				"<{%fg 3%}> => <{%reset%}>" +
+				"<{%fg 2%}>[secret]<{%reset%}>" +
+				"<{%fg 3%}>\n<{%reset%}>",
+		},
+		{
+			name: "stack output secret became plain with showSecrets = true",
+			oldState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.MakeSecret(resource.NewProperty("initial")),
+				}),
+			},
+			newState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.NewProperty("changed"),
+				}),
+			},
+			showSecrets: true,
+			expected: "<{%fg 3%}>  ~ secret: <{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 1%}>initial<{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 3%}> => <{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 2%}>changed<{%reset%}>" +
+				"<{%fg 3%}>\"\n<{%reset%}>",
+		},
+		{
+			name: "stack output plain became secret with showSecrets = true",
+			oldState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.NewProperty("initial"),
+				}),
+			},
+			newState: engine.StepEventStateMetadata{
+				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",
+				Type: "pulumi:pulumi:Stack",
+				Outputs: resource.NewPropertyMapFromMap(map[string]any{
+					"secret": resource.MakeSecret(resource.NewProperty("changed")),
+				}),
+			},
+			showSecrets: true,
+			expected: "<{%fg 3%}>  ~ secret: <{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 1%}>initial<{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 3%}> => <{%reset%}>" +
+				"<{%fg 3%}>\"<{%reset%}>" +
+				"<{%fg 2%}>changed<{%reset%}>" +
+				"<{%fg 3%}>\"\n<{%reset%}>",
+		},
+		{
 			name: "truncates with truncateOutput=true",
 			oldState: engine.StepEventStateMetadata{
 				URN:  "urn:pulumi:test::stack::pulumi:pulumi:Stack::test-stack",


### PR DESCRIPTION
Currently, when the old value or the new value are secret, we still show `[secret] => [secret]` (depending on which value is secret of course, for these property values.

However that's not correct, as the user explicitly asked for `--show-secrets`.  Make sure we honor that setting.
