### PR TITLE
allow deployment to be optional in BeginUpdateRequest

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1824,7 +1824,7 @@ func (b *cloudBackend) createAndStartUpdate(
 
 		// Cache the deployment, stack tags, and stack for later use.
 		b.cachedUpdateData = &cachedUpdateData{
-			deployment: &resp.Deployment,
+			deployment: resp.Deployment,
 			stackTags:  resp.Stack.Tags,
 			stackRef:   stackRef,
 		}
@@ -2369,7 +2369,8 @@ func (b *cloudBackend) ExportDeploymentForVersion(
 func (b *cloudBackend) exportDeployment(
 	ctx context.Context, stackRef backend.StackReference, version *int,
 ) (*apitype.UntypedDeployment, error) {
-	if version == nil && b.cachedUpdateData != nil && b.cachedUpdateData.stackRef.String() == stackRef.String() {
+	if version == nil && b.cachedUpdateData != nil && b.cachedUpdateData.deployment != nil &&
+		b.cachedUpdateData.stackRef.String() == stackRef.String() {
 		logging.V(7).Infof("Using cached deployment from begin-update for %s", stackRef)
 		return b.cachedUpdateData.deployment, nil
 	}

--- a/sdk/go/common/apitype/updates.go
+++ b/sdk/go/common/apitype/updates.go
@@ -320,6 +320,7 @@ type BeginUpdateRequest struct {
 type BeginUpdateResponse struct {
 	StartUpdateResponse
 	UpdateProgramResponse
-	Deployment UntypedDeployment `json:"deployment"`
-	Stack      Stack             `json:"stack"`
+	// Deployment may be omitted by the service; the client then fetches it separately.
+	Deployment *UntypedDeployment `json:"deployment,omitempty"`
+	Stack      Stack              `json:"stack"`
 }


### PR DESCRIPTION
For now the service will always send it (though we will fetch it separately if it doesn't), but this enables us to potentially cache the last deployment locally in the future, and save time downloading the deployment, if it didn't change.

No current functional changes here, but this enables future improvements in a backwards compatible way.
