### PR TITLE
Pass CLI stack creation options as a struct and hoist the `Created stack` announcement

### DIFF
--- a/changelog/pending/20260811--cli-stack--created-stack-announcement.yaml
+++ b/changelog/pending/20260811--cli-stack--created-stack-announcement.yaml
@@ -1,0 +1,6 @@
+component: cli/stack
+kind: fix
+body: Announce `Created stack` when creating a stack against the Pulumi Cloud backend
+time: 2026-08-11T00:00:00+00:00
+custom:
+  PR: "24280"

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -861,10 +861,7 @@ func (b *diyBackend) CreateStack(
 		}
 	}
 
-	stack := newStack(diyStackRef, b)
-	b.d.Infof(diag.Message("", "Created stack '%s'"), stack.Ref())
-
-	return stack, nil
+	return newStack(diyStackRef, b), nil
 }
 
 func (b *diyBackend) GetStack(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1339,10 +1339,9 @@ func (b *cloudBackend) CreateStack(
 
 	stack, err := newStack(ctx, apistack, b)
 	if err != nil {
-		fmt.Printf("Created stack '%s'\n", stack.Ref())
+		return nil, err
 	}
-
-	return stack, err
+	return stack, nil
 }
 
 func (b *cloudBackend) ListStacks(

--- a/pkg/cmd/pulumi/do/do_global.go
+++ b/pkg/cmd/pulumi/do/do_global.go
@@ -95,14 +95,8 @@ func ensureGlobalStack(
 		return nil, fmt.Errorf("look up global stack: %w", err)
 	}
 	if stack == nil {
-		stack, err = cmdStack.CreateStack(
-			ctx, sink, ws, b, ref, root,
-			nil,   /*teams*/
-			false, /*setCurrent — we handle selection ourselves below to target the global project*/
-			"",    /*secretsProvider*/
-			false, /*useRemoteConfig*/
-			"",    /*configFile*/
-		)
+		// SetCurrent stays off: we handle selection ourselves below to target the global project.
+		stack, err = cmdStack.CreateStack(ctx, sink, ws, b, ref, root, cmdStack.CreateStackOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("create global stack: %w", err)
 		}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -433,7 +433,7 @@ func NewUpCmd() *cobra.Command {
 				false /*setCurrent*/, yes, opts.Display, secretsProvider, false /*useRemoteConfig*/, configFile); err != nil {
 				return err
 			}
-			// The backend will print "Created stack '<stack>'." on success.
+			// cmdStack.CreateStack prints "Created stack '<stack>'" on success.
 		}
 
 		// Prompt for config values (if needed) and save.

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -387,7 +387,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			args.remoteStackConfig, ""); err != nil {
 			return err
 		}
-		// The backend will print "Created stack '<stack>'" on success.
+		// cmdStack.CreateStack prints "Created stack '<stack>'" on success.
 		fmt.Fprintln(args.stdout)
 	}
 

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -65,13 +65,18 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 	contract.Requiref(b != nil, "b", "must not be nil")
 	contract.Requiref(root != "", "root", "must not be empty")
 
+	createOpts := cmdStack.CreateStackOptions{
+		SetCurrent:      setCurrent,
+		SecretsProvider: secretsProvider,
+		UseRemoteConfig: useRemoteConfig,
+		ConfigFile:      configFile,
+	}
 	if stack != "" {
 		stackName, err := buildStackName(ctx, b, stack)
 		if err != nil {
 			return nil, err
 		}
-		s, err := cmdStack.InitStack(
-			ctx, sink, ws, b, stackName, root, setCurrent, secretsProvider, useRemoteConfig, configFile)
+		s, err := cmdStack.InitStack(ctx, sink, ws, b, stackName, root, createOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -94,8 +99,7 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		if err != nil {
 			return nil, err
 		}
-		s, err := cmdStack.InitStack(
-			ctx, sink, ws, b, formattedStackName, root, setCurrent, secretsProvider, useRemoteConfig, configFile)
+		s, err := cmdStack.InitStack(ctx, sink, ws, b, formattedStackName, root, createOpts)
 		if err != nil {
 			if !yes {
 				// Let the user know about the error and loop around to try again.

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -163,7 +163,9 @@ func RequireStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, 
 			return nil, err
 		}
 
-		return CreateStack(ctx, sink, ws, b, stackRef, root, nil, lopt.SetCurrent(), "", false, configFile)
+		return CreateStack(ctx, sink, ws, b, stackRef, root, CreateStackOptions{
+			SetCurrent: lopt.SetCurrent(), ConfigFile: configFile,
+		})
 	}
 
 	return nil, backenderr.StackNotFoundError{StackName: stackName}
@@ -306,7 +308,9 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 			return nil, parseErr
 		}
 
-		return CreateStack(ctx, sink, ws, b, stackRef, root, nil, lopt.SetCurrent(), "", false, configFile)
+		return CreateStack(ctx, sink, ws, b, stackRef, root, CreateStackOptions{
+			SetCurrent: lopt.SetCurrent(), ConfigFile: configFile,
+		})
 	}
 
 	// With the stack name selected, look it up from the backend.
@@ -333,16 +337,32 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	return stack, nil
 }
 
+// CreateStackOptions are the options for creating a stack from the CLI.
+type CreateStackOptions struct {
+	// Teams to grant access to the new stack.
+	Teams []string
+	// SetCurrent selects the new stack as the current one.
+	SetCurrent bool
+	// SecretsProvider names the secrets provider to configure the stack with.
+	SecretsProvider string
+	// UseRemoteConfig stores the stack's configuration in an ESC environment.
+	UseRemoteConfig bool
+	// ConfigFile overrides the path the stack's configuration is read from and written to.
+	ConfigFile string
+	// Quiet suppresses the "Created stack" announcement so the caller can own the creation summary.
+	Quiet bool
+}
+
 // InitStack creates the stack.
 func InitStack(
 	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b backend.Backend, stackName string,
-	root string, setCurrent bool, secretsProvider string, useRemoteConfig bool, configFile string,
+	root string, opts CreateStackOptions,
 ) (backend.Stack, error) {
 	stackRef, err := b.ParseStackReference(stackName)
 	if err != nil {
 		return nil, err
 	}
-	return CreateStack(ctx, sink, ws, b, stackRef, root, nil, setCurrent, secretsProvider, useRemoteConfig, configFile)
+	return CreateStack(ctx, sink, ws, b, stackRef, root, opts)
 }
 
 // ErrSaveStackConfig wraps `SaveProjectStack` errors that occur in `CreateStack` after the
@@ -353,11 +373,10 @@ var ErrSaveStackConfig = errors.New("saving stack config")
 
 // CreateStack creates a stack with the given name, and optionally selects it as the current.
 func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
-	b backend.Backend, stackRef backend.StackReference,
-	root string, teams []string, setCurrent bool,
-	secretsProvider string, useRemoteConfig bool, configFile string,
+	b backend.Backend, stackRef backend.StackReference, root string, opts CreateStackOptions,
 ) (backend.Stack, error) {
-	ps, needsSave, sm, err := createSecretsManagerForNewStack(ctx, sink, ws, b, stackRef, secretsProvider, configFile)
+	ps, needsSave, sm, err := createSecretsManagerForNewStack(
+		ctx, sink, ws, b, stackRef, opts.SecretsProvider, opts.ConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not create secrets manager for new stack: %w", err)
 	}
@@ -391,23 +410,23 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 		}
 	}
 
-	opts := backend.CreateStackOptions{
-		Teams: teams,
+	backendOpts := backend.CreateStackOptions{
+		Teams: opts.Teams,
 	}
 
 	var escEnvironment string
-	if useRemoteConfig {
+	if opts.UseRemoteConfig {
 		proj, found := stackRef.Project()
 		if !found {
 			return nil, errors.New("could not get project from stack reference")
 		}
 		escEnvironment = proj.String() + "/" + stackRef.Name().String()
-		opts.Config = &apitype.StackConfig{
+		backendOpts.Config = &apitype.StackConfig{
 			Environment: escEnvironment,
 		}
 	}
 
-	stack, err := b.CreateStack(ctx, stackRef, root, initialState, &opts)
+	stack, err := b.CreateStack(ctx, stackRef, root, initialState, &backendOpts)
 	if err != nil {
 		// If it's a well-known error, don't wrap it.
 		if _, ok := err.(*backenderr.StackAlreadyExistsError); ok {
@@ -419,6 +438,10 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 		return nil, fmt.Errorf("could not create stack: %w", err)
 	}
 
+	if !opts.Quiet {
+		sink.Infof(diag.Message("", "Created stack '%s'"), stack.Ref())
+	}
+
 	if escEnvironment != "" {
 		// Shared helper without a *cobra.Command writer; uses process stdout.
 		fmt.Printf("Created environment %s for stack configuration\n", escEnvironment) //nolint:forbidigo
@@ -426,13 +449,13 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 
 	// Now that we've created the stack, we'll write out any necessary configuration changes.
 	if needsSave {
-		err = SaveProjectStack(ctx, stack, ps, configFile)
+		err = SaveProjectStack(ctx, stack, ps, opts.ConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrSaveStackConfig, err)
 		}
 	}
 
-	if setCurrent {
+	if opts.SetCurrent {
 		if err = state.SetCurrentStack(ws, state.BackendURLKey(b), stack.Ref().FullyQualifiedName().String()); err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/stack/io_test.go
+++ b/pkg/cmd/pulumi/stack/io_test.go
@@ -15,9 +15,11 @@
 package stack
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -88,14 +92,14 @@ func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {
 		) (backend.Stack, error) {
 			err := json.Unmarshal(initialState.Deployment, &actualDeployment)
 			require.NoError(t, err)
-			return nil, nil
+			return &backend.MockStack{RefF: func() backend.StackReference { return ref }}, nil
 		},
 		DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
 			return expectedSm, nil
 		},
 	}
 
-	stackRef := &backend.MockStackReference{}
+	stackRef := &backend.MockStackReference{StringV: "dev"}
 
 	// Act.
 	//nolint:errcheck
@@ -105,14 +109,62 @@ func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {
 		pkgWorkspace.Instance,
 		mockBackend,
 		stackRef,
-		"",    /*root*/
-		nil,   /*opts*/
-		false, /*setCurrent*/
-		"",    /*secretsProvider*/
-		false, /* useRemoteConfig */
-		"",    /*configFile*/
+		"", /*root*/
+		CreateStackOptions{},
 	)
 
 	// Assert.
 	assert.Equal(t, expectedSm.State(), actualDeployment.SecretsProviders.State)
+}
+
+// Tests that CreateStack announces the new stack unless Quiet is set.
+func TestCreateStackQuiet(t *testing.T) {
+	t.Parallel()
+
+	for _, quiet := range []bool{false, true} {
+		t.Run(fmt.Sprintf("quiet=%v", quiet), func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange.
+			var buf bytes.Buffer
+			sink := diag.DefaultSink(&buf, io.Discard, diag.FormatOptions{Color: colors.Never})
+
+			mockBackend := &backend.MockBackend{
+				NameF: func() string {
+					return "mock"
+				},
+				CreateStackF: func(
+					ctx context.Context,
+					ref backend.StackReference,
+					projectRoot string,
+					initialState *apitype.UntypedDeployment,
+					opts *backend.CreateStackOptions,
+				) (backend.Stack, error) {
+					return &backend.MockStack{RefF: func() backend.StackReference { return ref }}, nil
+				},
+				DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
+					return nil, nil
+				},
+			}
+
+			// Act.
+			_, err := CreateStack(
+				t.Context(),
+				sink,
+				pkgWorkspace.Instance,
+				mockBackend,
+				&backend.MockStackReference{StringV: "quietstack"},
+				"", /*root*/
+				CreateStackOptions{Quiet: quiet},
+			)
+
+			// Assert.
+			require.NoError(t, err)
+			if quiet {
+				assert.NotContains(t, buf.String(), "Created stack")
+			} else {
+				assert.Contains(t, buf.String(), "Created stack 'quietstack'")
+			}
+		})
+	}
 }

--- a/pkg/cmd/pulumi/stack/stack_migrate.go
+++ b/pkg/cmd/pulumi/stack/stack_migrate.go
@@ -453,13 +453,9 @@ func (cmd *stackMigrateCmd) Run(
 		}
 	}()
 
-	targetStack, err = CreateStack(
-		ctx, sink, ws, targetBE, targetRef, root, nil,
-		false,
-		cmd.secretsProvider,
-		false,
-		"",
-	)
+	targetStack, err = CreateStack(ctx, sink, ws, targetBE, targetRef, root, CreateStackOptions{
+		SecretsProvider: cmd.secretsProvider,
+	})
 	if err != nil {
 		// Only adopt-and-rollback when ErrSaveStackConfig signals b.CreateStack succeeded.
 		// Other failures (AlreadyExists / OverLimit / network / SM construct) might leave a

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -203,9 +203,12 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 		return projectErr
 	}
 
-	teams := sanitizeTeams(cmd.teams)
-	newStack, err := CreateStack(ctx, cmdutil.Diag(), ws, b, stackRef, root, teams,
-		!cmd.noSelect, cmd.secretsProvider, cmd.remoteConfig, "")
+	newStack, err := CreateStack(ctx, cmdutil.Diag(), ws, b, stackRef, root, CreateStackOptions{
+		Teams:           sanitizeTeams(cmd.teams),
+		SetCurrent:      !cmd.noSelect,
+		SecretsProvider: cmd.secretsProvider,
+		UseRemoteConfig: cmd.remoteConfig,
+	})
 	if err != nil {
 		if errors.Is(err, backend.ErrTeamsNotSupported) {
 			return fmt.Errorf("stack %s uses the %s backend: "+

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -95,7 +95,9 @@ func newStackSelectCmd() *cobra.Command {
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
-					s, err := InitStack(ctx, sink, ws, b, stack, root, false, secretsProvider, false /*useRemoteConfig*/, "")
+					s, err := InitStack(ctx, sink, ws, b, stack, root, CreateStackOptions{
+						SecretsProvider: secretsProvider,
+					})
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
## What

`cmdStack.CreateStack`/`InitStack` take a `CreateStackOptions` struct in place of four positional parameters, the struct gains a `Quiet` option, and the `Created stack` announcement moves out of the backends into `cmdStack.CreateStack`.

## Why

A caller needs to be able to own the stack-creation summary — the guided `pulumi new` confirmation shows the stack name itself — which requires a way to suppress the announcement, and the positional parameter list was already at four and growing.

Hoisting the announcement also fixes a bug: `cloudBackend.CreateStack` printed its announcement under `if err != nil` — inverted since #19324 changed `newStack` to return an error — so stack creation against the Pulumi Cloud backend has been silent on success since ~April 2025, and on a `newStack` error it would have dereferenced a nil stack. The CLI-layer print restores the announcement, and the error path now returns early; hence the changelog entry.

## How

`cmdStack.CreateStack` is the only production caller of `Backend.CreateStack`, so printing there preserves CLI output and ordering at every call site (`stack init`, `stack select`, `stack migrate`, `up`, `new`, `do`). The DIY and cloud backends no longer do UI output and `backend.CreateStackOptions` is untouched; direct backend callers outside the CLI funnel (e.g. the test-language runner) no longer print the message, and the cloud announcement now goes to the diag sink's stderr stream, matching DIY. `TestCreateStackQuiet` covers the `Quiet` gate against a mock backend.

## References
- #24320 and #24223 build on `Quiet`


