### PR TITLE
Add `--diff` to `pulumi stack history events --summary`

### DIFF
--- a/changelog/pending/cli-feat-20260811-171544.yaml
+++ b/changelog/pending/cli-feat-20260811-171544.yaml
@@ -2,3 +2,5 @@ component: cli
 kind: feat
 body: Add --diff to `pulumi stack history events --summary` to include each resource's property diff in the summary
 time: 2026-08-11T17:15:44.719007+02:00
+custom:
+    PR: "24266"

--- a/changelog/pending/cli-feat-20260811-171544.yaml
+++ b/changelog/pending/cli-feat-20260811-171544.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Add --diff to `pulumi stack history events --summary` to include each resource's property diff in the summary
+time: 2026-08-11T17:15:44.719007+02:00

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -236,43 +236,29 @@ func emitDiffEntry(out map[string]PropertyDiffJSON, path resource.PropertyPath, 
 
 // jsonPropertyValue renders a property value as a plain JSON-marshalable
 // value, masking secrets and unknowns the same way the human diff display
-// does.
+// does. A sibling of massagePropertyValue, which cannot be extended to cover
+// unknowns without changing the existing `--json` output.
 func jsonPropertyValue(v resource.PropertyValue, showSecrets bool) any {
-	switch {
-	case v.IsSecret():
-		if !showSecrets {
-			return "[secret]"
-		}
-		return jsonPropertyValue(v.SecretValue().Element, showSecrets)
-	case v.IsComputed():
-		return "[unknown]"
-	case v.IsOutput():
-		o := v.OutputValue()
+	return v.MapRepl(nil, func(v resource.PropertyValue) (any, bool) {
 		switch {
-		case !o.Known:
-			return "[unknown]"
-		case o.Secret && !showSecrets:
-			return "[secret]"
+		case v.IsSecret() && !showSecrets:
+			return "[secret]", true
+		case v.IsSecret():
+			return jsonPropertyValue(v.SecretValue().Element, showSecrets), true
+		case v.IsComputed():
+			return "[unknown]", true
+		case v.IsOutput() && !v.OutputValue().Known:
+			return "[unknown]", true
+		case v.IsOutput() && v.OutputValue().Secret && !showSecrets:
+			return "[secret]", true
+		case v.IsOutput():
+			return jsonPropertyValue(v.OutputValue().Element, showSecrets), true
+		case v.IsString() && !utf8.ValidString(v.StringValue()):
+			return byteStringDisplay(v.StringValue()), true
 		default:
-			return jsonPropertyValue(o.Element, showSecrets)
+			return nil, false
 		}
-	case v.IsString() && !utf8.ValidString(v.StringValue()):
-		return byteStringDisplay(v.StringValue())
-	case v.IsArray():
-		arr := make([]any, len(v.ArrayValue()))
-		for i, e := range v.ArrayValue() {
-			arr[i] = jsonPropertyValue(e, showSecrets)
-		}
-		return arr
-	case v.IsObject():
-		obj := make(map[string]any, len(v.ObjectValue()))
-		for k, e := range v.ObjectValue() {
-			obj[string(k)] = jsonPropertyValue(e, showSecrets)
-		}
-		return obj
-	default:
-		return v.Mappable()
-	}
+	})
 }
 
 // writeSummaryJSON encodes a SummaryJSON to w as a single line.

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -181,38 +181,36 @@ func NewDiffJSONFromAPI(md apitype.StepEventMetadata) map[string]PropertyDiffJSO
 func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,
 	hidden []resource.PropertyPath, showSecrets bool,
 ) {
-	at := func(k resource.PropertyKey) resource.PropertyPath {
-		return append(slices.Clone(path), string(k))
-	}
 	for k, v := range diff.Adds {
-		emitDiffEntry(out, at(k), PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+		emitDiffEntry(out, append(slices.Clone(path), string(k)),
+			PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
 	}
 	for k, v := range diff.Deletes {
-		emitDiffEntry(out, at(k), PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+		emitDiffEntry(out, append(slices.Clone(path), string(k)),
+			PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
 	}
 	for k, v := range diff.Updates {
-		flattenValueDiff(out, at(k), v, hidden, showSecrets)
+		flattenValueDiff(out, append(slices.Clone(path), string(k)), v, hidden, showSecrets)
 	}
 }
 
 func flattenValueDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff resource.ValueDiff,
 	hidden []resource.PropertyPath, showSecrets bool,
 ) {
-	at := func(i int) resource.PropertyPath {
-		return append(slices.Clone(path), i)
-	}
 	switch {
 	case diff.Object != nil:
 		flattenObjectDiff(out, path, diff.Object, hidden, showSecrets)
 	case diff.Array != nil:
 		for i, v := range diff.Array.Adds {
-			emitDiffEntry(out, at(i), PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+			emitDiffEntry(out, append(slices.Clone(path), i),
+				PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
 		}
 		for i, v := range diff.Array.Deletes {
-			emitDiffEntry(out, at(i), PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+			emitDiffEntry(out, append(slices.Clone(path), i),
+				PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
 		}
 		for i, v := range diff.Array.Updates {
-			flattenValueDiff(out, at(i), v, hidden, showSecrets)
+			flattenValueDiff(out, append(slices.Clone(path), i), v, hidden, showSecrets)
 		}
 	default:
 		emitDiffEntry(out, path, PropertyDiffJSON{

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -65,8 +65,9 @@ type ResourceJSON struct {
 	// Parent is the URN of this resource's parent, if any.
 	Parent string `json:"parent,omitempty"`
 	// Diff maps changed property paths to their old/new values. It is only
-	// populated when the caller asked for a diff (`--diff`).
-	Diff map[string]PropertyDiffJSON `json:"diff,omitempty"`
+	// populated when the caller asked for a diff (`--diff`), and is not yet
+	// part of the JSON wire shape.
+	Diff map[string]PropertyDiffJSON `json:"-"`
 }
 
 // PropertyDiffJSON describes the change to a single property path within a

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -103,28 +103,27 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *Re
 		return nil
 	}
 
-	// Parent lives on the post-step state when there is one, and falls back to
-	// the pre-step state for deletes (where New is nil).
-	var parent string
-	switch {
-	case p.Metadata.New != nil:
-		parent = string(p.Metadata.New.Parent)
-	case p.Metadata.Old != nil:
-		parent = string(p.Metadata.Old.Parent)
-	}
-
-	r := NewResourceJSON(p.Metadata.URN, apitype.OpType(p.Metadata.Op), parent)
+	r := NewResourceJSON(&p.Metadata)
 	return &r
 }
 
-// NewResourceJSON builds the per-resource summary entry from the fields
-// shared by the live display and `pulumi stack history events --summary`.
-func NewResourceJSON(urn resource.URN, op apitype.OpType, parent string) ResourceJSON {
+// NewResourceJSON builds the per-resource summary entry shared by the live
+// display and `pulumi stack history events --summary`. The parent lives on
+// the post-step state when there is one, and falls back to the pre-step
+// state for deletes (where New is nil).
+func NewResourceJSON(m *engine.StepEventMetadata) ResourceJSON {
+	var parent string
+	switch {
+	case m.New != nil:
+		parent = string(m.New.Parent)
+	case m.Old != nil:
+		parent = string(m.Old.Parent)
+	}
 	return ResourceJSON{
-		URN:    string(urn),
-		Type:   string(urn.Type()),
-		Name:   urn.Name(),
-		Op:     op,
+		URN:    string(m.URN),
+		Type:   string(m.URN.Type()),
+		Name:   m.URN.Name(),
+		Op:     apitype.OpType(m.Op),
 		Parent: parent,
 	}
 }
@@ -169,13 +168,14 @@ func NewDiffJSON(m *engine.StepEventMetadata, refresh, showSecrets bool) map[str
 	return out
 }
 
-// NewDiffJSONFromAPI is NewDiffJSON for step metadata that has already been
-// serialized to its API shape, as returned by the Pulumi Cloud events
-// endpoint. Secret values in such metadata are already blinded, so there is
-// no showSecrets option to offer.
-func NewDiffJSONFromAPI(md apitype.StepEventMetadata, refresh bool) map[string]PropertyDiffJSON {
-	em := convertJSONStepEventMetadata(md)
-	return NewDiffJSON(&em, refresh, false /* showSecrets */)
+// RefreshDiffJSON returns the diff a refresh step reveals on its outputs
+// event — an update carrying a detailed diff from the provider read, or a
+// delete of a resource that no longer exists — and nil for anything else.
+func RefreshDiffJSON(m *engine.StepEventMetadata, showSecrets bool) map[string]PropertyDiffJSON {
+	if (m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete {
+		return NewDiffJSON(m, true /* refresh */, showSecrets)
+	}
+	return nil
 }
 
 func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -168,16 +168,6 @@ func NewDiffJSON(m *engine.StepEventMetadata, refresh, showSecrets bool) map[str
 	return out
 }
 
-// RefreshDiffJSON returns the diff a refresh step reveals on its outputs
-// event — an update carrying a detailed diff from the provider read, or a
-// delete of a resource that no longer exists — and nil for anything else.
-func RefreshDiffJSON(m *engine.StepEventMetadata, showSecrets bool) map[string]PropertyDiffJSON {
-	if (m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete {
-		return NewDiffJSON(m, true /* refresh */, showSecrets)
-	}
-	return nil
-}
-
 func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,
 	hidden []resource.PropertyPath, showSecrets bool,
 ) {

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -49,8 +51,8 @@ type SummaryJSON struct {
 }
 
 // ResourceJSON is the per-resource entry that appears in SummaryJSON.Resources.
-// It is intentionally compact: callers that need full diffs / property values
-// should use `--json` (the streaming event format) instead.
+// It is intentionally compact: callers that need full property values should
+// use `--json` (the streaming event format) instead.
 type ResourceJSON struct {
 	// URN is the canonical, globally-unique identifier of the resource.
 	URN string `json:"urn"`
@@ -62,6 +64,20 @@ type ResourceJSON struct {
 	Op apitype.OpType `json:"op"`
 	// Parent is the URN of this resource's parent, if any.
 	Parent string `json:"parent,omitempty"`
+	// Diff maps changed property paths to their old/new values. It is only
+	// populated when the caller asked for a diff (`--diff`).
+	Diff map[string]PropertyDiffJSON `json:"diff,omitempty"`
+}
+
+// PropertyDiffJSON describes the change to a single property path within a
+// resource's diff.
+type PropertyDiffJSON struct {
+	// Kind is one of "add", "delete", or "update".
+	Kind string `json:"kind"`
+	// Old is the value before the operation; unset for adds.
+	Old any `json:"old,omitempty"`
+	// New is the value after the operation; unset for deletes.
+	New any `json:"new,omitempty"`
 }
 
 // summaryJSONFromEvent extracts the summary JSON shape from a SummaryEventPayload.
@@ -110,6 +126,152 @@ func NewResourceJSON(urn resource.URN, op apitype.OpType, parent string) Resourc
 		Name:   urn.Name(),
 		Op:     op,
 		Parent: parent,
+	}
+}
+
+// NewDiffJSON flattens a step's property diff into path → change entries,
+// drawing on the same sources as the human diff view: the provider's detailed
+// diff when present, otherwise a diff computed from the step's old and new
+// inputs.
+func NewDiffJSON(m *engine.StepEventMetadata, refresh, showSecrets bool) map[string]PropertyDiffJSON {
+	// An OpSame might have a diff due to metadata changes (e.g. protect) but we
+	// should never report a property diff. See
+	// https://github.com/pulumi/pulumi/issues/15944 for context.
+	if m.Op == deploy.OpSame {
+		return nil
+	}
+
+	var diff *resource.ObjectDiff
+	var hidden []resource.PropertyPath
+	switch {
+	case m.DetailedDiff != nil:
+		// TranslateDetailedDiff already excludes hidden (HideDiffs) paths.
+		diff, _ = engine.TranslateDetailedDiff(m, refresh)
+	case m.Old == nil && m.New != nil:
+		diff = resource.PropertyMap{}.Diff(m.New.Inputs, resource.IsInternalPropertyKey)
+		hidden = m.New.HideDiffs
+	case m.Old != nil && m.New == nil:
+		diff = m.Old.Inputs.Diff(resource.PropertyMap{}, resource.IsInternalPropertyKey)
+		hidden = m.Old.HideDiffs
+	case m.Old != nil && m.New != nil:
+		diff = m.Old.Inputs.Diff(m.New.Inputs, resource.IsInternalPropertyKey)
+		hidden = m.New.HideDiffs
+	}
+	if diff == nil {
+		return nil
+	}
+
+	out := map[string]PropertyDiffJSON{}
+	flattenObjectDiff(out, nil, diff, hidden, showSecrets)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// NewDiffJSONFromAPI is NewDiffJSON for step metadata that has already been
+// serialized to its API shape, as returned by the Pulumi Cloud events
+// endpoint. Secret values in such metadata are already blinded, so there is
+// no showSecrets option to offer.
+func NewDiffJSONFromAPI(md apitype.StepEventMetadata, refresh bool) map[string]PropertyDiffJSON {
+	em := convertJSONStepEventMetadata(md)
+	return NewDiffJSON(&em, refresh, false /* showSecrets */)
+}
+
+func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,
+	hidden []resource.PropertyPath, showSecrets bool,
+) {
+	at := func(k resource.PropertyKey) resource.PropertyPath {
+		return append(slices.Clone(path), string(k))
+	}
+	for k, v := range diff.Adds {
+		emitDiffEntry(out, at(k), PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+	}
+	for k, v := range diff.Deletes {
+		emitDiffEntry(out, at(k), PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+	}
+	for k, v := range diff.Updates {
+		flattenValueDiff(out, at(k), v, hidden, showSecrets)
+	}
+}
+
+func flattenValueDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff resource.ValueDiff,
+	hidden []resource.PropertyPath, showSecrets bool,
+) {
+	at := func(i int) resource.PropertyPath {
+		return append(slices.Clone(path), i)
+	}
+	switch {
+	case diff.Object != nil:
+		flattenObjectDiff(out, path, diff.Object, hidden, showSecrets)
+	case diff.Array != nil:
+		for i, v := range diff.Array.Adds {
+			emitDiffEntry(out, at(i), PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+		}
+		for i, v := range diff.Array.Deletes {
+			emitDiffEntry(out, at(i), PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+		}
+		for i, v := range diff.Array.Updates {
+			flattenValueDiff(out, at(i), v, hidden, showSecrets)
+		}
+	default:
+		emitDiffEntry(out, path, PropertyDiffJSON{
+			Kind: "update",
+			Old:  jsonPropertyValue(diff.Old, showSecrets),
+			New:  jsonPropertyValue(diff.New, showSecrets),
+		}, hidden)
+	}
+}
+
+func emitDiffEntry(out map[string]PropertyDiffJSON, path resource.PropertyPath, d PropertyDiffJSON,
+	hidden []resource.PropertyPath,
+) {
+	for _, h := range hidden {
+		if h.Contains(path) {
+			return
+		}
+	}
+	out[path.String()] = d
+}
+
+// jsonPropertyValue renders a property value as a plain JSON-marshalable
+// value, masking secrets and unknowns the same way the human diff display
+// does.
+func jsonPropertyValue(v resource.PropertyValue, showSecrets bool) any {
+	switch {
+	case v.IsSecret():
+		if !showSecrets {
+			return "[secret]"
+		}
+		return jsonPropertyValue(v.SecretValue().Element, showSecrets)
+	case v.IsComputed():
+		return "[unknown]"
+	case v.IsOutput():
+		o := v.OutputValue()
+		switch {
+		case !o.Known:
+			return "[unknown]"
+		case o.Secret && !showSecrets:
+			return "[secret]"
+		default:
+			return jsonPropertyValue(o.Element, showSecrets)
+		}
+	case v.IsString() && !utf8.ValidString(v.StringValue()):
+		return byteStringDisplay(v.StringValue())
+	case v.IsArray():
+		arr := make([]any, len(v.ArrayValue()))
+		for i, e := range v.ArrayValue() {
+			arr[i] = jsonPropertyValue(e, showSecrets)
+		}
+		return arr
+	case v.IsObject():
+		obj := make(map[string]any, len(v.ObjectValue()))
+		for k, e := range v.ObjectValue() {
+			obj[string(k)] = jsonPropertyValue(e, showSecrets)
+		}
+		return obj
+	default:
+		return v.Mappable()
 	}
 }
 

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -103,27 +103,28 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *Re
 		return nil
 	}
 
-	r := NewResourceJSON(&p.Metadata)
+	// Parent lives on the post-step state when there is one, and falls back to
+	// the pre-step state for deletes (where New is nil).
+	var parent string
+	switch {
+	case p.Metadata.New != nil:
+		parent = string(p.Metadata.New.Parent)
+	case p.Metadata.Old != nil:
+		parent = string(p.Metadata.Old.Parent)
+	}
+
+	r := NewResourceJSON(p.Metadata.URN, apitype.OpType(p.Metadata.Op), parent)
 	return &r
 }
 
-// NewResourceJSON builds the per-resource summary entry shared by the live
-// display and `pulumi stack history events --summary`. The parent lives on
-// the post-step state when there is one, and falls back to the pre-step
-// state for deletes (where New is nil).
-func NewResourceJSON(m *engine.StepEventMetadata) ResourceJSON {
-	var parent string
-	switch {
-	case m.New != nil:
-		parent = string(m.New.Parent)
-	case m.Old != nil:
-		parent = string(m.Old.Parent)
-	}
+// NewResourceJSON builds the per-resource summary entry from the fields
+// shared by the live display and `pulumi stack history events --summary`.
+func NewResourceJSON(urn resource.URN, op apitype.OpType, parent string) ResourceJSON {
 	return ResourceJSON{
-		URN:    string(m.URN),
-		Type:   string(m.URN.Type()),
-		Name:   m.URN.Name(),
-		Op:     apitype.OpType(m.Op),
+		URN:    string(urn),
+		Type:   string(urn.Type()),
+		Name:   urn.Name(),
+		Op:     op,
 		Parent: parent,
 	}
 }
@@ -166,6 +167,15 @@ func NewDiffJSON(m *engine.StepEventMetadata, refresh, showSecrets bool) map[str
 		return nil
 	}
 	return out
+}
+
+// NewDiffJSONFromAPI is NewDiffJSON for step metadata that has already been
+// serialized to its API shape, as returned by the Pulumi Cloud events
+// endpoint. Secret values in such metadata are already blinded, so there is
+// no showSecrets option to offer.
+func NewDiffJSONFromAPI(md apitype.StepEventMetadata) map[string]PropertyDiffJSON {
+	em := convertJSONStepEventMetadata(md)
+	return NewDiffJSON(&em, false /* refresh */, false /* showSecrets */)
 }
 
 func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -181,16 +181,24 @@ func NewDiffJSONFromAPI(md apitype.StepEventMetadata) map[string]PropertyDiffJSO
 func flattenObjectDiff(out map[string]PropertyDiffJSON, path resource.PropertyPath, diff *resource.ObjectDiff,
 	hidden []resource.PropertyPath, showSecrets bool,
 ) {
+	// Internal (__meta-style) keys reach us through provider detailed diffs;
+	// hide them as the rest of the display does.
 	for k, v := range diff.Adds {
-		emitDiffEntry(out, append(slices.Clone(path), string(k)),
-			PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+		if !resource.IsInternalPropertyKey(k) {
+			emitDiffEntry(out, append(slices.Clone(path), string(k)),
+				PropertyDiffJSON{Kind: "add", New: jsonPropertyValue(v, showSecrets)}, hidden)
+		}
 	}
 	for k, v := range diff.Deletes {
-		emitDiffEntry(out, append(slices.Clone(path), string(k)),
-			PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+		if !resource.IsInternalPropertyKey(k) {
+			emitDiffEntry(out, append(slices.Clone(path), string(k)),
+				PropertyDiffJSON{Kind: "delete", Old: jsonPropertyValue(v, showSecrets)}, hidden)
+		}
 	}
 	for k, v := range diff.Updates {
-		flattenValueDiff(out, append(slices.Clone(path), string(k)), v, hidden, showSecrets)
+		if !resource.IsInternalPropertyKey(k) {
+			flattenValueDiff(out, append(slices.Clone(path), string(k)), v, hidden, showSecrets)
+		}
 	}
 }
 

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -356,6 +356,8 @@ func TestNewDiffJSON_DetailedDiff(t *testing.T) {
 		DetailedDiff: map[string]plugin.PropertyDiff{
 			"tags.env":  {Kind: plugin.DiffUpdate},
 			"tags.team": {Kind: plugin.DiffAdd},
+			// Internal keys (as reported by e.g. the AWS provider) are hidden.
+			"__meta": {Kind: plugin.DiffUpdate},
 		},
 		Old: &engine.StepEventStateMetadata{Outputs: resource.PropertyMap{
 			"tags": resource.NewProperty(resource.PropertyMap{"env": resource.NewProperty("dev")}),

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -246,6 +247,154 @@ func TestTapSummaryJSON_OmitsResourcesFieldWhenEmpty(t *testing.T) {
 	}
 
 	assert.NotContains(t, buf.String(), `"resources"`)
+}
+
+func TestNewDiffJSON_ComputedInputsDiff(t *testing.T) {
+	t.Parallel()
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"region": resource.NewProperty("us-west-2"),
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("dev"),
+				"gone": resource.NewProperty("bye"),
+			}),
+			"password": resource.MakeSecret(resource.NewProperty("hunter2")),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"region": resource.NewProperty("us-east-1"),
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("prod"),
+				"team": resource.NewProperty("infra"),
+			}),
+			"password": resource.MakeSecret(resource.NewProperty("hunter3")),
+			"arn":      resource.MakeComputed(resource.NewProperty("")),
+		}},
+	}
+
+	got := NewDiffJSON(&m, false, false)
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"region":    {Kind: "update", Old: "us-west-2", New: "us-east-1"},
+		"tags.env":  {Kind: "update", Old: "dev", New: "prod"},
+		"tags.gone": {Kind: "delete", Old: "bye"},
+		"tags.team": {Kind: "add", New: "infra"},
+		"password":  {Kind: "update", Old: "[secret]", New: "[secret]"},
+		"arn":       {Kind: "add", New: "[unknown]"},
+	}, got)
+
+	// With showSecrets, secret values are revealed.
+	withSecrets := NewDiffJSON(&m, false, true)
+	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "hunter2", New: "hunter3"}, withSecrets["password"])
+}
+
+func TestNewDiffJSON_CreateAndDelete(t *testing.T) {
+	t.Parallel()
+
+	inputs := resource.PropertyMap{
+		"bucket": resource.NewProperty("my-bucket"),
+		"tags":   resource.NewProperty(resource.PropertyMap{"env": resource.NewProperty("dev")}),
+	}
+
+	create := engine.StepEventMetadata{
+		Op:  deploy.OpCreate,
+		New: &engine.StepEventStateMetadata{Inputs: inputs},
+	}
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"bucket": {Kind: "add", New: "my-bucket"},
+		"tags":   {Kind: "add", New: map[string]any{"env": "dev"}},
+	}, NewDiffJSON(&create, false, false))
+
+	del := engine.StepEventMetadata{
+		Op:  deploy.OpDelete,
+		Old: &engine.StepEventStateMetadata{Inputs: inputs},
+	}
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"bucket": {Kind: "delete", Old: "my-bucket"},
+		"tags":   {Kind: "delete", Old: map[string]any{"env": "dev"}},
+	}, NewDiffJSON(&del, false, false))
+}
+
+func TestNewDiffJSON_ArrayAndSameSkipped(t *testing.T) {
+	t.Parallel()
+
+	// OpSame never reports a property diff, even if the inputs differ.
+	same := engine.StepEventMetadata{
+		Op:  deploy.OpSame,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"a": resource.NewProperty("1")}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"a": resource.NewProperty("2")}},
+	}
+	assert.Nil(t, NewDiffJSON(&same, false, false))
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"subnets": resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("a"),
+				resource.NewProperty("b"),
+			}),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"subnets": resource.NewProperty([]resource.PropertyValue{
+				resource.NewProperty("a"),
+				resource.NewProperty("c"),
+				resource.NewProperty("d"),
+			}),
+		}},
+	}
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"subnets[1]": {Kind: "update", Old: "b", New: "c"},
+		"subnets[2]": {Kind: "add", New: "d"},
+	}, NewDiffJSON(&m, false, false))
+}
+
+func TestNewDiffJSON_DetailedDiff(t *testing.T) {
+	t.Parallel()
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		DetailedDiff: map[string]plugin.PropertyDiff{
+			"tags.env":  {Kind: plugin.DiffUpdate},
+			"tags.team": {Kind: plugin.DiffAdd},
+		},
+		Old: &engine.StepEventStateMetadata{Outputs: resource.PropertyMap{
+			"tags": resource.NewProperty(resource.PropertyMap{"env": resource.NewProperty("dev")}),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("prod"),
+				"team": resource.NewProperty("infra"),
+			}),
+		}},
+	}
+
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"tags.env":  {Kind: "update", Old: "dev", New: "prod"},
+		"tags.team": {Kind: "add", New: "infra"},
+	}, NewDiffJSON(&m, false, false))
+}
+
+func TestNewDiffJSON_HiddenPathsExcluded(t *testing.T) {
+	t.Parallel()
+
+	m := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"visible": resource.NewProperty("1"),
+			"hidden":  resource.NewProperty("1"),
+		}},
+		New: &engine.StepEventStateMetadata{
+			Inputs: resource.PropertyMap{
+				"visible": resource.NewProperty("2"),
+				"hidden":  resource.NewProperty("2"),
+			},
+			HideDiffs: []resource.PropertyPath{{"hidden"}},
+		},
+	}
+
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"visible": {Kind: "update", Old: "1", New: "2"},
+	}, NewDiffJSON(&m, false, false))
 }
 
 func TestTapSummaryJSON_ReturnsOnCancelEvent(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -70,6 +71,7 @@ type stackHistoryEventsArgs struct {
 	count               int
 	all                 bool
 	summary             bool
+	diff                bool
 	render              historyEventsRenderers
 }
 
@@ -105,7 +107,8 @@ func newStackHistoryEventsCmd(
 			"Pass --summary to reduce the update's full event stream to a compact\n" +
 			"summary with the same base shape as a live `pulumi up --output json`,\n" +
 			"extended with the update's error diagnostics and failed-resource\n" +
-			"markers — useful for diagnosing an update after the fact.\n" +
+			"markers — useful for diagnosing an update after the fact. Add --diff\n" +
+			"to include each resource's property diff in the summary.\n" +
 			"\n" +
 			"This command requires the Pulumi Cloud backend.",
 		Example: "  # Show the first page of events in a human-readable table.\n" +
@@ -122,6 +125,9 @@ func newStackHistoryEventsCmd(
 			"  pulumi stack history events <update-id> \\\n" +
 			"      --urn urn:pulumi:dev::proj::aws:s3/bucket:Bucket::my-bucket",
 		RunE: func(cmd *cobra.Command, positional []string) error {
+			if args.diff && !args.summary {
+				return errors.New("--diff can only be used with --summary")
+			}
 			args.updateID = positional[0]
 			args.render = outputFormat.Get()
 			sink := diag.DefaultSink(cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{
@@ -151,6 +157,8 @@ func newStackHistoryEventsCmd(
 		"Return every event for the update")
 	cmd.Flags().BoolVar(&args.summary, "summary", false,
 		"Reduce the update's events to a single summary document with error diagnostics; implies --all")
+	cmd.Flags().BoolVar(&args.diff, "diff", false,
+		"Include each resource's property diff in the --summary output")
 	cmd.MarkFlagsMutuallyExclusive("count", "all")
 	cmd.MarkFlagsMutuallyExclusive("summary", "count")
 	cmd.MarkFlagsMutuallyExclusive("summary", "event-type")
@@ -188,7 +196,7 @@ func runStackHistoryEvents(
 
 	events := iterateEngineEvents(ctx, c, update, opts, args.all || args.summary, args.count)
 	if args.summary {
-		summary, err := buildUpdateSummary(events)
+		summary, err := buildUpdateSummary(events, args.diff)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary.go
@@ -27,10 +27,10 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	pkgdisplay "github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 // updateSummary is the document emitted by `pulumi stack history events
@@ -58,31 +58,42 @@ type diagnosticSummary struct {
 	Message  string `json:"message"`
 }
 
+func summaryResourceFor(m apitype.StepEventMetadata) summaryResource {
+	// Parent falls back to the pre-step state for deletes, where New is nil.
+	var parent string
+	switch {
+	case m.New != nil:
+		parent = m.New.Parent
+	case m.Old != nil:
+		parent = m.Old.Parent
+	}
+	return summaryResource{ResourceJSON: display.NewResourceJSON(resource.URN(m.URN), m.Op, parent)}
+}
+
 // buildUpdateSummary reduces an engine event stream to an updateSummary,
 // mirroring the live summary tap (display.tapSummaryJSON): one resource entry
 // per attempted operation, unchanged (`same`) resources omitted. When
 // includeDiff is set, each entry carries its property diff too.
-//
-// Events arrive in their API shape and are converted back to engine events up
-// front so the rest of the reduction can share the display package's helpers.
 func buildUpdateSummary(
 	events iter.Seq2[apitype.EngineEvent, error], includeDiff bool,
 ) (*updateSummary, error) {
 	s := &updateSummary{}
 
 	var startTs, endTs int
-	var summaryEvent *engine.SummaryEventPayload
+	var summaryEvent *apitype.SummaryEvent
 	anyFailed := false
 	anyError := false
 
-	markFailed := func(m engine.StepEventMetadata) {
+	markFailed := func(m apitype.StepEventMetadata) {
 		for i := len(s.Resources) - 1; i >= 0; i-- {
-			if s.Resources[i].URN == string(m.URN) {
+			if s.Resources[i].URN == m.URN {
 				s.Resources[i].Failed = true
 				return
 			}
 		}
-		s.Resources = append(s.Resources, summaryResource{ResourceJSON: display.NewResourceJSON(&m), Failed: true})
+		r := summaryResourceFor(m)
+		r.Failed = true
+		s.Resources = append(s.Resources, r)
 	}
 
 	for ev, err := range events {
@@ -97,48 +108,44 @@ func buildUpdateSummary(
 				endTs = ev.Timestamp
 			}
 		}
-		e, err := display.ConvertJSONEvent(ev)
-		if err != nil {
-			// An event kind this CLI doesn't know about; skip it, as the switch
-			// below would anyway.
-			continue
-		}
-		switch e.Type { //nolint:exhaustive // we only care about a few event types here
-		case engine.SummaryEvent:
-			p := e.Payload().(engine.SummaryEventPayload)
-			summaryEvent = &p
-		case engine.ResourcePreEvent:
-			if m := e.Payload().(engine.ResourcePreEventPayload).Metadata; m.Op != deploy.OpSame {
-				r := summaryResource{ResourceJSON: display.NewResourceJSON(&m)}
+		switch {
+		case ev.SummaryEvent != nil:
+			summaryEvent = ev.SummaryEvent
+		case ev.ResourcePreEvent != nil:
+			if m := ev.ResourcePreEvent.Metadata; m.Op != apitype.OpSame {
+				r := summaryResourceFor(m)
 				if includeDiff {
-					r.Diff = display.NewDiffJSON(&m, false /* refresh */, false /* showSecrets */)
+					r.Diff = display.NewDiffJSONFromAPI(m)
 				}
 				s.Resources = append(s.Resources, r)
 			}
-		case engine.ResourceOperationFailed:
+		case ev.ResOpFailedEvent != nil:
 			anyFailed = true
-			markFailed(e.Payload().(engine.ResourceOperationFailedPayload).Metadata)
-		case engine.DiagEvent:
-			d := e.Payload().(engine.DiagEventPayload)
+			markFailed(ev.ResOpFailedEvent.Metadata)
+		case ev.DiagnosticEvent != nil:
+			d := ev.DiagnosticEvent
 			// A failing program reports through the language host's stderr, which
 			// arrives as "info#err" rather than "error" — for a preview that never
 			// reached a resource operation it is the only record of what went wrong.
 			// It doesn't imply failure on its own (a program can write to stderr and
 			// succeed), so only "error" contributes to the result below.
-			if d.Ephemeral || (d.Severity != diag.Error && d.Severity != diag.Infoerr) {
+			if d.Ephemeral || (d.Severity != string(diag.Error) && d.Severity != string(diag.Infoerr)) {
 				continue
 			}
-			anyError = anyError || d.Severity == diag.Error
+			anyError = anyError || d.Severity == string(diag.Error)
 			s.Diagnostics = append(s.Diagnostics, diagnosticSummary{
-				Severity: string(d.Severity),
-				URN:      string(d.URN),
+				Severity: d.Severity,
+				URN:      d.URN,
 				Message:  strings.TrimRight(plain(d.Message), "\n"),
 			})
 		}
 	}
 
 	if summaryEvent != nil {
-		s.Summary = summaryEvent.ResourceChanges
+		s.Summary = make(pkgdisplay.ResourceChanges, len(summaryEvent.ResourceChanges))
+		for op, n := range summaryEvent.ResourceChanges {
+			s.Summary[pkgdisplay.StepOp(op)] = n
+		}
 	}
 
 	switch {
@@ -154,8 +161,8 @@ func buildUpdateSummary(
 	}
 
 	switch {
-	case summaryEvent != nil && summaryEvent.Duration > 0:
-		s.Duration = summaryEvent.Duration
+	case summaryEvent != nil && summaryEvent.DurationSeconds > 0:
+		s.Duration = time.Duration(summaryEvent.DurationSeconds) * time.Second
 	case endTs > startTs:
 		s.Duration = time.Duration(endTs-startTs) * time.Second
 	}

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary.go
@@ -27,10 +27,10 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	pkgdisplay "github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 // updateSummary is the document emitted by `pulumi stack history events
@@ -58,42 +58,31 @@ type diagnosticSummary struct {
 	Message  string `json:"message"`
 }
 
-func summaryResourceFor(m apitype.StepEventMetadata) summaryResource {
-	// Parent falls back to the pre-step state for deletes, where New is nil.
-	var parent string
-	switch {
-	case m.New != nil:
-		parent = m.New.Parent
-	case m.Old != nil:
-		parent = m.Old.Parent
-	}
-	return summaryResource{ResourceJSON: display.NewResourceJSON(resource.URN(m.URN), m.Op, parent)}
-}
-
 // buildUpdateSummary reduces an engine event stream to an updateSummary,
 // mirroring the live summary tap (display.tapSummaryJSON): one resource entry
 // per attempted operation, unchanged (`same`) resources omitted. When
 // includeDiff is set, each entry carries its property diff too.
+//
+// Events arrive in their API shape and are converted back to engine events up
+// front so the rest of the reduction can share the display package's helpers.
 func buildUpdateSummary(
 	events iter.Seq2[apitype.EngineEvent, error], includeDiff bool,
 ) (*updateSummary, error) {
 	s := &updateSummary{}
 
 	var startTs, endTs int
-	var summaryEvent *apitype.SummaryEvent
+	var summaryEvent *engine.SummaryEventPayload
 	anyFailed := false
 	anyError := false
 
-	markFailed := func(m apitype.StepEventMetadata) {
+	markFailed := func(m engine.StepEventMetadata) {
 		for i := len(s.Resources) - 1; i >= 0; i-- {
-			if s.Resources[i].URN == m.URN {
+			if s.Resources[i].URN == string(m.URN) {
 				s.Resources[i].Failed = true
 				return
 			}
 		}
-		r := summaryResourceFor(m)
-		r.Failed = true
-		s.Resources = append(s.Resources, r)
+		s.Resources = append(s.Resources, summaryResource{ResourceJSON: display.NewResourceJSON(&m), Failed: true})
 	}
 
 	for ev, err := range events {
@@ -108,60 +97,65 @@ func buildUpdateSummary(
 				endTs = ev.Timestamp
 			}
 		}
-		switch {
-		case ev.SummaryEvent != nil:
-			summaryEvent = ev.SummaryEvent
-		case ev.ResourcePreEvent != nil:
-			if m := ev.ResourcePreEvent.Metadata; m.Op != apitype.OpSame {
-				r := summaryResourceFor(m)
+		e, err := display.ConvertJSONEvent(ev)
+		if err != nil {
+			// An event kind this CLI doesn't know about; skip it, as the switch
+			// below would anyway.
+			continue
+		}
+		switch e.Type { //nolint:exhaustive // we only care about a few event types here
+		case engine.SummaryEvent:
+			p := e.Payload().(engine.SummaryEventPayload)
+			summaryEvent = &p
+		case engine.ResourcePreEvent:
+			if m := e.Payload().(engine.ResourcePreEventPayload).Metadata; m.Op != deploy.OpSame {
+				r := summaryResource{ResourceJSON: display.NewResourceJSON(&m)}
 				if includeDiff {
-					r.Diff = display.NewDiffJSONFromAPI(m, false /* refresh */)
+					r.Diff = display.NewDiffJSON(&m, false /* refresh */, false /* showSecrets */)
 				}
 				s.Resources = append(s.Resources, r)
 			}
-		case ev.ResOutputsEvent != nil:
+		case engine.ResourceOutputsEvent:
 			// Refresh steps only reveal their diff once the provider has read the
-			// resource's current state, which arrives on the outputs event as an
-			// update (with a detailed diff) or a delete.
+			// resource's current state, which arrives on the outputs event.
 			if !includeDiff {
 				continue
 			}
-			m := ev.ResOutputsEvent.Metadata
-			if (m.Op == apitype.OpUpdate && m.DetailedDiff != nil) || m.Op == apitype.OpDelete {
-				for i := len(s.Resources) - 1; i >= 0; i-- {
-					if s.Resources[i].URN == m.URN && s.Resources[i].Op == apitype.OpRefresh {
-						s.Resources[i].Diff = display.NewDiffJSONFromAPI(m, true /* refresh */)
-						break
-					}
+			m := e.Payload().(engine.ResourceOutputsEventPayload).Metadata
+			d := display.RefreshDiffJSON(&m, false /* showSecrets */)
+			if d == nil {
+				continue
+			}
+			for i := len(s.Resources) - 1; i >= 0; i-- {
+				if s.Resources[i].URN == string(m.URN) && s.Resources[i].Op == apitype.OpRefresh {
+					s.Resources[i].Diff = d
+					break
 				}
 			}
-		case ev.ResOpFailedEvent != nil:
+		case engine.ResourceOperationFailed:
 			anyFailed = true
-			markFailed(ev.ResOpFailedEvent.Metadata)
-		case ev.DiagnosticEvent != nil:
-			d := ev.DiagnosticEvent
+			markFailed(e.Payload().(engine.ResourceOperationFailedPayload).Metadata)
+		case engine.DiagEvent:
+			d := e.Payload().(engine.DiagEventPayload)
 			// A failing program reports through the language host's stderr, which
 			// arrives as "info#err" rather than "error" — for a preview that never
 			// reached a resource operation it is the only record of what went wrong.
 			// It doesn't imply failure on its own (a program can write to stderr and
 			// succeed), so only "error" contributes to the result below.
-			if d.Ephemeral || (d.Severity != string(diag.Error) && d.Severity != string(diag.Infoerr)) {
+			if d.Ephemeral || (d.Severity != diag.Error && d.Severity != diag.Infoerr) {
 				continue
 			}
-			anyError = anyError || d.Severity == string(diag.Error)
+			anyError = anyError || d.Severity == diag.Error
 			s.Diagnostics = append(s.Diagnostics, diagnosticSummary{
-				Severity: d.Severity,
-				URN:      d.URN,
+				Severity: string(d.Severity),
+				URN:      string(d.URN),
 				Message:  strings.TrimRight(plain(d.Message), "\n"),
 			})
 		}
 	}
 
 	if summaryEvent != nil {
-		s.Summary = make(pkgdisplay.ResourceChanges, len(summaryEvent.ResourceChanges))
-		for op, n := range summaryEvent.ResourceChanges {
-			s.Summary[pkgdisplay.StepOp(op)] = n
-		}
+		s.Summary = summaryEvent.ResourceChanges
 	}
 
 	switch {
@@ -177,8 +171,8 @@ func buildUpdateSummary(
 	}
 
 	switch {
-	case summaryEvent != nil && summaryEvent.DurationSeconds > 0:
-		s.Duration = time.Duration(summaryEvent.DurationSeconds) * time.Second
+	case summaryEvent != nil && summaryEvent.Duration > 0:
+		s.Duration = summaryEvent.Duration
 	case endTs > startTs:
 		s.Duration = time.Duration(endTs-startTs) * time.Second
 	}

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary.go
@@ -72,8 +72,11 @@ func summaryResourceFor(m apitype.StepEventMetadata) summaryResource {
 
 // buildUpdateSummary reduces an engine event stream to an updateSummary,
 // mirroring the live summary tap (display.tapSummaryJSON): one resource entry
-// per attempted operation, unchanged (`same`) resources omitted.
-func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSummary, error) {
+// per attempted operation, unchanged (`same`) resources omitted. When
+// includeDiff is set, each entry carries its property diff too.
+func buildUpdateSummary(
+	events iter.Seq2[apitype.EngineEvent, error], includeDiff bool,
+) (*updateSummary, error) {
 	s := &updateSummary{}
 
 	var startTs, endTs int
@@ -110,7 +113,27 @@ func buildUpdateSummary(events iter.Seq2[apitype.EngineEvent, error]) (*updateSu
 			summaryEvent = ev.SummaryEvent
 		case ev.ResourcePreEvent != nil:
 			if m := ev.ResourcePreEvent.Metadata; m.Op != apitype.OpSame {
-				s.Resources = append(s.Resources, summaryResourceFor(m))
+				r := summaryResourceFor(m)
+				if includeDiff {
+					r.Diff = display.NewDiffJSONFromAPI(m, false /* refresh */)
+				}
+				s.Resources = append(s.Resources, r)
+			}
+		case ev.ResOutputsEvent != nil:
+			// Refresh steps only reveal their diff once the provider has read the
+			// resource's current state, which arrives on the outputs event as an
+			// update (with a detailed diff) or a delete.
+			if !includeDiff {
+				continue
+			}
+			m := ev.ResOutputsEvent.Metadata
+			if (m.Op == apitype.OpUpdate && m.DetailedDiff != nil) || m.Op == apitype.OpDelete {
+				for i := len(s.Resources) - 1; i >= 0; i-- {
+					if s.Resources[i].URN == m.URN && s.Resources[i].Op == apitype.OpRefresh {
+						s.Resources[i].Diff = display.NewDiffJSONFromAPI(m, true /* refresh */)
+						break
+					}
+				}
 			}
 		case ev.ResOpFailedEvent != nil:
 			anyFailed = true
@@ -202,6 +225,29 @@ func renderUpdateSummaryText(w io.Writer, s *updateSummary) error {
 		t.Render()
 	}
 
+	diffed := false
+	for _, r := range s.Resources {
+		if len(r.Diff) == 0 {
+			continue
+		}
+		if !diffed {
+			fmt.Fprintln(w, "\nDiffs:")
+			diffed = true
+		}
+		fmt.Fprintf(w, "  %s (%s)\n", r.Name, r.Type)
+		for _, path := range slices.Sorted(maps.Keys(r.Diff)) {
+			d := r.Diff[path]
+			switch d.Kind {
+			case "add":
+				fmt.Fprintf(w, "    + %s: %s\n", path, compactJSON(d.New))
+			case "delete":
+				fmt.Fprintf(w, "    - %s: %s\n", path, compactJSON(d.Old))
+			default:
+				fmt.Fprintf(w, "    ~ %s: %s => %s\n", path, compactJSON(d.Old), compactJSON(d.New))
+			}
+		}
+	}
+
 	if len(s.Diagnostics) > 0 {
 		fmt.Fprintln(w, "\nDiagnostics:")
 		for _, d := range s.Diagnostics {
@@ -214,4 +260,13 @@ func renderUpdateSummaryText(w io.Writer, s *updateSummary) error {
 	}
 
 	return nil
+}
+
+// compactJSON renders a diff value on one line for the text view.
+func compactJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
 }

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary.go
@@ -115,23 +115,6 @@ func buildUpdateSummary(
 				}
 				s.Resources = append(s.Resources, r)
 			}
-		case engine.ResourceOutputsEvent:
-			// Refresh steps only reveal their diff once the provider has read the
-			// resource's current state, which arrives on the outputs event.
-			if !includeDiff {
-				continue
-			}
-			m := e.Payload().(engine.ResourceOutputsEventPayload).Metadata
-			d := display.RefreshDiffJSON(&m, false /* showSecrets */)
-			if d == nil {
-				continue
-			}
-			for i := len(s.Resources) - 1; i >= 0; i-- {
-				if s.Resources[i].URN == string(m.URN) && s.Resources[i].Op == apitype.OpRefresh {
-					s.Resources[i].Diff = d
-					break
-				}
-			}
 		case engine.ResourceOperationFailed:
 			anyFailed = true
 			markFailed(e.Payload().(engine.ResourceOperationFailedPayload).Metadata)

--- a/pkg/cmd/pulumi/stack/stack_history_events_summary_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_summary_test.go
@@ -107,7 +107,7 @@ func TestBuildUpdateSummary(t *testing.T) {
 		},
 	)
 
-	s, err := buildUpdateSummary(events)
+	s, err := buildUpdateSummary(events, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, apitype.OperationResultFailed, s.Result)
@@ -149,7 +149,7 @@ func TestBuildUpdateSummary_BaseShapeMatchesLive(t *testing.T) {
 				ResourceChanges: map[apitype.OpType]int{apitype.OpCreate: 1},
 			},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 
 	encoded, err := json.Marshal(s)
@@ -176,7 +176,7 @@ func TestBuildUpdateSummary_FailureMarksLastEntryForURN(t *testing.T) {
 				Metadata: apitype.StepEventMetadata{Op: apitype.OpCreate, URN: urn, Type: "aws:s3/bucket:Bucket"},
 			},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 
 	require.Len(t, s.Resources, 1)
@@ -188,21 +188,21 @@ func TestBuildUpdateSummary_ResultFallbacks(t *testing.T) {
 	t.Parallel()
 
 	// No summary event, no failures: unknown.
-	s, err := buildUpdateSummary(eventSeq())
+	s, err := buildUpdateSummary(eventSeq(), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResult("unknown"), s.Result)
 
 	// No summary event, but an error diagnostic: failed.
 	s, err = buildUpdateSummary(eventSeq(apitype.EngineEvent{
 		DiagnosticEvent: &apitype.DiagnosticEvent{Message: "boom", Severity: "error"},
-	}))
+	}), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultFailed, s.Result)
 
 	// Summary event without a result (older updates): succeeded.
 	s, err = buildUpdateSummary(eventSeq(apitype.EngineEvent{
 		SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1},
-	}))
+	}), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultSucceeded, s.Result)
 
@@ -213,7 +213,7 @@ func TestBuildUpdateSummary_ResultFallbacks(t *testing.T) {
 			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "npm notice", Severity: "info#err"},
 		},
 		apitype.EngineEvent{SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1}},
-	))
+	), false)
 	require.NoError(t, err)
 	assert.Equal(t, apitype.OperationResultSucceeded, s.Result)
 	require.Len(t, s.Diagnostics, 1)
@@ -241,7 +241,7 @@ func TestBuildUpdateSummary_ReportsProgramErrors(t *testing.T) {
 		apitype.EngineEvent{
 			SummaryEvent: &apitype.SummaryEvent{DurationSeconds: 1, Result: apitype.OperationResultFailed},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, apitype.OperationResultFailed, s.Result)
@@ -261,7 +261,7 @@ func TestBuildUpdateSummary_DurationFallsBackToTimestamps(t *testing.T) {
 			Timestamp:       1030,
 			DiagnosticEvent: &apitype.DiagnosticEvent{Message: "boom", Severity: "error"},
 		},
-	))
+	), false)
 	require.NoError(t, err)
 	assert.Equal(t, 30*time.Second, s.Duration)
 }
@@ -274,8 +274,56 @@ func TestBuildUpdateSummary_PropagatesIteratorError(t *testing.T) {
 		yield(apitype.EngineEvent{}, boom)
 	}
 
-	_, err := buildUpdateSummary(events)
+	_, err := buildUpdateSummary(events, false)
 	assert.ErrorIs(t, err, boom)
+}
+
+func TestBuildUpdateSummary_IncludesDiffWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	urn := "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b"
+	events := func() iter.Seq2[apitype.EngineEvent, error] {
+		return eventSeq(preEvent(1, apitype.OpUpdate, urn, "aws:s3/bucket:Bucket",
+			apitype.StepEventMetadata{
+				Old: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "private"}},
+				New: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "public-read"}},
+			}))
+	}
+
+	s, err := buildUpdateSummary(events(), true)
+	require.NoError(t, err)
+	require.Len(t, s.Resources, 1)
+	assert.Equal(t, map[string]display.PropertyDiffJSON{
+		"acl": {Kind: "update", Old: "private", New: "public-read"},
+	}, s.Resources[0].Diff)
+
+	// Without --diff the field stays empty.
+	s, err = buildUpdateSummary(events(), false)
+	require.NoError(t, err)
+	require.Len(t, s.Resources, 1)
+	assert.Nil(t, s.Resources[0].Diff)
+}
+
+func TestRenderUpdateSummaryText_Diffs(t *testing.T) {
+	t.Parallel()
+
+	s, err := buildUpdateSummary(eventSeq(preEvent(1, apitype.OpUpdate,
+		"urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b", "aws:s3/bucket:Bucket",
+		apitype.StepEventMetadata{
+			Old: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "private", "gone": true}},
+			New: &apitype.StepEventStateMetadata{Inputs: map[string]any{"acl": "public-read", "new": float64(1)}},
+		})), true)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, renderUpdateSummaryText(&buf, s))
+	out := buf.String()
+
+	assert.Contains(t, out, "Diffs:")
+	assert.Contains(t, out, "b (aws:s3/bucket:Bucket)")
+	assert.Contains(t, out, `~ acl: "private" => "public-read"`)
+	assert.Contains(t, out, `- gone: true`)
+	assert.Contains(t, out, `+ new: 1`)
 }
 
 func TestRenderUpdateSummaryJSON_SingleLine(t *testing.T) {
@@ -283,7 +331,7 @@ func TestRenderUpdateSummaryJSON_SingleLine(t *testing.T) {
 
 	s, err := buildUpdateSummary(eventSeq(apitype.EngineEvent{
 		SummaryEvent: &apitype.SummaryEvent{Result: apitype.OperationResultSucceeded},
-	}))
+	}), false)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
@@ -321,7 +369,7 @@ func TestRenderUpdateSummaryText(t *testing.T) {
 			},
 		},
 	)
-	s, err := buildUpdateSummary(events)
+	s, err := buildUpdateSummary(events, false)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Each resource entry in the summary gains a `diff` map of property paths to `{kind, old, new}` entries, built from the same sources as the human diff view: the provider's detailed diff when present, otherwise a diff computed from the step's old and new inputs. Secrets in history events are already blinded server-side and render as `[secret]`; the text view lists the changes one path per line.

This PR also introduces the shared diff-building machinery in `pkg/backend/display`; a follow-up composes `--diff` with `--output json` on the live commands.

Part of #24263

🤖 Generated with [Claude Code](https://claude.com/claude-code)