### PR TITLE
[programgen/go] Add repro for nondeterministic object map inference

### DIFF
--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type exprTestCase struct {
@@ -229,6 +231,26 @@ func TestArgumentTypeName(t *testing.T) {
 	assert.Equal(t,
 		g.argumentTypeName(model.NewOutputType(model.StringType), false /*isInput*/),
 		g.argumentTypeName(model.StringType, true /*isInput*/))
+}
+
+func TestArgumentTypeNameMixedNullObjectIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	g := newTestGenerator(t, filepath.Join("transpiled_examples", "random-pp", "random.pp"))
+
+	// PCL represents a null literal as a ConstType whose underlying type is
+	// NoneType. An object with null and non-null values is not uniform. Go can
+	// select a different starting position each time it iterates over this map,
+	// but the generated type must not depend on that position.
+	nullType := model.NewConstType(model.NoneType, cty.NullVal(cty.DynamicPseudoType))
+	mixedObjectType := model.NewObjectType(map[string]model.Type{
+		"null":  nullType,
+		"value": model.StringType,
+	})
+	for i := 0; i < 1000; i++ {
+		require.Equal(t, "map[string]interface{}", g.argumentTypeName(mixedObjectType, false /*isInput*/),
+			"map type changed on iteration %d", i)
+	}
 }
 
 func TestNotYetImplementedEmittedWhenGeneratingFunctions(t *testing.T) {


### PR DESCRIPTION
## Summary

Reproduction for #24256.

This draft adds a failing regression test for Go program generation. A PCL null literal has a `ConstType` with an underlying `NoneType`. When an object contains both this null type and another value type, `argumentTypeName` can infer either:

- `map[string]interface{}`
- a typed map such as `map[string]string`

The result depends on the iteration order of `model.ObjectType.Properties`.

The test calls `argumentTypeName` repeatedly with the same object type and requires `map[string]interface{}`. The current implementation fails with output such as:

```text
expected: map[string]interface{}
actual:   map[string]string
```

This draft contains only the reproduction. It does not contain a fix.

## Test plan

- [x] Added appropriate unit tests
- [ ] Added a test in `pkg/engine/lifecycletest`
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language`
- [ ] Added a golden test in `pkg/backend/display`

Focused reproduction:

```bash
cd pkg
go test -count=1 -tags all ./codegen/go \
  -run '^TestArgumentTypeNameMixedNullObjectIsDeterministic$'
```

The test currently fails as intended.

## Validation

- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass
- [ ] `make check_proto` — clean

The changed Go file was formatted with `gofmt`. Broader validation is deferred because this draft intentionally adds a failing test.

## Changelog

- [ ] Changelog entry added

This reproduction does not need a changelog entry.

## Risk

This draft changes only a test. It cannot merge until the program-generation defect is fixed.

