### PR TITLE
Always advertise the terminal auth method type on ACP initialize

### DIFF
--- a/changelog/pending/20260723--cli-neo--always-advertise-terminal-auth-type.yaml
+++ b/changelog/pending/20260723--cli-neo--always-advertise-terminal-auth-type.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: fix
+body: Always advertise the `terminal` auth method type on the ACP initialize response so editors can run `pulumi login` for authentication
+time: 2026-07-23T00:00:00+00:00
+custom:
+  PR: ""

--- a/pkg/cmd/pulumi/neo/acp/agent.go
+++ b/pkg/cmd/pulumi/neo/acp/agent.go
@@ -144,31 +144,15 @@ func (a *Agent) initialize(req *jsonrpc2.Request) (any, error) {
 			Title:   a.identity.Title,
 			Version: a.version,
 		},
-		AuthMethods: advertisedAuthMethods(a.identity.AuthMethods, params.ClientCapabilities),
+		// Advertised as-is, type included, regardless of the client's auth
+		// capabilities: the spec requires every method to carry its type
+		// discriminator and keeps capabilities.auth orthogonal
+		// (https://agentclientprotocol.com/protocol/v2/authentication). Clients
+		// that don't understand a type ignore the method or display it
+		// generically, falling back to the description or the
+		// pre-stabilization terminal-auth meta (see MetaKeyTerminalAuth).
+		AuthMethods: a.identity.AuthMethods,
 	}, nil
-}
-
-// advertisedAuthMethods tailors the identity's auth methods to the client's
-// capabilities. A terminal-typed method is advertised as-is only when the
-// client declared the auth.terminal capability; otherwise it is degraded to the
-// untyped (agent-default) form — Type/Args/Env cleared, ID/Name/Description
-// kept — so the editor still surfaces the method's description telling the user
-// how to authenticate out of band. IDs are stable across the two forms. Meta is
-// kept even on degrade: clients ignore unrecognized "_meta" keys by spec, and
-// editors that support only the pre-stabilization terminal-auth meta (see
-// MetaKeyTerminalAuth) may not declare the auth.terminal capability.
-func advertisedAuthMethods(methods []AuthMethod, caps ClientCapabilities) []AuthMethod {
-	if caps.Auth.Terminal {
-		return methods
-	}
-	degraded := make([]AuthMethod, len(methods))
-	for i, m := range methods {
-		if m.Type == AuthMethodTypeTerminal {
-			m.Type, m.Args, m.Env = "", nil, nil
-		}
-		degraded[i] = m
-	}
-	return degraded
 }
 
 // authenticate handles the `authenticate` request. Login itself happens outside
@@ -185,8 +169,6 @@ func (a *Agent) authenticate(ctx context.Context, req *jsonrpc2.Request) (any, e
 	if err != nil {
 		return nil, err
 	}
-	// Method IDs survive capability degrading (see advertisedAuthMethods), so
-	// validate against the identity list directly.
 	if !slices.ContainsFunc(a.identity.AuthMethods, func(m AuthMethod) bool { return m.ID == params.MethodID }) {
 		return nil, &jsonrpc2.Error{
 			Code:    jsonrpc2.CodeInvalidParams,

--- a/pkg/cmd/pulumi/neo/acp/agent_test.go
+++ b/pkg/cmd/pulumi/neo/acp/agent_test.go
@@ -32,8 +32,8 @@ const testAuthMethod = "test-login"
 
 // testIdentity is the agent identity used across these tests, standing in for
 // whatever an embedding application (e.g. neo) injects via NewAgent. The auth
-// method is terminal-typed so initialize tests can observe capability-based
-// degradation.
+// method is terminal-typed so initialize tests can observe that the type is
+// advertised regardless of client capabilities.
 var testIdentity = Identity{
 	Name:  "test-agent",
 	Title: "Test Agent",
@@ -107,7 +107,6 @@ func TestInitializeNegotiatesAndCapturesCapabilities(t *testing.T) {
 	assert.Equal(t, ProtocolVersion, res.ProtocolVersion)
 	require.NotNil(t, res.AgentInfo)
 	assert.Equal(t, "v3.999.0", res.AgentInfo.Version)
-	// The client supports terminal auth, so the method is advertised as-is.
 	require.Len(t, res.AuthMethods, 1)
 	assert.Equal(t, testIdentity.AuthMethods[0], res.AuthMethods[0])
 
@@ -122,13 +121,15 @@ func TestInitializeNegotiatesAndCapturesCapabilities(t *testing.T) {
 	assert.True(t, caps.Auth.Terminal)
 }
 
-func TestInitializeDegradesTerminalAuthMethods(t *testing.T) {
+func TestInitializeAdvertisesTypedAuthMethodsWithoutAuthCapability(t *testing.T) {
 	t.Parallel()
 
 	agent := NewAgent(testIdentity, "v3.999.0", &fakeDelegate{})
 	client := newTestPeers(t, agent)
 
-	// Without auth.terminal, expect the degraded (untyped) form.
+	// Even without auth.terminal the method keeps its type: the spec requires
+	// the type discriminator on every method, and clients that don't understand
+	// it ignore the method or display it generically.
 	var res InitializeResult
 	err := client.Call(t.Context(), "initialize", InitializeParams{
 		ProtocolVersion:    ProtocolVersion,
@@ -140,14 +141,10 @@ func TestInitializeDegradesTerminalAuthMethods(t *testing.T) {
 	got := res.AuthMethods[0]
 	assert.Equal(t, testAuthMethod, got.ID)
 	assert.Equal(t, "Test login", got.Name)
-	assert.Empty(t, got.Type)
-	assert.Empty(t, got.Args)
-	assert.Empty(t, got.Env)
-	// Meta survives degrade: pre-stabilization terminal-auth clients may not
-	// declare auth.terminal, and others ignore unknown "_meta" keys by spec.
+	assert.Equal(t, AuthMethodTypeTerminal, got.Type)
+	assert.Equal(t, testIdentity.AuthMethods[0].Args, got.Args)
+	assert.Equal(t, testIdentity.AuthMethods[0].Env, got.Env)
 	assert.Contains(t, got.Meta, MetaKeyTerminalAuth)
-	// The identity itself is not mutated by degradation.
-	assert.Equal(t, AuthMethodTypeTerminal, testIdentity.AuthMethods[0].Type)
 }
 
 func TestAuthenticateAcknowledgesWhenLoggedIn(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/acp/types.go
+++ b/pkg/cmd/pulumi/neo/acp/types.go
@@ -65,7 +65,10 @@ type ClientCapabilities struct {
 }
 
 // AuthCapability reports the editor's support for typed authentication methods
-// (https://agentclientprotocol.com/rfds/auth-methods).
+// (https://agentclientprotocol.com/rfds/auth-methods). Informational: auth
+// methods are advertised with their type either way, per the spec's
+// orthogonality of capabilities.auth
+// (https://agentclientprotocol.com/protocol/v2/authentication).
 type AuthCapability struct {
 	// Terminal reports whether the editor can run a terminal-typed auth method:
 	// re-launching the agent binary in a real terminal with the method's
@@ -111,8 +114,10 @@ type PromptCapabilities struct {
 // AuthMethodTypeTerminal marks an AuthMethod whose setup is an interactive
 // terminal flow: the client re-launches the agent binary in a real terminal,
 // with the method's Args and Env replacing the configured launch values for
-// that run only. Only advertised to clients that declare the auth.terminal
-// capability (see AuthCapability).
+// that run only. Always advertised with the method: per the spec every method
+// carries its type discriminator, and clients that don't understand a type
+// ignore the method or display it generically
+// (https://agentclientprotocol.com/protocol/v2/authentication).
 const AuthMethodTypeTerminal = "terminal"
 
 // AuthMethod is one authentication option the agent advertises on initialize.

--- a/pkg/cmd/pulumi/neo/acp/types_test.go
+++ b/pkg/cmd/pulumi/neo/acp/types_test.go
@@ -59,7 +59,7 @@ func TestSessionUpdateDiscriminators(t *testing.T) {
 }
 
 // TestAuthMethodWireShape verifies the typed-auth fields marshal when set and
-// disappear when zero, so a degraded (untyped) method advertises exactly the
+// disappear when zero, so an untyped method advertises exactly the
 // pre-typed-auth wire shape.
 func TestAuthMethodWireShape(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/neo/acp_adapter.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter.go
@@ -41,10 +41,10 @@ import (
 // terminal, since an interactive login cannot run over the stdio JSON-RPC
 // channel. The same flow is duplicated as pre-stabilization terminal-auth meta
 // for editors (e.g. current stable Zed) that execute that instead of the typed
-// fields; there the command is explicit, so we name our own binary. For editors
-// without either mechanism the agent degrades the method to the untyped form
-// and the description tells the user to run `pulumi login` themselves; in
-// every case `authenticate` only verifies that a login session exists (see
+// fields; there the command is explicit, so we name our own binary. Editors
+// without either mechanism ignore the type per spec and surface the
+// description telling the user to run `pulumi login` themselves; in every case
+// `authenticate` only verifies that a login session exists (see
 // acpDelegate.CheckAuth).
 func neoACPIdentity() acp.Identity {
 	// Fall back to resolution via PATH if we can't name our own binary.

--- a/pkg/cmd/pulumi/neo/acp_adapter_test.go
+++ b/pkg/cmd/pulumi/neo/acp_adapter_test.go
@@ -54,7 +54,8 @@ func TestNeoACPIdentityAdvertisesTerminalLogin(t *testing.T) {
 	assert.Equal(t, acp.AuthMethodTypeTerminal, m.Type)
 	assert.Equal(t, []string{"login"}, m.Args)
 	assert.Empty(t, m.Env)
-	assert.NotEmpty(t, m.Description, "description doubles as the degraded-method guidance")
+	assert.NotEmpty(t, m.Description,
+		"description doubles as the guidance for editors that don't understand the terminal type")
 
 	// The pre-stabilization terminal-auth meta mirrors the typed fields with an
 	// explicit command (our own binary) for editors that only execute the meta


### PR DESCRIPTION
Per the ACP spec, every auth method carries its type discriminator and `capabilities.auth` is orthogonal (https://agentclientprotocol.com/protocol/v2/authentication), so this drops the capability-based degrading of terminal-typed auth methods on `initialize`. The method is now advertised as-is; clients that don't understand the `terminal` type ignore it or display it generically, falling back to the description or the pre-stabilization terminal-auth meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)