### PR TITLE
deployment settings: add the missing apitype fields

### DIFF
--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -134,12 +134,72 @@ type GitHubAppIntegration struct {
 }
 
 type DeploymentSettings struct {
+	// Version is assigned by the service and is not accepted on write.
+	Version       int                       `json:"version,omitempty"`
 	Tag           string                    `json:"tag,omitempty" yaml:"tag,omitempty"`
 	Executor      *ExecutorContext          `json:"executorContext,omitempty" yaml:"executorContext,omitempty"`
 	SourceContext *SourceContext            `json:"sourceContext,omitempty" yaml:"sourceContext,omitempty"`
 	GitHub        *DeploymentSettingsGitHub `json:"gitHub,omitempty" yaml:"gitHub,omitempty"`
+	VCS           *DeploymentSettingsVCS    `json:"vcs,omitempty"`
 	Operation     *OperationContext         `json:"operationContext,omitempty" yaml:"operationContext,omitempty"`
-	AgentPoolID   *string                   `json:"agentPoolID,omitempty" yaml:"agentPoolID,omitempty"`
+	// SettingsSource records what configured these settings. It is set by the service and is not
+	// accepted on write. It is not named Source because SourceContext already occupies that meaning
+	// on this type.
+	SettingsSource *DeploymentSettingsSource `json:"source,omitempty"`
+	AgentPoolID    *string                   `json:"agentPoolID,omitempty" yaml:"agentPoolID,omitempty"`
+	CacheOptions   *CacheOptions             `json:"cacheOptions,omitempty"`
+}
+
+// DeploymentSettingsSource identifies what configured a stack's deployment settings. The review
+// stack values mark settings the service generated from a template stack rather than settings a
+// user wrote, so an edit against them is not durable.
+type DeploymentSettingsSource string
+
+const (
+	DeploymentSettingsSourceConsole                DeploymentSettingsSource = "console"
+	DeploymentSettingsSourceAPI                    DeploymentSettingsSource = "api"
+	DeploymentSettingsSourceProvider               DeploymentSettingsSource = "provider"
+	DeploymentSettingsSourceGitHubReviewStack      DeploymentSettingsSource = "github-review-stack"
+	DeploymentSettingsSourceAzureDevOpsReviewStack DeploymentSettingsSource = "azure-devops-review-stack"
+	DeploymentSettingsSourceGitLabReviewStack      DeploymentSettingsSource = "gitlab-review-stack"
+	DeploymentSettingsSourceBitBucketReviewStack   DeploymentSettingsSource = "bitbucket-review-stack"
+	DeploymentSettingsSourceGitHubGitOps           DeploymentSettingsSource = "github-gitops"
+)
+
+// CacheOptions controls dependency caching between deployments.
+type CacheOptions struct {
+	Enable bool `json:"enable"`
+}
+
+// VCSProvider identifies which version control provider a DeploymentSettingsVCS describes.
+type VCSProvider string
+
+const (
+	VCSProviderGitHub      VCSProvider = "github"
+	VCSProviderGitLab      VCSProvider = "gitlab"
+	VCSProviderAzureDevOps VCSProvider = "azure_devops"
+	VCSProviderBitbucket   VCSProvider = "bitbucket"
+	VCSProviderCustom      VCSProvider = "custom"
+)
+
+// DeploymentSettingsVCS is the provider-agnostic replacement for DeploymentSettingsGitHub. The
+// service models it as a union discriminated on Provider, but every member shares the same body,
+// so one flat struct covers the wire format in both directions.
+type DeploymentSettingsVCS struct {
+	// Provider carries no omitempty: the service rejects a vcs object that does not name one.
+	Provider            VCSProvider `json:"provider"`
+	Repository          string      `json:"repository,omitempty"`
+	DeployCommits       bool        `json:"deployCommits,omitempty"`
+	DeployTags          bool        `json:"deployTags,omitempty"`
+	Paths               []string    `json:"paths,omitempty"`
+	TagFilters          []string    `json:"tagFilters,omitempty"`
+	InstallationID      string      `json:"installationId,omitempty"`
+	PullRequestTemplate bool        `json:"pullRequestTemplate,omitempty"`
+	PreviewPullRequests bool        `json:"previewPullRequests,omitempty"`
+	DeployPullRequest   *int64      `json:"deployPullRequest,omitempty"`
+	// ReviewStackLabels is honored only when Provider is VCSProviderGitHub. Other providers accept
+	// it and discard it without an error.
+	ReviewStackLabels []string `json:"reviewStackLabels,omitempty"`
 }
 
 type DeploymentSettingsGitHub struct {
@@ -149,6 +209,10 @@ type DeploymentSettingsGitHub struct {
 	PreviewPullRequests bool     `json:"previewPullRequests,omitempty" yaml:"previewPullRequests,omitempty"`
 	DeployPullRequest   *int64   `json:"deployPullRequest,omitempty" yaml:"deployPullRequest,omitempty"`
 	Paths               []string `json:"paths,omitempty" yaml:"paths,omitempty"`
+	InstallationID      string   `json:"installationId,omitempty"`
+	ReviewStackLabels   []string `json:"reviewStackLabels,omitempty"`
+	DeployTags          bool     `json:"deployTags,omitempty"`
+	TagFilters          []string `json:"tagFilters,omitempty"`
 }
 
 type ExecutorContext struct {
@@ -165,19 +229,24 @@ type ExecutorContext struct {
 
 // A DockerImage describes a Docker image reference + optional credentials for use with a job definition.
 type DockerImage struct {
-	Reference   string                  `json:"reference" yaml:"reference"`
+	Reference string `json:"reference" yaml:"reference"`
+	// IsDefault tells the workflow runner to use its own built-in image and ignore Reference. It is
+	// set by the service and is not accepted on write.
+	IsDefault   bool                    `json:"isDefault,omitempty"`
 	Credentials *DockerImageCredentials `json:"credentials,omitempty" yaml:"credentials,omitempty"`
 }
 
 type dockerImageJSON struct {
 	Reference   string                  `json:"reference" yaml:"reference"`
+	IsDefault   bool                    `json:"isDefault,omitempty"`
 	Credentials *DockerImageCredentials `json:"credentials,omitempty" yaml:"credentials,omitempty"`
 }
 
 func (d *DockerImage) MarshalJSON() ([]byte, error) {
-	if d.Credentials != nil {
+	if d.Credentials != nil || d.IsDefault {
 		return json.Marshal(dockerImageJSON{
 			Reference:   d.Reference,
+			IsDefault:   d.IsDefault,
 			Credentials: d.Credentials,
 		})
 	}
@@ -187,7 +256,7 @@ func (d *DockerImage) MarshalJSON() ([]byte, error) {
 func (d *DockerImage) UnmarshalJSON(bytes []byte) error {
 	var image dockerImageJSON
 	if err := json.Unmarshal(bytes, &image); err == nil {
-		d.Reference, d.Credentials = image.Reference, image.Credentials
+		d.Reference, d.IsDefault, d.Credentials = image.Reference, image.IsDefault, image.Credentials
 		return nil
 	}
 
@@ -195,7 +264,7 @@ func (d *DockerImage) UnmarshalJSON(bytes []byte) error {
 	if err := json.Unmarshal(bytes, &reference); err != nil {
 		return err
 	}
-	d.Reference, d.Credentials = reference, nil
+	d.Reference, d.IsDefault, d.Credentials = reference, false, nil
 	return nil
 }
 
@@ -205,9 +274,12 @@ type DockerImageCredentials struct {
 	Password SecretValue `json:"password" yaml:"password"`
 }
 
-// SourceContext describes some source code, and how to obtain it.
+// SourceContext describes some source code, and how to obtain it. Only one of its fields may be
+// specified.
 type SourceContext struct {
-	Git *SourceContextGit `json:"git,omitempty" yaml:"git,omitempty"`
+	Git      *SourceContextGit      `json:"git,omitempty" yaml:"git,omitempty"`
+	Hg       *SourceContextHg       `json:"hg,omitempty"`
+	Template *SourceContextTemplate `json:"template,omitempty"`
 }
 
 type SourceContextGit struct {
@@ -224,6 +296,11 @@ type SourceContextGit struct {
 	// is mutually exclusive with the Branch setting. Either value needs to be specified.
 	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
 
+	// (optional) Tag is the git tag that triggered this deployment. It is set by the service when a
+	// deployment is queued by a tag push, and is mutually exclusive with Branch. When it is set,
+	// Commit is also set to the SHA the tag points at.
+	Tag string `json:"tag,omitempty"`
+
 	// (optional) GitAuth allows configuring git authentication options
 	// There are 3 different authentication options:
 	//   * SSH private key (and its optional password)
@@ -233,6 +310,29 @@ type SourceContextGit struct {
 	// with ssh private key/password preferred first, then personal access token, and finally
 	// basic auth credentials.
 	GitAuth *GitAuthConfig `json:"gitAuth,omitempty" yaml:"gitAuth,omitempty"`
+}
+
+// SourceContextHg describes a Mercurial source.
+type SourceContextHg struct {
+	RepoURL  string `json:"repoUrl,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	RepoDir  string `json:"repoDir,omitempty"`
+	Revision string `json:"revision,omitempty"`
+	// HgAuth reuses GitAuthConfig; the service models Mercurial credentials with the same shape.
+	HgAuth *GitAuthConfig `json:"hgAuth,omitempty"`
+}
+
+// SourceContextTemplate describes a source drawn from a template rather than from a repository
+// checkout.
+type SourceContextTemplate struct {
+	// SourceURL is either a registry reference of the form
+	// registry://templates/source/<publisher>/<name>[@<version>] or a plain VCS URL.
+	SourceURL string         `json:"sourceUrl,omitempty"`
+	GitAuth   *GitAuthConfig `json:"gitAuth,omitempty"`
+	// ProjectSourceURL is the template source configured on the stack's project. Deployments fall
+	// back to it when SourceURL is blank. It is read-only: it cannot be set through deployment
+	// settings requests.
+	ProjectSourceURL string `json:"projectSourceUrl,omitempty"`
 }
 
 // GitAuthConfig specifies git authentication configuration options.
@@ -255,7 +355,7 @@ type SSHAuth struct {
 	Password      *SecretValue `json:"password,omitempty" yaml:"password,omitempty"`
 }
 
-// BasicAuth configures git authentication through basic auth —
+// BasicAuth configures git authentication through basic auth:
 // i.e. username and password. Both UserName and Password are required.
 type BasicAuth struct {
 	UserName SecretValue `json:"userName" yaml:"userName"`
@@ -279,6 +379,16 @@ type OperationContext struct {
 
 	// Options is a bag of settings to specify or override default behavior
 	Options *OperationContextOptions `json:"options,omitempty" yaml:"options,omitempty"`
+
+	// Role is the deployment role the operation assumes.
+	Role *DeploymentRole `json:"role,omitempty"`
+}
+
+// DeploymentRole identifies a deployment role.
+type DeploymentRole struct {
+	ID                string  `json:"id"`
+	Name              string  `json:"name,omitempty"`
+	DefaultIdentifier *string `json:"defaultIdentifier,omitempty"`
 }
 
 type OperationContextOIDCConfiguration struct {

--- a/sdk/go/common/apitype/deployments_test.go
+++ b/sdk/go/common/apitype/deployments_test.go
@@ -310,7 +310,7 @@ func TestSecretValueRoundTripJSON(t *testing.T) {
 // emits a bare string when only Reference is set and an object otherwise. The same
 // staged convergence is planned (see pulumi/pulumi-service TYPE_MIGRATION_PLAN.md
 // Phase 1a). Unlike SecretValue, DockerImage's UnmarshalJSON already accepts both
-// forms, so no compat-read code change is needed in the CLI — but we lock in the
+// forms, so no compat-read code change is needed in the CLI, but we lock in the
 // current MarshalJSON output and the dual-form UnmarshalJSON behavior so a future
 // flip is intentional and reviewable.
 
@@ -341,6 +341,11 @@ func TestDockerImageMarshalJSONUnchanged(t *testing.T) {
 				},
 			},
 			want: `{"reference":"alpine:latest","credentials":{"username":"user","password":{"secret":"pw"}}}`,
+		},
+		{
+			name: "isDefault emits object even without credentials",
+			in:   DockerImage{Reference: "alpine:latest", IsDefault: true},
+			want: `{"reference":"alpine:latest","isDefault":true}`,
 		},
 	}
 
@@ -387,6 +392,11 @@ func TestDockerImageUnmarshalJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "object with isDefault",
+			input: `{"reference":"alpine:latest","isDefault":true}`,
+			want:  DockerImage{Reference: "alpine:latest", IsDefault: true},
+		},
 	}
 
 	for _, tc := range cases {
@@ -395,6 +405,524 @@ func TestDockerImageUnmarshalJSON(t *testing.T) {
 			var got DockerImage
 			require.NoError(t, json.Unmarshal([]byte(tc.input), &got))
 			assert.Equal(t, tc.want, got)
+
+			marshaled, err := json.Marshal(&tc.want)
+			require.NoError(t, err)
+			var back DockerImage
+			require.NoError(t, json.Unmarshal(marshaled, &back))
+			assert.Equal(t, tc.want, back)
+		})
+	}
+}
+
+// TestDeploymentSettingsVCSRoundTrip covers the provider-discriminated VCS union. The service
+// rejects a vcs object whose provider it does not recognize, so the discriminator must be emitted
+// even when every other field is zero.
+func TestDeploymentSettingsVCSRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	deployPR := int64(42)
+
+	cases := []struct {
+		name string
+		in   DeploymentSettingsVCS
+		want string
+	}{
+		{
+			name: "github provider only",
+			in:   DeploymentSettingsVCS{Provider: VCSProviderGitHub},
+			want: `{"provider":"github"}`,
+		},
+		{
+			name: "gitlab provider only",
+			in:   DeploymentSettingsVCS{Provider: VCSProviderGitLab},
+			want: `{"provider":"gitlab"}`,
+		},
+		{
+			name: "azure devops provider only",
+			in:   DeploymentSettingsVCS{Provider: VCSProviderAzureDevOps},
+			want: `{"provider":"azure_devops"}`,
+		},
+		{
+			name: "bitbucket provider only",
+			in:   DeploymentSettingsVCS{Provider: VCSProviderBitbucket},
+			want: `{"provider":"bitbucket"}`,
+		},
+		{
+			name: "custom provider only",
+			in:   DeploymentSettingsVCS{Provider: VCSProviderCustom},
+			want: `{"provider":"custom"}`,
+		},
+		{
+			name: "github fully populated",
+			in: DeploymentSettingsVCS{
+				Provider:            VCSProviderGitHub,
+				Repository:          "acme/infra",
+				DeployCommits:       true,
+				DeployTags:          true,
+				Paths:               []string{"infra/**", "**/{apps,libs}/**"},
+				TagFilters:          []string{"v*"},
+				InstallationID:      "12345",
+				PullRequestTemplate: true,
+				PreviewPullRequests: true,
+				DeployPullRequest:   &deployPR,
+				ReviewStackLabels:   []string{"deploy"},
+			},
+			want: `{
+				"provider": "github",
+				"repository": "acme/infra",
+				"deployCommits": true,
+				"deployTags": true,
+				"paths": ["infra/**", "**/{apps,libs}/**"],
+				"tagFilters": ["v*"],
+				"installationId": "12345",
+				"pullRequestTemplate": true,
+				"previewPullRequests": true,
+				"deployPullRequest": 42,
+				"reviewStackLabels": ["deploy"]
+			}`,
+		},
+		{
+			name: "gitlab fully populated",
+			in: DeploymentSettingsVCS{
+				Provider:            VCSProviderGitLab,
+				Repository:          "acme/infra",
+				DeployCommits:       true,
+				DeployTags:          true,
+				Paths:               []string{"infra/**"},
+				TagFilters:          []string{"v*"},
+				InstallationID:      "67890",
+				PullRequestTemplate: true,
+				PreviewPullRequests: true,
+				DeployPullRequest:   &deployPR,
+			},
+			want: `{
+				"provider": "gitlab",
+				"repository": "acme/infra",
+				"deployCommits": true,
+				"deployTags": true,
+				"paths": ["infra/**"],
+				"tagFilters": ["v*"],
+				"installationId": "67890",
+				"pullRequestTemplate": true,
+				"previewPullRequests": true,
+				"deployPullRequest": 42
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+
+			var back DeploymentSettingsVCS
+			require.NoError(t, json.Unmarshal(got, &back))
+			assert.Equal(t, tc.in, back)
+		})
+	}
+}
+
+func TestDeploymentRoleRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	identifier := "arn:aws:iam::123456789012:role/pulumi"
+
+	cases := []struct {
+		name string
+		in   DeploymentRole
+		want string
+	}{
+		{
+			name: "id only",
+			in:   DeploymentRole{ID: "role-1"},
+			want: `{"id":"role-1"}`,
+		},
+		{
+			name: "empty id is emitted",
+			in:   DeploymentRole{},
+			want: `{"id":""}`,
+		},
+		{
+			name: "fully populated",
+			in:   DeploymentRole{ID: "role-1", Name: "deployer", DefaultIdentifier: &identifier},
+			want: `{"id":"role-1","name":"deployer","defaultIdentifier":"arn:aws:iam::123456789012:role/pulumi"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+
+			var back DeploymentRole
+			require.NoError(t, json.Unmarshal(got, &back))
+			assert.Equal(t, tc.in, back)
+		})
+	}
+}
+
+func TestCacheOptionsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   CacheOptions
+		want string
+	}{
+		{name: "disabled", in: CacheOptions{}, want: `{"enable":false}`},
+		{name: "enabled", in: CacheOptions{Enable: true}, want: `{"enable":true}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+
+			var back CacheOptions
+			require.NoError(t, json.Unmarshal(got, &back))
+			assert.Equal(t, tc.in, back)
+		})
+	}
+}
+
+func TestSourceContextHgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   SourceContextHg
+		want string
+	}{
+		{
+			name: "repo and branch",
+			in:   SourceContextHg{RepoURL: "https://hg.example.com/infra", Branch: "default"},
+			want: `{"repoUrl":"https://hg.example.com/infra","branch":"default"}`,
+		},
+		{
+			name: "fully populated",
+			in: SourceContextHg{
+				RepoURL:  "https://hg.example.com/infra",
+				Branch:   "default",
+				RepoDir:  "infra",
+				Revision: "9f2c1a",
+				HgAuth: &GitAuthConfig{
+					BasicAuth: &BasicAuth{
+						UserName: SecretValue{Value: "user"},
+						Password: SecretValue{Value: "pw", Secret: true},
+					},
+				},
+			},
+			want: `{
+				"repoUrl": "https://hg.example.com/infra",
+				"branch": "default",
+				"repoDir": "infra",
+				"revision": "9f2c1a",
+				"hgAuth": {"basicAuth": {"userName": "user", "password": {"secret": "pw"}}}
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+
+			var back SourceContextHg
+			require.NoError(t, json.Unmarshal(got, &back))
+			assert.Equal(t, tc.in, back)
+		})
+	}
+}
+
+func TestSourceContextTemplateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   SourceContextTemplate
+		want string
+	}{
+		{
+			name: "registry source url",
+			in:   SourceContextTemplate{SourceURL: "registry://templates/source/pulumi/aws-vpc@2.1.0"},
+			want: `{"sourceUrl":"registry://templates/source/pulumi/aws-vpc@2.1.0"}`,
+		},
+		{
+			name: "inherited project source url",
+			in:   SourceContextTemplate{ProjectSourceURL: "https://github.com/acme/templates"},
+			want: `{"projectSourceUrl":"https://github.com/acme/templates"}`,
+		},
+		{
+			name: "vcs source url with auth",
+			in: SourceContextTemplate{
+				SourceURL: "https://github.com/acme/templates",
+				GitAuth: &GitAuthConfig{
+					PersonalAccessToken: &SecretValue{Value: "token", Secret: true},
+				},
+				ProjectSourceURL: "https://github.com/acme/project-templates",
+			},
+			want: `{
+				"sourceUrl": "https://github.com/acme/templates",
+				"gitAuth": {"accessToken": {"secret": "token"}},
+				"projectSourceUrl": "https://github.com/acme/project-templates"
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+
+			var back SourceContextTemplate
+			require.NoError(t, json.Unmarshal(got, &back))
+			assert.Equal(t, tc.in, back)
+		})
+	}
+}
+
+// TestDeploymentSettingsRoundTrip decodes whole settings bodies and re-encodes them, so a field
+// missing from the CLI type shows up as a dropped key rather than as a silently ignored one.
+func TestDeploymentSettingsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	deployPR := int64(7)
+
+	cases := []struct {
+		name string
+		wire string
+		want DeploymentSettings
+	}{
+		{
+			name: "github vcs",
+			wire: `{
+				"version": 3,
+				"source": "console",
+				"vcs": {
+					"provider": "github",
+					"repository": "acme/infra",
+					"deployCommits": true,
+					"paths": ["infra/**"],
+					"installationId": "12345",
+					"reviewStackLabels": ["deploy"]
+				},
+				"cacheOptions": {"enable": true}
+			}`,
+			want: DeploymentSettings{
+				Version:        3,
+				SettingsSource: new(DeploymentSettingsSourceConsole),
+				VCS: &DeploymentSettingsVCS{
+					Provider:          VCSProviderGitHub,
+					Repository:        "acme/infra",
+					DeployCommits:     true,
+					Paths:             []string{"infra/**"},
+					InstallationID:    "12345",
+					ReviewStackLabels: []string{"deploy"},
+				},
+				CacheOptions: &CacheOptions{Enable: true},
+			},
+		},
+		{
+			name: "gitlab vcs",
+			wire: `{
+				"version": 4,
+				"source": "gitlab-review-stack",
+				"vcs": {
+					"provider": "gitlab",
+					"repository": "acme/infra",
+					"deployTags": true,
+					"tagFilters": ["v*"],
+					"previewPullRequests": true,
+					"deployPullRequest": 7
+				}
+			}`,
+			want: DeploymentSettings{
+				Version:        4,
+				SettingsSource: new(DeploymentSettingsSourceGitLabReviewStack),
+				VCS: &DeploymentSettingsVCS{
+					Provider:            VCSProviderGitLab,
+					Repository:          "acme/infra",
+					DeployTags:          true,
+					TagFilters:          []string{"v*"},
+					PreviewPullRequests: true,
+					DeployPullRequest:   &deployPR,
+				},
+			},
+		},
+		{
+			name: "azure devops vcs",
+			wire: `{
+				"source": "azure-devops-review-stack",
+				"vcs": {"provider": "azure_devops", "repository": "acme/infra", "pullRequestTemplate": true}
+			}`,
+			want: DeploymentSettings{
+				SettingsSource: new(DeploymentSettingsSourceAzureDevOpsReviewStack),
+				VCS: &DeploymentSettingsVCS{
+					Provider:            VCSProviderAzureDevOps,
+					Repository:          "acme/infra",
+					PullRequestTemplate: true,
+				},
+			},
+		},
+		{
+			name: "bitbucket vcs",
+			wire: `{
+				"source": "bitbucket-review-stack",
+				"vcs": {"provider": "bitbucket", "repository": "acme/infra"}
+			}`,
+			want: DeploymentSettings{
+				SettingsSource: new(DeploymentSettingsSourceBitBucketReviewStack),
+				VCS:            &DeploymentSettingsVCS{Provider: VCSProviderBitbucket, Repository: "acme/infra"},
+			},
+		},
+		{
+			name: "custom vcs",
+			wire: `{
+				"source": "api",
+				"vcs": {"provider": "custom", "repository": "https://vcs.example.com/acme/infra"}
+			}`,
+			want: DeploymentSettings{
+				SettingsSource: new(DeploymentSettingsSourceAPI),
+				VCS: &DeploymentSettingsVCS{
+					Provider:   VCSProviderCustom,
+					Repository: "https://vcs.example.com/acme/infra",
+				},
+			},
+		},
+		{
+			name: "legacy github block",
+			wire: `{
+				"source": "github-gitops",
+				"gitHub": {
+					"repository": "acme/infra",
+					"installationId": "12345",
+					"reviewStackLabels": ["deploy"],
+					"deployTags": true,
+					"tagFilters": ["v*"]
+				}
+			}`,
+			want: DeploymentSettings{
+				SettingsSource: new(DeploymentSettingsSourceGitHubGitOps),
+				GitHub: &DeploymentSettingsGitHub{
+					Repository:        "acme/infra",
+					InstallationID:    "12345",
+					ReviewStackLabels: []string{"deploy"},
+					DeployTags:        true,
+					TagFilters:        []string{"v*"},
+				},
+			},
+		},
+		{
+			name: "git source with tag",
+			wire: `{
+				"sourceContext": {
+					"git": {
+						"repoUrl": "https://github.com/acme/infra",
+						"branch": "",
+						"tag": "v1.2.3",
+						"commit": "abc123"
+					}
+				}
+			}`,
+			want: DeploymentSettings{
+				SourceContext: &SourceContext{
+					Git: &SourceContextGit{
+						RepoURL: "https://github.com/acme/infra",
+						Tag:     "v1.2.3",
+						Commit:  "abc123",
+					},
+				},
+			},
+		},
+		{
+			name: "mercurial source",
+			wire: `{
+				"sourceContext": {
+					"hg": {"repoUrl": "https://hg.example.com/infra", "branch": "default", "revision": "9f2c1a"}
+				}
+			}`,
+			want: DeploymentSettings{
+				SourceContext: &SourceContext{
+					Hg: &SourceContextHg{
+						RepoURL:  "https://hg.example.com/infra",
+						Branch:   "default",
+						Revision: "9f2c1a",
+					},
+				},
+			},
+		},
+		{
+			name: "template source",
+			wire: `{
+				"sourceContext": {
+					"template": {
+						"sourceUrl": "registry://templates/source/pulumi/aws-vpc@2.1.0",
+						"projectSourceUrl": "https://github.com/acme/templates"
+					}
+				}
+			}`,
+			want: DeploymentSettings{
+				SourceContext: &SourceContext{
+					Template: &SourceContextTemplate{
+						SourceURL:        "registry://templates/source/pulumi/aws-vpc@2.1.0",
+						ProjectSourceURL: "https://github.com/acme/templates",
+					},
+				},
+			},
+		},
+		{
+			name: "deployment role",
+			wire: `{
+				"operationContext": {
+					"preRunCommands": null,
+					"operation": "",
+					"environmentVariables": null,
+					"role": {"id": "role-1", "name": "deployer"}
+				}
+			}`,
+			want: DeploymentSettings{
+				Operation: &OperationContext{
+					Role: &DeploymentRole{ID: "role-1", Name: "deployer"},
+				},
+			},
+		},
+		{
+			name: "default executor image",
+			wire: `{
+				"executorContext": {
+					"workingDirectory": "",
+					"executorImage": {"reference": "acme/img:1", "isDefault": true}
+				}
+			}`,
+			want: DeploymentSettings{
+				Executor: &ExecutorContext{
+					ExecutorImage: &DockerImage{Reference: "acme/img:1", IsDefault: true},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got DeploymentSettings
+			require.NoError(t, json.Unmarshal([]byte(tc.wire), &got))
+			assert.Equal(t, tc.want, got)
+
+			out, err := json.Marshal(got)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.wire, string(out))
 		})
 	}
 }


### PR DESCRIPTION
The CLI's deployment settings types cover a fraction of what the service accepts and returns, so
`pulumi deployment settings get` cannot render most of a stack's configuration and `edit` cannot
write it. This fills in the gaps ahead of the two command PRs stacked on top, which consume them.

The central addition is `DeploymentSettingsVCS`, the provider-agnostic replacement for
`DeploymentSettingsGitHub`. The service models it as a union discriminated on the provider, but every
member carries the same body, so one flat struct covers the wire format for all five providers in
both directions rather than five near-identical structs plus a custom unmarshaller.

The rest is additive: the deployment role, cache options, Mercurial and template sources, a git tag
on the git source, the default-image marker on `DockerImage`, the settings version and source, and
the four legacy GitHub fields that were already accepted by the service but absent here.

No user-visible change on its own, hence no changelog entry.
