### PR TITLE
do: only delete snippets once the operation succeeded

### DIFF
--- a/changelog/pending/cli-do-fix-20260818-113339.yaml
+++ b/changelog/pending/cli-do-fix-20260818-113339.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: fix
+body: Keep snippets when delete fails, so delete can be retried
+time: 2026-08-18T11:33:39.573721677+02:00

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -166,6 +166,11 @@ type deploymentOptions struct {
 	// Resources to import, if this is an import.
 	imports []deploy.Import
 
+	// the snippet list persisted before the deployment runs, and the tracker deciding which
+	// held-back snippet deletions may be persisted afterwards (see Update)
+	snippetsPrePersist []resource.Snippet
+	snippetDeletions   *snippetDeletionTracker
+
 	// true if this deployment is (only) a refresh operation. This should not be
 	// confused with UpdateOptions.Refresh, which will be true whenever a refresh
 	// is happening as part of an operation (e.g. `up --refresh`).
@@ -265,7 +270,9 @@ func newDeployment(
 		return nil, err
 	}
 	if len(opts.Snippets) > 0 && !opts.DryRun {
-		if err := persistValidatedSnippets(baseCtx, ctx.SnapshotManager, target.Snapshot.Snippets, plugctx); err != nil {
+		if err := persistValidatedSnippets(
+			baseCtx, ctx.SnapshotManager, target.Snapshot.Snippets, opts.snippetsPrePersist, plugctx,
+		); err != nil {
 			contract.IgnoreClose(plugctx)
 			return nil, err
 		}

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -2276,3 +2276,230 @@ options {
 	require.Equal(t, resource.PropertyMap{"propA": resource.NewProperty(false)}, res.Inputs)
 	require.Contains(t, res.Provider, providerURN, "the resource should still use the explicit provider")
 }
+
+// pclSnippetDeleteFailPlan returns a TestPlan whose pkgA provider fails deletes for which
+// failDelete returns true.
+func pclSnippetDeleteFailPlan(t *testing.T, failDelete func(plugin.DeleteRequest) bool) *lt.TestPlan {
+	t.Helper()
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(pclSnippetSchemaPropA)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					id, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					return plugin.CreateResponse{ID: resource.ID(id.String()), Properties: cr.Properties}, nil
+				},
+				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
+					if !req.OldInputs["propA"].DeepEquals(req.NewInputs["propA"]) {
+						return plugin.DiffResult{Changes: plugin.DiffSome, ReplaceKeys: []resource.PropertyKey{"propA"}}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+				DeleteF: func(_ context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					if failDelete(req) {
+						return plugin.DeleteResponse{Status: resource.StatusUnknown}, errors.New("no valid credential sources found")
+					}
+					return plugin.DeleteResponse{Status: resource.StatusOK}, nil
+				},
+			}, nil
+		}),
+	}
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	return &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
+		},
+	}
+}
+
+func pclSnippetResourceNames(snap *deploy.Snapshot) map[string]bool {
+	names := map[string]bool{}
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			names[r.URN.Name()] = true
+		}
+	}
+	return names
+}
+
+// TestPclSnippetDeleteFailureKeepsSnippet checks that a snippet is only removed from the snapshot
+// once its resource has actually been deleted, so a failed delete can be retried.
+func TestPclSnippetDeleteFailureKeepsSnippet(t *testing.T) {
+	t.Parallel()
+
+	var deleteFails atomic.Bool
+	p := pclSnippetDeleteFailPlan(t, func(plugin.DeleteRequest) bool { return deleteFails.Load() })
+
+	snippetUUID := newPclSnippetUUID(t)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
+		pclSnippetForRes(snippetUUID, "test-resource", `propA = true`),
+	}, nil)
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+	require.Len(t, snap.Resources, 2)
+
+	// Delete the snippet the way `pulumi do delete` does, with the provider delete failing.
+	deleteFails.Store(true)
+	deleteOpts := p.Options
+	deleteOpts.UpdateOptions = UpdateOptions{
+		Snippets:       map[uuid.UUID]*resource.Snippet{uuid.Must(uuid.FromString(snippetUUID)): nil},
+		TargetSnippets: []string{snippetUUID},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "1")
+	require.ErrorContains(t, err, "no valid credential sources found")
+	require.Len(t, snap.Snippets, 1, "failed delete must keep the snippet")
+	require.Equal(t, snippetUUID, snap.Snippets[0].UUID)
+	require.True(t, pclSnippetResourceNames(snap)["test-resource"], "failed delete must keep the resource")
+
+	// Retrying once the provider works again deletes the resource and removes the snippet.
+	deleteFails.Store(false)
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+	require.Empty(t, snap.Snippets)
+	require.Empty(t, pclSnippetResourceNames(snap), "snippet resource should be gone")
+}
+
+// TestPclSnippetDeletePartialFailure checks that when several snippets are deleted in one
+// operation and only some resource deletes fail, only the snippets whose resources survived are
+// kept.
+func TestPclSnippetDeletePartialFailure(t *testing.T) {
+	t.Parallel()
+
+	var r1DeleteFails atomic.Bool
+	p := pclSnippetDeleteFailPlan(t, func(req plugin.DeleteRequest) bool {
+		return r1DeleteFails.Load() && req.URN.Name() == "r1"
+	})
+
+	s1UUID := newPclSnippetUUID(t)
+	s2UUID := newPclSnippetUUID(t)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
+		pclSnippetForRes(s1UUID, "r1", `propA = true`),
+		pclSnippetForRes(s2UUID, "r2", `propA = false`),
+	}, nil)
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+	require.Len(t, snap.Resources, 3)
+
+	// Delete both snippets with r1's delete failing: s1 must survive with its resource, s2 and
+	// r2 must be gone.
+	r1DeleteFails.Store(true)
+	deleteOpts := p.Options
+	deleteOpts.UpdateOptions = UpdateOptions{
+		Snippets: map[uuid.UUID]*resource.Snippet{
+			uuid.Must(uuid.FromString(s1UUID)): nil,
+			uuid.Must(uuid.FromString(s2UUID)): nil,
+		},
+		TargetSnippets:  []string{s1UUID, s2UUID},
+		ContinueOnError: true,
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "1")
+	require.ErrorContains(t, err, "no valid credential sources found")
+	require.Len(t, snap.Snippets, 1)
+	require.Equal(t, s1UUID, snap.Snippets[0].UUID)
+	names := pclSnippetResourceNames(snap)
+	require.True(t, names["r1"], "failed delete must keep its resource")
+	require.False(t, names["r2"], "successful delete must remove its resource")
+
+	// Retrying the remaining snippet once the provider works removes everything.
+	r1DeleteFails.Store(false)
+	deleteOpts.UpdateOptions = UpdateOptions{
+		Snippets:       map[uuid.UUID]*resource.Snippet{uuid.Must(uuid.FromString(s1UUID)): nil},
+		TargetSnippets: []string{s1UUID},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+	require.Empty(t, snap.Snippets)
+	require.Empty(t, pclSnippetResourceNames(snap), "all snippet resources should be gone")
+}
+
+// TestPclSnippetDeleteWithPendingDelete checks that a snippet whose resource has both a live copy
+// and a pending-delete copy in the snapshot (from an earlier failed replacement delete) is only
+// removed once both copies are gone.
+func TestPclSnippetDeleteWithPendingDelete(t *testing.T) {
+	t.Parallel()
+
+	var failAll atomic.Bool
+	var failID atomic.Value
+	failID.Store("")
+	p := pclSnippetDeleteFailPlan(t, func(req plugin.DeleteRequest) bool {
+		return failAll.Load() || (failID.Load().(string) != "" && failID.Load().(string) == string(req.ID))
+	})
+
+	snippetUUID := newPclSnippetUUID(t)
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
+		pclSnippetForRes(snippetUUID, "test-resource", `propA = true`),
+	}, nil)
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	// Change an input that requires replacement, with all deletes failing: the new copy is
+	// created but the old one cannot be deleted, leaving it in the snapshot as a pending delete.
+	// Both copies carry the snippet's UUID.
+	failAll.Store(true)
+	snap.Snippets[0].Code = `propA = false`
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.ErrorContains(t, err, "no valid credential sources found")
+	var live, pending *pkgresource.State
+	for _, r := range snap.Resources {
+		if r.Type != "pkgA:index:res" {
+			continue
+		}
+		if r.Delete {
+			pending = r
+		} else {
+			live = r
+		}
+	}
+	require.NotNil(t, live, "the replacement copy should be live in the snapshot")
+	require.NotNil(t, pending, "the failed replacement delete should leave a pending-delete copy")
+	require.Equal(t, snippetUUID, live.SnippetID)
+	require.Equal(t, snippetUUID, pending.SnippetID)
+
+	// Delete the snippet with only the live copy's delete failing: the pending copy is removed,
+	// but the snippet must survive because its live resource is still in the stack.
+	failAll.Store(false)
+	failID.Store(string(live.ID))
+	deleteOpts := p.Options
+	deleteOpts.UpdateOptions = UpdateOptions{
+		Snippets:        map[uuid.UUID]*resource.Snippet{uuid.Must(uuid.FromString(snippetUUID)): nil},
+		TargetSnippets:  []string{snippetUUID},
+		ContinueOnError: true,
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "2")
+	require.ErrorContains(t, err, "no valid credential sources found")
+	require.Len(t, snap.Snippets, 1, "the snippet must survive while its live resource remains")
+	count := 0
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			count++
+			require.False(t, r.Delete, "the pending-delete copy should be gone")
+		}
+	}
+	require.Equal(t, 1, count)
+
+	// Retrying with a working provider removes the remaining copy and the snippet.
+	failID.Store("")
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "3")
+	require.NoError(t, err)
+	require.Empty(t, snap.Snippets)
+	require.Empty(t, pclSnippetResourceNames(snap))
+}

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -2336,8 +2336,8 @@ func pclSnippetResourceNames(snap *deploy.Snapshot) map[string]bool {
 func TestPclSnippetDeleteFailureKeepsSnippet(t *testing.T) {
 	t.Parallel()
 
-	var deleteFails atomic.Bool
-	p := pclSnippetDeleteFailPlan(t, func(plugin.DeleteRequest) bool { return deleteFails.Load() })
+	deleteFails := false
+	p := pclSnippetDeleteFailPlan(t, func(plugin.DeleteRequest) bool { return deleteFails })
 
 	snippetUUID := newPclSnippetUUID(t)
 	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
@@ -2349,7 +2349,7 @@ func TestPclSnippetDeleteFailureKeepsSnippet(t *testing.T) {
 	require.Len(t, snap.Resources, 2)
 
 	// Delete the snippet the way `pulumi do delete` does, with the provider delete failing.
-	deleteFails.Store(true)
+	deleteFails = true
 	deleteOpts := p.Options
 	deleteOpts.UpdateOptions = UpdateOptions{
 		Snippets:       map[uuid.UUID]*resource.Snippet{uuid.Must(uuid.FromString(snippetUUID)): nil},
@@ -2363,7 +2363,7 @@ func TestPclSnippetDeleteFailureKeepsSnippet(t *testing.T) {
 	require.True(t, pclSnippetResourceNames(snap)["test-resource"], "failed delete must keep the resource")
 
 	// Retrying once the provider works again deletes the resource and removes the snippet.
-	deleteFails.Store(false)
+	deleteFails = false
 	snap, err = lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
@@ -2377,9 +2377,9 @@ func TestPclSnippetDeleteFailureKeepsSnippet(t *testing.T) {
 func TestPclSnippetDeletePartialFailure(t *testing.T) {
 	t.Parallel()
 
-	var r1DeleteFails atomic.Bool
+	r1DeleteFails := false
 	p := pclSnippetDeleteFailPlan(t, func(req plugin.DeleteRequest) bool {
-		return r1DeleteFails.Load() && req.URN.Name() == "r1"
+		return r1DeleteFails && req.URN.Name() == "r1"
 	})
 
 	s1UUID := newPclSnippetUUID(t)
@@ -2395,7 +2395,7 @@ func TestPclSnippetDeletePartialFailure(t *testing.T) {
 
 	// Delete both snippets with r1's delete failing: s1 must survive with its resource, s2 and
 	// r2 must be gone.
-	r1DeleteFails.Store(true)
+	r1DeleteFails = true
 	deleteOpts := p.Options
 	deleteOpts.UpdateOptions = UpdateOptions{
 		Snippets: map[uuid.UUID]*resource.Snippet{
@@ -2415,7 +2415,7 @@ func TestPclSnippetDeletePartialFailure(t *testing.T) {
 	require.False(t, names["r2"], "successful delete must remove its resource")
 
 	// Retrying the remaining snippet once the provider works removes everything.
-	r1DeleteFails.Store(false)
+	r1DeleteFails = false
 	deleteOpts.UpdateOptions = UpdateOptions{
 		Snippets:       map[uuid.UUID]*resource.Snippet{uuid.Must(uuid.FromString(s1UUID)): nil},
 		TargetSnippets: []string{s1UUID},
@@ -2427,17 +2427,17 @@ func TestPclSnippetDeletePartialFailure(t *testing.T) {
 	require.Empty(t, pclSnippetResourceNames(snap), "all snippet resources should be gone")
 }
 
-// TestPclSnippetDeleteWithPendingDelete checks that a snippet whose resource has both a live copy
-// and a pending-delete copy in the snapshot (from an earlier failed replacement delete) is only
-// removed once both copies are gone.
+// TestPclSnippetDeleteWithPendingDelete checks that pending-delete copies left behind by an
+// earlier failed replacement do not keep a snippet alive: once the live resource is deleted the
+// snippet is removed even if the copy's own deletion failed, and the copy is then cleaned up by
+// the ordinary pending-delete retry without the resource being recreated.
 func TestPclSnippetDeleteWithPendingDelete(t *testing.T) {
 	t.Parallel()
 
-	var failAll atomic.Bool
-	var failID atomic.Value
-	failID.Store("")
+	failAll := false
+	failID := ""
 	p := pclSnippetDeleteFailPlan(t, func(req plugin.DeleteRequest) bool {
-		return failAll.Load() || (failID.Load().(string) != "" && failID.Load().(string) == string(req.ID))
+		return failAll || (failID != "" && failID == string(req.ID))
 	})
 
 	snippetUUID := newPclSnippetUUID(t)
@@ -2451,7 +2451,7 @@ func TestPclSnippetDeleteWithPendingDelete(t *testing.T) {
 	// Change an input that requires replacement, with all deletes failing: the new copy is
 	// created but the old one cannot be deleted, leaving it in the snapshot as a pending delete.
 	// Both copies carry the snippet's UUID.
-	failAll.Store(true)
+	failAll = true
 	snap.Snippets[0].Code = `propA = false`
 	snap, err = lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
@@ -2472,10 +2472,10 @@ func TestPclSnippetDeleteWithPendingDelete(t *testing.T) {
 	require.Equal(t, snippetUUID, live.SnippetID)
 	require.Equal(t, snippetUUID, pending.SnippetID)
 
-	// Delete the snippet with only the live copy's delete failing: the pending copy is removed,
-	// but the snippet must survive because its live resource is still in the stack.
-	failAll.Store(false)
-	failID.Store(string(live.ID))
+	// Delete the snippet with only the pending copy's delete failing: the live resource is gone,
+	// so the snippet is removed even though the operation failed and the copy remains.
+	failAll = false
+	failID = string(pending.ID)
 	deleteOpts := p.Options
 	deleteOpts.UpdateOptions = UpdateOptions{
 		Snippets:        map[uuid.UUID]*resource.Snippet{uuid.Must(uuid.FromString(snippetUUID)): nil},
@@ -2485,20 +2485,20 @@ func TestPclSnippetDeleteWithPendingDelete(t *testing.T) {
 	snap, err = lt.TestOp(Update).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "2")
 	require.ErrorContains(t, err, "no valid credential sources found")
-	require.Len(t, snap.Snippets, 1, "the snippet must survive while its live resource remains")
+	require.Empty(t, snap.Snippets, "the snippet must not be kept alive by a pending-delete copy")
 	count := 0
 	for _, r := range snap.Resources {
 		if r.Type == "pkgA:index:res" {
 			count++
-			require.False(t, r.Delete, "the pending-delete copy should be gone")
+			require.True(t, r.Delete, "only the pending-delete copy should remain")
 		}
 	}
 	require.Equal(t, 1, count)
 
-	// Retrying with a working provider removes the remaining copy and the snippet.
-	failID.Store("")
+	// The next update retries the pending delete and, with the snippet gone, recreates nothing.
+	failID = ""
 	snap, err = lt.TestOp(Update).RunStep(
-		p.GetProject(), p.GetTarget(t, snap), deleteOpts, false, p.BackendClient, nil, "3")
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "3")
 	require.NoError(t, err)
 	require.Empty(t, snap.Snippets)
 	require.Empty(t, pclSnippetResourceNames(snap))

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
 	"github.com/pulumi/pulumi/pkg/v3/resource/autonaming"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -554,8 +555,35 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	if err != nil {
 		return nil, nil, err
 	}
+	// Snippet deletions are held back until the resources they registered are gone: removing a
+	// snippet whose resource delete then fails would orphan the resource with no way to retry
+	// the deletion.
+	var snippetsPre []resource.Snippet
+	var snippetDeletions *snippetDeletionTracker
 	if len(opts.Snippets) > 0 {
 		u.Target = targetWithSnippets(u.Target, effectiveSnippets)
+
+		upserts := make(map[uuid.UUID]*resource.Snippet, len(opts.Snippets))
+		deleted := map[string]bool{}
+		for id, snippet := range opts.Snippets {
+			if snippet == nil {
+				deleted[id.String()] = true
+				continue
+			}
+			upserts[id] = snippet
+		}
+		snippetsPre = effectiveSnippets
+		if len(deleted) > 0 {
+			snippetsPre, err = applySnippetUpdates(baseSnippets, upserts)
+			if err != nil {
+				return nil, nil, err
+			}
+			var oldResources []*pkgresource.State
+			if u.Target != nil && u.Target.Snapshot != nil {
+				oldResources = u.Target.Snapshot.Resources
+			}
+			snippetDeletions = newSnippetDeletionTracker(deleted, oldResources)
+		}
 	}
 
 	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "update", ctx.ParentSpan)
@@ -576,27 +604,92 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	// We skip the target check here because the targeted resource may not exist yet.
 
 	return update(ctx, info, &deploymentOptions{
-		UpdateOptions: opts,
-		SourceFunc:    newUpdateSource,
-		Events:        emitter,
-		Diag:          newEventSink(emitter, false),
-		StatusDiag:    newEventSink(emitter, true),
-		DryRun:        dryRun,
-		pluginManager: ctx.PluginManager,
+		UpdateOptions:      opts,
+		SourceFunc:         newUpdateSource,
+		Events:             emitter,
+		Diag:               newEventSink(emitter, false),
+		StatusDiag:         newEventSink(emitter, true),
+		DryRun:             dryRun,
+		pluginManager:      ctx.PluginManager,
+		snippetsPrePersist: snippetsPre,
+		snippetDeletions:   snippetDeletions,
 	})
 }
 
+// snippetDeletionTracker counts, for each snippet being deleted, how many old resources it
+// registered are still in the stack. A snippet's deletion is only persisted once its count
+// reaches zero, so a failed resource delete keeps its snippet and can be retried.
+type snippetDeletionTracker struct {
+	mu        sync.Mutex
+	surviving map[string]int
+}
+
+func newSnippetDeletionTracker(deleted map[string]bool, oldResources []*pkgresource.State) *snippetDeletionTracker {
+	t := &snippetDeletionTracker{surviving: make(map[string]int, len(deleted))}
+	for id := range deleted {
+		t.surviving[id] = 0
+	}
+	for _, r := range oldResources {
+		if r == nil || r.ViewOf != "" {
+			continue
+		}
+		if _, ok := t.surviving[r.SnippetID]; ok {
+			t.surviving[r.SnippetID]++
+		}
+	}
+	return t
+}
+
+// recordStep notes when a successfully applied step removed a resource registered by one of the
+// tracked snippets.
+func (t *snippetDeletionTracker) recordStep(step deploy.Step) {
+	if step.Op() != deploy.OpDelete && step.Op() != deploy.OpDeleteReplaced &&
+		step.Op() != deploy.OpRemovePendingReplace {
+		return
+	}
+	old := step.Old()
+	if old == nil || old.ViewOf != "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.surviving[old.SnippetID]; ok {
+		t.surviving[old.SnippetID]--
+	}
+}
+
+// remaining filters snippets down to those that must still be persisted, dropping the tracked
+// deletions whose resources are all gone. The second return value reports whether anything was
+// dropped.
+func (t *snippetDeletionTracker) remaining(snippets []resource.Snippet) ([]resource.Snippet, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	dropped := false
+	out := slice.Prealloc[resource.Snippet](len(snippets))
+	for _, s := range snippets {
+		if n, ok := t.surviving[s.UUID]; ok && n <= 0 {
+			dropped = true
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, dropped
+}
+
+// persistValidatedSnippets validates the snippets in validate and persists the persist list on
+// the snapshot manager; the two differ for deletions, which are persisted only after the
+// deployment succeeds.
 func persistValidatedSnippets(
 	ctx context.Context,
 	manager SnapshotManager,
-	snippets []resource.Snippet,
+	validate, persist []resource.Snippet,
 	plugctx *plugin.Context,
 ) error {
 	if manager == nil {
 		return nil
 	}
 	loader := schema.NewPluginLoader(plugctx)
-	for _, snippet := range snippets {
+	for _, snippet := range validate {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -604,7 +697,7 @@ func persistValidatedSnippets(
 			return err
 		}
 	}
-	return manager.SetSnippets(snippets)
+	return manager.SetSnippets(persist)
 }
 
 func installPlugins(
@@ -1129,6 +1222,14 @@ func update(
 	// Execute the deployment.
 	plan, changes, err := deployment.run(ctx)
 
+	if !opts.DryRun && opts.snippetDeletions != nil && ctx.SnapshotManager != nil {
+		if remaining, dropped := opts.snippetDeletions.remaining(opts.snippetsPrePersist); dropped {
+			if serr := ctx.SnapshotManager.SetSnippets(remaining); serr != nil {
+				err = errors.Join(err, fmt.Errorf("persist snippet deletions: %w", serr))
+			}
+		}
+	}
+
 	if ctx.FinalizeUpdateFunc != nil {
 		ctx.FinalizeUpdateFunc()
 	}
@@ -1241,6 +1342,10 @@ func (acts *updateActions) OnResourceStepPost(
 		steps := atomic.LoadInt32(&acts.Steps)
 		acts.Opts.Events.resourceOperationFailedEvent(step, status, steps, acts.Opts.Debug, acts.Opts.ShowSecrets)
 	} else {
+		if t := acts.Opts.snippetDeletions; t != nil {
+			t.recordStep(step)
+		}
+
 		op, record := step.Op(), step.Logical()
 		if acts.Opts.isRefresh && op == deploy.OpRefresh {
 			// Refreshes are handled specially.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -630,7 +630,7 @@ func newSnippetDeletionTracker(deleted map[string]bool, oldResources []*pkgresou
 		t.surviving[id] = 0
 	}
 	for _, r := range oldResources {
-		if r == nil || r.ViewOf != "" {
+		if r == nil || r.ViewOf != "" || r.Delete {
 			continue
 		}
 		if _, ok := t.surviving[r.SnippetID]; ok {
@@ -643,12 +643,11 @@ func newSnippetDeletionTracker(deleted map[string]bool, oldResources []*pkgresou
 // recordStep notes when a successfully applied step removed a resource registered by one of the
 // tracked snippets.
 func (t *snippetDeletionTracker) recordStep(step deploy.Step) {
-	if step.Op() != deploy.OpDelete && step.Op() != deploy.OpDeleteReplaced &&
-		step.Op() != deploy.OpRemovePendingReplace {
+	if step.Op() != deploy.OpDelete && step.Op() != deploy.OpRemovePendingReplace {
 		return
 	}
 	old := step.Old()
-	if old == nil || old.ViewOf != "" {
+	if old == nil || old.ViewOf != "" || old.Delete {
 		return
 	}
 	t.mu.Lock()


### PR DESCRIPTION
Currently when a delete operation fails in `pulumi do`, we have already persisted the snipped deletion, meaning there is no way to retry.  This is unlike regular resources, which remain in state until the deletion operation succeeds.  We should give the same care to snippets, so we don't orphan resources because of failed deletion operations.
