### PR TITLE
[codegen/pcl] Add repro for context-dependent recursive conversion caching

### DIFF
--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -807,6 +807,51 @@ func TestRecursiveObjectTypeConvertsFromFiniteSource(t *testing.T) {
 	})
 }
 
+// TestRecursiveObjectTypeConversionCacheIsContextIndependent verifies that a
+// conversion result computed while another recursive conversion is in flight
+// does not escape into the shared conversion cache.
+func TestRecursiveObjectTypeConversionCacheIsContextIndependent(t *testing.T) {
+	t.Parallel()
+
+	newTypes := func() (destination, source, intermediate *ObjectType) {
+		destinationProperties := map[string]Type{}
+		destination = NewObjectType(destinationProperties)
+
+		sourceProperties := map[string]Type{}
+		source = NewObjectType(sourceProperties)
+
+		intermediateProperties := map[string]Type{}
+		intermediate = NewObjectType(intermediateProperties)
+
+		destinationProperties["child"] = destination
+		destinationProperties["value"] = BoolType
+
+		// The source cannot convert because value is an object, not a bool.
+		// Following child first checks the intermediate type while the
+		// (destination, source) pair is in the cycle set.
+		sourceProperties["child"] = intermediate
+		sourceProperties["extra"] = StringType
+		sourceProperties["value"] = NewObjectType(map[string]Type{})
+
+		// The intermediate type points back to source. It also cannot convert
+		// when checked independently because that path reaches source.value.
+		intermediateProperties["child"] = source
+		intermediateProperties["extra"] = StringType
+		intermediateProperties["value"] = BoolType
+		return destination, source, intermediate
+	}
+
+	for i := 0; i < 1000; i++ {
+		cleanDestination, _, cleanIntermediate := newTypes()
+		require.Equal(t, NoConversion, cleanDestination.ConversionFrom(cleanIntermediate))
+
+		destination, source, intermediate := newTypes()
+		require.Equal(t, NoConversion, destination.ConversionFrom(source))
+		require.Equal(t, NoConversion, destination.ConversionFrom(intermediate),
+			"in-flight conversion result escaped into the cache on iteration %d", i)
+	}
+}
+
 // TestRecursiveObjectTypeViaInputUnion mirrors the InputShape/PlainShape
 // pattern produced by codegen/pcl.schemaTypeToType: the schema property is
 // reachable as `Optional<Union<recursiveInputObj | Output<recursivePlainObj>>>`,


### PR DESCRIPTION
## Summary

Reproduction for #24257.

This draft adds a failing regression test for recursive model conversion caching.

The test constructs three recursive object types. It first confirms that a conversion from the intermediate type is `NoConversion`. It then performs a related recursive conversion and repeats the original check.

The current implementation changes the result to:

```text
expected: NoConversion
actual:   SafeConversion
```

An in-flight coinductive `SafeConversion` result escapes into the destination type's shared conversion cache. That result depends on the active recursive cycle set, but the cache key does not include that context.

The test repeats the construction to expose the property-map ordering dependency. This draft contains only the reproduction and does not propose a cache fix.

## Test plan

- [x] Added appropriate unit tests
- [ ] Added a test in `pkg/engine/lifecycletest`
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language`
- [ ] Added a golden test in `pkg/backend/display`

Focused reproduction:

```bash
cd pkg
go test -count=1 -tags all ./codegen/hcl2/model \
  -run '^TestRecursiveObjectTypeConversionCacheIsContextIndependent$'
```

The test currently fails as intended.

## Validation

- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass
- [ ] `make check_proto` — clean

The changed Go file was formatted with `gofmt`. Broader validation is deferred because this draft intentionally adds a failing test.

## Changelog

- [ ] Changelog entry added

This reproduction does not need a changelog entry.

## Risk

This draft changes only a test. It cannot merge until recursive conversion results are cached independently of in-flight cycle context.

