### PR TITLE
Make `--diff` compose with `--output json`

### DIFF
--- a/changelog/pending/cli-feat-20260811-161045.yaml
+++ b/changelog/pending/cli-feat-20260811-161045.yaml
@@ -2,3 +2,5 @@ component: cli
 kind: feat
 body: Support combining --diff with --output json on up, preview, destroy, and refresh, and add --diff to `pulumi stack history events --summary`, to include each resource's property diff in the structured summary
 time: 2026-08-11T16:10:45.483909+02:00
+custom:
+    PR: "24264"

--- a/changelog/pending/cli-feat-20260811-161045.yaml
+++ b/changelog/pending/cli-feat-20260811-161045.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Support combining --diff with --output json on up, preview, destroy, and refresh, and add --diff to `pulumi stack history events --summary`, to include each resource's property diff in the structured summary
+time: 2026-08-11T16:10:45.483909+02:00

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -49,8 +51,8 @@ type SummaryJSON struct {
 }
 
 // ResourceJSON is the per-resource entry that appears in SummaryJSON.Resources.
-// It is intentionally compact: callers that need full diffs / property values
-// should use `--json` (the streaming event format) instead.
+// It is intentionally compact: callers that need full property values should
+// use `--json` (the streaming event format) instead.
 type ResourceJSON struct {
 	// URN is the canonical, globally-unique identifier of the resource.
 	URN string `json:"urn"`
@@ -62,6 +64,20 @@ type ResourceJSON struct {
 	Op apitype.OpType `json:"op"`
 	// Parent is the URN of this resource's parent, if any.
 	Parent string `json:"parent,omitempty"`
+	// Diff maps changed property paths to their old/new values. It is only
+	// populated when `--diff` is combined with `--output json`.
+	Diff map[string]PropertyDiffJSON `json:"diff,omitempty"`
+}
+
+// PropertyDiffJSON describes the change to a single property path within a
+// resource's diff.
+type PropertyDiffJSON struct {
+	// Kind is one of "add", "delete", or "update".
+	Kind string `json:"kind"`
+	// Old is the value before the operation; unset for adds.
+	Old any `json:"old,omitempty"`
+	// New is the value after the operation; unset for deletes.
+	New any `json:"new,omitempty"`
 }
 
 // summaryJSONFromEvent extracts the summary JSON shape from a SummaryEventPayload.
@@ -113,6 +129,152 @@ func NewResourceJSON(urn resource.URN, op apitype.OpType, parent string) Resourc
 	}
 }
 
+// NewDiffJSON flattens a step's property diff into path → change entries,
+// drawing on the same sources as the human diff view: the provider's detailed
+// diff when present, otherwise a diff computed from the step's old and new
+// inputs.
+func NewDiffJSON(m *engine.StepEventMetadata, refresh, showSecrets bool) map[string]PropertyDiffJSON {
+	// An OpSame might have a diff due to metadata changes (e.g. protect) but we
+	// should never report a property diff. See
+	// https://github.com/pulumi/pulumi/issues/15944 for context.
+	if m.Op == deploy.OpSame {
+		return nil
+	}
+
+	var diff *resource.ObjectDiff
+	var hidden []resource.PropertyPath
+	switch {
+	case m.DetailedDiff != nil:
+		// TranslateDetailedDiff already excludes hidden (HideDiffs) paths.
+		diff, _ = engine.TranslateDetailedDiff(m, refresh)
+	case m.Old == nil && m.New != nil:
+		diff = resource.PropertyMap{}.Diff(m.New.Inputs, resource.IsInternalPropertyKey)
+		hidden = m.New.HideDiffs
+	case m.Old != nil && m.New == nil:
+		diff = m.Old.Inputs.Diff(resource.PropertyMap{}, resource.IsInternalPropertyKey)
+		hidden = m.Old.HideDiffs
+	case m.Old != nil && m.New != nil:
+		diff = m.Old.Inputs.Diff(m.New.Inputs, resource.IsInternalPropertyKey)
+		hidden = m.New.HideDiffs
+	}
+	if diff == nil {
+		return nil
+	}
+
+	out := map[string]PropertyDiffJSON{}
+	flattenObjectDiff(out, nil, diff, hidden, showSecrets)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// NewDiffJSONFromAPI is NewDiffJSON for step metadata that has already been
+// serialized to its API shape, as returned by the Pulumi Cloud events
+// endpoint. Secret values in such metadata are already blinded, so there is
+// no showSecrets option to offer.
+func NewDiffJSONFromAPI(md apitype.StepEventMetadata, refresh bool) map[string]PropertyDiffJSON {
+	em := convertJSONStepEventMetadata(md)
+	return NewDiffJSON(&em, refresh, false /* showSecrets */)
+}
+
+func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,
+	hidden []resource.PropertyPath, showSecrets bool,
+) {
+	at := func(k resource.PropertyKey) resource.PropertyPath {
+		return append(slices.Clone(path), string(k))
+	}
+	for k, v := range diff.Adds {
+		emitDiffEntry(out, at(k), PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+	}
+	for k, v := range diff.Deletes {
+		emitDiffEntry(out, at(k), PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+	}
+	for k, v := range diff.Updates {
+		flattenValueDiff(out, at(k), v, hidden, showSecrets)
+	}
+}
+
+func flattenValueDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff resource.ValueDiff,
+	hidden []resource.PropertyPath, showSecrets bool,
+) {
+	at := func(i int) resource.PropertyPath {
+		return append(slices.Clone(path), i)
+	}
+	switch {
+	case diff.Object != nil:
+		flattenObjectDiff(out, path, diff.Object, hidden, showSecrets)
+	case diff.Array != nil:
+		for i, v := range diff.Array.Adds {
+			emitDiffEntry(out, at(i), PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+		}
+		for i, v := range diff.Array.Deletes {
+			emitDiffEntry(out, at(i), PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+		}
+		for i, v := range diff.Array.Updates {
+			flattenValueDiff(out, at(i), v, hidden, showSecrets)
+		}
+	default:
+		emitDiffEntry(out, path, PropertyDiffJSON{
+			Kind: "update",
+			Old:  jsonPropertyValue(diff.Old, showSecrets),
+			New:  jsonPropertyValue(diff.New, showSecrets),
+		}, hidden)
+	}
+}
+
+func emitDiffEntry(out map[string]PropertyDiffJSON, path resource.PropertyPath, d PropertyDiffJSON,
+	hidden []resource.PropertyPath,
+) {
+	for _, h := range hidden {
+		if h.Contains(path) {
+			return
+		}
+	}
+	out[path.String()] = d
+}
+
+// jsonPropertyValue renders a property value as a plain JSON-marshalable
+// value, masking secrets and unknowns the same way the human diff display
+// does.
+func jsonPropertyValue(v resource.PropertyValue, showSecrets bool) any {
+	switch {
+	case v.IsSecret():
+		if !showSecrets {
+			return "[secret]"
+		}
+		return jsonPropertyValue(v.SecretValue().Element, showSecrets)
+	case v.IsComputed():
+		return "[unknown]"
+	case v.IsOutput():
+		o := v.OutputValue()
+		switch {
+		case !o.Known:
+			return "[unknown]"
+		case o.Secret && !showSecrets:
+			return "[secret]"
+		default:
+			return jsonPropertyValue(o.Element, showSecrets)
+		}
+	case v.IsString() && !utf8.ValidString(v.StringValue()):
+		return byteStringDisplay(v.StringValue())
+	case v.IsArray():
+		arr := make([]any, len(v.ArrayValue()))
+		for i, e := range v.ArrayValue() {
+			arr[i] = jsonPropertyValue(e, showSecrets)
+		}
+		return arr
+	case v.IsObject():
+		obj := make(map[string]any, len(v.ObjectValue()))
+		for k, e := range v.ObjectValue() {
+			obj[string(k)] = jsonPropertyValue(e, showSecrets)
+		}
+		return obj
+	default:
+		return v.Mappable()
+	}
+}
+
 // writeSummaryJSON encodes a SummaryJSON to w as a single line.
 func writeSummaryJSON(w io.Writer, s SummaryJSON) error {
 	var buf bytes.Buffer
@@ -143,15 +305,37 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 	if stderr == nil {
 		stderr = os.Stderr
 	}
+	// `--diff` composed with `--output json`: include each resource's property
+	// diff in the summary.
+	includeDiff := opts.Type == DisplayDiff
 	go func() {
 		defer close(out)
 		var resources []ResourceJSON
+		indexByURN := map[resource.URN]int{}
 		for e := range in {
-			switch e.Type { //nolint:exhaustive // we only care about two event types here
+			switch e.Type { //nolint:exhaustive // we only care about a few event types here
 			case engine.ResourcePreEvent:
 				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
 					if r := resourceJSONFromEvent(payload, opts.ShowSameResources); r != nil {
+						if includeDiff {
+							r.Diff = NewDiffJSON(&payload.Metadata, false /* refresh */, opts.ShowSecrets)
+						}
+						indexByURN[payload.Metadata.URN] = len(resources)
 						resources = append(resources, *r)
+					}
+				}
+			case engine.ResourceOutputsEvent:
+				// Refresh steps only reveal their diff once the provider has read
+				// the resource's current state, which arrives on the outputs event
+				// as an update (with a detailed diff) or a delete.
+				if !includeDiff {
+					break
+				}
+				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok {
+					m := payload.Metadata
+					if i, ok := indexByURN[m.URN]; ok && resources[i].Op == apitype.OpRefresh &&
+						((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {
+						resources[i].Diff = NewDiffJSON(&m, true /* refresh */, opts.ShowSecrets)
 					}
 				}
 			case engine.SummaryEvent:

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -246,6 +247,239 @@ func TestTapSummaryJSON_OmitsResourcesFieldWhenEmpty(t *testing.T) {
 	}
 
 	assert.NotContains(t, buf.String(), `"resources"`)
+}
+
+func TestNewDiffJSON_ComputedInputsDiff(t *testing.T) {
+	t.Parallel()
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"region": resource.NewProperty("us-west-2"),
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("dev"),
+				"gone": resource.NewProperty("bye"),
+			}),
+			"password": resource.MakeSecret(resource.NewProperty("hunter2")),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"region": resource.NewProperty("us-east-1"),
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("prod"),
+				"team": resource.NewProperty("infra"),
+			}),
+			"password": resource.MakeSecret(resource.NewProperty("hunter3")),
+			"arn":      resource.MakeComputed(resource.NewProperty("")),
+		}},
+	}
+
+	got := NewDiffJSON(&m, false, false)
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"region":    {Kind: "update", Old: "us-west-2", New: "us-east-1"},
+		"tags.env":  {Kind: "update", Old: "dev", New: "prod"},
+		"tags.gone": {Kind: "delete", Old: "bye"},
+		"tags.team": {Kind: "add", New: "infra"},
+		"password":  {Kind: "update", Old: "[secret]", New: "[secret]"},
+		"arn":       {Kind: "add", New: "[unknown]"},
+	}, got)
+
+	// With showSecrets, secret values are revealed.
+	withSecrets := NewDiffJSON(&m, false, true)
+	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "hunter2", New: "hunter3"}, withSecrets["password"])
+}
+
+func TestNewDiffJSON_CreateAndDelete(t *testing.T) {
+	t.Parallel()
+
+	inputs := resource.PropertyMap{
+		"bucket": resource.NewProperty("my-bucket"),
+		"tags":   resource.NewProperty(resource.PropertyMap{"env": resource.NewProperty("dev")}),
+	}
+
+	create := engine.StepEventMetadata{
+		Op:  deploy.OpCreate,
+		New: &engine.StepEventStateMetadata{Inputs: inputs},
+	}
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"bucket": {Kind: "add", New: "my-bucket"},
+		"tags":   {Kind: "add", New: map[string]any{"env": "dev"}},
+	}, NewDiffJSON(&create, false, false))
+
+	del := engine.StepEventMetadata{
+		Op:  deploy.OpDelete,
+		Old: &engine.StepEventStateMetadata{Inputs: inputs},
+	}
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"bucket": {Kind: "delete", Old: "my-bucket"},
+		"tags":   {Kind: "delete", Old: map[string]any{"env": "dev"}},
+	}, NewDiffJSON(&del, false, false))
+}
+
+func TestNewDiffJSON_ArrayAndSameSkipped(t *testing.T) {
+	t.Parallel()
+
+	// OpSame never reports a property diff, even if the inputs differ.
+	same := engine.StepEventMetadata{
+		Op:  deploy.OpSame,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"a": resource.NewProperty("1")}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"a": resource.NewProperty("2")}},
+	}
+	assert.Nil(t, NewDiffJSON(&same, false, false))
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"subnets": resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("a"),
+				resource.NewProperty("b"),
+			}),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"subnets": resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("a"),
+				resource.NewProperty("c"),
+				resource.NewProperty("d"),
+			}),
+		}},
+	}
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"subnets[1]": {Kind: "update", Old: "b", New: "c"},
+		"subnets[2]": {Kind: "add", New: "d"},
+	}, NewDiffJSON(&m, false, false))
+}
+
+func TestNewDiffJSON_DetailedDiff(t *testing.T) {
+	t.Parallel()
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		DetailedDiff: map[string]plugin.PropertyDiff{
+			"tags.env":  {Kind: plugin.DiffUpdate},
+			"tags.team": {Kind: plugin.DiffAdd},
+		},
+		Old: &engine.StepEventStateMetadata{Outputs: resource.PropertyMap{
+			"tags": resource.NewProperty(resource.PropertyMap{"env": resource.NewProperty("dev")}),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("prod"),
+				"team": resource.NewProperty("infra"),
+			}),
+		}},
+	}
+
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"tags.env":  {Kind: "update", Old: "dev", New: "prod"},
+		"tags.team": {Kind: "add", New: "infra"},
+	}, NewDiffJSON(&m, false, false))
+}
+
+func TestNewDiffJSON_HiddenPathsExcluded(t *testing.T) {
+	t.Parallel()
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"visible": resource.NewProperty("1"),
+			"hidden":  resource.NewProperty("1"),
+		}},
+		New: &engine.StepEventStateMetadata{
+			Inputs: resource.PropertyMap{
+				"visible": resource.NewProperty("2"),
+				"hidden":  resource.NewProperty("2"),
+			},
+			HideDiffs: []resource.PropertyPath{{"hidden"}},
+		},
+	}
+
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"visible": {Kind: "update", Old: "1", New: "2"},
+	}, NewDiffJSON(&m, false, false))
+}
+
+// makeDiffPreEvent builds a pre-event carrying old/new inputs so the tap can
+// compute a property diff.
+func makeDiffPreEvent(op display.StepOp, urn resource.URN, old, new resource.PropertyMap,
+) engine.ResourcePreEventPayload {
+	meta := engine.StepEventMetadata{Op: op, URN: urn}
+	if old != nil {
+		meta.Old = &engine.StepEventStateMetadata{URN: urn, Inputs: old}
+	}
+	if new != nil {
+		meta.New = &engine.StepEventStateMetadata{URN: urn, Inputs: new}
+	}
+	return engine.ResourcePreEventPayload{Metadata: meta}
+}
+
+func TestTapSummaryJSON_IncludesDiffOnlyInDiffMode(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	makeEvents := func() chan engine.Event {
+		in := make(chan engine.Event, 2)
+		in <- engine.NewEvent(makeDiffPreEvent(deploy.OpUpdate, urn,
+			resource.PropertyMap{"a": resource.NewProperty("1")},
+			resource.PropertyMap{"a": resource.NewProperty("2")}))
+		in <- engine.NewEvent(engine.SummaryEventPayload{Result: apitype.OperationResultSucceeded})
+		close(in)
+		return in
+	}
+
+	// Default (progress) mode: no diff key at all.
+	var plain bytes.Buffer
+	for range tapSummaryJSON(makeEvents(), Options{Stdout: &plain}) { //nolint:revive // intentional drain
+	}
+	assert.NotContains(t, plain.String(), `"diff"`)
+
+	// Diff mode: the changed property is reported.
+	var buf bytes.Buffer
+	for range tapSummaryJSON(makeEvents(), Options{Stdout: &buf, Type: DisplayDiff}) { //nolint:revive // drain
+	}
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	require.Len(t, summary.Resources, 1)
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"a": {Kind: "update", Old: "1", New: "2"},
+	}, summary.Resources[0].Diff)
+}
+
+func TestTapSummaryJSON_RefreshDiffArrivesOnOutputsEvent(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	inputs := resource.PropertyMap{"acl": resource.NewProperty("private")}
+
+	// The pre-event announces the refresh with identical old/new state; the
+	// outputs event carries the update discovered by the provider read.
+	in := make(chan engine.Event, 3)
+	in <- engine.NewEvent(makeDiffPreEvent(deploy.OpRefresh, urn, inputs, inputs))
+	in <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:           deploy.OpUpdate,
+			URN:          urn,
+			DetailedDiff: map[string]plugin.PropertyDiff{"acl": {Kind: plugin.DiffUpdate}},
+			Old:          &engine.StepEventStateMetadata{URN: urn, Outputs: inputs},
+			New: &engine.StepEventStateMetadata{
+				URN:     urn,
+				Inputs:  inputs,
+				Outputs: resource.PropertyMap{"acl": resource.NewProperty("public-read")},
+			},
+		},
+	})
+	in <- engine.NewEvent(engine.SummaryEventPayload{Result: apitype.OperationResultSucceeded})
+	close(in)
+
+	var buf bytes.Buffer
+	for range tapSummaryJSON(in, Options{Stdout: &buf, Type: DisplayDiff}) { //nolint:revive // intentional drain
+	}
+
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	require.Len(t, summary.Resources, 1)
+	assert.Equal(t, apitype.OpRefresh, summary.Resources[0].Op)
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"acl": {Kind: "update", Old: "private", New: "public-read"},
+	}, summary.Resources[0].Diff)
 }
 
 func TestTapSummaryJSON_ReturnsOnCancelEvent(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -70,6 +71,7 @@ type stackHistoryEventsArgs struct {
 	count               int
 	all                 bool
 	summary             bool
+	diff                bool
 	render              historyEventsRenderers
 }
 
@@ -105,7 +107,8 @@ func newStackHistoryEventsCmd(
 			"Pass --summary to reduce the update's full event stream to a compact\n" +
 			"summary with the same base shape as a live `pulumi up --output json`,\n" +
 			"extended with the update's error diagnostics and failed-resource\n" +
-			"markers — useful for diagnosing an update after the fact.\n" +
+			"markers — useful for diagnosing an update after the fact. Add --diff\n" +
+			"to include each resource's property diff in the summary.\n" +
 			"\n" +
 			"This command requires the Pulumi Cloud backend.",
 		Example: "  # Show the first page of events in a human-readable table.\n" +
@@ -122,6 +125,9 @@ func newStackHistoryEventsCmd(
 			"  pulumi stack history events <update-id> \\\n" +
 			"      --urn urn:pulumi:dev::proj::aws:s3/bucket:Bucket::my-bucket",
 		RunE: func(cmd *cobra.Command, positional []string) error {
+			if args.diff && !args.summary {
+				return errors.New("--diff can only be used with --summary")
+			}
 			args.updateID = positional[0]
 			args.render = outputFormat.Get()
 			sink := diag.DefaultSink(cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{
@@ -151,6 +157,8 @@ func newStackHistoryEventsCmd(
 		"Return every event for the update")
 	cmd.Flags().BoolVar(&args.summary, "summary", false,
 		"Reduce the update's events to a single summary document with error diagnostics; implies --all")
+	cmd.Flags().BoolVar(&args.diff, "diff", false,
+		"Include each resource's property diff in the --summary output")
 	cmd.MarkFlagsMutuallyExclusive("count", "all")
 	cmd.MarkFlagsMutuallyExclusive("summary", "count")
 	cmd.MarkFlagsMutuallyExclusive("summary", "event-type")
@@ -188,7 +196,7 @@ func runStackHistoryEvents(
 
 	events := iterateEngineEvents(ctx, c, update, opts, args.all || args.summary, args.count)
 	if args.summary {
-		summary, err := buildUpdateSummary(events)
+		summary, err := buildUpdateSummary(events, args.diff)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary.go
@@ -72,8 +72,11 @@ func summaryResourceFor(m apitype.StepEventMetadata) summaryResource {
 
 // buildUpdateSummary reduces an engine event stream to an updateSummary,
 // mirroring the live summary tap (display.tapSummaryJSON): one resource entry
-// per attempted operation, unchanged (`same`) resources omitted.
-func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSummary, error) {
+// per attempted operation, unchanged (`same`) resources omitted. When
+// includeDiff is set, each entry carries its property diff too.
+func buildUpdateSummary(
+	events iter.Seq2[apitype.EngineEvent, error], includeDiff bool,
+) (*updateSummary, error) {
 	s := &updateSummary{}
 
 	var startTs, endTs int
@@ -110,7 +113,27 @@ func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSu
 			summaryEvent = ev.SummaryEvent
 		case ev.ResourcePreEvent != nil:
 			if m := ev.ResourcePreEvent.Metadata; m.Op != apitype.OpSame {
-				s.Resources = append(s.Resources, summaryResourceFor(m))
+				r := summaryResourceFor(m)
+				if includeDiff {
+					r.Diff = display.NewDiffJSONFromAPI(m, false /* refresh */)
+				}
+				s.Resources = append(s.Resources, r)
+			}
+		case ev.ResOutputsEvent != nil:
+			// Refresh steps only reveal their diff once the provider has read the
+			// resource's current state, which arrives on the outputs event as an
+			// update (with a detailed diff) or a delete.
+			if !includeDiff {
+				continue
+			}
+			m := ev.ResOutputsEvent.Metadata
+			if (m.Op == apitype.OpUpdate && m.DetailedDiff != nil) || m.Op == apitype.OpDelete {
+				for i := len(s.Resources) - 1; i >= 0; i-- {
+					if s.Resources[i].URN == m.URN && s.Resources[i].Op == apitype.OpRefresh {
+						s.Resources[i].Diff = display.NewDiffJSONFromAPI(m, true /* refresh */)
+						break
+					}
+				}
 			}
 		case ev.ResOpFailedEvent != nil:
 			anyFailed = true
@@ -202,6 +225,29 @@ func renderUpdateSummaryText(w io.Writer, s *updateSummary) error {
 		t.Render()
 	}
 
+	diffed := false
+	for _, r := range s.Resources {
+		if len(r.Diff) == 0 {
+			continue
+		}
+		if !diffed {
+			fmt.Fprintln(w, "\nDiffs:")
+			diffed = true
+		}
+		fmt.Fprintf(w, "  %s (%s)\n", r.Name, r.Type)
+		for _, path := range slices.Sorted(maps.Keys(r.Diff)) {
+			d := r.Diff[path]
+			switch d.Kind {
+			case "add":
+				fmt.Fprintf(w, "    + %s: %s\n", path, compactJSON(d.New))
+			case "delete":
+				fmt.Fprintf(w, "    - %s: %s\n", path, compactJSON(d.Old))
+			default:
+				fmt.Fprintf(w, "    ~ %s: %s => %s\n", path, compactJSON(d.Old), compactJSON(d.New))
+			}
+		}
+	}
+
 	if len(s.Diagnostics) > 0 {
 		fmt.Fprintln(w, "\nDiagnostics:")
 		for _, d := range s.Diagnostics {
@@ -214,4 +260,13 @@ func renderUpdateSummaryText(w io.Writer, s *updateSummary) error {
 	}
 
 	return nil
+}
+
+// compactJSON renders a diff value on one line for the text view.
+func compactJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
 }

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary_test.go
@@ -107,7 +107,7 @@ func TestBuildUpdateSummary(t *testing.T) {
 		},
 	)
 
-	s, err := buildUpdateSummary(events)
+	s, err := buildUpdateSummary(events, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, apitype.OperationResultFailed, s.Result)
@@ -149,7 +149,7 @@ func TestBuildUpdateSummary_BaseShapeMatchesLive(t *testing.T) {
 				ResourceChanges: map[apitype.OpType]int{apitype.OpCreate: 1},
 			},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 
 	encoded, err := json.Marshal(s)
@@ -176,7 +176,7 @@ func TestBuildUpdateSummary_FailureMarksLastEntryForURN(t *testing.T) {
 				Metadata: apitype.StepEventMetadata{Op: apitype.OpCreate, URN: urn, Type: "aws:s3/bucket:Bucket"},
 			},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 
 	require.Len(t, s.Resources, 1)
@@ -188,21 +188,21 @@ func TestBuildUpdateSummary_ResultFallbacks(t *testing.T) {
 	t.Parallel()
 
 	// No summary event, no failures: unknown.
-	s, err := buildUpdateSummary(eventSeq())
+	s, err := buildUpdateSummary(eventSeq(), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResult("unknown"), s.Result)
 
 	// No summary event, but an error diagnostic: failed.
 	s, err = buildUpdateSummary(eventSeq(apitype.EngineEvent{
 		DiagnosticEvent: &apitype.DiagnosticEvent{Message: "boom", Severity: "error"},
-	}))
+	}), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultFailed, s.Result)
 
 	// Summary event without a result (older updates): succeeded.
 	s, err = buildUpdateSummary(eventSeq(apitype.EngineEvent{
 		SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1},
-	}))
+	}), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultSucceeded, s.Result)
 
@@ -213,7 +213,7 @@ func TestBuildUpdateSummary_ResultFallbacks(t *testing.T) {
 			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "npm notice", Severity: "info#err"},
 		},
 		apitype.EngineEvent{SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1}},
-	))
+	), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultSucceeded, s.Result)
 	require.Len(t, s.Diagnostics, 1)
@@ -241,7 +241,7 @@ func TestBuildUpdateSummary_ReportsProgramErrors(t *testing.T) {
 		apitype.EngineEvent{
 			SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1, Result: apitype.OperationResultFailed},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, apitype.OperationResultFailed, s.Result)
@@ -261,7 +261,7 @@ func TestBuildUpdateSummary_DurationFallsBackToTimestamps(t *testing.T) {
 			Timestamp:       1030,
 			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "boom", Severity: "error"},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 	assert.Equal(t, 30*time.Second, s.Duration)
 }
@@ -274,8 +274,56 @@ func TestBuildUpdateSummary_PropagatesIteratorError(t *testing.T) {
 		yield(apitype.EngineEvent{}, boom)
 	}
 
-	_, err := buildUpdateSummary(events)
+	_, err := buildUpdateSummary(events, false)
 	assert.ErrorIs(t, err, boom)
+}
+
+func TestBuildUpdateSummary_IncludesDiffWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	urn := "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b"
+	events := func() iter.Seq2[apitype.EngineEvent, error] {
+		return eventSeq(preEvent(1, apitype.OpUpdate, urn, "aws:s3/bucket:Bucket",
+			apitype.StepEventMetadata{
+				Old: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "private"}},
+				New: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "public-read"}},
+			}))
+	}
+
+	s, err := buildUpdateSummary(events(), true)
+	require.NoError(t, err)
+	require.Len(t, s.Resources, 1)
+	assert.Equal(t, map[string]display.PropertyDiffJSON{
+		"acl": {Kind: "update", Old: "private", New: "public-read"},
+	}, s.Resources[0].Diff)
+
+	// Without --diff the field stays empty.
+	s, err = buildUpdateSummary(events(), false)
+	require.NoError(t, err)
+	require.Len(t, s.Resources, 1)
+	assert.Nil(t, s.Resources[0].Diff)
+}
+
+func TestRenderUpdateSummaryText_Diffs(t *testing.T) {
+	t.Parallel()
+
+	s, err := buildUpdateSummary(eventSeq(preEvent(1, apitype.OpUpdate,
+		"urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b", "aws:s3/bucket:Bucket",
+		apitype.StepEventMetadata{
+			Old: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "private", "gone": true}},
+			New: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "public-read", "new": float64(1)}},
+		})), true)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, renderUpdateSummaryText(&buf, s))
+	out := buf.String()
+
+	assert.Contains(t, out, "Diffs:")
+	assert.Contains(t, out, "b (aws:s3/bucket:Bucket)")
+	assert.Contains(t, out, `~ acl: "private" => "public-read"`)
+	assert.Contains(t, out, `- gone: true`)
+	assert.Contains(t, out, `+ new: 1`)
 }
 
 func TestRenderUpdateSummaryJSON_SingleLine(t *testing.T) {
@@ -283,7 +331,7 @@ func TestRenderUpdateSummaryJSON_SingleLine(t *testing.T) {
 
 	s, err := buildUpdateSummary(eventSeq(apitype.EngineEvent{
 		SummaryEvent: &apitype.SummaryEvent{Result: apitype.OperationResultSucceeded},
-	}))
+	}), false)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
@@ -321,7 +369,7 @@ func TestRenderUpdateSummaryText(t *testing.T) {
 			},
 		},
 	)
-	s, err := buildUpdateSummary(events)
+	s, err := buildUpdateSummary(events, false)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer


### PR DESCRIPTION
`--diff` now adds a per-resource property diff to the structured summary emitted by `up`, `preview`, `destroy`, and `refresh` with `--output json`. Each affected resource carries a flat `diff` map of property paths to `{kind, old, new}` entries, built from the same sources as the human diff view: the provider's detailed diff when present, otherwise a diff of the step's old and new inputs. Secrets stay masked unless `--show-secrets` is set, and unknowns render as `[unknown]`. For refreshes, the diff is attached when the provider read arrives on the outputs event.

`pulumi stack history events --summary` gains a matching `--diff` flag, reusing the same builder over the cloud's serialized events, with a simple path-per-line rendering in the text view.

Fixes #24263

🤖 Generated with [Claude Code](https://claude.com/claude-code)