### PR TITLE
Make `--diff` compose with `--output json` on `up`, `preview`, `destroy`, and `refresh`

### DIFF
--- a/changelog/pending/cli-feat-20260811-171707.yaml
+++ b/changelog/pending/cli-feat-20260811-171707.yaml
@@ -2,3 +2,5 @@ component: cli
 kind: feat
 body: Support combining --diff with --output json on up, preview, destroy, and refresh to include each resource's property diff in the structured summary
 time: 2026-08-11T17:17:07.692676+02:00
+custom:
+    PR: "24269"

--- a/changelog/pending/cli-feat-20260811-171707.yaml
+++ b/changelog/pending/cli-feat-20260811-171707.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Support combining --diff with --output json on up, preview, destroy, and refresh to include each resource's property diff in the structured summary
+time: 2026-08-11T17:17:07.692676+02:00

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -305,15 +305,37 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 	if stderr == nil {
 		stderr = os.Stderr
 	}
+	// `--diff` composed with `--output json`: include each resource's property
+	// diff in the summary.
+	includeDiff := opts.Type == DisplayDiff
 	go func() {
 		defer close(out)
 		var resources []ResourceJSON
+		indexByURN := map[resource.URN]int{}
 		for e := range in {
-			switch e.Type { //nolint:exhaustive // we only care about two event types here
+			switch e.Type { //nolint:exhaustive // we only care about a few event types here
 			case engine.ResourcePreEvent:
 				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
 					if r := resourceJSONFromEvent(payload, opts.ShowSameResources); r != nil {
+						if includeDiff {
+							r.Diff = NewDiffJSON(&payload.Metadata, false /* refresh */, opts.ShowSecrets)
+						}
+						indexByURN[payload.Metadata.URN] = len(resources)
 						resources = append(resources, *r)
+					}
+				}
+			case engine.ResourceOutputsEvent:
+				// Refresh steps only reveal their diff once the provider has read
+				// the resource's current state, which arrives on the outputs event
+				// as an update (with a detailed diff) or a delete.
+				if !includeDiff {
+					break
+				}
+				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok {
+					m := payload.Metadata
+					if i, ok := indexByURN[m.URN]; ok && resources[i].Op == apitype.OpRefresh &&
+						((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {
+						resources[i].Diff = NewDiffJSON(&m, true /* refresh */, opts.ShowSecrets)
 					}
 				}
 			case engine.SummaryEvent:

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -326,16 +326,16 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 				}
 			case engine.ResourceOutputsEvent:
 				// Refresh steps only reveal their diff once the provider has read
-				// the resource's current state, which arrives on the outputs event
-				// as an update (with a detailed diff) or a delete.
+				// the resource's current state, which arrives on the outputs event.
 				if !includeDiff {
 					break
 				}
 				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok {
 					m := payload.Metadata
-					if i, ok := indexByURN[m.URN]; ok && resources[i].Op == apitype.OpRefresh &&
-						((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {
-						resources[i].Diff = NewDiffJSON(&m, true /* refresh */, opts.ShowSecrets)
+					if i, ok := indexByURN[m.URN]; ok && resources[i].Op == apitype.OpRefresh {
+						if d := RefreshDiffJSON(&m, opts.ShowSecrets); d != nil {
+							resources[i].Diff = d
+						}
 					}
 				}
 			case engine.SummaryEvent:

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -397,6 +397,91 @@ func TestNewDiffJSON_HiddenPathsExcluded(t *testing.T) {
 	}, NewDiffJSON(&m, false, false))
 }
 
+// makeDiffPreEvent builds a pre-event carrying old/new inputs so the tap can
+// compute a property diff.
+func makeDiffPreEvent(op display.StepOp, urn resource.URN, old, new resource.PropertyMap,
+) engine.ResourcePreEventPayload {
+	meta := engine.StepEventMetadata{Op: op, URN: urn}
+	if old != nil {
+		meta.Old = &engine.StepEventStateMetadata{URN: urn, Inputs: old}
+	}
+	if new != nil {
+		meta.New = &engine.StepEventStateMetadata{URN: urn, Inputs: new}
+	}
+	return engine.ResourcePreEventPayload{Metadata: meta}
+}
+
+func TestTapSummaryJSON_IncludesDiffOnlyInDiffMode(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	makeEvents := func() chan engine.Event {
+		in := make(chan engine.Event, 2)
+		in <- engine.NewEvent(makeDiffPreEvent(deploy.OpUpdate, urn,
+			resource.PropertyMap{"a": resource.NewProperty("1")},
+			resource.PropertyMap{"a": resource.NewProperty("2")}))
+		in <- engine.NewEvent(engine.SummaryEventPayload{Result: apitype.OperationResultSucceeded})
+		close(in)
+		return in
+	}
+
+	// Default (progress) mode: no diff key at all.
+	var plain bytes.Buffer
+	for range tapSummaryJSON(makeEvents(), Options{Stdout: &plain}) { //nolint:revive // intentional drain
+	}
+	assert.NotContains(t, plain.String(), `"diff"`)
+
+	// Diff mode: the changed property is reported.
+	var buf bytes.Buffer
+	for range tapSummaryJSON(makeEvents(), Options{Stdout: &buf, Type: DisplayDiff}) { //nolint:revive // drain
+	}
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	require.Len(t, summary.Resources, 1)
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"a": {Kind: "update", Old: "1", New: "2"},
+	}, summary.Resources[0].Diff)
+}
+
+func TestTapSummaryJSON_RefreshDiffArrivesOnOutputsEvent(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	inputs := resource.PropertyMap{"acl": resource.NewProperty("private")}
+
+	// The pre-event announces the refresh with identical old/new state; the
+	// outputs event carries the update discovered by the provider read.
+	in := make(chan engine.Event, 3)
+	in <- engine.NewEvent(makeDiffPreEvent(deploy.OpRefresh, urn, inputs, inputs))
+	in <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:           deploy.OpUpdate,
+			URN:          urn,
+			DetailedDiff: map[string]plugin.PropertyDiff{"acl": {Kind: plugin.DiffUpdate}},
+			Old:          &engine.StepEventStateMetadata{URN: urn, Outputs: inputs},
+			New: &engine.StepEventStateMetadata{
+				URN:     urn,
+				Inputs:  inputs,
+				Outputs: resource.PropertyMap{"acl": resource.NewProperty("public-read")},
+			},
+		},
+	})
+	in <- engine.NewEvent(engine.SummaryEventPayload{Result: apitype.OperationResultSucceeded})
+	close(in)
+
+	var buf bytes.Buffer
+	for range tapSummaryJSON(in, Options{Stdout: &buf, Type: DisplayDiff}) { //nolint:revive // intentional drain
+	}
+
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	require.Len(t, summary.Resources, 1)
+	assert.Equal(t, apitype.OpRefresh, summary.Resources[0].Op)
+	assert.Equal(t, map[string]PropertyDiffJSON{
+		"acl": {Kind: "update", Old: "private", New: "public-read"},
+	}, summary.Resources[0].Diff)
+}
+
 func TestTapSummaryJSON_ReturnsOnCancelEvent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Stacked on #24266 — please merge that one first.

`--diff` now adds each resource's property diff to the structured summary emitted by `up`, `preview`, `destroy`, and `refresh` with `--output json`, using the diff-building machinery from #24266. Secrets stay masked unless `--show-secrets` is set, and unknowns render as `[unknown]`. For refreshes, the diff is attached when the provider read arrives on the outputs event.

Fixes #24263

🤖 Generated with [Claude Code](https://claude.com/claude-code)