### PR TITLE
Add missing `program` arg for `preview_refresh` and `preview_destroy`

### DIFF
--- a/changelog/pending/auto-python-fix-20260811-171809.yaml
+++ b/changelog/pending/auto-python-fix-20260811-171809.yaml
@@ -1,0 +1,4 @@
+component: auto/python
+kind: fix
+body: Add missing `program` argument on `preview_refresh` and `preview_destroy` stack methods
+time: 2026-08-11T17:18:09.10822+02:00

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -674,6 +674,7 @@ class Stack:
         :param suppress_progress: Suppress display of periodic progress dots
         :param run_program: Run the program in the workspace to refresh the stack
         :param config_file: Path to a Pulumi config file to use for this update.
+        :param program: The inline program.
         :returns: RefreshResult
         """
         program = program or self.workspace.program
@@ -772,6 +773,7 @@ class Stack:
         suppress_progress: Optional[bool] = None,
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
+        program: Optional[PulumiFn] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run refresh of the stack, returning pending changes.
@@ -799,8 +801,10 @@ class Stack:
         :param suppress_progress: Suppress display of periodic progress dots
         :param run_program: Run the program in the workspace to refresh the stack
         :param config_file: Path to a Pulumi config file to use for this update.
+        :param program: The inline program.
         :returns: PreviewResult
         """
+        program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
         args = ["refresh", "--preview-only"]
 
@@ -816,7 +820,7 @@ class Stack:
         kind = ExecKind.LOCAL.value
         on_exit = None
 
-        if self.workspace.program:
+        if program:
             self._check_inline_support()
 
             kind = ExecKind.INLINE.value
@@ -824,7 +828,7 @@ class Stack:
                 futures.ThreadPoolExecutor(max_workers=4),
                 options=_GRPC_CHANNEL_OPTIONS,
             )
-            language_server = LanguageServer(self.workspace.program)
+            language_server = LanguageServer(program)
             language_pb2_grpc.add_LanguageRuntimeServicer_to_server(
                 language_server, server
             )
@@ -964,6 +968,7 @@ class Stack:
         :param preview_only: Deprecated, use `preview_destroy` instead. Only show a preview of the destroy, but don't perform the destroy itself
         :param run_program: Run the program in the workspace to destroy the stack
         :param config_file: Path to a Pulumi config file to use for this update.
+        :param program: The inline program.
         :param diff: Display operation as a rich diff showing the overall change.
         :returns: DestroyResult
         """
@@ -1070,6 +1075,7 @@ class Stack:
         refresh: Optional[bool] = None,
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
+        program: Optional[PulumiFn] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run deletion of resources in a stack, leaving all history and configuration intact.
@@ -1097,8 +1103,10 @@ class Stack:
         :param refresh: Refresh the state of the stack's resources against the cloud provider before running destroy.
         :param run_program: Run the program in the workspace to destroy the stack
         :param config_file: Path to a Pulumi config file to use for this update.
+        :param program: The inline program.
         :returns: DestroyResult
         """
+        program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
         args = ["destroy", "--preview-only"]
 
@@ -1114,7 +1122,7 @@ class Stack:
         kind = ExecKind.LOCAL.value
         on_exit = None
 
-        if self.workspace.program:
+        if program:
             self._check_inline_support()
 
             kind = ExecKind.INLINE.value
@@ -1122,7 +1130,7 @@ class Stack:
                 futures.ThreadPoolExecutor(max_workers=4),
                 options=_GRPC_CHANNEL_OPTIONS,
             )
-            language_server = LanguageServer(self.workspace.program)
+            language_server = LanguageServer(program)
             language_pb2_grpc.add_LanguageRuntimeServicer_to_server(
                 language_server, server
             )


### PR DESCRIPTION
stack methods

While most operations allow passing a specific program via the `program` arg, `preview_refresh` and `preview_destroy` are missing this option.

This PR adds the program option to these methods and adds a missing docstring description for this argument in the `refresh` method.

Fixes #24273

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
