### PR TITLE
Fix the missing `Created stack` announcement for the Pulumi Cloud backend

### DIFF
--- a/changelog/pending/20260811--cli-stack--created-stack-announcement.yaml
+++ b/changelog/pending/20260811--cli-stack--created-stack-announcement.yaml
@@ -1,0 +1,4 @@
+component: cli/stack
+kind: fix
+body: Announce `Created stack` when creating a stack against the Pulumi Cloud backend
+time: 2026-08-11T00:00:00+00:00

--- a/changelog/pending/20260811--cli-stack--created-stack-announcement.yaml
+++ b/changelog/pending/20260811--cli-stack--created-stack-announcement.yaml
@@ -2,3 +2,5 @@ component: cli/stack
 kind: fix
 body: Announce `Created stack` when creating a stack against the Pulumi Cloud backend
 time: 2026-08-11T00:00:00+00:00
+custom:
+  PR: "24279"

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1337,10 +1337,11 @@ func (b *cloudBackend) CreateStack(
 
 	stack, err := newStack(ctx, apistack, b)
 	if err != nil {
-		fmt.Printf("Created stack '%s'\n", stack.Ref())
+		return nil, err
 	}
+	fmt.Printf("Created stack '%s'\n", stack.Ref())
 
-	return stack, err
+	return stack, nil
 }
 
 func (b *cloudBackend) ListStacks(


### PR DESCRIPTION
# Description

`cloudBackend.CreateStack` printed its `Created stack '<name>'` announcement under `if err != nil` — inverted since #19324 changed `newStack` to return an error — so stack creation against the Pulumi Cloud backend has been silent on success since ~April 2025, and on a `newStack` error it would have dereferenced a nil stack. The DIY backend still announces, and callers (`pulumi new`, `pulumi up`) carry comments assuming the backend prints this line.

This restores the success announcement and returns early on error.

Extracted from #24223, where the guided flow needs to suppress this line (that suppression arrives separately as a `Quiet` option).

## Testing

Existing `httpstate` package tests pass against the corrected control flow:

```
$ go test -count=1 ./backend/httpstate/
ok  	github.com/pulumi/pulumi/pkg/v3/backend/httpstate	8.166s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)