### PR TITLE
Add stateful patch method

### DIFF
--- a/changelog/pending/20260804--cli-do--stateful-patch.yaml
+++ b/changelog/pending/20260804--cli-do--stateful-patch.yaml
@@ -1,4 +1,4 @@
 component: cli/do
 kind: feat
-body: "`pulumi do <pkg> <resource> patch <name>` now works in stateful mode, overlaying the supplied inputs onto the existing snippet"
+body: Make "`pulumi do <pkg> <resource> patch <name>` work in stateful mode, overlaying the supplied inputs onto the existing snippet"
 time: 2026-08-04T00:00:00+00:00

--- a/changelog/pending/20260804--cli-do--stateful-patch.yaml
+++ b/changelog/pending/20260804--cli-do--stateful-patch.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: feat
+body: "`pulumi do <pkg> <resource> patch <name>` now works in stateful mode, overlaying the supplied inputs onto the existing snippet"
+time: 2026-08-04T00:00:00+00:00

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -485,8 +485,7 @@ expression in the input format (e.g. YAML interpolations or fn:: invocations).`,
 		"Output format for resource operation results (supported: default, json)")
 	cmd.Flags().BoolVar(&stateless, "stateless", false,
 		"Run create/patch/delete directly against the provider without persisting state. "+
-			"Required for now: the stateful (engine-driven) implementation is still in development, "+
-			"so patch/delete error out unless --stateless is set.")
+			"Required for delete until stateful delete is implemented.")
 	cmd.Flags().StringVar(
 		&pkg, "package", "", "The package to load, in the form 'name@version' or "+
 			"a path to a plugin binary or folder. If the package supports "+

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -145,7 +145,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so patch/delete error out unless --stateless is set.
+      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for delete until stateful delete is implemented.
 `
 	assert.Equal(t, expected, stdout.String())
 }

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -93,18 +93,19 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		"The URN of a provider resource in the current stack whose inputs to use as the "+
 			"base of the provider configuration (requires a stack context)")
 	addPersistentInputFlags(cmd, pc.spec.Name(), pc.providerDef.InputProperties)
-	// `create` and `upsert` have different UX between stateful (takes a resource <name> and adds a
+	// `create`/`upsert`/`patch` have different UX between stateful (takes a resource <name> and adds a
 	// snippet to the stack) and stateless (uses the resource type's short name and calls the
 	// provider directly), so the command trees diverge here.
 	if pc.stateless {
 		cmd.AddCommand(pc.newStatelessResourceCreateCommand(res))
 		cmd.AddCommand(pc.newStatelessResourceUpsertCommand(res))
+		cmd.AddCommand(pc.newStatelessResourcePatchCommand(res))
 	} else {
 		cmd.AddCommand(pc.newStatefulResourceCreateCommand(res))
 		cmd.AddCommand(pc.newStatefulResourceUpsertCommand(res))
+		cmd.AddCommand(pc.newStatefulResourcePatchCommand(res))
 	}
 	cmd.AddCommand(pc.newResourceReadCommand(res))
-	cmd.AddCommand(pc.newResourcePatchCommand(res))
 	cmd.AddCommand(pc.newResourceDeleteCommand(res))
 	if res.ListInputs != nil {
 		cmd.AddCommand(pc.newResourceListCommand(res))
@@ -281,7 +282,40 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 	}
 }
 
-func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.Command {
+// newStatefulResourcePatchCommand patches the existing snippet for (name, res.Token) by
+// overriding only the top-level PCL attributes the user supplies. The rest of the snippet's
+// code — other attributes, options blocks, comments — and its References/Descriptor are
+// preserved verbatim.
+func (pc *packageCommand) newStatefulResourcePatchCommand(res *schema.Resource) *cobra.Command {
+	var inputFile string
+	var inputFormat string
+	var resourcesFile string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "patch <name>",
+		Short: "Patch a resource",
+		Long: "Patch a resource.\n\n" +
+			"Only the inputs supplied here override the corresponding attributes in the existing " +
+			"resource snippet; all other snippet content is preserved. Fails if no resource with " +
+			"the given name exists.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contract.Assertf(!pc.stateless, "stateful patch should not be registered in stateless mode")
+			return pc.runStatefulSnippetPatch(cmd, res, args[0], inputFile, inputFormat, resourcesFile, yes)
+		},
+	}
+	cmd.Flags().StringVar(&inputFormat, "input", "yaml",
+		"Format of the resource inputs file (any language name supported by an installed converter)")
+	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
+	cmd.Flags().StringVar(&resourcesFile, "resources-file", "",
+		"Path to a JSON file mapping identifiers to resource URNs that input expressions may reference")
+	cmd.Flags().BoolVar(&yes, "yes", false,
+		"Automatically approve and perform the operation without a confirmation prompt")
+	addInputFlags(cmd, "input", res.InputProperties)
+	return cmd
+}
+
+func (pc *packageCommand) newStatelessResourcePatchCommand(res *schema.Resource) *cobra.Command {
 	var inputFile string
 	var inputFormat string
 	var yes bool
@@ -290,9 +324,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 		Short: "Patch a resource",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !pc.stateless {
-				return errStatefulNotImplemented("patch")
-			}
+			contract.Assertf(pc.stateless, "stateless patch should not be registered in stateful mode")
 			if err := pc.requireYesIfNonInteractive(yes); err != nil {
 				return err
 			}
@@ -636,14 +668,6 @@ func (pc *packageCommand) printListResults(cmd *cobra.Command, results []plugin.
 	}
 	fmt.Fprint(cmd.OutOrStdout(), output)
 	return nil
-}
-
-// errStatefulNotImplemented is returned from create/patch/delete when the user did not pass
-// --stateless. The stateful (engine-driven) implementation of these operations is the planned
-// default but isn't built yet, so for now the only working path is opting in to the stateless one.
-func errStatefulNotImplemented(op string) error {
-	return fmt.Errorf("`%s` is not yet implemented in stateful mode; pass --stateless to use the "+
-		"direct-provider implementation", op)
 }
 
 func formatDeleteSummary(res *schema.Resource, id resource.ID, dryrun bool) string {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -154,7 +154,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so patch/delete error out unless --stateless is set.
+      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for delete until stateful delete is implemented.
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
@@ -209,7 +209,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for now: the stateful (engine-driven) implementation is still in development, so patch/delete error out unless --stateless is set.
+      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for delete until stateful delete is implemented.
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 
 	"github.com/blang/semver"
@@ -321,6 +322,120 @@ func (pc *packageCommand) runStatefulSnippetUpdate(cmd *cobra.Command, args stat
 			verb, args.name, result.SnippetUUIDs[len(result.SnippetUUIDs)-1])
 	}
 	return nil
+}
+
+// runStatefulSnippetPatch finds the existing snippet for (name, res.Token), overlays the patch
+// inputs onto its PCL Code, and re-runs the stateful update. The snippet's UUID, References,
+// and Descriptor are preserved so the engine treats this as an in-place update.
+func (pc *packageCommand) runStatefulSnippetPatch(
+	cmd *cobra.Command, res *schema.Resource, name, inputFile, inputFormat, resourcesFile string, yes bool,
+) error {
+	contract.Assertf(pc.runStatefulUpdate != nil, "stateful snippet update is not wired up in this build")
+
+	contract.Assertf(pc.proj != nil, "project must be set (the global fallback should have supplied one)")
+	if err := pc.requireYesIfNonInteractive(yes); err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	stack, err := pc.loadStackForStateful(ctx, displayOpts)
+	if err != nil {
+		return err
+	}
+	snap, err := stack.Snapshot(ctx, backendSecrets.DefaultProvider)
+	if err != nil {
+		return fmt.Errorf("load stack snapshot: %w", err)
+	}
+
+	var existing *resource.Snippet
+	if snap != nil {
+		for i := range snap.Snippets {
+			s := snap.Snippets[i]
+			if s.Name == name && s.Type == res.Token {
+				existing = &s
+				break
+			}
+		}
+	}
+	if existing == nil {
+		return fmt.Errorf("resource %s %q does not exist in stack %s", res.Token, name, stack.Ref())
+	}
+
+	userResources, err := readResourceReferences(resourcesFile)
+	if err != nil {
+		return err
+	}
+	resources := mergeResourceNames(autoResourceNames(snap), userResources)
+	resourceInfos, err := resourceReferenceInfos(resources, snap)
+	if err != nil {
+		return err
+	}
+
+	inputFlags := collectInputFlags(cmd, "input", res.InputProperties)
+	patch, patchFilename, resourceNames, err := parseFile(
+		ctx, inputFile, "input", inputFormat, res.Token,
+		pc.converter, pc.loaderTarget, pc.packageDescriptor, inputFlags, resourceInfos,
+	)
+	if err != nil {
+		return fmt.Errorf("read input file: %w", err)
+	}
+	patchReferences, err := applyResourceNameRemaps(resources, resourceNames)
+	if err != nil {
+		return err
+	}
+	references, err := mergePatchReferences(existing.References, patchReferences)
+	if err != nil {
+		return err
+	}
+
+	sourceFilename := fmt.Sprintf("<snippet %s>", existing.UUID)
+	merged, err := mergePCLAttributesIntoPCL([]byte(existing.Code), sourceFilename, patch, patchFilename)
+	if err != nil {
+		return fmt.Errorf("merge patch inputs: %w", err)
+	}
+	references = filterReferencesByPCLUsage(references, merged, sourceFilename)
+
+	patched := *existing
+	patched.Code = string(merged)
+	patched.References = references
+
+	result, err := pc.runStatefulUpdate(ctx, cmd.Flags(), StatefulUpdateRequest{
+		Snippets:    []resource.Snippet{patched},
+		Stack:       stack,
+		DryRun:      pc.dryrun,
+		Yes:         yes,
+		ShowSecrets: pc.showSecrets,
+		Proj:        pc.proj,
+		Root:        pc.root,
+		Sink:        pc.diagFwd,
+	})
+	if err != nil {
+		return err
+	}
+	if result != nil && !pc.dryrun && len(result.SnippetUUIDs) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "Patched %s (snippet %s)\n", name, result.SnippetUUIDs[len(result.SnippetUUIDs)-1])
+	}
+	return nil
+}
+
+func mergePatchReferences(existing, patch map[string]string) (map[string]string, error) {
+	if len(existing) == 0 && len(patch) == 0 {
+		return nil, nil
+	}
+
+	merged := make(map[string]string, len(existing)+len(patch))
+	maps.Copy(merged, existing)
+	for name, urn := range patch {
+		if existingURN, ok := merged[name]; ok && existingURN != urn {
+			return nil, fmt.Errorf(
+				"resource reference %q already points to %s and cannot be patched to point to %s",
+				name, existingURN, urn,
+			)
+		}
+		merged[name] = urn
+	}
+	return merged, nil
 }
 
 func (pc *packageCommand) runStatefulSnippetDelete(

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -513,6 +513,110 @@ func TestDoCmdResourceUpsertReusesExistingSnippet(t *testing.T) {
 	_ = stderr
 }
 
+//nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
+func TestDoCmdResourcePatchMergesAndFiltersReferences(t *testing.T) {
+	oldURN := resource.URN("urn:pulumi:dev::proj::azure:index:myResource::old")
+	newURN := resource.URN("urn:pulumi:dev::proj::azure:index:myResource::new")
+	existing := resource.Snippet{
+		UUID: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+		Name: "myres", Type: "azure:index:myResource",
+		Code:       "name = old.name\nsize = 1\n",
+		Descriptor: resource.PackageDescriptor{Name: "azure"},
+		References: map[string]string{
+			"old": string(oldURN),
+		},
+	}
+	snapshot := &deploy.Snapshot{
+		Resources: []*pkgresource.State{
+			{Type: oldURN.Type(), URN: oldURN, Custom: true, ID: "old-id"},
+			{Type: newURN.Type(), URN: newURN, Custom: true, ID: "new-id"},
+		},
+		Snippets: []resource.Snippet{existing},
+	}
+	mws, mlm := installMockUpsertBackend(t, snapshot)
+
+	var got StatefulUpdateRequest
+	stub := func(_ context.Context, _ *pflag.FlagSet, req StatefulUpdateRequest,
+	) (*StatefulUpdateResult, error) {
+		got = req
+		return &StatefulUpdateResult{SnippetUUIDs: []string{req.Snippets[len(req.Snippets)-1].UUID}}, nil
+	}
+	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		return &testProvider{spec: doResourceSpec(false)}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, stub)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	inputFile := writeHCLFile(t, "patch.pcl", `name = new.name`)
+	resourcesFile := writeHCLFile(t, "resources.json", `{"new":"`+string(newURN)+`"}`)
+	cmd.SetArgs([]string{
+		"azure:index:myResource", "patch", "myres", "--yes",
+		"--input", "pcl", "--input-file", inputFile, "--resources-file", resourcesFile,
+	})
+	require.NoError(t, cmd.Execute())
+
+	require.Len(t, got.Snippets, 1)
+	patched := got.Snippets[0]
+	assert.Equal(t, existing.UUID, patched.UUID)
+	assert.Contains(t, patched.Code, "name = new.name")
+	assert.Contains(t, patched.Code, "size = 1")
+	assert.Equal(t, map[string]string{"new": string(newURN)}, patched.References)
+	_ = stdout
+	_ = stderr
+}
+
+//nolint:paralleltest // installMockUpsertBackend calls t.Setenv.
+func TestDoCmdResourcePatchRejectsReferenceRemapConflict(t *testing.T) {
+	oldURN := resource.URN("urn:pulumi:dev::proj::azure:index:myResource::old")
+	newURN := resource.URN("urn:pulumi:dev::proj::azure:index:myResource::new")
+	existing := resource.Snippet{
+		UUID: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+		Name: "myres", Type: "azure:index:myResource",
+		Code:       "name = hi.name\n",
+		Descriptor: resource.PackageDescriptor{Name: "azure"},
+		References: map[string]string{
+			"hi": string(oldURN),
+		},
+	}
+	snapshot := &deploy.Snapshot{
+		Resources: []*pkgresource.State{
+			{Type: oldURN.Type(), URN: oldURN, Custom: true, ID: "old-id"},
+			{Type: newURN.Type(), URN: newURN, Custom: true, ID: "new-id"},
+		},
+		Snippets: []resource.Snippet{existing},
+	}
+	mws, mlm := installMockUpsertBackend(t, snapshot)
+
+	stub := func(context.Context, *pflag.FlagSet, StatefulUpdateRequest) (*StatefulUpdateResult, error) {
+		require.Fail(t, "conflicting patch references must not run an update")
+		return nil, nil
+	}
+	loader := func(_ context.Context, _ *plugin.Context, _, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		return &testProvider{spec: doResourceSpec(false)}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin, stub)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	inputFile := writeHCLFile(t, "patch.pcl", `name = hi.name`)
+	resourcesFile := writeHCLFile(t, "resources.json", `{"hi":"`+string(newURN)+`"}`)
+	cmd.SetArgs([]string{
+		"azure:index:myResource", "patch", "myres", "--yes",
+		"--input", "pcl", "--input-file", inputFile, "--resources-file", resourcesFile,
+	})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, `resource reference "hi" already points to`)
+	require.ErrorContains(t, err, string(oldURN))
+	require.ErrorContains(t, err, string(newURN))
+	_ = stdout
+	_ = stderr
+}
+
 // TestDoCmdResourceUpsertEndToEnd drives `pulumi do <token> upsert` through the real deployment
 // engine (via the lifecycletest framework) so we can assert that a fresh snippet ends up in the
 // snapshot and the engine creates the underlying resource. The runStatefulUpdate stub bridges the

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -615,6 +615,43 @@ func mergeAbsentAttributeLiteralsIntoPCL(
 	return file.Bytes(), nil
 }
 
+// mergePCLAttributesIntoPCL takes the top-level attributes from `patch` and writes them into
+// `source`, overriding any attribute of the same name and preserving all other content (existing
+// attributes, blocks, and comments). Non-attribute content in `patch` (blocks, comments) is
+// ignored — patch semantics only touch inputs.
+func mergePCLAttributesIntoPCL(
+	source []byte, sourceFilename string, patch []byte, patchFilename string,
+) ([]byte, error) {
+	if len(patch) == 0 {
+		return source, nil
+	}
+	patchFile, diags := hclwrite.ParseConfig(patch, patchFilename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	patchAttrs := patchFile.Body().Attributes()
+	if len(patchAttrs) == 0 {
+		return source, nil
+	}
+	if len(source) > 0 && source[len(source)-1] != '\n' {
+		source = append(append([]byte{}, source...), '\n')
+	}
+	file, diags := hclwrite.ParseConfig(source, sourceFilename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	body := file.Body()
+	names := make([]string, 0, len(patchAttrs))
+	for name := range patchAttrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		body.SetAttributeRaw(name, patchAttrs[name].Expr().BuildTokens(nil))
+	}
+	return file.Bytes(), nil
+}
+
 // injectProviderOptionInPCL rewrites a resource snippet's PCL to reference the (external) provider
 // snippet's URN via the given identifier (declared by the snippet's References map). If the
 // source already has a top-level `options` block, `provider = <name>` is added inside it (unless


### PR DESCRIPTION
Adds stateful patch support, look up by name and then merge new attributes over the PCL.