### PR TITLE
Fix Neo cancel ack blocked by local tool execution

### DIFF
--- a/changelog/pending/cli-fix-20260811-180500.yaml
+++ b/changelog/pending/cli-fix-20260811-180500.yaml
@@ -1,7 +1,7 @@
-component: cli
+component: cli/neo
 kind: fix
-body: '`pulumi neo`: cancelling a task now interrupts a running local tool call
-    instead of waiting for it to finish'
+body: Cancelling a task now interrupts a running local tool call instead of waiting
+    for it to finish
 time: 2026-08-11T18:05:00+03:00
 custom:
     PR: "24268"

--- a/changelog/pending/cli-fix-20260811-180500.yaml
+++ b/changelog/pending/cli-fix-20260811-180500.yaml
@@ -1,0 +1,8 @@
+component: cli
+kind: fix
+body: '`pulumi neo`: backend events (including cancellation) now reach the TUI while
+    a local tool call is running, and cancelling a task interrupts the in-flight
+    shell or Pulumi operation instead of waiting for it to finish'
+time: 2026-08-11T18:05:00+03:00
+custom:
+    PR: "24268"

--- a/changelog/pending/cli-fix-20260811-180500.yaml
+++ b/changelog/pending/cli-fix-20260811-180500.yaml
@@ -1,8 +1,7 @@
 component: cli
 kind: fix
-body: '`pulumi neo`: backend events (including cancellation) now reach the TUI while
-    a local tool call is running, and cancelling a task interrupts the in-flight
-    shell or Pulumi operation instead of waiting for it to finish'
+body: '`pulumi neo`: cancelling a task now interrupts a running local tool call
+    instead of waiting for it to finish'
 time: 2026-08-11T18:05:00+03:00
 custom:
     PR: "24268"

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -337,7 +337,7 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		// running to completion against a cancelled turn. The handlers are
 		// ctx-aware: shell kills the process, pulumi does an engine graceful
 		// cancel. Batches enqueued after this point (a new turn) get a fresh
-		// context. No-op when nothing is running.
+		// context.
 		if s.batchCancel != nil {
 			s.batchCancel()
 			s.batchCancel = nil

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -55,6 +55,20 @@ type ToolHandler interface {
 	Invoke(ctx context.Context, method string, args json.RawMessage) (any, error)
 }
 
+// toolBatch is one assistant message's worth of CLI tool calls queued for the tool
+// worker. The context is carried in the struct (a work-queue item, not an API) so a
+// cancelled backend event can stop the batch it belongs to.
+type toolBatch struct {
+	ctx   context.Context
+	calls []apitype.AgentBackendEventToolCall
+}
+
+// batchQueueCap bounds the tool-batch queue. The protocol is turn-based — the agent
+// waits for tool_result before issuing more CLI calls — so more than one queued batch
+// is already anomalous. If the queue ever fills, enqueueBatch blocks the drain loop,
+// degrading to the old synchronous behavior instead of dropping work.
+const batchQueueCap = 8
+
 // EventStreamer is the subset of *client.Client we depend on for the SSE event stream and
 // for posting CLI tool result user events back to the Neo task. It is an interface so the
 // loop can be unit-tested without a live HTTP backend.
@@ -89,6 +103,24 @@ type Session struct {
 	// assistant_message with no pending CLI tool calls is written to it and Run
 	// returns nil.
 	Output io.Writer
+
+	// Tool-worker state, initialized by Run rather than at construction so the
+	// exported literal shape used by callers is unchanged.
+	//
+	// batches queues one entry per assistant message whose CLI tool calls we must
+	// execute. A single worker goroutine consumes it, so batches stay strictly
+	// serialized (tools/pulumi.go's process-global os.Chdir depends on this) while
+	// drainStream keeps reading the SSE stream (pulumi/pulumi-service#44059).
+	batches chan toolBatch
+	// batchErrs delivers a fatal runBatch error (exec_tool_call post failure) from
+	// the worker back to drainStream/Run, preserving the pre-worker behavior where
+	// such an error aborted the session. Capacity 1; only the first error matters.
+	batchErrs chan error
+	// batchCtx/batchCancel cover every batch enqueued since the last cancelled
+	// event. Only the Run goroutine touches them (handleEvent and Run's shutdown
+	// path), so no locking is needed.
+	batchCtx    context.Context
+	batchCancel context.CancelFunc
 }
 
 // Run drives the loop. It blocks until ctx is cancelled (clean shutdown, returns nil),
@@ -96,12 +128,41 @@ type Session struct {
 // error). Mid-stream network drops are reopened silently with Last-Event-ID so the
 // server replays missed events; the user sees no signal unless the retry budget is
 // exhausted.
-func (s *Session) Run(ctx context.Context) error {
+func (s *Session) Run(ctx context.Context) (err error) {
 	var (
 		lastEventID = s.LastEventID
 		failures    int
 		deadline    time.Time
 	)
+
+	s.batches = make(chan toolBatch, batchQueueCap)
+	s.batchErrs = make(chan error, 1)
+	workerDone := make(chan struct{})
+	go s.toolWorker(workerDone)
+	defer func() {
+		// On an error exit, stop the in-flight tool promptly. On a clean exit
+		// leave the batch ctx alone until the worker drains: ctx-cancel exits
+		// already propagate (batchCtx is a child of ctx), and a clean stream
+		// close waits for the batch to finish and post its result — the same
+		// observable behavior as the old synchronous code.
+		if err != nil && s.batchCancel != nil {
+			s.batchCancel()
+		}
+		close(s.batches)
+		<-workerDone
+		if s.batchCancel != nil {
+			s.batchCancel()
+		}
+		// The worker may have hit a fatal error after drainStream last looked;
+		// don't swallow it on an otherwise-clean exit.
+		if err == nil {
+			select {
+			case werr := <-s.batchErrs:
+				err = werr
+			default:
+			}
+		}
+	}()
 
 	for {
 		stream, err := s.Client.StreamNeoTaskEvents(ctx, s.OrgName, s.TaskID, lastEventID)
@@ -153,6 +214,10 @@ func (s *Session) drainStream(
 		select {
 		case <-ctx.Done():
 			return gotEvent, nil
+		case err := <-s.batchErrs:
+			// The tool worker hit a fatal error (see runBatch); abort the drain
+			// so Run applies its usual transient/fatal classification.
+			return gotEvent, err
 		case evt, ok := <-stream:
 			if !ok {
 				return gotEvent, nil
@@ -260,6 +325,19 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		s.logf("warning: skipping malformed backend event: %v", err)
 		return nil
 	}
+	if head.Type == backendEventCancelled {
+		// Server-side cancel: stop the in-flight and any queued tool batches so
+		// long-running local tools (shell, pulumi_up) stop now rather than
+		// running to completion against a cancelled turn. The handlers are
+		// ctx-aware: shell kills the process, pulumi does an engine graceful
+		// cancel. Batches enqueued after this point (a new turn) get a fresh
+		// context. No-op when nothing is running.
+		if s.batchCancel != nil {
+			s.batchCancel()
+			s.batchCancel = nil
+		}
+		return nil
+	}
 	if head.Type != backendEventAssistantMessage {
 		return nil
 	}
@@ -293,12 +371,56 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		}
 		return nil
 	}
-	return s.runBatch(ctx, cliCalls)
+	return s.enqueueBatch(ctx, cliCalls)
+}
+
+// enqueueBatch hands the batch to the tool worker and returns immediately so the
+// drain loop keeps reading the stream while tools run. The batch context is shared
+// by every batch enqueued since the last cancelled event: one server-side cancel
+// stops the running batch and everything queued behind it.
+func (s *Session) enqueueBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
+	if s.batchCancel == nil {
+		s.batchCtx, s.batchCancel = context.WithCancel(ctx)
+	}
+	select {
+	case s.batches <- toolBatch{ctx: s.batchCtx, calls: calls}:
+		return nil
+	case err := <-s.batchErrs:
+		// A blocked enqueue must not mask a fatal worker error.
+		return err
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+// toolWorker executes queued batches one at a time, in arrival order, until Run
+// closes the intake. It survives stream reconnects (it is per-Run, not per-stream)
+// and keeps running after a batch error so replayed events after a transient
+// reconnect can still execute tools.
+func (s *Session) toolWorker(done chan<- struct{}) {
+	defer close(done)
+	for batch := range s.batches {
+		if err := s.runBatch(batch.ctx, batch.calls); err != nil {
+			// Non-blocking: only the first error matters — by the time a second
+			// could occur, Run is already aborting or reconnecting.
+			select {
+			case s.batchErrs <- err:
+			default:
+			}
+		}
+	}
 }
 
 func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	items := make([]apitype.AgentUserEventToolResultItem, 0, len(calls))
 	for _, call := range calls {
+		// A cancelled batch context means the server abandoned this turn (or
+		// the session is shutting down): stop dispatching. The agent is not
+		// waiting for results from a cancelled turn, so skipping the posts is
+		// correct and they would fail with context.Canceled anyway.
+		if ctx.Err() != nil {
+			return nil
+		}
 		sendUI(s.UIEvents, UIToolStarted{Name: call.Name, Args: call.Args})
 
 		// The agent runtime relies on exec_tool_call to transition the call into its
@@ -311,6 +433,11 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 			Name:       call.Name,
 		}
 		if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
+			// A post failure caused by cancellation is not session-fatal; the
+			// turn is being abandoned anyway.
+			if ctx.Err() != nil {
+				return nil
+			}
 			return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
 		}
 
@@ -334,6 +461,11 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		})
 	}
 
+	// The turn was cancelled while a tool ran: the agent is not waiting for
+	// these results, so don't post them.
+	if ctx.Err() != nil {
+		return nil
+	}
 	result := apitype.AgentUserEventToolResult{
 		Type:        userEventToolResult,
 		ToolResults: items,

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -56,17 +56,15 @@ type ToolHandler interface {
 }
 
 // toolBatch is one assistant message's worth of CLI tool calls queued for the tool
-// worker. The context is carried in the struct (a work-queue item, not an API) so a
-// cancelled backend event can stop the batch it belongs to.
+// worker, along with the context that cancels it.
 type toolBatch struct {
 	ctx   context.Context
 	calls []apitype.AgentBackendEventToolCall
 }
 
-// batchQueueCap bounds the tool-batch queue. The protocol is turn-based — the agent
-// waits for tool_result before issuing more CLI calls — so more than one queued batch
-// is already anomalous. If the queue ever fills, enqueueBatch blocks the drain loop,
-// degrading to the old synchronous behavior instead of dropping work.
+// batchQueueCap bounds the tool-batch queue. The protocol is turn-based, so more
+// than one queued batch is already anomalous; if the queue fills, enqueueBatch
+// blocks the drain loop rather than dropping work.
 const batchQueueCap = 8
 
 // EventStreamer is the subset of *client.Client we depend on for the SSE event stream and
@@ -104,21 +102,18 @@ type Session struct {
 	// returns nil.
 	Output io.Writer
 
-	// Tool-worker state, initialized by Run rather than at construction so the
-	// exported literal shape used by callers is unchanged.
+	// Tool-worker state, initialized by Run.
 	//
-	// batches queues one entry per assistant message whose CLI tool calls we must
-	// execute. A single worker goroutine consumes it, so batches stay strictly
-	// serialized (tools/pulumi.go's process-global os.Chdir depends on this) while
-	// drainStream keeps reading the SSE stream (pulumi/pulumi-service#44059).
+	// batches queues one entry per assistant message with CLI tool calls. A single
+	// worker goroutine consumes it, keeping batches serialized (tools/pulumi.go's
+	// process-global os.Chdir depends on this) while drainStream keeps reading the
+	// SSE stream (pulumi/pulumi-service#44059).
 	batches chan toolBatch
-	// batchErrs delivers a fatal runBatch error (exec_tool_call post failure) from
-	// the worker back to drainStream/Run, preserving the pre-worker behavior where
-	// such an error aborted the session. Capacity 1; only the first error matters.
+	// batchErrs delivers a fatal runBatch error back to drainStream/Run.
+	// Capacity 1; only the first error matters.
 	batchErrs chan error
 	// batchCtx/batchCancel cover every batch enqueued since the last cancelled
-	// event. Only the Run goroutine touches them (handleEvent and Run's shutdown
-	// path), so no locking is needed.
+	// event. Only the Run goroutine touches them, so no locking is needed.
 	batchCtx    context.Context
 	batchCancel context.CancelFunc
 }
@@ -127,8 +122,7 @@ type Session struct {
 // the stream ends cleanly (returns nil), or an unrecoverable error occurs (returns the
 // error). Mid-stream network drops are reopened silently with Last-Event-ID so the
 // server replays missed events; the user sees no signal unless the retry budget is
-// exhausted. Run initializes the tool-worker state on Session, so it must be called
-// at most once per Session.
+// exhausted. Run must be called at most once per Session.
 func (s *Session) Run(ctx context.Context) error {
 	s.batches = make(chan toolBatch, batchQueueCap)
 	s.batchErrs = make(chan error, 1)
@@ -137,11 +131,8 @@ func (s *Session) Run(ctx context.Context) error {
 
 	err := s.streamLoop(ctx)
 
-	// On an error exit, stop the in-flight tool promptly. On a clean exit leave
-	// the batch ctx alone until the worker drains: ctx-cancel exits already
-	// propagate (batchCtx is a child of ctx), and a clean stream close waits for
-	// the batch to finish and post its result — the same observable behavior as
-	// the old synchronous code.
+	// On an error exit, stop the in-flight tool promptly. On a clean exit let
+	// the worker drain first so the final batch still posts its result.
 	if err != nil && s.batchCancel != nil {
 		s.batchCancel()
 	}
@@ -150,8 +141,7 @@ func (s *Session) Run(ctx context.Context) error {
 	if s.batchCancel != nil {
 		s.batchCancel()
 	}
-	// The worker may have hit a fatal error after drainStream last looked; don't
-	// swallow it on an otherwise-clean exit.
+	// Don't swallow a worker error that arrived after drainStream last looked.
 	if err == nil {
 		select {
 		case err = <-s.batchErrs:
@@ -221,8 +211,7 @@ func (s *Session) drainStream(
 		case <-ctx.Done():
 			return gotEvent, nil
 		case err := <-s.batchErrs:
-			// The tool worker hit a fatal error (see runBatch); abort the drain
-			// so Run applies its usual transient/fatal classification.
+			// Fatal tool-worker error; abort the drain.
 			return gotEvent, err
 		case evt, ok := <-stream:
 			if !ok {
@@ -332,12 +321,9 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		return nil
 	}
 	if head.Type == backendEventCancelled {
-		// Server-side cancel: stop the in-flight and any queued tool batches so
-		// long-running local tools (shell, pulumi_up) stop now rather than
-		// running to completion against a cancelled turn. The handlers are
-		// ctx-aware: shell kills the process, pulumi does an engine graceful
-		// cancel. Batches enqueued after this point (a new turn) get a fresh
-		// context.
+		// Server-side cancel: stop the in-flight and any queued tool batches
+		// rather than letting them run to completion against a cancelled turn.
+		// Batches enqueued after this point (a new turn) get a fresh context.
 		if s.batchCancel != nil {
 			s.batchCancel()
 			s.batchCancel = nil
@@ -380,10 +366,10 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 	return s.enqueueBatch(ctx, cliCalls)
 }
 
-// enqueueBatch hands the batch to the tool worker and returns immediately so the
-// drain loop keeps reading the stream while tools run. The batch context is shared
-// by every batch enqueued since the last cancelled event: one server-side cancel
-// stops the running batch and everything queued behind it.
+// enqueueBatch hands the batch to the tool worker so the drain loop keeps reading
+// the stream while tools run. Every batch since the last cancelled event shares
+// one context: a single cancel stops the running batch and everything queued
+// behind it.
 func (s *Session) enqueueBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	if s.batchCancel == nil {
 		s.batchCtx, s.batchCancel = context.WithCancel(ctx)
@@ -400,15 +386,13 @@ func (s *Session) enqueueBatch(ctx context.Context, calls []apitype.AgentBackend
 }
 
 // toolWorker executes queued batches one at a time, in arrival order, until Run
-// closes the intake. It survives stream reconnects (it is per-Run, not per-stream)
-// and keeps running after a batch error so replayed events after a transient
-// reconnect can still execute tools.
+// closes the intake. It is per-Run, not per-stream, so it survives reconnects and
+// keeps running after a batch error.
 func (s *Session) toolWorker(done chan<- struct{}) {
 	defer close(done)
 	for batch := range s.batches {
 		if err := s.runBatch(batch.ctx, batch.calls); err != nil {
-			// Non-blocking: only the first error matters — by the time a second
-			// could occur, Run is already aborting or reconnecting.
+			// Non-blocking: only the first error matters.
 			select {
 			case s.batchErrs <- err:
 			default:
@@ -420,10 +404,7 @@ func (s *Session) toolWorker(done chan<- struct{}) {
 func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	items := make([]apitype.AgentUserEventToolResultItem, 0, len(calls))
 	for _, call := range calls {
-		// A cancelled batch context means the server abandoned this turn (or
-		// the session is shutting down): stop dispatching. The agent is not
-		// waiting for results from a cancelled turn, so skipping the posts is
-		// correct and they would fail with context.Canceled anyway.
+		// Cancelled turn: the agent isn't waiting for results, stop dispatching.
 		if ctx.Err() != nil {
 			return nil
 		}
@@ -439,8 +420,7 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 			Name:       call.Name,
 		}
 		if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
-			// A post failure caused by cancellation is not session-fatal; the
-			// turn is being abandoned anyway.
+			// A post failure caused by cancellation is not session-fatal.
 			if ctx.Err() != nil {
 				return nil
 			}
@@ -467,8 +447,7 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		})
 	}
 
-	// The turn was cancelled while a tool ran: the agent is not waiting for
-	// these results, so don't post them.
+	// Don't post results for a cancelled turn.
 	if ctx.Err() != nil {
 		return nil
 	}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -127,42 +127,48 @@ type Session struct {
 // the stream ends cleanly (returns nil), or an unrecoverable error occurs (returns the
 // error). Mid-stream network drops are reopened silently with Last-Event-ID so the
 // server replays missed events; the user sees no signal unless the retry budget is
-// exhausted.
-func (s *Session) Run(ctx context.Context) (err error) {
+// exhausted. Run initializes the tool-worker state on Session, so it must be called
+// at most once per Session.
+func (s *Session) Run(ctx context.Context) error {
+	s.batches = make(chan toolBatch, batchQueueCap)
+	s.batchErrs = make(chan error, 1)
+	workerDone := make(chan struct{})
+	go s.toolWorker(workerDone)
+
+	err := s.streamLoop(ctx)
+
+	// On an error exit, stop the in-flight tool promptly. On a clean exit leave
+	// the batch ctx alone until the worker drains: ctx-cancel exits already
+	// propagate (batchCtx is a child of ctx), and a clean stream close waits for
+	// the batch to finish and post its result — the same observable behavior as
+	// the old synchronous code.
+	if err != nil && s.batchCancel != nil {
+		s.batchCancel()
+	}
+	close(s.batches)
+	<-workerDone
+	if s.batchCancel != nil {
+		s.batchCancel()
+	}
+	// The worker may have hit a fatal error after drainStream last looked; don't
+	// swallow it on an otherwise-clean exit.
+	if err == nil {
+		select {
+		case err = <-s.batchErrs:
+		default:
+		}
+	}
+	return err
+}
+
+// streamLoop opens and drains the SSE stream until the session ends, reconnecting
+// transparently (with Last-Event-ID resume) on transient failures.
+func (s *Session) streamLoop(ctx context.Context) error {
 	var (
 		lastEventID = s.LastEventID
 		failures    int
 		deadline    time.Time
 	)
-
-	s.batches = make(chan toolBatch, batchQueueCap)
-	s.batchErrs = make(chan error, 1)
-	workerDone := make(chan struct{})
-	go s.toolWorker(workerDone)
-	defer func() {
-		// On an error exit, stop the in-flight tool promptly. On a clean exit
-		// leave the batch ctx alone until the worker drains: ctx-cancel exits
-		// already propagate (batchCtx is a child of ctx), and a clean stream
-		// close waits for the batch to finish and post its result — the same
-		// observable behavior as the old synchronous code.
-		if err != nil && s.batchCancel != nil {
-			s.batchCancel()
-		}
-		close(s.batches)
-		<-workerDone
-		if s.batchCancel != nil {
-			s.batchCancel()
-		}
-		// The worker may have hit a fatal error after drainStream last looked;
-		// don't swallow it on an otherwise-clean exit.
-		if err == nil {
-			select {
-			case werr := <-s.batchErrs:
-				err = werr
-			default:
-			}
-		}
-	}()
 
 	for {
 		stream, err := s.Client.StreamNeoTaskEvents(ctx, s.OrgName, s.TaskID, lastEventID)

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -56,7 +56,7 @@ type ToolHandler interface {
 }
 
 // toolBatch is one assistant message's worth of CLI tool calls queued for the tool
-// worker, along with the context that cancels it.
+// worker.
 type toolBatch struct {
 	ctx   context.Context
 	calls []apitype.AgentBackendEventToolCall
@@ -109,8 +109,7 @@ type Session struct {
 	// process-global os.Chdir depends on this) while drainStream keeps reading the
 	// SSE stream (pulumi/pulumi-service#44059).
 	batches chan toolBatch
-	// batchErrs delivers a fatal runBatch error back to drainStream/Run.
-	// Capacity 1; only the first error matters.
+	// batchErrs delivers the first fatal runBatch error back to drainStream/Run.
 	batchErrs chan error
 	// batchCtx/batchCancel cover every batch enqueued since the last cancelled
 	// event. Only the Run goroutine touches them, so no locking is needed.
@@ -141,7 +140,6 @@ func (s *Session) Run(ctx context.Context) error {
 	if s.batchCancel != nil {
 		s.batchCancel()
 	}
-	// Don't swallow a worker error that arrived after drainStream last looked.
 	if err == nil {
 		select {
 		case err = <-s.batchErrs:
@@ -211,7 +209,6 @@ func (s *Session) drainStream(
 		case <-ctx.Done():
 			return gotEvent, nil
 		case err := <-s.batchErrs:
-			// Fatal tool-worker error; abort the drain.
 			return gotEvent, err
 		case evt, ok := <-stream:
 			if !ok {
@@ -321,9 +318,6 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		return nil
 	}
 	if head.Type == backendEventCancelled {
-		// Server-side cancel: stop the in-flight and any queued tool batches
-		// rather than letting them run to completion against a cancelled turn.
-		// Batches enqueued after this point (a new turn) get a fresh context.
 		if s.batchCancel != nil {
 			s.batchCancel()
 			s.batchCancel = nil
@@ -392,7 +386,6 @@ func (s *Session) toolWorker(done chan<- struct{}) {
 	defer close(done)
 	for batch := range s.batches {
 		if err := s.runBatch(batch.ctx, batch.calls); err != nil {
-			// Non-blocking: only the first error matters.
 			select {
 			case s.batchErrs <- err:
 			default:
@@ -404,7 +397,7 @@ func (s *Session) toolWorker(done chan<- struct{}) {
 func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	items := make([]apitype.AgentUserEventToolResultItem, 0, len(calls))
 	for _, call := range calls {
-		// Cancelled turn: the agent isn't waiting for results, stop dispatching.
+		// The agent isn't waiting for results from a cancelled turn.
 		if ctx.Err() != nil {
 			return nil
 		}
@@ -447,7 +440,6 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		})
 	}
 
-	// Don't post results for a cancelled turn.
 	if ctx.Err() != nil {
 		return nil
 	}

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1573,15 +1573,13 @@ func (b *blockedHandler) Invoke(_ context.Context, _ string, _ json.RawMessage) 
 	return map[string]any{"ok": true}, nil
 }
 
-// TestSession_CancelledEventDeliveredWhileLocalToolRuns encodes desired
-// behavior for pulumi/pulumi-service#44059: a cancelled backend event must
-// reach the TUI even while a local tool call is executing. Today drainStream
-// invokes tool handlers synchronously, so nothing is read off the SSE stream
-// until the tool returns — a long-running shell or pulumi_up call blocks the
-// cancellation acknowledgement (and everything else) for its full duration.
+// TestSession_CancelledEventDeliveredWhileLocalToolRuns is a regression test
+// for pulumi/pulumi-service#44059: a cancelled backend event must reach the
+// TUI even while a local tool call is executing. Tool batches run on a worker
+// goroutine so the drain loop keeps reading the SSE stream — a long-running
+// shell or pulumi_up call must not block the cancellation acknowledgement.
 func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	t.Parallel()
-	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
 
 	streamer := newFakeStreamer()
 	bh := &blockedHandler{started: make(chan struct{}), release: make(chan struct{})}
@@ -1644,4 +1642,199 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("session did not exit")
 	}
+}
+
+// ctxReportingHandler blocks inside Invoke until its context is cancelled,
+// reporting the ctx error it observed on finished.
+type ctxReportingHandler struct {
+	started  chan struct{}
+	finished chan error
+}
+
+func (h *ctxReportingHandler) Invoke(ctx context.Context, _ string, _ json.RawMessage) (any, error) {
+	close(h.started)
+	<-ctx.Done()
+	h.finished <- ctx.Err()
+	return nil, ctx.Err()
+}
+
+// TestSession_CancelledEventCancelsInFlightBatchContext verifies that a
+// server-side cancelled event cancels the running tool's context (so shell
+// kills its process and pulumi does an engine graceful-cancel), that no
+// tool_result is posted for the cancelled turn, and that the next turn's
+// batch runs with a fresh, non-cancelled context.
+func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+	first := &ctxReportingHandler{started: make(chan struct{}), finished: make(chan error, 1)}
+	secondCtxErr := make(chan error, 1)
+	second := &probeHandler{invoke: func(ctx context.Context) (any, error) {
+		secondCtxErr <- ctx.Err()
+		return map[string]any{"ok": true}, nil
+	}}
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{"blocking": first, "probe": second},
+		OrgName:  "org",
+		TaskID:   "task",
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type: backendEventAssistantMessage,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{ToolCallID: "c1", Name: "blocking__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+		},
+	})}
+	select {
+	case <-first.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool handler never started")
+	}
+
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventCancelled{
+		Type: backendEventCancelled,
+	})}
+	select {
+	case err := <-first.finished:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled event did not cancel the in-flight tool context")
+	}
+
+	// A new turn dispatches another CLI call: it must run with a fresh context.
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type: backendEventAssistantMessage,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{ToolCallID: "c2", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+		},
+	})}
+	select {
+	case err := <-secondCtxErr:
+		require.NoError(t, err, "batch after a cancelled turn must get a fresh context")
+	case <-time.After(5 * time.Second):
+		t.Fatal("second tool call never ran")
+	}
+
+	close(streamer.stream)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not exit")
+	}
+
+	// The cancelled turn posted its exec_tool_call but must not post a
+	// tool_result; the fresh turn posts both.
+	streamer.mu.Lock()
+	defer streamer.mu.Unlock()
+	var execNames []string
+	var resultIDs []string
+	for _, p := range streamer.posted {
+		switch evt := p.(type) {
+		case apitype.AgentUserEventExecToolCall:
+			execNames = append(execNames, evt.Name)
+		case apitype.AgentUserEventToolResult:
+			for _, item := range evt.ToolResults {
+				resultIDs = append(resultIDs, item.ToolCallID)
+			}
+		}
+	}
+	assert.Equal(t, []string{"blocking__run", "probe__run"}, execNames)
+	assert.Equal(t, []string{"c2"}, resultIDs)
+}
+
+// probeHandler delegates Invoke to a closure, for tests that only care about
+// the context or ordering.
+type probeHandler struct {
+	invoke func(ctx context.Context) (any, error)
+}
+
+func (h *probeHandler) Invoke(ctx context.Context, _ string, _ json.RawMessage) (any, error) {
+	return h.invoke(ctx)
+}
+
+// TestSession_BatchesRunSeriallyAcrossAssistantMessages locks down that tool
+// batches from consecutive assistant messages never run concurrently:
+// tools/pulumi.go's process-global os.Chdir depends on serialized dispatch.
+func TestSession_BatchesRunSeriallyAcrossAssistantMessages(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+	var mu sync.Mutex
+	var active, maxActive int
+	ran := make(chan struct{}, 2)
+	handler := &probeHandler{invoke: func(_ context.Context) (any, error) {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+		time.Sleep(20 * time.Millisecond)
+		mu.Lock()
+		active--
+		mu.Unlock()
+		ran <- struct{}{}
+		return map[string]any{"ok": true}, nil
+	}}
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{"shell": handler},
+		OrgName:  "org",
+		TaskID:   "task",
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	for _, id := range []string{"c1", "c2"} {
+		streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+			Type: backendEventAssistantMessage,
+			ToolCalls: []apitype.AgentBackendEventToolCall{
+				{ToolCallID: id, Name: "shell__" + id, Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+			},
+		})}
+	}
+	for range 2 {
+		select {
+		case <-ran:
+		case <-time.After(5 * time.Second):
+			t.Fatal("tool call never completed")
+		}
+	}
+
+	close(streamer.stream)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not exit")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, maxActive, "tool batches must not run concurrently")
+
+	// Posted order must be exec(c1), result(c1), exec(c2), result(c2).
+	streamer.mu.Lock()
+	defer streamer.mu.Unlock()
+	require.Len(t, streamer.posted, 4)
+	exec1, ok := streamer.posted[0].(apitype.AgentUserEventExecToolCall)
+	require.True(t, ok)
+	assert.Equal(t, "c1", exec1.ToolCallID)
+	res1, ok := streamer.posted[1].(apitype.AgentUserEventToolResult)
+	require.True(t, ok)
+	require.Len(t, res1.ToolResults, 1)
+	assert.Equal(t, "c1", res1.ToolResults[0].ToolCallID)
+	exec2, ok := streamer.posted[2].(apitype.AgentUserEventExecToolCall)
+	require.True(t, ok)
+	assert.Equal(t, "c2", exec2.ToolCallID)
+	res2, ok := streamer.posted[3].(apitype.AgentUserEventToolResult)
+	require.True(t, ok)
+	require.Len(t, res2.ToolResults, 1)
+	assert.Equal(t, "c2", res2.ToolResults[0].ToolCallID)
 }

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1623,8 +1623,8 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 		Type: backendEventCancelled,
 	})}
 
-	// Desired: UICancelled reaches the TUI promptly, without waiting for the
-	// tool to finish.
+	// UICancelled must reach the TUI promptly, without waiting for the tool
+	// to finish.
 	gotCancelled := func() bool {
 		for {
 			select {

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1600,7 +1600,6 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
 
-	// An assistant_message dispatching one CLI tool call.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type:    backendEventAssistantMessage,
 		IsFinal: true,
@@ -1614,8 +1613,6 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 		t.Fatal("tool handler never started")
 	}
 
-	// Cancel server-side while the tool is still running; UICancelled must
-	// reach the TUI without waiting for the tool to finish.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventCancelled{
 		Type: backendEventCancelled,
 	})}
@@ -1635,7 +1632,6 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	require.Eventually(t, gotCancelled, 2*time.Second, 20*time.Millisecond,
 		"cancelled event must be delivered while a local tool call is still executing")
 
-	// Unblock the tool and shut down.
 	close(release)
 	close(streamer.stream)
 	select {
@@ -1655,7 +1651,6 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 	streamer := newFakeStreamer()
 	started := make(chan struct{})
 	finished := make(chan error, 1)
-	// Blocks until its context is cancelled.
 	first := &probeHandler{invoke: func(ctx context.Context) (any, error) {
 		close(started)
 		<-ctx.Done()
@@ -1699,7 +1694,6 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		t.Fatal("cancelled event did not cancel the in-flight tool context")
 	}
 
-	// A new turn's CLI call must run with a fresh context.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type: backendEventAssistantMessage,
 		ToolCalls: []apitype.AgentBackendEventToolCall{

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1560,3 +1560,88 @@ func TestSession_RunDoesNotCloseUIEvents(t *testing.T) {
 		sendUI(uiCh, UIWarning{Message: "x"})
 	})
 }
+
+// blockedHandler blocks inside Invoke until released, signalling entry via started.
+type blockedHandler struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockedHandler) Invoke(_ context.Context, _ string, _ json.RawMessage) (any, error) {
+	close(b.started)
+	<-b.release
+	return map[string]any{"ok": true}, nil
+}
+
+// TestSession_CancelledEventDeliveredWhileLocalToolRuns encodes desired
+// behavior for pulumi/pulumi-service#44059: a cancelled backend event must
+// reach the TUI even while a local tool call is executing. Today drainStream
+// invokes tool handlers synchronously, so nothing is read off the SSE stream
+// until the tool returns — a long-running shell or pulumi_up call blocks the
+// cancellation acknowledgement (and everything else) for its full duration.
+func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
+	t.Parallel()
+	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
+
+	streamer := newFakeStreamer()
+	bh := &blockedHandler{started: make(chan struct{}), release: make(chan struct{})}
+	uiCh := make(chan UIEvent, 16)
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{"shell": bh},
+		OrgName:  "org",
+		TaskID:   "task",
+		UIEvents: uiCh,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	// A final assistant_message dispatching one CLI tool call: the session
+	// starts executing it locally.
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		IsFinal: true,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{ToolCallID: "c1", Name: "shell__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+		},
+	})}
+	select {
+	case <-bh.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool handler never started")
+	}
+
+	// The task is cancelled server-side while the local tool is still running.
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventCancelled{
+		Type: backendEventCancelled,
+	})}
+
+	// Desired: UICancelled reaches the TUI promptly, without waiting for the
+	// tool to finish.
+	gotCancelled := func() bool {
+		for {
+			select {
+			case ev := <-uiCh:
+				if _, ok := ev.(UICancelled); ok {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}
+	require.Eventually(t, gotCancelled, 2*time.Second, 20*time.Millisecond,
+		"cancelled event must be delivered while a local tool call is still executing")
+
+	// Unblock the tool and shut down.
+	close(bh.release)
+	close(streamer.stream)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not exit")
+	}
+}

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1561,16 +1561,14 @@ func TestSession_RunDoesNotCloseUIEvents(t *testing.T) {
 	})
 }
 
-// blockedHandler blocks inside Invoke until released, signalling entry via started.
-type blockedHandler struct {
-	started chan struct{}
-	release chan struct{}
+// probeHandler delegates Invoke to a closure, for tests that need to observe or
+// control the timing and context of tool execution.
+type probeHandler struct {
+	invoke func(ctx context.Context) (any, error)
 }
 
-func (b *blockedHandler) Invoke(_ context.Context, _ string, _ json.RawMessage) (any, error) {
-	close(b.started)
-	<-b.release
-	return map[string]any{"ok": true}, nil
+func (h *probeHandler) Invoke(ctx context.Context, _ string, _ json.RawMessage) (any, error) {
+	return h.invoke(ctx)
 }
 
 // TestSession_CancelledEventDeliveredWhileLocalToolRuns is a regression test
@@ -1582,7 +1580,15 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	t.Parallel()
 
 	streamer := newFakeStreamer()
-	bh := &blockedHandler{started: make(chan struct{}), release: make(chan struct{})}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	// Deliberately ignores ctx: the point is that events flow even while a tool
+	// keeps running.
+	bh := &probeHandler{invoke: func(_ context.Context) (any, error) {
+		close(started)
+		<-release
+		return map[string]any{"ok": true}, nil
+	}}
 	uiCh := make(chan UIEvent, 16)
 	s := &Session{
 		Client:   streamer,
@@ -1607,7 +1613,7 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 		},
 	})}
 	select {
-	case <-bh.started:
+	case <-started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("tool handler never started")
 	}
@@ -1635,27 +1641,13 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 		"cancelled event must be delivered while a local tool call is still executing")
 
 	// Unblock the tool and shut down.
-	close(bh.release)
+	close(release)
 	close(streamer.stream)
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("session did not exit")
 	}
-}
-
-// ctxReportingHandler blocks inside Invoke until its context is cancelled,
-// reporting the ctx error it observed on finished.
-type ctxReportingHandler struct {
-	started  chan struct{}
-	finished chan error
-}
-
-func (h *ctxReportingHandler) Invoke(ctx context.Context, _ string, _ json.RawMessage) (any, error) {
-	close(h.started)
-	<-ctx.Done()
-	h.finished <- ctx.Err()
-	return nil, ctx.Err()
 }
 
 // TestSession_CancelledEventCancelsInFlightBatchContext verifies that a
@@ -1667,7 +1659,15 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 	t.Parallel()
 
 	streamer := newFakeStreamer()
-	first := &ctxReportingHandler{started: make(chan struct{}), finished: make(chan error, 1)}
+	started := make(chan struct{})
+	finished := make(chan error, 1)
+	// Blocks until its context is cancelled, reporting the ctx error it observed.
+	first := &probeHandler{invoke: func(ctx context.Context) (any, error) {
+		close(started)
+		<-ctx.Done()
+		finished <- ctx.Err()
+		return nil, ctx.Err()
+	}}
 	secondCtxErr := make(chan error, 1)
 	second := &probeHandler{invoke: func(ctx context.Context) (any, error) {
 		secondCtxErr <- ctx.Err()
@@ -1690,7 +1690,7 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		},
 	})}
 	select {
-	case <-first.started:
+	case <-started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("tool handler never started")
 	}
@@ -1699,7 +1699,7 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		Type: backendEventCancelled,
 	})}
 	select {
-	case err := <-first.finished:
+	case err := <-finished:
 		require.ErrorIs(t, err, context.Canceled)
 	case <-time.After(5 * time.Second):
 		t.Fatal("cancelled event did not cancel the in-flight tool context")
@@ -1745,16 +1745,6 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 	}
 	assert.Equal(t, []string{"blocking__run", "probe__run"}, execNames)
 	assert.Equal(t, []string{"c2"}, resultIDs)
-}
-
-// probeHandler delegates Invoke to a closure, for tests that only care about
-// the context or ordering.
-type probeHandler struct {
-	invoke func(ctx context.Context) (any, error)
-}
-
-func (h *probeHandler) Invoke(ctx context.Context, _ string, _ json.RawMessage) (any, error) {
-	return h.invoke(ctx)
 }
 
 // TestSession_BatchesRunSeriallyAcrossAssistantMessages locks down that tool

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1561,8 +1561,8 @@ func TestSession_RunDoesNotCloseUIEvents(t *testing.T) {
 	})
 }
 
-// probeHandler delegates Invoke to a closure, for tests that need to observe or
-// control the timing and context of tool execution.
+// probeHandler delegates Invoke to a closure so tests can observe or control
+// tool execution.
 type probeHandler struct {
 	invoke func(ctx context.Context) (any, error)
 }
@@ -1573,17 +1573,14 @@ func (h *probeHandler) Invoke(ctx context.Context, _ string, _ json.RawMessage) 
 
 // TestSession_CancelledEventDeliveredWhileLocalToolRuns is a regression test
 // for pulumi/pulumi-service#44059: a cancelled backend event must reach the
-// TUI even while a local tool call is executing. Tool batches run on a worker
-// goroutine so the drain loop keeps reading the SSE stream — a long-running
-// shell or pulumi_up call must not block the cancellation acknowledgement.
+// TUI even while a local tool call is executing.
 func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	t.Parallel()
 
 	streamer := newFakeStreamer()
 	started := make(chan struct{})
 	release := make(chan struct{})
-	// Deliberately ignores ctx: the point is that events flow even while a tool
-	// keeps running.
+	// Deliberately ignores ctx: events must flow even while a tool keeps running.
 	bh := &probeHandler{invoke: func(_ context.Context) (any, error) {
 		close(started)
 		<-release
@@ -1603,8 +1600,7 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
 
-	// A final assistant_message dispatching one CLI tool call: the session
-	// starts executing it locally.
+	// An assistant_message dispatching one CLI tool call.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type:    backendEventAssistantMessage,
 		IsFinal: true,
@@ -1618,13 +1614,12 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 		t.Fatal("tool handler never started")
 	}
 
-	// The task is cancelled server-side while the local tool is still running.
+	// Cancel server-side while the tool is still running; UICancelled must
+	// reach the TUI without waiting for the tool to finish.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventCancelled{
 		Type: backendEventCancelled,
 	})}
 
-	// UICancelled must reach the TUI promptly, without waiting for the tool
-	// to finish.
 	gotCancelled := func() bool {
 		for {
 			select {
@@ -1651,17 +1646,16 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 }
 
 // TestSession_CancelledEventCancelsInFlightBatchContext verifies that a
-// server-side cancelled event cancels the running tool's context (so shell
-// kills its process and pulumi does an engine graceful-cancel), that no
+// server-side cancelled event cancels the running tool's context, that no
 // tool_result is posted for the cancelled turn, and that the next turn's
-// batch runs with a fresh, non-cancelled context.
+// batch runs with a fresh context.
 func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 	t.Parallel()
 
 	streamer := newFakeStreamer()
 	started := make(chan struct{})
 	finished := make(chan error, 1)
-	// Blocks until its context is cancelled, reporting the ctx error it observed.
+	// Blocks until its context is cancelled.
 	first := &probeHandler{invoke: func(ctx context.Context) (any, error) {
 		close(started)
 		<-ctx.Done()
@@ -1705,7 +1699,7 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		t.Fatal("cancelled event did not cancel the in-flight tool context")
 	}
 
-	// A new turn dispatches another CLI call: it must run with a fresh context.
+	// A new turn's CLI call must run with a fresh context.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type: backendEventAssistantMessage,
 		ToolCalls: []apitype.AgentBackendEventToolCall{
@@ -1727,8 +1721,8 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		t.Fatal("session did not exit")
 	}
 
-	// The cancelled turn posted its exec_tool_call but must not post a
-	// tool_result; the fresh turn posts both.
+	// The cancelled turn posts exec_tool_call but no tool_result; the fresh
+	// turn posts both.
 	streamer.mu.Lock()
 	defer streamer.mu.Unlock()
 	var execNames []string
@@ -1748,8 +1742,8 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 }
 
 // TestSession_BatchesRunSeriallyAcrossAssistantMessages locks down that tool
-// batches from consecutive assistant messages never run concurrently:
-// tools/pulumi.go's process-global os.Chdir depends on serialized dispatch.
+// batches never run concurrently: tools/pulumi.go's process-global os.Chdir
+// depends on serialized dispatch.
 func TestSession_BatchesRunSeriallyAcrossAssistantMessages(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -220,9 +220,8 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	// cmdStack.LoadProjectStack (called via GetStackConfiguration below) walks up
 	// from os.Getwd() to find Pulumi.<stack>.yaml, so we chdir into the project
 	// directory for the duration of the call. The engine itself derives its own
-	// working directory from op.Root and doesn't depend on cwd. Session runs tool
-	// batches on a single worker goroutine — one batch at a time, calls within a
-	// batch serial — so we don't lock here, but os.Chdir is process-global —
+	// working directory from op.Root and doesn't depend on cwd. The Session runs
+	// tool calls serially so we don't lock here, but os.Chdir is process-global —
 	// concurrent callers from outside the Session would race.
 	prevDir, err := os.Getwd()
 	if err != nil {

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -220,9 +220,10 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	// cmdStack.LoadProjectStack (called via GetStackConfiguration below) walks up
 	// from os.Getwd() to find Pulumi.<stack>.yaml, so we chdir into the project
 	// directory for the duration of the call. The engine itself derives its own
-	// working directory from op.Root and doesn't depend on cwd. Session.runBatch
-	// dispatches tool calls serially so we don't lock here, but os.Chdir is
-	// process-global — concurrent callers from outside the Session would race.
+	// working directory from op.Root and doesn't depend on cwd. Session runs tool
+	// batches on a single worker goroutine — one batch at a time, calls within a
+	// batch serial — so we don't lock here, but os.Chdir is process-global —
+	// concurrent callers from outside the Session would race.
 	prevDir, err := os.Getwd()
 	if err != nil {
 		return failedResult(a, "", fmt.Errorf("recording working directory: %w", err))


### PR DESCRIPTION
Part of pulumi/pulumi-service#44059 (Esc during a Neo task shows "Cancelling..." for minutes).

`Session.drainStream` executed local tool calls synchronously on the SSE drain goroutine, so a `cancelled` backend event couldn't reach the TUI until the current tool finished.

- Tool batches now run on a dedicated worker goroutine (still strictly serialized — `tools/pulumi.go`'s process-global `os.Chdir` depends on that), so the drain loop keeps reading and forwarding events while a tool runs.
- A `cancelled` event cancels the in-flight batch's context: shell kills its process, pulumi does an engine graceful-cancel. The next turn gets a fresh context.
- Fatal `exec_tool_call` post errors still abort the session; clean exits wait for in-flight batches to post their results.

Un-skips the repro test and adds tests for tool-context cancellation and batch serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)