### PR TITLE
fix l2-nested-collections golden files

### DIFF
--- a/sdk/go/pulumi-language-go/testdata/published/projects/l1-for-expression/go.mod
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l1-for-expression/go.mod
@@ -2,6 +2,6 @@ module l1-for-expression
 
 go 1.25
 
-require github.com/pulumi/pulumi/sdk/v3 v3.30.0
+require github.com/pulumi/pulumi/sdk/v3 v3.256.0
 
 replace github.com/pulumi/pulumi/sdk/v3 => /ROOT/artifacts/github.com_pulumi_pulumi_sdk_v3


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/24060 we require a newer version of the pulumi SDK.  Not sure why this didn't fail in that PR, but this will allow us to get CI green again.
