### PR TITLE
deployment settings: render every source kind and the missing fields in `get`

### DIFF
--- a/changelog/pending/cli-deployment-feat-20260811-120200.yaml
+++ b/changelog/pending/cli-deployment-feat-20260811-120200.yaml
@@ -1,0 +1,4 @@
+component: cli/deployment
+kind: feat
+body: "`pulumi deployment settings get` renders every source kind and shows environment variable values, changing the `--json` shape of `environmentVariables` from a list of names to a list of objects"
+time: 2026-08-11T12:02:00+00:00

--- a/changelog/pending/cli-deployment-feat-20260811-120200.yaml
+++ b/changelog/pending/cli-deployment-feat-20260811-120200.yaml
@@ -1,4 +1,4 @@
 component: cli/deployment
 kind: feat
-body: "`pulumi deployment settings get` renders every source kind and shows environment variable values, changing the `--json` shape of `environmentVariables` from a list of names to a list of objects"
+body: "Make `pulumi deployment settings get` render every source kind and show environment variable values, changing the `--json` shape of `environmentVariables` from a list of names to a list of objects"
 time: 2026-08-11T12:02:00+00:00

--- a/changelog/pending/cli-deployment-feat-20260811-120200.yaml
+++ b/changelog/pending/cli-deployment-feat-20260811-120200.yaml
@@ -1,4 +1,4 @@
 component: cli/deployment
 kind: feat
-body: "Make `pulumi deployment settings get` render every source kind and show environment variable values, changing the `--json` shape of `environmentVariables` from a list of names to a list of objects"
+body: "Make `pulumi deployment settings get` render every source kind and show environment variable values, changing the `--output=json` shape of `environmentVariables` from a list of names to a list of objects"
 time: 2026-08-11T12:02:00+00:00

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -125,25 +125,25 @@ func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature"}}}`, string(captured.patch))
 
 	assert.Equal(t, `Source: GitHub
-  Repository:               acme/infra
-  Branch:                   main
-  Commit:                   abc123
-  Pulumi.yaml folder:       stacks/prod
-  Run previews for PRs:     yes
-  Run updates on push:      yes
-  PR stack template:        no
-  Path filters:             stacks/prod/**
+  Repository:                    acme/infra
+  Branch:                        main
+  Commit:                        abc123
+  Pulumi.yaml folder:            stacks/prod
+  Run previews for PRs:          yes
+  Run updates on push:           yes
+  PR stack template:             no
+  Path filters:                  stacks/prod/**
 
 Deployment runner
-  Runner pool:              pool-1
-  Executor image:           pulumi/pulumi:latest
+  Runner pool:                   pool-1
+  Executor image:                pulumi/pulumi:latest
 
 Pre-run commands
   echo hi
 
 Environment variables
-  BAZ
-  FOO
+  BAZ:                           qux
+  FOO:                           bar
 `, buf.String())
 }
 
@@ -176,7 +176,10 @@ func TestDeploymentSettingsEdit_JSONOutput(t *testing.T) {
 			"executorImage": "pulumi/pulumi:latest"
 		},
 		"preRunCommands": ["echo hi"],
-		"environmentVariables": ["BAZ", "FOO"]
+		"environmentVariables": [
+			{"name": "BAZ", "value": "qux"},
+			{"name": "FOO", "value": "bar"}
+		]
 	}`, buf.String())
 }
 

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -142,6 +142,7 @@ Pre-run commands
   echo hi
 
 Environment variables
+  API_KEY:                       [secret]
   BAZ:                           qux
   FOO:                           bar
 `, buf.String())
@@ -177,6 +178,7 @@ func TestDeploymentSettingsEdit_JSONOutput(t *testing.T) {
 		},
 		"preRunCommands": ["echo hi"],
 		"environmentVariables": [
+			{"name": "API_KEY", "secret": true},
 			{"name": "BAZ", "value": "qux"},
 			{"name": "FOO", "value": "bar"}
 		]

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get.go
@@ -148,9 +148,9 @@ func runDeploymentSettingsGet(
 
 type deploymentSettingsGetRenderFunc func(w io.Writer, settings apitype.DeploymentSettings) error
 
-// deploymentSettingsView is the shared shape for both text and JSON output. Secret material (env
-// var values, git and Mercurial credentials) is never surfaced; authentication is reported as a
-// mode only.
+// deploymentSettingsView is the shared shape for both text and JSON output, and carries no secret
+// material: an environment variable the service marks secret loses its value, and credentials
+// survive only as an authentication mode or a presence flag.
 type deploymentSettingsView struct {
 	Tag                  string              `json:"tag,omitempty"`
 	Version              int                 `json:"version,omitempty"`

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -147,33 +148,71 @@ func runDeploymentSettingsGet(
 
 type deploymentSettingsGetRenderFunc func(w io.Writer, settings apitype.DeploymentSettings) error
 
-// deploymentSettingsView is the shared shape for both text and JSON output.
-// Secret material (env var values, git auth) is intentionally not surfaced.
+// deploymentSettingsView is the shared shape for both text and JSON output. Secret material (env
+// var values, git and Mercurial credentials) is never surfaced; authentication is reported as a
+// mode only.
 type deploymentSettingsView struct {
-	Tag                  string        `json:"tag,omitempty"`
-	Source               *sourceView   `json:"source,omitempty"`
-	Runner               *runnerView   `json:"runner,omitempty"`
-	PreRunCommands       []string      `json:"preRunCommands,omitempty"`
-	EnvironmentVariables []string      `json:"environmentVariables,omitempty"`
-	OIDC                 *oidcView     `json:"oidc,omitempty"`
-	Advanced             *advancedView `json:"advanced,omitempty"`
+	Tag                  string              `json:"tag,omitempty"`
+	Version              int                 `json:"version,omitempty"`
+	SettingsSource       string              `json:"settingsSource,omitempty"`
+	DeploymentRole       *deploymentRoleView `json:"deploymentRole,omitempty"`
+	CacheEnabled         *bool               `json:"cacheEnabled,omitempty"`
+	Source               *sourceView         `json:"source,omitempty"`
+	Runner               *runnerView         `json:"runner,omitempty"`
+	PreRunCommands       []string            `json:"preRunCommands,omitempty"`
+	EnvironmentVariables []envVarView        `json:"environmentVariables,omitempty"`
+	OIDC                 *oidcView           `json:"oidc,omitempty"`
+	Advanced             *advancedView       `json:"advanced,omitempty"`
 }
 
+// deploymentRoleView carries the id alongside the name because the id is what `edit` accepts, so
+// dropping it would leave the rendered role unusable as an input.
+type deploymentRoleView struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+type envVarView struct {
+	Name   string `json:"name"`
+	Value  string `json:"value,omitempty"`
+	Secret bool   `json:"secret,omitempty"`
+}
+
+// Source kinds for a source that is not backed by a VCS integration. A sourceView.Kind that is not
+// one of these is an apitype.VCSProvider value.
+const (
+	sourceKindGit      = "git"
+	sourceKindHg       = "hg"
+	sourceKindTemplate = "template"
+)
+
 type sourceView struct {
-	Kind                string   `json:"kind"`
-	Repository          string   `json:"repository,omitempty"`
-	Branch              string   `json:"branch,omitempty"`
-	Commit              string   `json:"commit,omitempty"`
-	Folder              string   `json:"folder,omitempty"`
-	PreviewPullRequests *bool    `json:"previewPullRequests,omitempty"`
-	RunUpdatesOnPush    *bool    `json:"runUpdatesOnPush,omitempty"`
-	PullRequestTemplate *bool    `json:"pullRequestTemplate,omitempty"`
-	PathFilters         []string `json:"pathFilters,omitempty"`
+	Kind                     string   `json:"kind"`
+	Repository               string   `json:"repository,omitempty"`
+	InstallationID           string   `json:"installationId,omitempty"`
+	Branch                   string   `json:"branch,omitempty"`
+	Commit                   string   `json:"commit,omitempty"`
+	Revision                 string   `json:"revision,omitempty"`
+	GitTag                   string   `json:"gitTag,omitempty"`
+	Folder                   string   `json:"folder,omitempty"`
+	TemplateSourceURL        string   `json:"templateSourceUrl,omitempty"`
+	ProjectTemplateSourceURL string   `json:"projectTemplateSourceUrl,omitempty"`
+	Auth                     string   `json:"auth,omitempty"`
+	PreviewPullRequests      *bool    `json:"previewPullRequests,omitempty"`
+	RunUpdatesOnPush         *bool    `json:"runUpdatesOnPush,omitempty"`
+	PullRequestTemplate      *bool    `json:"pullRequestTemplate,omitempty"`
+	DeployPullRequest        *int64   `json:"deployPullRequest,omitempty"`
+	DeployTags               bool     `json:"deployTags,omitempty"`
+	TagFilters               []string `json:"tagFilters,omitempty"`
+	PathFilters              []string `json:"pathFilters,omitempty"`
+	ReviewStackLabels        []string `json:"reviewStackLabels,omitempty"`
 }
 
 type runnerView struct {
 	Pool             string `json:"pool,omitempty"`
 	ExecutorImage    string `json:"executorImage,omitempty"`
+	DefaultImage     bool   `json:"defaultImage,omitempty"`
+	ImageCredentials bool   `json:"imageCredentials,omitempty"`
 	ExecutorRootPath string `json:"executorRootPath,omitempty"`
 }
 
@@ -210,23 +249,27 @@ type advancedView struct {
 	SkipIntermediateDeployments bool   `json:"skipIntermediateDeployments,omitempty"`
 	Shell                       string `json:"shell,omitempty"`
 	DeleteAfterDestroy          bool   `json:"deleteAfterDestroy,omitempty"`
+	RemediateIfDriftDetected    bool   `json:"remediateIfDriftDetected,omitempty"`
 }
 
 func toDeploymentSettingsView(s apitype.DeploymentSettings) deploymentSettingsView {
-	v := deploymentSettingsView{Tag: s.Tag}
+	v := deploymentSettingsView{Tag: s.Tag, Version: s.Version}
+	if s.SettingsSource != nil {
+		v.SettingsSource = string(*s.SettingsSource)
+	}
+	if s.CacheOptions != nil {
+		enable := s.CacheOptions.Enable
+		v.CacheEnabled = &enable
+	}
 	v.Source = buildSourceView(s)
 	v.Runner = buildRunnerView(s)
 	if s.Operation != nil {
 		if len(s.Operation.PreRunCommands) > 0 {
 			v.PreRunCommands = s.Operation.PreRunCommands
 		}
-		if len(s.Operation.EnvironmentVariables) > 0 {
-			names := make([]string, 0, len(s.Operation.EnvironmentVariables))
-			for k := range s.Operation.EnvironmentVariables {
-				names = append(names, k)
-			}
-			sort.Strings(names)
-			v.EnvironmentVariables = names
+		v.EnvironmentVariables = buildEnvVarViews(s.Operation.EnvironmentVariables)
+		if s.Operation.Role != nil {
+			v.DeploymentRole = &deploymentRoleView{ID: s.Operation.Role.ID, Name: s.Operation.Role.Name}
 		}
 		v.OIDC = buildOIDCView(s.Operation.OIDC)
 		v.Advanced = buildAdvancedView(s.Operation.Options)
@@ -234,41 +277,158 @@ func toDeploymentSettingsView(s apitype.DeploymentSettings) deploymentSettingsVi
 	return v
 }
 
-func buildSourceView(s apitype.DeploymentSettings) *sourceView {
-	hasGitHub := s.GitHub != nil && s.GitHub.Repository != ""
-	var git *apitype.SourceContextGit
-	if s.SourceContext != nil {
-		git = s.SourceContext.Git
-	}
-	hasGit := git != nil && (git.RepoURL != "" || git.Branch != "" || git.Commit != "" || git.RepoDir != "")
-	if !hasGitHub && !hasGit {
+func buildEnvVarViews(vars map[string]apitype.SecretValue) []envVarView {
+	if len(vars) == 0 {
 		return nil
 	}
-	out := &sourceView{}
-	if hasGitHub {
-		out.Kind = "github"
-		out.Repository = s.GitHub.Repository
-		preview := s.GitHub.PreviewPullRequests
-		push := s.GitHub.DeployCommits
-		template := s.GitHub.PullRequestTemplate
-		out.PreviewPullRequests = &preview
-		out.RunUpdatesOnPush = &push
-		out.PullRequestTemplate = &template
-		if len(s.GitHub.Paths) > 0 {
-			out.PathFilters = s.GitHub.Paths
-		}
-	} else {
-		out.Kind = "git"
-		if git != nil {
-			out.Repository = git.RepoURL
-		}
+	names := make([]string, 0, len(vars))
+	for k := range vars {
+		names = append(names, k)
 	}
-	if git != nil {
-		out.Branch = git.Branch
-		out.Commit = git.Commit
-		out.Folder = git.RepoDir
+	sort.Strings(names)
+	out := make([]envVarView, 0, len(names))
+	for _, name := range names {
+		v := vars[name]
+		e := envVarView{Name: name, Secret: v.Secret}
+		if !v.Secret {
+			e.Value = v.Value
+		}
+		out = append(out, e)
 	}
 	return out
+}
+
+// deploymentRoleLabel renders a role as "name (id)". An assigned role reaches the CLI without a
+// name only when the service fails to resolve it, so the id stands in rather than any wording that
+// would imply no role is assigned.
+func deploymentRoleLabel(r *deploymentRoleView) string {
+	switch {
+	case r == nil:
+		return ""
+	case r.Name == "":
+		return r.ID
+	case r.ID == "":
+		return r.Name
+	default:
+		return fmt.Sprintf("%s (%s)", r.Name, r.ID)
+	}
+}
+
+// refsHeadsPrefix is stripped for display only. The service prepends it on every enqueue and the
+// executor normalizes again, so the CLI keeps writing bare branch names.
+const refsHeadsPrefix = "refs/heads/"
+
+func buildSourceView(s apitype.DeploymentSettings) *sourceView {
+	var git *apitype.SourceContextGit
+	var hg *apitype.SourceContextHg
+	var template *apitype.SourceContextTemplate
+	if s.SourceContext != nil {
+		git, hg, template = s.SourceContext.Git, s.SourceContext.Hg, s.SourceContext.Template
+	}
+	hasGit := git != nil && (git.RepoURL != "" || git.Branch != "" || git.Commit != "" ||
+		git.RepoDir != "" || git.Tag != "" || git.GitAuth != nil)
+	hasHg := hg != nil && (hg.RepoURL != "" || hg.Branch != "" || hg.Revision != "" ||
+		hg.RepoDir != "" || hg.HgAuth != nil)
+	hasTemplate := template != nil && (template.SourceURL != "" || template.ProjectSourceURL != "")
+
+	out := &sourceView{}
+	switch {
+	case s.VCS != nil:
+		out.Kind = string(s.VCS.Provider)
+		out.Repository = s.VCS.Repository
+		out.InstallationID = s.VCS.InstallationID
+		preview, push, prTemplate := s.VCS.PreviewPullRequests, s.VCS.DeployCommits, s.VCS.PullRequestTemplate
+		out.PreviewPullRequests, out.RunUpdatesOnPush, out.PullRequestTemplate = &preview, &push, &prTemplate
+		out.DeployPullRequest = s.VCS.DeployPullRequest
+		out.DeployTags = s.VCS.DeployTags
+		out.TagFilters = s.VCS.TagFilters
+		out.PathFilters = s.VCS.Paths
+		if s.VCS.Provider == apitype.VCSProviderGitHub {
+			out.ReviewStackLabels = s.VCS.ReviewStackLabels
+		}
+	case s.GitHub != nil && s.GitHub.Repository != "":
+		out.Kind = string(apitype.VCSProviderGitHub)
+		out.Repository = s.GitHub.Repository
+		out.InstallationID = s.GitHub.InstallationID
+		preview, push, prTemplate := s.GitHub.PreviewPullRequests, s.GitHub.DeployCommits, s.GitHub.PullRequestTemplate
+		out.PreviewPullRequests, out.RunUpdatesOnPush, out.PullRequestTemplate = &preview, &push, &prTemplate
+		out.DeployPullRequest = s.GitHub.DeployPullRequest
+		out.DeployTags = s.GitHub.DeployTags
+		out.TagFilters = s.GitHub.TagFilters
+		out.PathFilters = s.GitHub.Paths
+		out.ReviewStackLabels = s.GitHub.ReviewStackLabels
+	case hasGit:
+		out.Kind = sourceKindGit
+		out.Repository = git.RepoURL
+	case hasHg:
+		out.Kind = sourceKindHg
+		out.Repository = hg.RepoURL
+	case hasTemplate:
+		out.Kind = sourceKindTemplate
+		out.TemplateSourceURL = template.SourceURL
+		if template.SourceURL == "" {
+			out.ProjectTemplateSourceURL = template.ProjectSourceURL
+		}
+		out.Auth = gitAuthMode(template.GitAuth)
+		return out
+	default:
+		return nil
+	}
+
+	switch {
+	case hasGit:
+		out.Branch = strings.TrimPrefix(git.Branch, refsHeadsPrefix)
+		out.Commit = git.Commit
+		out.GitTag = git.Tag
+		out.Folder = git.RepoDir
+		out.Auth = gitAuthMode(git.GitAuth)
+	case hasHg:
+		out.Branch = strings.TrimPrefix(hg.Branch, refsHeadsPrefix)
+		out.Revision = hg.Revision
+		out.Folder = hg.RepoDir
+		out.Auth = gitAuthMode(hg.HgAuth)
+	}
+	return out
+}
+
+// gitAuthMode reports which credential the deployment will use, following the service's precedence
+// when more than one is populated.
+func gitAuthMode(a *apitype.GitAuthConfig) string {
+	switch {
+	case a == nil:
+		return ""
+	case a.SSHAuth != nil:
+		return "SSH key"
+	case a.PersonalAccessToken != nil:
+		return "Access token"
+	case a.BasicAuth != nil:
+		return "Basic auth"
+	default:
+		return ""
+	}
+}
+
+func sourceSectionTitle(kind string) string {
+	switch kind {
+	case string(apitype.VCSProviderGitHub):
+		return "Source: GitHub"
+	case string(apitype.VCSProviderGitLab):
+		return "Source: GitLab"
+	case string(apitype.VCSProviderAzureDevOps):
+		return "Source: Azure DevOps"
+	case string(apitype.VCSProviderBitbucket):
+		return "Source: Bitbucket"
+	case string(apitype.VCSProviderCustom):
+		return "Source: Custom"
+	case sourceKindGit:
+		return "Source: Git"
+	case sourceKindHg:
+		return "Source: Mercurial"
+	case sourceKindTemplate:
+		return "Source: Template"
+	default:
+		return "Source"
+	}
 }
 
 func buildRunnerView(s apitype.DeploymentSettings) *runnerView {
@@ -277,14 +437,17 @@ func buildRunnerView(s apitype.DeploymentSettings) *runnerView {
 		out.Pool = *s.AgentPoolID
 	}
 	if s.Executor != nil {
-		if s.Executor.ExecutorImage != nil {
-			out.ExecutorImage = s.Executor.ExecutorImage.Reference
+		if img := s.Executor.ExecutorImage; img != nil {
+			out.ExecutorImage = img.Reference
+			out.DefaultImage = img.IsDefault
+			out.ImageCredentials = img.Credentials != nil
 		}
 		if s.Executor.ExecutorRootPath != nil {
 			out.ExecutorRootPath = *s.Executor.ExecutorRootPath
 		}
 	}
-	if out.Pool == "" && out.ExecutorImage == "" && out.ExecutorRootPath == "" {
+	if out.Pool == "" && out.ExecutorImage == "" && out.ExecutorRootPath == "" &&
+		!out.DefaultImage && !out.ImageCredentials {
 		return nil
 	}
 	return out
@@ -338,7 +501,7 @@ func buildAdvancedView(o *apitype.OperationContextOptions) *advancedView {
 		return nil
 	}
 	if !o.SkipInstallDependencies && !o.SkipIntermediateDeployments &&
-		o.Shell == "" && !o.DeleteAfterDestroy {
+		o.Shell == "" && !o.DeleteAfterDestroy && !o.RemediateIfDriftDetected {
 		return nil
 	}
 	return &advancedView{
@@ -346,6 +509,7 @@ func buildAdvancedView(o *apitype.OperationContextOptions) *advancedView {
 		SkipIntermediateDeployments: o.SkipIntermediateDeployments,
 		Shell:                       o.Shell,
 		DeleteAfterDestroy:          o.DeleteAfterDestroy,
+		RemediateIfDriftDetected:    o.RemediateIfDriftDetected,
 	}
 }
 
@@ -354,18 +518,18 @@ func buildAdvancedView(o *apitype.OperationContextOptions) *advancedView {
 func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) error {
 	v := toDeploymentSettingsView(s)
 
-	// Value column is the same across all sections
-	const valueColumn = 29
+	// Value column is the same across all sections, and is set by the longest label.
+	const valueColumn = 34
 	kv := func(indent int, label, value string) {
 		prefix := strings.Repeat(" ", indent) + label + ":"
 		fmt.Fprintf(w, "%-*s %s\n", valueColumn-2, prefix, value)
 	}
-	first := true
+	printedAny := false
 	section := func(title string) {
-		if !first {
+		if printedAny {
 			fmt.Fprintln(w)
 		}
-		first = false
+		printedAny = true
 		fmt.Fprintln(w, title)
 	}
 	yesno := func(b bool) string {
@@ -375,22 +539,37 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		return "no"
 	}
 
-	if v.Tag != "" {
-		kv(0, "Tag", v.Tag)
-		first = false
+	version := ""
+	if v.Version != 0 {
+		version = strconv.Itoa(v.Version)
+	}
+	cache := ""
+	if v.CacheEnabled != nil {
+		cache = "disabled"
+		if *v.CacheEnabled {
+			cache = "enabled"
+		}
+	}
+	for _, entry := range []struct{ label, value string }{
+		{"Tag", v.Tag},
+		{"Version", version},
+		{"Settings source", v.SettingsSource},
+		{"Deployment role", deploymentRoleLabel(v.DeploymentRole)},
+		{"Dependency cache", cache},
+	} {
+		if entry.value != "" {
+			kv(0, entry.label, entry.value)
+			printedAny = true
+		}
 	}
 
 	if v.Source != nil {
-		switch v.Source.Kind {
-		case "github":
-			section("Source: GitHub")
-		case "git":
-			section("Source: Git")
-		default:
-			section("Source")
-		}
+		section(sourceSectionTitle(v.Source.Kind))
 		if v.Source.Repository != "" {
 			kv(2, "Repository", v.Source.Repository)
+		}
+		if v.Source.InstallationID != "" {
+			kv(2, "Installation ID", v.Source.InstallationID)
 		}
 		if v.Source.Branch != "" {
 			kv(2, "Branch", v.Source.Branch)
@@ -398,8 +577,23 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		if v.Source.Commit != "" {
 			kv(2, "Commit", v.Source.Commit)
 		}
+		if v.Source.Revision != "" {
+			kv(2, "Revision", v.Source.Revision)
+		}
+		if v.Source.GitTag != "" {
+			kv(2, "Git tag", v.Source.GitTag)
+		}
 		if v.Source.Folder != "" {
 			kv(2, "Pulumi.yaml folder", v.Source.Folder)
+		}
+		if v.Source.TemplateSourceURL != "" {
+			kv(2, "Template source", v.Source.TemplateSourceURL)
+		}
+		if v.Source.ProjectTemplateSourceURL != "" {
+			kv(2, "Project template source", v.Source.ProjectTemplateSourceURL)
+		}
+		if v.Source.Auth != "" {
+			kv(2, "Authentication", v.Source.Auth)
 		}
 		if v.Source.PreviewPullRequests != nil {
 			kv(2, "Run previews for PRs", yesno(*v.Source.PreviewPullRequests))
@@ -410,8 +604,20 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		if v.Source.PullRequestTemplate != nil {
 			kv(2, "PR stack template", yesno(*v.Source.PullRequestTemplate))
 		}
+		if v.Source.DeployPullRequest != nil {
+			kv(2, "Deploy PR", strconv.FormatInt(*v.Source.DeployPullRequest, 10))
+		}
+		if v.Source.DeployTags {
+			kv(2, "Deploy on tag", "yes")
+		}
+		if len(v.Source.TagFilters) > 0 {
+			kv(2, "Tag filters", strings.Join(v.Source.TagFilters, ", "))
+		}
 		if len(v.Source.PathFilters) > 0 {
 			kv(2, "Path filters", strings.Join(v.Source.PathFilters, ", "))
+		}
+		if len(v.Source.ReviewStackLabels) > 0 {
+			kv(2, "Review stack labels", strings.Join(v.Source.ReviewStackLabels, ", "))
 		}
 	}
 
@@ -422,6 +628,12 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		}
 		if v.Runner.ExecutorImage != "" {
 			kv(2, "Executor image", v.Runner.ExecutorImage)
+		}
+		if v.Runner.DefaultImage {
+			kv(2, "Default image", "yes")
+		}
+		if v.Runner.ImageCredentials {
+			kv(2, "Image credentials", "configured")
 		}
 		if v.Runner.ExecutorRootPath != "" {
 			kv(2, "Executor root path", v.Runner.ExecutorRootPath)
@@ -437,8 +649,12 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 
 	if len(v.EnvironmentVariables) > 0 {
 		section("Environment variables")
-		for _, n := range v.EnvironmentVariables {
-			fmt.Fprintf(w, "  %s\n", n)
+		for _, e := range v.EnvironmentVariables {
+			value := e.Value
+			if e.Secret {
+				value = "[secret]"
+			}
+			kv(2, e.Name, value)
 		}
 	}
 
@@ -500,7 +716,7 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 			kv(2, "Skip install dependencies", "yes")
 		}
 		if v.Advanced.SkipIntermediateDeployments {
-			kv(2, "Skip intermediate", "yes")
+			kv(2, "Skip intermediate deployments", "yes")
 		}
 		if v.Advanced.Shell != "" {
 			kv(2, "Shell", v.Advanced.Shell)
@@ -508,6 +724,13 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		if v.Advanced.DeleteAfterDestroy {
 			kv(2, "Delete after destroy", "yes")
 		}
+		if v.Advanced.RemediateIfDriftDetected {
+			kv(2, "Remediate on drift", "yes")
+		}
+	}
+
+	if !printedAny {
+		fmt.Fprintln(w, "No deployment settings are configured for this stack.")
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
@@ -88,8 +88,9 @@ func sampleDeploymentSettings() *apitype.DeploymentSettings {
 			Operation:      apitype.Update,
 			PreRunCommands: []string{"echo hi"},
 			EnvironmentVariables: map[string]apitype.SecretValue{
-				"FOO": {Value: "bar"},
-				"BAZ": {Value: "qux"},
+				"FOO":     {Value: "bar"},
+				"BAZ":     {Value: "qux"},
+				"API_KEY": {Value: "s3cret", Secret: true},
 			},
 		},
 		AgentPoolID: &agentPool,
@@ -123,6 +124,7 @@ Pre-run commands
   echo hi
 
 Environment variables
+  API_KEY:                       [secret]
   BAZ:                           qux
   FOO:                           bar
 `, buf.String())
@@ -168,6 +170,7 @@ func TestDeploymentSettingsGet_JSONOutput(t *testing.T) {
 		},
 		"preRunCommands": ["echo hi"],
 		"environmentVariables": [
+			{"name": "API_KEY", "secret": true},
 			{"name": "BAZ", "value": "qux"},
 			{"name": "FOO", "value": "bar"}
 		]
@@ -220,6 +223,8 @@ func TestDeploymentSettingsGet_RichSections(t *testing.T) {
 
 	thirtyMin, err := time.ParseDuration("30m")
 	require.NoError(t, err)
+	fifteenMin, err := time.ParseDuration("15m")
+	require.NoError(t, err)
 	settings := &apitype.DeploymentSettings{
 		Tag: "rev-42",
 		Operation: &apitype.OperationContext{
@@ -231,24 +236,31 @@ func TestDeploymentSettingsGet_RichSections(t *testing.T) {
 					Duration:    apitype.DeploymentDuration(thirtyMin),
 					PolicyARNs:  []string{"arn:aws:iam::aws:policy/ReadOnlyAccess"},
 				},
+				Azure: &apitype.OperationContextAzureOIDCConfiguration{
+					ClientID:       "client-1",
+					TenantID:       "tenant-1",
+					SubscriptionID: "sub-1",
+				},
 				GCP: &apitype.OperationContextGCPOIDCConfiguration{
 					ProjectID:      "123456",
 					WorkloadPoolID: "pulumi-pool",
 					ProviderID:     "pulumi",
 					ServiceAccount: "pulumi@my-project.iam.gserviceaccount.com",
+					Region:         "us-central1",
+					TokenLifetime:  apitype.DeploymentDuration(fifteenMin),
 				},
 			},
 			Options: &apitype.OperationContextOptions{
-				SkipInstallDependencies: true,
-				Shell:                   "bash",
+				SkipInstallDependencies:     true,
+				SkipIntermediateDeployments: true,
+				Shell:                       "bash",
+				DeleteAfterDestroy:          true,
+				RemediateIfDriftDetected:    true,
 			},
 		},
 	}
 
-	var buf bytes.Buffer
-	c := &mockDeploymentSettingsGetClient{resp: settings}
-	require.NoError(t, runDeploymentSettingsGet(t.Context(), &buf, stubSettingsGetFactory(c),
-		deploymentSettingsGetArgs{outputFormat: defaultDeploymentSettingsGetOutputFormat()}))
+	text, jsonOut := renderBoth(t, settings)
 
 	assert.Equal(t, `Tag:                             rev-42
 
@@ -258,16 +270,57 @@ OIDC
     Session name:                pulumi-deploy
     Session duration:            30m0s
     Policy ARNs:                 arn:aws:iam::aws:policy/ReadOnlyAccess
+  Azure
+    Client ID:                   client-1
+    Tenant ID:                   tenant-1
+    Subscription ID:             sub-1
   GCP
     Project number:              123456
     Workload pool:               pulumi-pool
     Provider:                    pulumi
     Service account:             pulumi@my-project.iam.gserviceaccount.com
+    Region:                      us-central1
+    Token lifetime:              15m0s
 
 Advanced
   Skip install dependencies:     yes
+  Skip intermediate deployments: yes
   Shell:                         bash
-`, buf.String())
+  Delete after destroy:          yes
+  Remediate on drift:            yes
+`, text)
+
+	assert.JSONEq(t, `{
+		"tag": "rev-42",
+		"oidc": {
+			"aws": {
+				"roleArn": "arn:aws:iam::123:role/pulumi-deploy",
+				"sessionName": "pulumi-deploy",
+				"sessionDuration": "30m0s",
+				"policyArns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+			},
+			"azure": {
+				"clientId": "client-1",
+				"tenantId": "tenant-1",
+				"subscriptionId": "sub-1"
+			},
+			"gcp": {
+				"projectNumber": "123456",
+				"workloadPoolId": "pulumi-pool",
+				"providerId": "pulumi",
+				"serviceAccount": "pulumi@my-project.iam.gserviceaccount.com",
+				"region": "us-central1",
+				"tokenLifetime": "15m0s"
+			}
+		},
+		"advanced": {
+			"skipInstallDependencies": true,
+			"skipIntermediateDeployments": true,
+			"shell": "bash",
+			"deleteAfterDestroy": true,
+			"remediateIfDriftDetected": true
+		}
+	}`, jsonOut)
 }
 
 // renderBoth runs the same settings through the text and JSON renderers.

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
@@ -106,25 +106,25 @@ func TestDeploymentSettingsGet_DefaultOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, `Source: GitHub
-  Repository:               acme/infra
-  Branch:                   main
-  Commit:                   abc123
-  Pulumi.yaml folder:       stacks/prod
-  Run previews for PRs:     yes
-  Run updates on push:      yes
-  PR stack template:        no
-  Path filters:             stacks/prod/**
+  Repository:                    acme/infra
+  Branch:                        main
+  Commit:                        abc123
+  Pulumi.yaml folder:            stacks/prod
+  Run previews for PRs:          yes
+  Run updates on push:           yes
+  PR stack template:             no
+  Path filters:                  stacks/prod/**
 
 Deployment runner
-  Runner pool:              pool-1
-  Executor image:           pulumi/pulumi:latest
+  Runner pool:                   pool-1
+  Executor image:                pulumi/pulumi:latest
 
 Pre-run commands
   echo hi
 
 Environment variables
-  BAZ
-  FOO
+  BAZ:                           qux
+  FOO:                           bar
 `, buf.String())
 }
 
@@ -138,7 +138,7 @@ func TestDeploymentSettingsGet_DefaultOutput_Empty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Nothing configured, hide all sections
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "No deployment settings are configured for this stack.\n", buf.String())
 }
 
 func TestDeploymentSettingsGet_JSONOutput(t *testing.T) {
@@ -167,7 +167,10 @@ func TestDeploymentSettingsGet_JSONOutput(t *testing.T) {
 			"executorImage": "pulumi/pulumi:latest"
 		},
 		"preRunCommands": ["echo hi"],
-		"environmentVariables": ["BAZ", "FOO"]
+		"environmentVariables": [
+			{"name": "BAZ", "value": "qux"},
+			{"name": "FOO", "value": "bar"}
+		]
 	}`, buf.String())
 }
 
@@ -247,24 +250,605 @@ func TestDeploymentSettingsGet_RichSections(t *testing.T) {
 	require.NoError(t, runDeploymentSettingsGet(t.Context(), &buf, stubSettingsGetFactory(c),
 		deploymentSettingsGetArgs{outputFormat: defaultDeploymentSettingsGetOutputFormat()}))
 
-	assert.Equal(t, `Tag:                        rev-42
+	assert.Equal(t, `Tag:                             rev-42
 
 OIDC
   AWS
-    Role ARN:               arn:aws:iam::123:role/pulumi-deploy
-    Session name:           pulumi-deploy
-    Session duration:       30m0s
-    Policy ARNs:            arn:aws:iam::aws:policy/ReadOnlyAccess
+    Role ARN:                    arn:aws:iam::123:role/pulumi-deploy
+    Session name:                pulumi-deploy
+    Session duration:            30m0s
+    Policy ARNs:                 arn:aws:iam::aws:policy/ReadOnlyAccess
   GCP
-    Project number:         123456
-    Workload pool:          pulumi-pool
-    Provider:               pulumi
-    Service account:        pulumi@my-project.iam.gserviceaccount.com
+    Project number:              123456
+    Workload pool:               pulumi-pool
+    Provider:                    pulumi
+    Service account:             pulumi@my-project.iam.gserviceaccount.com
 
 Advanced
-  Skip install dependencies: yes
-  Shell:                    bash
+  Skip install dependencies:     yes
+  Shell:                         bash
 `, buf.String())
+}
+
+// renderBoth runs the same settings through the text and JSON renderers.
+func renderBoth(t *testing.T, settings *apitype.DeploymentSettings) (string, string) {
+	t.Helper()
+	c := &mockDeploymentSettingsGetClient{resp: settings}
+
+	var text bytes.Buffer
+	require.NoError(t, runDeploymentSettingsGet(t.Context(), &text, stubSettingsGetFactory(c),
+		deploymentSettingsGetArgs{outputFormat: defaultDeploymentSettingsGetOutputFormat()}))
+
+	var jsonOut bytes.Buffer
+	require.NoError(t, runDeploymentSettingsGet(t.Context(), &jsonOut, stubSettingsGetFactory(c),
+		deploymentSettingsGetJSONArgs(t)))
+
+	return text.String(), jsonOut.String()
+}
+
+func TestDeploymentSettingsGet_VCSProviders(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider apitype.VCSProvider
+		heading  string
+	}{
+		{apitype.VCSProviderGitHub, "Source: GitHub"},
+		{apitype.VCSProviderGitLab, "Source: GitLab"},
+		{apitype.VCSProviderAzureDevOps, "Source: Azure DevOps"},
+		{apitype.VCSProviderBitbucket, "Source: Bitbucket"},
+		{apitype.VCSProviderCustom, "Source: Custom"},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.provider), func(t *testing.T) {
+			t.Parallel()
+
+			settings := &apitype.DeploymentSettings{
+				VCS: &apitype.DeploymentSettingsVCS{
+					Provider:            tc.provider,
+					Repository:          "acme/infra",
+					InstallationID:      "inst-7",
+					DeployCommits:       true,
+					PreviewPullRequests: true,
+					DeployTags:          true,
+					TagFilters:          []string{"v*"},
+					Paths:               []string{"stacks/prod/**"},
+				},
+				SourceContext: &apitype.SourceContext{
+					Git: &apitype.SourceContextGit{Branch: "main"},
+				},
+			}
+
+			text, jsonOut := renderBoth(t, settings)
+
+			assert.Equal(t, tc.heading+`
+  Repository:                    acme/infra
+  Installation ID:               inst-7
+  Branch:                        main
+  Run previews for PRs:          yes
+  Run updates on push:           yes
+  PR stack template:             no
+  Deploy on tag:                 yes
+  Tag filters:                   v*
+  Path filters:                  stacks/prod/**
+`, text)
+
+			assert.JSONEq(t, `{
+				"source": {
+					"kind": "`+string(tc.provider)+`",
+					"repository": "acme/infra",
+					"installationId": "inst-7",
+					"branch": "main",
+					"previewPullRequests": true,
+					"runUpdatesOnPush": true,
+					"pullRequestTemplate": false,
+					"deployTags": true,
+					"tagFilters": ["v*"],
+					"pathFilters": ["stacks/prod/**"]
+				}
+			}`, jsonOut)
+		})
+	}
+}
+
+func TestDeploymentSettingsGet_ReviewStackLabelsAreGitHubOnly(t *testing.T) {
+	t.Parallel()
+
+	vcs := func(p apitype.VCSProvider) *apitype.DeploymentSettings {
+		return &apitype.DeploymentSettings{
+			VCS: &apitype.DeploymentSettingsVCS{
+				Provider:          p,
+				Repository:        "acme/infra",
+				ReviewStackLabels: []string{"deploy", "preview"},
+			},
+		}
+	}
+
+	text, jsonOut := renderBoth(t, vcs(apitype.VCSProviderGitHub))
+	assert.Contains(t, text, "  Review stack labels:           deploy, preview\n")
+	assert.Contains(t, jsonOut, `"reviewStackLabels"`)
+
+	text, jsonOut = renderBoth(t, vcs(apitype.VCSProviderGitLab))
+	assert.NotContains(t, text, "Review stack labels")
+	assert.NotContains(t, jsonOut, "reviewStackLabels")
+}
+
+func TestDeploymentSettingsGet_LegacyGitHubFields(t *testing.T) {
+	t.Parallel()
+
+	deployPR := int64(42)
+	settings := &apitype.DeploymentSettings{
+		GitHub: &apitype.DeploymentSettingsGitHub{
+			Repository:        "acme/infra",
+			InstallationID:    "inst-7",
+			DeployPullRequest: &deployPR,
+			DeployTags:        true,
+			TagFilters:        []string{"v*", "release-*"},
+			ReviewStackLabels: []string{"deploy"},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Source: GitHub
+  Repository:                    acme/infra
+  Installation ID:               inst-7
+  Run previews for PRs:          no
+  Run updates on push:           no
+  PR stack template:             no
+  Deploy PR:                     42
+  Deploy on tag:                 yes
+  Tag filters:                   v*, release-*
+  Review stack labels:           deploy
+`, text)
+
+	assert.JSONEq(t, `{
+		"source": {
+			"kind": "github",
+			"repository": "acme/infra",
+			"installationId": "inst-7",
+			"previewPullRequests": false,
+			"runUpdatesOnPush": false,
+			"pullRequestTemplate": false,
+			"deployPullRequest": 42,
+			"deployTags": true,
+			"tagFilters": ["v*", "release-*"],
+			"reviewStackLabels": ["deploy"]
+		}
+	}`, jsonOut)
+}
+
+func TestDeploymentSettingsGet_VCSTakesPrecedenceOverLegacyGitHub(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		GitHub: &apitype.DeploymentSettingsGitHub{Repository: "acme/legacy"},
+		VCS: &apitype.DeploymentSettingsVCS{
+			Provider:   apitype.VCSProviderGitLab,
+			Repository: "acme/current",
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Source: GitLab
+  Repository:                    acme/current
+  Run previews for PRs:          no
+  Run updates on push:           no
+  PR stack template:             no
+`, text)
+	assert.NotContains(t, jsonOut, "acme/legacy")
+}
+
+func TestDeploymentSettingsGet_BranchStripsRefsHeads(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		SourceContext: &apitype.SourceContext{
+			Git: &apitype.SourceContextGit{
+				RepoURL: "https://example.com/acme/infra",
+				Branch:  "refs/heads/release/1.0",
+			},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Source: Git
+  Repository:                    https://example.com/acme/infra
+  Branch:                        release/1.0
+`, text)
+
+	assert.JSONEq(t, `{
+		"source": {
+			"kind": "git",
+			"repository": "https://example.com/acme/infra",
+			"branch": "release/1.0"
+		}
+	}`, jsonOut)
+}
+
+func TestDeploymentSettingsGet_GitTag(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		SourceContext: &apitype.SourceContext{
+			Git: &apitype.SourceContextGit{
+				RepoURL: "https://example.com/acme/infra",
+				Commit:  "abc123",
+				Tag:     "v1.2.3",
+			},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Source: Git
+  Repository:                    https://example.com/acme/infra
+  Commit:                        abc123
+  Git tag:                       v1.2.3
+`, text)
+	assert.JSONEq(t, `{
+		"source": {
+			"kind": "git",
+			"repository": "https://example.com/acme/infra",
+			"commit": "abc123",
+			"gitTag": "v1.2.3"
+		}
+	}`, jsonOut)
+}
+
+func TestDeploymentSettingsGet_GitAuthModes(t *testing.T) {
+	t.Parallel()
+
+	sshOnly := &apitype.GitAuthConfig{
+		SSHAuth: &apitype.SSHAuth{SSHPrivateKey: apitype.SecretValue{Value: "PRIVATE-KEY", Secret: true}},
+	}
+	tokenOnly := &apitype.GitAuthConfig{
+		PersonalAccessToken: &apitype.SecretValue{Value: "TOKEN", Secret: true},
+	}
+	basicOnly := &apitype.GitAuthConfig{
+		BasicAuth: &apitype.BasicAuth{
+			UserName: apitype.SecretValue{Value: "user"},
+			Password: apitype.SecretValue{Value: "PASSWORD", Secret: true},
+		},
+	}
+
+	cases := []struct {
+		name string
+		auth *apitype.GitAuthConfig
+		want string
+	}{
+		{"ssh", sshOnly, "SSH key"},
+		{"token", tokenOnly, "Access token"},
+		{"basic", basicOnly, "Basic auth"},
+		{"ssh wins over token and basic", &apitype.GitAuthConfig{
+			SSHAuth:             sshOnly.SSHAuth,
+			PersonalAccessToken: tokenOnly.PersonalAccessToken,
+			BasicAuth:           basicOnly.BasicAuth,
+		}, "SSH key"},
+		{"token wins over basic", &apitype.GitAuthConfig{
+			PersonalAccessToken: tokenOnly.PersonalAccessToken,
+			BasicAuth:           basicOnly.BasicAuth,
+		}, "Access token"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &apitype.DeploymentSettings{
+				SourceContext: &apitype.SourceContext{
+					Git: &apitype.SourceContextGit{
+						RepoURL: "https://example.com/acme/infra",
+						GitAuth: tc.auth,
+					},
+				},
+			}
+
+			text, jsonOut := renderBoth(t, settings)
+
+			assert.Equal(t, `Source: Git
+  Repository:                    https://example.com/acme/infra
+  Authentication:                `+tc.want+"\n", text)
+			assert.JSONEq(t, `{
+				"source": {
+					"kind": "git",
+					"repository": "https://example.com/acme/infra",
+					"auth": "`+tc.want+`"
+				}
+			}`, jsonOut)
+
+			for _, material := range []string{"PRIVATE-KEY", "TOKEN", "PASSWORD"} {
+				assert.NotContains(t, text, material)
+				assert.NotContains(t, jsonOut, material)
+			}
+		})
+	}
+}
+
+func TestDeploymentSettingsGet_MercurialSource(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		SourceContext: &apitype.SourceContext{
+			Hg: &apitype.SourceContextHg{
+				RepoURL:  "https://hg.example.com/acme/infra",
+				Branch:   "refs/heads/default",
+				Revision: "9f2c4a1",
+				RepoDir:  "stacks/prod",
+				HgAuth: &apitype.GitAuthConfig{
+					BasicAuth: &apitype.BasicAuth{
+						UserName: apitype.SecretValue{Value: "user"},
+						Password: apitype.SecretValue{Value: "PASSWORD", Secret: true},
+					},
+				},
+			},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Source: Mercurial
+  Repository:                    https://hg.example.com/acme/infra
+  Branch:                        default
+  Revision:                      9f2c4a1
+  Pulumi.yaml folder:            stacks/prod
+  Authentication:                Basic auth
+`, text)
+
+	assert.JSONEq(t, `{
+		"source": {
+			"kind": "hg",
+			"repository": "https://hg.example.com/acme/infra",
+			"branch": "default",
+			"revision": "9f2c4a1",
+			"folder": "stacks/prod",
+			"auth": "Basic auth"
+		}
+	}`, jsonOut)
+	assert.NotContains(t, jsonOut, "PASSWORD")
+}
+
+// The service accepts a vcs integration on top of a Mercurial checkout, so the checkout details
+// still have to render.
+func TestDeploymentSettingsGet_VCSWithMercurialCheckout(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		VCS: &apitype.DeploymentSettingsVCS{
+			Provider:   apitype.VCSProviderCustom,
+			Repository: "acme/infra",
+		},
+		SourceContext: &apitype.SourceContext{
+			Hg: &apitype.SourceContextHg{
+				RepoURL:  "https://hg.example.com/acme/infra",
+				Branch:   "refs/heads/default",
+				Revision: "9f2c4a1",
+				RepoDir:  "stacks/prod",
+			},
+		},
+	}
+
+	_, jsonOut := renderBoth(t, settings)
+
+	assert.JSONEq(t, `{
+		"source": {
+			"kind": "custom",
+			"repository": "acme/infra",
+			"branch": "default",
+			"revision": "9f2c4a1",
+			"folder": "stacks/prod",
+			"previewPullRequests": false,
+			"runUpdatesOnPush": false,
+			"pullRequestTemplate": false
+		}
+	}`, jsonOut)
+}
+
+func TestDeploymentSettingsGet_TemplateSource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit source url", func(t *testing.T) {
+		t.Parallel()
+
+		settings := &apitype.DeploymentSettings{
+			SourceContext: &apitype.SourceContext{
+				Template: &apitype.SourceContextTemplate{
+					SourceURL:        "registry://templates/source/acme/base@1.0.0",
+					ProjectSourceURL: "https://example.com/acme/templates",
+				},
+			},
+		}
+
+		text, jsonOut := renderBoth(t, settings)
+
+		assert.Equal(t, `Source: Template
+  Template source:               registry://templates/source/acme/base@1.0.0
+`, text)
+		assert.JSONEq(t, `{
+			"source": {
+				"kind": "template",
+				"templateSourceUrl": "registry://templates/source/acme/base@1.0.0"
+			}
+		}`, jsonOut)
+	})
+
+	t.Run("inherited from project", func(t *testing.T) {
+		t.Parallel()
+
+		settings := &apitype.DeploymentSettings{
+			SourceContext: &apitype.SourceContext{
+				Template: &apitype.SourceContextTemplate{
+					ProjectSourceURL: "https://example.com/acme/templates",
+					GitAuth: &apitype.GitAuthConfig{
+						PersonalAccessToken: &apitype.SecretValue{Value: "TOKEN", Secret: true},
+					},
+				},
+			},
+		}
+
+		text, jsonOut := renderBoth(t, settings)
+
+		assert.Equal(t, `Source: Template
+  Project template source:       https://example.com/acme/templates
+  Authentication:                Access token
+`, text)
+		assert.JSONEq(t, `{
+			"source": {
+				"kind": "template",
+				"projectTemplateSourceUrl": "https://example.com/acme/templates",
+				"auth": "Access token"
+			}
+		}`, jsonOut)
+	})
+}
+
+func TestDeploymentSettingsGet_EnvironmentVariableValues(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		Operation: &apitype.OperationContext{
+			EnvironmentVariables: map[string]apitype.SecretValue{
+				"LOG_LEVEL": {Value: "info"},
+				"API_KEY":   {Value: "API-KEY-PLAINTEXT", Secret: true},
+				"DB_PASS":   {Ciphertext: "AQID", Secret: true},
+			},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Environment variables
+  API_KEY:                       [secret]
+  DB_PASS:                       [secret]
+  LOG_LEVEL:                     info
+`, text)
+
+	assert.JSONEq(t, `{
+		"environmentVariables": [
+			{"name": "API_KEY", "secret": true},
+			{"name": "DB_PASS", "secret": true},
+			{"name": "LOG_LEVEL", "value": "info"}
+		]
+	}`, jsonOut)
+	assert.NotContains(t, jsonOut, "AQID")
+	assert.NotContains(t, jsonOut, "API-KEY-PLAINTEXT")
+	assert.NotContains(t, text, "API-KEY-PLAINTEXT")
+}
+
+func TestDeploymentSettingsGet_ExecutorImageDetails(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		Executor: &apitype.ExecutorContext{
+			ExecutorImage: &apitype.DockerImage{
+				Reference: "pulumi/pulumi:latest",
+				IsDefault: true,
+				Credentials: &apitype.DockerImageCredentials{
+					Username: "registry-user",
+					Password: apitype.SecretValue{Value: "REGISTRY-PASSWORD", Secret: true},
+				},
+			},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Deployment runner
+  Executor image:                pulumi/pulumi:latest
+  Default image:                 yes
+  Image credentials:             configured
+`, text)
+
+	assert.JSONEq(t, `{
+		"runner": {
+			"executorImage": "pulumi/pulumi:latest",
+			"defaultImage": true,
+			"imageCredentials": true
+		}
+	}`, jsonOut)
+	assert.NotContains(t, jsonOut, "REGISTRY-PASSWORD")
+	assert.NotContains(t, jsonOut, "registry-user")
+}
+
+func TestDeploymentSettingsGet_SettingsMetadata(t *testing.T) {
+	t.Parallel()
+
+	source := apitype.DeploymentSettingsSourceGitHubReviewStack
+	settings := &apitype.DeploymentSettings{
+		Tag:            "rev-42",
+		Version:        7,
+		SettingsSource: &source,
+		CacheOptions:   &apitype.CacheOptions{Enable: true},
+		Operation: &apitype.OperationContext{
+			Role: &apitype.DeploymentRole{ID: "role-1", Name: "prod-deployer"},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Tag:                             rev-42
+Version:                         7
+Settings source:                 github-review-stack
+Deployment role:                 prod-deployer (role-1)
+Dependency cache:                enabled
+`, text)
+
+	assert.JSONEq(t, `{
+		"tag": "rev-42",
+		"version": 7,
+		"settingsSource": "github-review-stack",
+		"deploymentRole": {"id": "role-1", "name": "prod-deployer"},
+		"cacheEnabled": true
+	}`, jsonOut)
+}
+
+// The service annotates an assigned role with its name on every read, so a role that arrives
+// without one is a resolution failure rather than an unassigned role: render the id, never wording
+// that would read as "no role".
+func TestDeploymentSettingsGet_DeploymentRoleWithoutName(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		Operation: &apitype.OperationContext{
+			Role: &apitype.DeploymentRole{ID: "role-1"},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, "Deployment role:                 role-1\n", text)
+	assert.JSONEq(t, `{"deploymentRole": {"id": "role-1"}}`, jsonOut)
+}
+
+func TestDeploymentSettingsGet_CacheDisabled(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{CacheOptions: &apitype.CacheOptions{Enable: false}}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, "Dependency cache:                disabled\n", text)
+	assert.JSONEq(t, `{"cacheEnabled": false}`, jsonOut)
+}
+
+func TestDeploymentSettingsGet_RemediateIfDriftDetectedOnly(t *testing.T) {
+	t.Parallel()
+
+	settings := &apitype.DeploymentSettings{
+		Operation: &apitype.OperationContext{
+			Options: &apitype.OperationContextOptions{RemediateIfDriftDetected: true},
+		},
+	}
+
+	text, jsonOut := renderBoth(t, settings)
+
+	assert.Equal(t, `Advanced
+  Remediate on drift:            yes
+`, text)
+	assert.JSONEq(t, `{"advanced": {"remediateIfDriftDetected": true}}`, jsonOut)
 }
 
 func TestDeploymentSettingsGet_ClientError(t *testing.T) {


### PR DESCRIPTION
`pulumi deployment settings get` assumed a stack was either GitHub-backed or plain git, so a GitLab,
Azure DevOps, Bitbucket or custom source printed as a bare "Source: Git" section with none of its
configuration, and a Mercurial or template source printed nothing at all. The source section now
keys off the stored provider and covers all five, plus Mercurial and templates.

The same pass adds the fields that were read from the service but never printed:

- the deployment role, the dependency cache setting, the settings version and source
- the git tag, the executor's default-image marker, drift remediation
- the tag filters, review stack labels, installation ID and deploy-PR number that already existed on
  the GitHub source

Environment variables now show their values, with secrets rendered as `[secret]` rather than
omitted, because a list of bare names does not tell you what a deployment will run with. **This
changes the `--output=json` shape of `environmentVariables` from a list of strings to a list of
objects.** Credentials themselves are still never printed: git and Mercurial authentication is
reported as a mode ("SSH key", "Access token", "Basic auth") and the executor image credentials as
a presence flag.

Branches are printed without their `refs/heads/` prefix. The service prepends it on every enqueue and
the executor normalizes again, so the prefix carries no information and the CLI keeps writing bare
branch names.

A stack with nothing configured now says so instead of printing an empty response, which reads like
the command failed.

`edit` renders its result through the same view, so its output changes with it.

