### PR TITLE
Honor the request context while an HTTP retry backs off

### DIFF
--- a/changelog/pending/20260811--cli--retry-backoff-honors-request-context.yaml
+++ b/changelog/pending/20260811--cli--retry-backoff-honors-request-context.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Exit promptly when a command is cancelled while an HTTP request is being retried
+time: 2026-08-11T12:40:00Z
+custom:
+    PR: "24276"

--- a/sdk/go/common/util/httputil/http.go
+++ b/sdk/go/common/util/httputil/http.go
@@ -15,7 +15,6 @@
 package httputil
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -144,9 +143,12 @@ func doWithRetry(req *http.Request, client *http.Client, opts RetryOpts) (*http.
 			return false, nil, nil
 		},
 	}
-	_, res, err := retry.Until(context.Background(), acceptor)
+	accepted, res, err := retry.Until(req.Context(), acceptor)
 	if err != nil {
 		return nil, err
+	}
+	if !accepted {
+		return nil, req.Context().Err()
 	}
 
 	return res.(*http.Response), nil

--- a/sdk/go/common/util/httputil/http_test.go
+++ b/sdk/go/common/util/httputil/http_test.go
@@ -201,6 +201,27 @@ func TestRetry429ContextCanceledDuringWait(t *testing.T) {
 	assert.Less(t, time.Since(start), 5*time.Second)
 }
 
+func TestRetryContextCanceledDuringBackoff(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "POST", server.URL, strings.NewReader("hello, server"))
+	require.NoError(t, err)
+
+	delay := 10 * time.Second
+	start := time.Now()
+	_, err = DoWithRetryOpts(req, server.Client(), RetryOpts{Delay: &delay}) //nolint:bodyclose // no response on error
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second, "the backoff must not outlive the request context")
+}
+
 func TestRetryAfterDelay(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Why

Cancelling a Pulumi command could leave the CLI sitting for seconds after it had
already decided to exit. `httputil.doWithRetry` drove its retry loop from
`context.Background()`, so cancelling a request aborted the in-flight HTTP call but
left the loop free to sit out its backoff before giving up.

This is reachable from any command whose request carries a cancellable context: the
Cloud API client (`pkg/backend/httpstate/client/api.go:483`), the esc client, and the
Automation API downloader. The Cloud client retries with `Delay: 1s, Backoff: 2.0,
MaxRetryCount: 4`, so a cancel costs an extra 1+2+4 = 7s, and up to `MaxDelay: 30s`
for longer sequences.

Found while reviewing #24226: Ctrl-C at the `pulumi new` template prompt printed its
error immediately, then hung ~7s in `templates.Source.Close()` waiting on an in-flight
registry fetch. A goroutine dump during the hang showed it parked in
`retry.(*Retryer).Until`.

### What

Pass the request's context to `retry.Until` so the backoff is cancellable. Callers
that build a bare `&http.Request{}` are unaffected — `req.Context()` is already
`context.Background()` for those.

### Testing

`TestRetryContextCanceledDuringBackoff` covers the 5xx backoff path. The adjacent
`TestRetry429ContextCanceledDuringWait` only covered `Retry-After`, which had its own
explicit context check and so kept passing while this path was broken.

`make lint` exits 0.

End to end, driving `pulumi new` over a pty and sending one Ctrl-C at the template
prompt: 7.01s to exit before, 0.01s after.

### References

- #24226 — where this surfaced

