### PR TITLE
Reject import files containing unknown values

### DIFF
--- a/changelog/pending/cli-import-fix-20260811-145123.yaml
+++ b/changelog/pending/cli-import-fix-20260811-145123.yaml
@@ -1,0 +1,4 @@
+component: cli/import
+kind: fix
+body: Reject import files containing unknown values instead of writing them into state
+time: 2026-08-11T14:51:23.589206+02:00

--- a/changelog/pending/cli-import-fix-20260811-145123.yaml
+++ b/changelog/pending/cli-import-fix-20260811-145123.yaml
@@ -1,4 +1,4 @@
 component: cli/import
 kind: fix
-body: Reject import files containing unknown values instead of writing them into state
+body: '`pulumi preview --import-file` no longer emits unknown values, and `pulumi import` rejects files that contain them'
 time: 2026-08-11T14:51:23.589206+02:00

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -662,9 +662,6 @@ func parseImportFile(
 			}
 		}
 
-		// Unknown values round-trip through the import file as computed properties. They come from a
-		// `pulumi preview --import-file` run where a value wasn't resolvable yet, and importing them
-		// writes the unknown placeholder into the state, leaving the resource unusable.
 		for field, props := range map[string]resource.PropertyMap{
 			"inputs":         imp.Inputs,
 			"outputs":        imp.Outputs,

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -662,6 +662,20 @@ func parseImportFile(
 			}
 		}
 
+		// Unknown values round-trip through the import file as computed properties. They come from a
+		// `pulumi preview --import-file` run where a value wasn't resolvable yet, and importing them
+		// writes the unknown placeholder into the state, leaving the resource unusable.
+		for field, props := range map[string]resource.PropertyMap{
+			"inputs":         imp.Inputs,
+			"outputs":        imp.Outputs,
+			"providerInputs": imp.ProviderInputs,
+		} {
+			if props.ContainsUnknowns() {
+				pusherrf("the %v for %v contain unknown values; fill them in before importing",
+					field, describeResource(i, spec))
+			}
+		}
+
 		imports[i] = imp
 	}
 

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/importer"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	resourcestack "github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	sdkconfig "github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -623,7 +624,9 @@ func TestParseImportFileUnknownValues(t *testing.T) {
 	t.Parallel()
 
 	// The placeholder `pulumi preview --import-file` writes out for a value that wasn't known yet.
-	const unknown = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+	unknown, err := resourcestack.SerializePropertyValue(
+		t.Context(), resource.MakeComputed(resource.NewProperty("")), sdkconfig.NopEncrypter, false)
+	require.NoError(t, err)
 
 	providerURN := resource.URN("urn:pulumi:stack::proj::pulumi:providers:aws::my-prov")
 	f := importFile{
@@ -645,7 +648,7 @@ func TestParseImportFileUnknownValues(t *testing.T) {
 			},
 		},
 	}
-	_, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
+	_, _, err = parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
 	assert.ErrorContains(t, err, "the providerInputs for resource 'thing' of type 'aws:s3:Bucket' contain unknown values")
 }
 

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -623,33 +623,62 @@ func TestParseImportFileProviderInputs(t *testing.T) {
 func TestParseImportFileUnknownValues(t *testing.T) {
 	t.Parallel()
 
-	// The placeholder `pulumi preview --import-file` writes out for a value that wasn't known yet.
+	// The marker the stack serialisation uses to stand in for an unknown value.
 	unknown, err := resourcestack.SerializePropertyValue(
 		t.Context(), resource.MakeComputed(resource.NewProperty("")), sdkconfig.NopEncrypter, false)
 	require.NoError(t, err)
 
 	providerURN := resource.URN("urn:pulumi:stack::proj::pulumi:providers:aws::my-prov")
-	f := importFile{
-		NameTable: map[string]resource.URN{
-			"my-prov": providerURN,
-		},
-		Resources: []importSpec{
-			{
-				Name:     "thing",
-				ID:       "thing-id",
-				Type:     "aws:s3:Bucket",
-				Provider: "my-prov",
+	spec := importSpec{
+		Name:     "thing",
+		ID:       "thing-id",
+		Type:     "aws:s3:Bucket",
+		Provider: "my-prov",
+	}
+
+	tests := []struct {
+		field string
+		give  func(importSpec) importFile
+	}{
+		{
+			field: "providerInputs",
+			give: func(spec importSpec) importFile {
+				return importFile{
+					Resources: []importSpec{spec},
+					ProviderInputs: map[string]map[string]any{
+						"my-prov": {"region": unknown, "version": "6.0.0"},
+					},
+				}
 			},
 		},
-		ProviderInputs: map[string]map[string]any{
-			"my-prov": {
-				"region":  unknown,
-				"version": "6.0.0",
+		{
+			field: "inputs",
+			give: func(spec importSpec) importFile {
+				spec.Inputs = map[string]any{"bucket": unknown}
+				return importFile{Resources: []importSpec{spec}}
+			},
+		},
+		{
+			field: "outputs",
+			give: func(spec importSpec) importFile {
+				spec.Outputs = map[string]any{"arn": []any{unknown}}
+				return importFile{Resources: []importSpec{spec}}
 			},
 		},
 	}
-	_, _, err = parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
-	assert.ErrorContains(t, err, "the providerInputs for resource 'thing' of type 'aws:s3:Bucket' contain unknown values")
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			t.Parallel()
+
+			f := tt.give(spec)
+			f.NameTable = map[string]resource.URN{"my-prov": providerURN}
+
+			_, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
+			assert.ErrorContains(t, err,
+				"the "+tt.field+" for resource 'thing' of type 'aws:s3:Bucket' contain unknown values")
+		})
+	}
 }
 
 func ptr[T any](v T) *T {

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -619,6 +619,36 @@ func TestParseImportFileProviderInputs(t *testing.T) {
 	assert.Equal(t, resource.NewProperty("6.0.0"), imports[0].ProviderInputs["version"])
 }
 
+func TestParseImportFileUnknownValues(t *testing.T) {
+	t.Parallel()
+
+	// The placeholder `pulumi preview --import-file` writes out for a value that wasn't known yet.
+	const unknown = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+
+	providerURN := resource.URN("urn:pulumi:stack::proj::pulumi:providers:aws::my-prov")
+	f := importFile{
+		NameTable: map[string]resource.URN{
+			"my-prov": providerURN,
+		},
+		Resources: []importSpec{
+			{
+				Name:     "thing",
+				ID:       "thing-id",
+				Type:     "aws:s3:Bucket",
+				Provider: "my-prov",
+			},
+		},
+		ProviderInputs: map[string]map[string]any{
+			"my-prov": {
+				"region":  unknown,
+				"version": "6.0.0",
+			},
+		},
+	}
+	_, _, err := parseImportFile(f, tokens.MustParseStackName("stack"), "proj", false, sdkconfig.NopDecrypter)
+	assert.ErrorContains(t, err, "the providerInputs for resource 'thing' of type 'aws:s3:Bucket' contain unknown values")
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -245,16 +246,29 @@ func buildImportFile(
 					contract.Assertf(preEvent.Metadata.Res.State != nil,
 						"%s: expected State to be non-nil for provider", urn)
 					if fullInputs := preEvent.Metadata.Res.State.Inputs; len(fullInputs) > 0 {
-						if fullInputs.ContainsUnknowns() {
-							return importFile{}, fmt.Errorf(
-								"the configuration of provider %s is not known during preview, "+
-									"so an import file cannot be generated for it", urn)
+						// Anything not known during the preview would be written out as the unknown
+						// placeholder, which is not a value the import system can use.
+						known, unknown := resource.PropertyMap{}, []string{}
+						for _, k := range fullInputs.StableKeys() {
+							if fullInputs[k].ContainsUnknowns() {
+								unknown = append(unknown, string(k))
+								continue
+							}
+							known[k] = fullInputs[k]
 						}
-						var serErr error
-						inputs, serErr = stack.SerializeProperties(ctx, fullInputs, enc, false)
-						if serErr != nil {
-							return importFile{}, fmt.Errorf(
-								"could not serialize provider inputs for %s: %w", urn, serErr)
+						if len(unknown) > 0 {
+							cmdutil.Diag().Warningf(diag.Message(urn,
+								"configuration of provider %s is not known during the preview and has "+
+									"been omitted from the import file, fill it in before importing: %s"),
+								urn, strings.Join(unknown, ", "))
+						}
+						if len(known) > 0 {
+							var serErr error
+							inputs, serErr = stack.SerializeProperties(ctx, known, enc, false)
+							if serErr != nil {
+								return importFile{}, fmt.Errorf(
+									"could not serialize provider inputs for %s: %w", urn, serErr)
+							}
 						}
 					}
 				} else {

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -245,6 +245,11 @@ func buildImportFile(
 					contract.Assertf(preEvent.Metadata.Res.State != nil,
 						"%s: expected State to be non-nil for provider", urn)
 					if fullInputs := preEvent.Metadata.Res.State.Inputs; len(fullInputs) > 0 {
+						if fullInputs.ContainsUnknowns() {
+							return importFile{}, fmt.Errorf(
+								"the configuration of provider %s is not known during preview, "+
+									"so an import file cannot be generated for it", urn)
+						}
 						var serErr error
 						inputs, serErr = stack.SerializeProperties(ctx, fullInputs, enc, false)
 						if serErr != nil {

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -495,9 +495,9 @@ func TestBuildImportFile_NewProvider(t *testing.T) {
 	assert.Nil(t, importFile.ProviderInputs)
 }
 
-// TestBuildImportFile_NewProviderUnknownInputs tests that we refuse to generate an import file for a
-// provider whose configuration isn't known during the preview, rather than writing the unknown
-// placeholder into it (#24151).
+// TestBuildImportFile_NewProviderUnknownInputs tests that provider configuration that isn't known
+// during the preview is left out of the import file rather than written to it as the unknown
+// placeholder (#24151).
 func TestBuildImportFile_NewProviderUnknownInputs(t *testing.T) {
 	t.Parallel()
 
@@ -521,9 +521,11 @@ func TestBuildImportFile_NewProviderUnknownInputs(t *testing.T) {
 
 	close(events)
 
-	_, err := importFilePromise.Result(t.Context())
-	assert.ErrorContains(t, err, "the configuration of provider "+string(providerState.URN)+
-		" is not known during preview")
+	importFile, err := importFilePromise.Result(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, importFile.Resources, 1)
+	assert.Equal(t, map[string]any{"version": "1.2.3"}, importFile.Resources[0].Inputs)
 }
 
 // TestBuildImportFile_NewProviderWithParent tests that a created explicit provider parented to

--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -495,6 +495,37 @@ func TestBuildImportFile_NewProvider(t *testing.T) {
 	assert.Nil(t, importFile.ProviderInputs)
 }
 
+// TestBuildImportFile_NewProviderUnknownInputs tests that we refuse to generate an import file for a
+// provider whose configuration isn't known during the preview, rather than writing the unknown
+// placeholder into it (#24151).
+func TestBuildImportFile_NewProviderUnknownInputs(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(t.Context(), events, sdkconfig.NopEncrypter)
+
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	providerState := makeStateMetadata(t, "prov", "pulumi:providers:pkg", true, stateOptions{
+		Inputs: resource.PropertyMap{
+			"version": resource.NewProperty("1.2.3"),
+			"region":  resource.MakeComputed(resource.NewProperty("")),
+		},
+	})
+	providerState.ID = providers.UnknownID
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, providerState),
+	})
+
+	close(events)
+
+	_, err := importFilePromise.Result(t.Context())
+	assert.ErrorContains(t, err, "the configuration of provider "+string(providerState.URN)+
+		" is not known during preview")
+}
+
 // TestBuildImportFile_NewProviderWithParent tests that a created explicit provider parented to
 // another resource is declared with its parent.
 func TestBuildImportFile_NewProviderWithParent(t *testing.T) {


### PR DESCRIPTION
Imports containing unknowns cause big problems (see attached issue). This PR checks inputs, outputs, and providerInputs for unknowns before reporting a successful import, and stops `pulumi preview --import-file` from writing such a file in the first place.

Fixes #24151

🤖 Generated with [Claude Code](https://claude.com/claude-code)