### PR TITLE
Include property diffs in `--output json` when combined with `--diff`

### DIFF
--- a/changelog/pending/cli-display-improvement-20260812-145301.yaml
+++ b/changelog/pending/cli-display-improvement-20260812-145301.yaml
@@ -3,3 +3,5 @@ kind: improvement
 body: Include per-property diffs in the resources listed by `--output json` when
   combined with `--diff` in `up`, `preview`, `destroy`, `refresh`, and `import`
 time: 2026-08-12T14:53:01.492735+02:00
+custom:
+  PR: "24296"

--- a/changelog/pending/cli-display-improvement-20260812-145301.yaml
+++ b/changelog/pending/cli-display-improvement-20260812-145301.yaml
@@ -1,0 +1,5 @@
+component: cli/display
+kind: improvement
+body: Include per-property diffs in the resources listed by `--output json` when
+  combined with `--diff` in `up`, `preview`, `destroy`, `refresh`, and `import`
+time: 2026-08-12T14:53:01.492735+02:00

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -470,13 +470,42 @@ func renderDiff(
 	fprintIgnoreError(out, opts.Color.Colorize(colors.Reset))
 }
 
+// diffAtPreEvent records a step and reports whether its diff is rendered at
+// the pre-event. Imports and refreshes only know their diff once outputs arrive.
+func diffAtPreEvent(m engine.StepEventMetadata, seen map[resource.URN]engine.StepEventMetadata) bool {
+	seen[m.URN] = m
+	return m.Op != deploy.OpRefresh && m.Op != deploy.OpImport
+}
+
+// diffAtOutputsEvent reports whether a step's diff is rendered at the outputs
+// event, and whether those outputs come from a refresh. There are two cases:
+//
+//   - Imports, where we now have information from the provider about the
+//     resource being imported.
+//   - Refreshes, where similarly we might have updated information about the
+//     resource from the provider.
+//
+// Note that refresh step result operations will be OpUpdates (something
+// changed in the provider), OpSames (nothing changed in the provider), or
+// OpDeletes (the resource was deleted in the provider). We only want to
+// display a diff in the OpUpdate case. In the OpSame case, there is no diff
+// (otherwise the operation would have been OpUpdate), and in the OpDelete
+// case, we will already be indicating a deletion and it doesn't make sense
+// to display a diff that shows that we are deleting everything.
+func diffAtOutputsEvent(
+	m engine.StepEventMetadata, seen map[resource.URN]engine.StepEventMetadata,
+) (refresh, ok bool) {
+	pre, has := seen[m.URN]
+	refresh = has && pre.Op == deploy.OpRefresh
+	return refresh, m.Op == deploy.OpImport || (refresh && m.Op == deploy.OpUpdate)
+}
+
 func renderDiffResourcePreEvent(
 	payload engine.ResourcePreEventPayload,
 	seen map[resource.URN]engine.StepEventMetadata,
 	opts Options,
 ) string {
-	seen[payload.Metadata.URN] = payload.Metadata
-	if payload.Metadata.Op == deploy.OpRefresh || payload.Metadata.Op == deploy.OpImport {
+	if !diffAtPreEvent(payload.Metadata, seen) {
 		return ""
 	}
 
@@ -494,27 +523,8 @@ func renderDiffResourceOutputsEvent(
 ) string {
 	out := &bytes.Buffer{}
 	if shouldShow(payload.Metadata, opts) || isRootStack(payload.Metadata) {
-		refresh := false // are these outputs from a refresh?
-		if m, has := seen[payload.Metadata.URN]; has && m.Op == deploy.OpRefresh {
-			refresh = true
-		}
-
-		// There are two cases where we want to display a diff at the point of a
-		// resource output event:
-		//
-		// * Imports, where we now have information from the provider about the
-		//   resource being imported.
-		// * Refreshes, where similarly we might have updated information about the
-		//   resource from the provider.
-		//
-		// Note that refresh step result operations will be OpUpdates (something
-		// changed in the provider), OpSames (nothing changed in the provider), or
-		// OpDeletes (the resource was deleted in the provider). We only want to
-		// display a diff in the OpUpdate case. In the OpSame case, there is no diff
-		// (otherwise the operation would have been OpUpdate), and in the OpDelete
-		// case, we will already be indicating a deletion and it doesn't make sense
-		// to display a diff that shows that we are deleting everything.
-		if payload.Metadata.Op == deploy.OpImport || (refresh && payload.Metadata.Op == deploy.OpUpdate) {
+		refresh, ok := diffAtOutputsEvent(payload.Metadata, seen)
+		if ok {
 			renderDiff(out, payload.Metadata, payload.Planning, payload.Debug, refresh, seen, opts)
 			return out.String()
 		}

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -443,14 +443,20 @@ func renderDiff(
 	// An OpSame might have a diff due to metadata changes (e.g. protect) but we should never print a property diff,
 	// even if the properties appear to have changed. See https://github.com/pulumi/pulumi/issues/15944 for context.
 	if metadata.Op != deploy.OpSame {
-		if metadata.DetailedDiff != nil {
+		if metadata.Old != nil && metadata.New != nil {
 			var buf bytes.Buffer
-			if diff, hidden := engine.TranslateDetailedDiff(&metadata, refresh); diff != nil {
-				PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1,
+			diff, include, hidden := stepDiff(&metadata, refresh)
+			if diff == nil && len(hidden) > 0 {
+				// All diffs are hidden, but there was a diff.
+				diff = &resource.ObjectDiff{}
+			}
+			if diff != nil {
+				PrintObjectDiff(&buf, *diff, include, planning, indent+1,
 					opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets, hidden)
 			} else {
+				// If there's no diff, render the resource as if nothing changed.
 				PrintObject(
-					&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true, /*prefix*/
+					&buf, metadata.New.Inputs, planning, indent+1, deploy.OpSame, true, /*prefix*/
 					opts.TruncateOutput, debug, opts.ShowSecrets)
 			}
 			details = buf.String()

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -214,13 +214,6 @@ func getResourcePropertiesDetails(
 	// indent everything an additional level, like other properties.
 	indent++
 
-	var hideDiff []resource.PropertyPath
-	if step.New != nil {
-		hideDiff = step.New.HideDiffs
-	} else if step.Old != nil {
-		hideDiff = step.Old.HideDiffs
-	}
-
 	old, new := step.Old, step.New
 	if old == nil && new != nil {
 		if len(new.Outputs) > 0 {
@@ -235,15 +228,40 @@ func getResourcePropertiesDetails(
 		if !summary {
 			PrintObject(&b, old.Inputs, planning, indent, step.Op, false, truncateOutput, debug, showSecrets)
 		}
-	} else if len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement {
-		printOldNewDiffs(&b, old.Outputs, new.Outputs, nil, planning, indent, step.Op,
-			summary, truncateOutput, debug, showSecrets, hideDiff)
-	} else {
-		printOldNewDiffs(&b, old.Inputs, new.Inputs, step.Diffs, planning, indent, step.Op,
-			summary, truncateOutput, debug, showSecrets, hideDiff)
 	}
 
 	return b.String()
+}
+
+// stepDiff computes the property diff a step displays: the provider's detailed
+// diff when present, an old-vs-new comparison otherwise; creates and deletes
+// diff against an empty state. include is the provider's ChangedKeys filter for
+// top-level properties, and hidden the paths whose diffs were suppressed.
+func stepDiff(m *engine.StepEventMetadata, refresh bool,
+) (*resource.ObjectDiff, []resource.PropertyKey, []resource.PropertyPath) {
+	old, new := m.Old, m.New
+	switch {
+	case m.Op == deploy.OpSame:
+		// An OpSame diff is metadata-only (e.g. protect); see pulumi/pulumi#15944.
+		return nil, nil, nil
+	case m.DetailedDiff != nil && old != nil && new != nil:
+		diff, hidden := engine.TranslateDetailedDiff(m, refresh)
+		return diff, nil, hidden
+	case old != nil && new != nil:
+		if len(new.Outputs) > 0 && m.Op != deploy.OpImport && m.Op != deploy.OpImportReplacement {
+			diff, hidden := diffOldNew(old.Outputs, new.Outputs, new.HideDiffs)
+			return diff, nil, hidden
+		}
+		diff, hidden := diffOldNew(old.Inputs, new.Inputs, new.HideDiffs)
+		return diff, m.Diffs, hidden
+	case new != nil:
+		diff, _ := diffOldNew(nil, new.Inputs, nil)
+		return diff, nil, nil
+	case old != nil:
+		diff, _ := diffOldNew(old.Inputs, nil, nil)
+		return diff, nil, nil
+	}
+	return nil, nil, nil
 }
 
 func maxKey(keys []resource.PropertyKey) int {
@@ -801,27 +819,6 @@ func diffOldNew(olds, news resource.PropertyMap, hidePaths []resource.PropertyPa
 	})
 
 	return diff, hiddenDiffs
-}
-
-func printOldNewDiffs(
-	b *bytes.Buffer, olds resource.PropertyMap, news resource.PropertyMap, include []resource.PropertyKey,
-	planning bool, indent int, op display.StepOp, summary bool, truncateOutput bool, debug bool, showSecrets bool,
-	hidePaths []resource.PropertyPath,
-) {
-	diff, hiddenDiffs := diffOldNew(olds, news, hidePaths)
-
-	// We have hidden all the diffs, but there was a diff.
-	if diff == nil && len(hiddenDiffs) > 0 {
-		diff = &resource.ObjectDiff{}
-	}
-
-	if diff != nil {
-		PrintObjectDiff(b, *diff, include, planning, indent, summary, truncateOutput, debug, showSecrets, hiddenDiffs)
-	} else {
-		// If there's no diff, report the op as Same - there's no diff to render
-		// so it should be rendered as if nothing changed.
-		PrintObject(b, news, planning, indent, deploy.OpSame, true, truncateOutput, debug, showSecrets)
-	}
 }
 
 func PrintObjectDiff(b *bytes.Buffer, diff resource.ObjectDiff, include []resource.PropertyKey,

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -774,14 +774,12 @@ func shortHash(hash string) string {
 	return hash
 }
 
-func printOldNewDiffs(
-	b *bytes.Buffer, olds resource.PropertyMap, news resource.PropertyMap, include []resource.PropertyKey,
-	planning bool, indent int, op display.StepOp, summary bool, truncateOutput bool, debug bool, showSecrets bool,
-	hidePaths []resource.PropertyPath,
-) {
+// diffOldNew diffs two property maps the way the diff display does: internal
+// keys are ignored, and diffs under hidePaths are suppressed and reported as
+// the second return value (sorted and de-duplicated).
+func diffOldNew(olds, news resource.PropertyMap, hidePaths []resource.PropertyPath,
+) (*resource.ObjectDiff, []resource.PropertyPath) {
 	var hiddenDiffs []resource.PropertyPath
-
-	// Get the full diff structure between the two, and print it (recursively).
 	diff := olds.DiffWithOptions(news,
 		resource.IgnoreKeyFunc(resource.IsInternalPropertyKey),
 		resource.IgnorePathFunc(func(path resource.PropertyPath) bool {
@@ -795,13 +793,22 @@ func printOldNewDiffs(
 		}),
 	)
 
-	// Ensure that our paths are unique and sorted
 	slices.SortFunc(hiddenDiffs, func(a, b resource.PropertyPath) int {
 		return cmp.Compare(a.String(), b.String())
 	})
 	hiddenDiffs = slices.CompactFunc(hiddenDiffs, func(a, b resource.PropertyPath) bool {
 		return a.String() == b.String()
 	})
+
+	return diff, hiddenDiffs
+}
+
+func printOldNewDiffs(
+	b *bytes.Buffer, olds resource.PropertyMap, news resource.PropertyMap, include []resource.PropertyKey,
+	planning bool, indent int, op display.StepOp, summary bool, truncateOutput bool, debug bool, showSecrets bool,
+	hidePaths []resource.PropertyPath,
+) {
+	diff, hiddenDiffs := diffOldNew(olds, news, hidePaths)
 
 	// We have hidden all the diffs, but there was a diff.
 	if diff == nil && len(hiddenDiffs) > 0 {

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -120,13 +120,21 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *Reso
 	return &r
 }
 
-// diffJSONFromStep flattens a step's property changes into a path → change map.
-// The diff itself is computed exactly as the human-readable display computes it
-// (renderDiff / getResourcePropertiesDetails); only the rendering differs.
+// diffJSONFromStep renders the diff computed by stepDiff — the same one the
+// human-readable display prints — as a flat path → change map.
 func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) map[string]PropertyDiffJSON {
-	// An OpSame diff is metadata-only (e.g. protect); see pulumi/pulumi#15944.
-	if m.Op == deploy.OpSame {
+	diff, include, _ := stepDiff(m, refresh)
+	if diff == nil {
 		return nil
+	}
+	if include != nil {
+		keep := make(map[resource.PropertyKey]bool, len(include))
+		for _, k := range include {
+			keep[k] = true
+		}
+		maps.DeleteFunc(diff.Adds, func(k resource.PropertyKey, _ resource.PropertyValue) bool { return !keep[k] })
+		maps.DeleteFunc(diff.Deletes, func(k resource.PropertyKey, _ resource.PropertyValue) bool { return !keep[k] })
+		maps.DeleteFunc(diff.Updates, func(k resource.PropertyKey, _ resource.ValueDiff) bool { return !keep[k] })
 	}
 
 	out := map[string]PropertyDiffJSON{}
@@ -140,43 +148,7 @@ func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) ma
 		}
 		out[path.String()] = entry
 	}
-
-	if m.DetailedDiff != nil && m.Old != nil && m.New != nil {
-		if diff, _ := engine.TranslateDetailedDiff(m, refresh); diff != nil {
-			flattenObjectDiff(nil, diff, add)
-		}
-	} else {
-		var olds, news resource.PropertyMap
-		var hide []resource.PropertyPath
-		var include []resource.PropertyKey
-		switch {
-		case m.Old != nil && m.New != nil:
-			isImport := m.Op == deploy.OpImport || m.Op == deploy.OpImportReplacement
-			if len(m.New.Outputs) > 0 && !isImport {
-				olds, news = m.Old.Outputs, m.New.Outputs
-			} else {
-				olds, news, include = m.Old.Inputs, m.New.Inputs, m.Diffs
-			}
-			hide = m.New.HideDiffs
-		case m.New != nil:
-			news = m.New.Inputs
-		case m.Old != nil:
-			olds = m.Old.Inputs
-		}
-
-		if diff, _ := diffOldNew(olds, news, hide); diff != nil {
-			if include != nil {
-				keep := make(map[resource.PropertyKey]bool, len(include))
-				for _, k := range include {
-					keep[k] = true
-				}
-				maps.DeleteFunc(diff.Adds, func(k resource.PropertyKey, _ resource.PropertyValue) bool { return !keep[k] })
-				maps.DeleteFunc(diff.Deletes, func(k resource.PropertyKey, _ resource.PropertyValue) bool { return !keep[k] })
-				maps.DeleteFunc(diff.Updates, func(k resource.PropertyKey, _ resource.ValueDiff) bool { return !keep[k] })
-			}
-			flattenObjectDiff(nil, diff, add)
-		}
-	}
+	flattenObjectDiff(nil, diff, add)
 
 	if len(out) == 0 {
 		return nil

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -94,11 +94,11 @@ func summaryJSONFromEvent(p engine.SummaryEventPayload) SummaryJSON {
 // per-resource JSON shape. Returns nil when the event should be skipped:
 // internal events never surface to users, and `same` (unchanged) resources are
 // omitted unless the display is configured to show them.
-func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *ResourceJSON {
+func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *ResourceJSON {
 	if p.Internal {
 		return nil
 	}
-	if p.Metadata.Op == deploy.OpSame && !opts.ShowSameResources {
+	if p.Metadata.Op == deploy.OpSame && !showSames {
 		return nil
 	}
 
@@ -113,10 +113,6 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *Reso
 	}
 
 	r := NewResourceJSON(p.Metadata.URN, apitype.OpType(p.Metadata.Op), parent)
-	// Imports only have their diff once outputs arrive, mirroring renderDiffResourcePreEvent.
-	if opts.Type == DisplayDiff && p.Metadata.Op != deploy.OpImport {
-		r.Diff = diffJSONFromStep(&p.Metadata, false /* refresh */, opts.ShowSecrets)
-	}
 	return &r
 }
 
@@ -248,25 +244,23 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 	go func() {
 		defer close(out)
 		var resources []ResourceJSON
-		refreshed := map[resource.URN]bool{}
+		seen := map[resource.URN]engine.StepEventMetadata{}
 		for e := range in {
 			switch e.Type { //nolint:exhaustive
 			case engine.ResourcePreEvent:
 				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
-					if payload.Metadata.Op == deploy.OpRefresh {
-						refreshed[payload.Metadata.URN] = true
-					}
-					if r := resourceJSONFromEvent(payload, opts); r != nil {
+					diffNow := diffAtPreEvent(payload.Metadata, seen)
+					if r := resourceJSONFromEvent(payload, opts.ShowSameResources); r != nil {
+						if diffNow && opts.Type == DisplayDiff {
+							r.Diff = diffJSONFromStep(&payload.Metadata, false /* refresh */, opts.ShowSecrets)
+						}
 						resources = append(resources, *r)
 					}
 				}
 			case engine.ResourceOutputsEvent:
-				// Import and refresh diffs only arrive on the outputs event,
-				// mirroring renderDiffResourceOutputsEvent.
 				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok && opts.Type == DisplayDiff {
 					m := payload.Metadata
-					refresh := refreshed[m.URN]
-					if m.Op == deploy.OpImport || (refresh && m.Op == deploy.OpUpdate) {
+					if refresh, ready := diffAtOutputsEvent(m, seen); ready {
 						diff := diffJSONFromStep(&m, refresh, opts.ShowSecrets)
 						for i := range resources {
 							if resources[i].URN == string(m.URN) {

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"time"
 
@@ -112,34 +113,24 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *Reso
 	}
 
 	r := NewResourceJSON(p.Metadata.URN, apitype.OpType(p.Metadata.Op), parent)
-	if opts.Type == DisplayDiff {
+	// Imports only have their diff once outputs arrive, mirroring renderDiffResourcePreEvent.
+	if opts.Type == DisplayDiff && p.Metadata.Op != deploy.OpImport {
 		r.Diff = diffJSONFromStep(&p.Metadata, false /* refresh */, opts.ShowSecrets)
 	}
 	return &r
 }
 
-// diffJSONFromStep flattens a step's property changes into a path → change map,
-// using the same sources as the human-readable diff display.
+// diffJSONFromStep flattens a step's property changes into a path → change map.
+// The diff itself is computed exactly as the human-readable display computes it
+// (renderDiff / getResourcePropertiesDetails); only the rendering differs.
 func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) map[string]PropertyDiffJSON {
 	// An OpSame diff is metadata-only (e.g. protect); see pulumi/pulumi#15944.
 	if m.Op == deploy.OpSame {
 		return nil
 	}
 
-	var hidden []resource.PropertyPath
-	if m.New != nil {
-		hidden = m.New.HideDiffs
-	} else if m.Old != nil {
-		hidden = m.Old.HideDiffs
-	}
-
 	out := map[string]PropertyDiffJSON{}
 	add := func(path resource.PropertyPath, kind string, old, new *resource.PropertyValue) {
-		for _, h := range hidden {
-			if h.Contains(path) {
-				return
-			}
-		}
 		entry := PropertyDiffJSON{Kind: kind}
 		if old != nil {
 			entry.Old = propertyValueJSON(*old, showSecrets)
@@ -150,26 +141,40 @@ func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) ma
 		out[path.String()] = entry
 	}
 
-	switch {
-	case m.DetailedDiff != nil && m.Old != nil && m.New != nil:
+	if m.DetailedDiff != nil && m.Old != nil && m.New != nil {
 		if diff, _ := engine.TranslateDetailedDiff(m, refresh); diff != nil {
 			flattenObjectDiff(nil, diff, add)
 		}
-	case m.Old != nil && m.New != nil:
-		if diff := m.Old.Inputs.Diff(m.New.Inputs, resource.IsInternalPropertyKey); diff != nil {
+	} else {
+		var olds, news resource.PropertyMap
+		var hide []resource.PropertyPath
+		var include []resource.PropertyKey
+		switch {
+		case m.Old != nil && m.New != nil:
+			isImport := m.Op == deploy.OpImport || m.Op == deploy.OpImportReplacement
+			if len(m.New.Outputs) > 0 && !isImport {
+				olds, news = m.Old.Outputs, m.New.Outputs
+			} else {
+				olds, news, include = m.Old.Inputs, m.New.Inputs, m.Diffs
+			}
+			hide = m.New.HideDiffs
+		case m.New != nil:
+			news = m.New.Inputs
+		case m.Old != nil:
+			olds = m.Old.Inputs
+		}
+
+		if diff, _ := diffOldNew(olds, news, hide); diff != nil {
+			if include != nil {
+				keep := make(map[resource.PropertyKey]bool, len(include))
+				for _, k := range include {
+					keep[k] = true
+				}
+				maps.DeleteFunc(diff.Adds, func(k resource.PropertyKey, _ resource.PropertyValue) bool { return !keep[k] })
+				maps.DeleteFunc(diff.Deletes, func(k resource.PropertyKey, _ resource.PropertyValue) bool { return !keep[k] })
+				maps.DeleteFunc(diff.Updates, func(k resource.PropertyKey, _ resource.ValueDiff) bool { return !keep[k] })
+			}
 			flattenObjectDiff(nil, diff, add)
-		}
-	case m.New != nil:
-		for k, v := range m.New.Inputs {
-			if !resource.IsInternalPropertyKey(k) {
-				add(resource.PropertyPath{string(k)}, "add", nil, &v)
-			}
-		}
-	case m.Old != nil:
-		for k, v := range m.Old.Inputs {
-			if !resource.IsInternalPropertyKey(k) {
-				add(resource.PropertyPath{string(k)}, "delete", &v, nil)
-			}
 		}
 	}
 
@@ -284,11 +289,13 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 					}
 				}
 			case engine.ResourceOutputsEvent:
-				// Refresh diffs only arrive on the outputs event, rewritten as an update or delete.
+				// Import and refresh diffs only arrive on the outputs event,
+				// mirroring renderDiffResourceOutputsEvent.
 				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok && opts.Type == DisplayDiff {
 					m := payload.Metadata
-					if refreshed[m.URN] && ((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {
-						diff := diffJSONFromStep(&m, true /* refresh */, opts.ShowSecrets)
+					refresh := refreshed[m.URN]
+					if m.Op == deploy.OpImport || (refresh && m.Op == deploy.OpUpdate) {
+						diff := diffJSONFromStep(&m, refresh, opts.ShowSecrets)
 						for i := range resources {
 							if resources[i].URN == string(m.URN) {
 								resources[i].Diff = diff

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -16,6 +16,7 @@ package display
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,8 +26,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 // SummaryJSON is a one-line JSON summary of a stack operation, intended for
@@ -49,8 +53,8 @@ type SummaryJSON struct {
 }
 
 // ResourceJSON is the per-resource entry that appears in SummaryJSON.Resources.
-// It is intentionally compact: callers that need full diffs / property values
-// should use `--json` (the streaming event format) instead.
+// It is intentionally compact: property-level detail only appears when the
+// caller opts in with `--diff`.
 type ResourceJSON struct {
 	// URN is the canonical, globally-unique identifier of the resource.
 	URN string `json:"urn"`
@@ -62,6 +66,18 @@ type ResourceJSON struct {
 	Op apitype.OpType `json:"op"`
 	// Parent is the URN of this resource's parent, if any.
 	Parent string `json:"parent,omitempty"`
+	// Diff maps property paths to their changes. Only populated when `--diff`
+	// is combined with `--output json`.
+	Diff map[string]PropertyDiffJSON `json:"diff,omitempty"`
+}
+
+// PropertyDiffJSON describes the change to a single property path within
+// ResourceJSON.Diff. Old is absent for adds and New is absent for deletes;
+// secret values are masked unless the caller passed `--show-secrets`.
+type PropertyDiffJSON struct {
+	Kind string `json:"kind"`
+	Old  any    `json:"old,omitzero"`
+	New  any    `json:"new,omitzero"`
 }
 
 // summaryJSONFromEvent extracts the summary JSON shape from a SummaryEventPayload.
@@ -79,11 +95,11 @@ func summaryJSONFromEvent(p engine.SummaryEventPayload) SummaryJSON {
 // per-resource JSON shape. Returns nil when the event should be skipped:
 // internal events never surface to users, and `same` (unchanged) resources are
 // omitted unless the display is configured to show them.
-func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *ResourceJSON {
+func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *ResourceJSON {
 	if p.Internal {
 		return nil
 	}
-	if p.Metadata.Op == deploy.OpSame && !showSames {
+	if p.Metadata.Op == deploy.OpSame && !opts.ShowSameResources {
 		return nil
 	}
 
@@ -98,7 +114,126 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *Re
 	}
 
 	r := NewResourceJSON(p.Metadata.URN, apitype.OpType(p.Metadata.Op), parent)
+	if opts.Type == DisplayDiff {
+		r.Diff = diffJSONFromStep(&p.Metadata, false /* refresh */, opts.ShowSecrets)
+	}
 	return &r
+}
+
+// diffJSONFromStep flattens the property changes carried by a step event into
+// the summary's path → change map, drawing on the same sources as the
+// human-readable diff display: the provider's detailed diff when present, and
+// an old-vs-new inputs comparison otherwise. Creates report every input as an
+// add and deletes report every input as a delete. Returns nil when the step
+// carries no property changes.
+func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) map[string]PropertyDiffJSON {
+	// An OpSame can carry a metadata-only diff (e.g. protect); never report a
+	// property diff for it. See https://github.com/pulumi/pulumi/issues/15944.
+	if m.Op == deploy.OpSame {
+		return nil
+	}
+
+	var hidden []resource.PropertyPath
+	if m.New != nil {
+		hidden = m.New.HideDiffs
+	} else if m.Old != nil {
+		hidden = m.Old.HideDiffs
+	}
+
+	out := map[string]PropertyDiffJSON{}
+	add := func(path resource.PropertyPath, kind string, old, new *resource.PropertyValue) {
+		for _, h := range hidden {
+			if h.Contains(path) {
+				return
+			}
+		}
+		entry := PropertyDiffJSON{Kind: kind}
+		if old != nil {
+			entry.Old = propertyValueJSON(*old, showSecrets)
+		}
+		if new != nil {
+			entry.New = propertyValueJSON(*new, showSecrets)
+		}
+		out[path.String()] = entry
+	}
+
+	switch {
+	case m.DetailedDiff != nil && m.Old != nil && m.New != nil:
+		if diff, _ := engine.TranslateDetailedDiff(m, refresh); diff != nil {
+			flattenObjectDiff(nil, diff, add)
+		}
+	case m.Old != nil && m.New != nil:
+		if diff := m.Old.Inputs.Diff(m.New.Inputs, resource.IsInternalPropertyKey); diff != nil {
+			flattenObjectDiff(nil, diff, add)
+		}
+	case m.New != nil:
+		for k, v := range m.New.Inputs {
+			if !resource.IsInternalPropertyKey(k) {
+				add(resource.PropertyPath{string(k)}, "add", nil, &v)
+			}
+		}
+	case m.Old != nil:
+		for k, v := range m.Old.Inputs {
+			if !resource.IsInternalPropertyKey(k) {
+				add(resource.PropertyPath{string(k)}, "delete", &v, nil)
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// propertyValueJSON prepares a property value for JSON output: secrets are
+// masked (unless showSecrets), and unknowns, assets, and resource references
+// are rendered the same way the preview digest renders resource states.
+func propertyValueJSON(v resource.PropertyValue, showSecrets bool) any {
+	serialized, err := stack.SerializePropertyValue(
+		context.TODO(), massagePropertyValue(v, showSecrets), config.NewPanicCrypter(), showSecrets)
+	if err != nil {
+		logging.V(7).Infof("not adding property value as there was an error serializing: %s", err)
+		return nil
+	}
+	return serialized
+}
+
+type addDiffEntry func(path resource.PropertyPath, kind string, old, new *resource.PropertyValue)
+
+func flattenObjectDiff(prefix resource.PropertyPath, d *resource.ObjectDiff, add addDiffEntry) {
+	for k, vd := range d.Updates {
+		flattenValueDiff(append(prefix, string(k)), vd, add)
+	}
+	for k, v := range d.Adds {
+		add(append(prefix, string(k)), "add", nil, &v)
+	}
+	for k, v := range d.Deletes {
+		add(append(prefix, string(k)), "delete", &v, nil)
+	}
+}
+
+func flattenValueDiff(path resource.PropertyPath, vd resource.ValueDiff, add addDiffEntry) {
+	switch {
+	case vd.Object != nil:
+		flattenObjectDiff(path, vd.Object, add)
+	case vd.Array != nil:
+		for i, ed := range vd.Array.Updates {
+			flattenValueDiff(append(path, i), ed, add)
+		}
+		for i, v := range vd.Array.Adds {
+			add(append(path, i), "add", nil, &v)
+		}
+		for i, v := range vd.Array.Deletes {
+			add(append(path, i), "delete", &v, nil)
+		}
+	case vd.Old.V == nil && vd.New.V != nil:
+		add(path, "add", nil, &vd.New)
+	case vd.Old.V != nil && vd.New.V == nil:
+		add(path, "delete", &vd.Old, nil)
+	default:
+		add(path, "update", &vd.Old, &vd.New)
+	}
 }
 
 // NewResourceJSON builds the per-resource summary entry from the fields
@@ -146,12 +281,32 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 	go func() {
 		defer close(out)
 		var resources []ResourceJSON
+		refreshed := map[resource.URN]bool{}
 		for e := range in {
-			switch e.Type { //nolint:exhaustive // we only care about two event types here
+			switch e.Type { //nolint:exhaustive // we only care about a few event types here
 			case engine.ResourcePreEvent:
 				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
-					if r := resourceJSONFromEvent(payload, opts.ShowSameResources); r != nil {
+					if payload.Metadata.Op == deploy.OpRefresh {
+						refreshed[payload.Metadata.URN] = true
+					}
+					if r := resourceJSONFromEvent(payload, opts); r != nil {
 						resources = append(resources, *r)
+					}
+				}
+			case engine.ResourceOutputsEvent:
+				// Refreshes only discover their changes after reading the
+				// resource: the outputs event carries them, rewritten as an
+				// update or delete. Attach the diff to the entry recorded by
+				// the pre-event.
+				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok && opts.Type == DisplayDiff {
+					m := payload.Metadata
+					if refreshed[m.URN] && ((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {
+						diff := diffJSONFromStep(&m, true /* refresh */, opts.ShowSecrets)
+						for i := range resources {
+							if resources[i].URN == string(m.URN) {
+								resources[i].Diff = diff
+							}
+						}
 					}
 				}
 			case engine.SummaryEvent:

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -66,14 +66,12 @@ type ResourceJSON struct {
 	Op apitype.OpType `json:"op"`
 	// Parent is the URN of this resource's parent, if any.
 	Parent string `json:"parent,omitempty"`
-	// Diff maps property paths to their changes. Only populated when `--diff`
-	// is combined with `--output json`.
+	// Diff maps property paths to their changes; only populated when `--diff` is set.
 	Diff map[string]PropertyDiffJSON `json:"diff,omitempty"`
 }
 
-// PropertyDiffJSON describes the change to a single property path within
-// ResourceJSON.Diff. Old is absent for adds and New is absent for deletes;
-// secret values are masked unless the caller passed `--show-secrets`.
+// PropertyDiffJSON is the change to a single property path in ResourceJSON.Diff.
+// Old is absent for adds, New for deletes.
 type PropertyDiffJSON struct {
 	Kind string `json:"kind"`
 	Old  any    `json:"old,omitzero"`
@@ -120,15 +118,10 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *Reso
 	return &r
 }
 
-// diffJSONFromStep flattens the property changes carried by a step event into
-// the summary's path → change map, drawing on the same sources as the
-// human-readable diff display: the provider's detailed diff when present, and
-// an old-vs-new inputs comparison otherwise. Creates report every input as an
-// add and deletes report every input as a delete. Returns nil when the step
-// carries no property changes.
+// diffJSONFromStep flattens a step's property changes into a path → change map,
+// using the same sources as the human-readable diff display.
 func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) map[string]PropertyDiffJSON {
-	// An OpSame can carry a metadata-only diff (e.g. protect); never report a
-	// property diff for it. See https://github.com/pulumi/pulumi/issues/15944.
+	// An OpSame diff is metadata-only (e.g. protect); see pulumi/pulumi#15944.
 	if m.Op == deploy.OpSame {
 		return nil
 	}
@@ -186,9 +179,6 @@ func diffJSONFromStep(m *engine.StepEventMetadata, refresh, showSecrets bool) ma
 	return out
 }
 
-// propertyValueJSON prepares a property value for JSON output: secrets are
-// masked (unless showSecrets), and unknowns, assets, and resource references
-// are rendered the same way the preview digest renders resource states.
 func propertyValueJSON(v resource.PropertyValue, showSecrets bool) any {
 	serialized, err := stack.SerializePropertyValue(
 		context.TODO(), massagePropertyValue(v, showSecrets), config.NewPanicCrypter(), showSecrets)
@@ -294,10 +284,7 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 					}
 				}
 			case engine.ResourceOutputsEvent:
-				// Refreshes only discover their changes after reading the
-				// resource: the outputs event carries them, rewritten as an
-				// update or delete. Attach the diff to the entry recorded by
-				// the pre-event.
+				// Refresh diffs only arrive on the outputs event, rewritten as an update or delete.
 				if payload, ok := e.Payload().(engine.ResourceOutputsEventPayload); ok && opts.Type == DisplayDiff {
 					m := payload.Metadata
 					if refreshed[m.URN] && ((m.Op == deploy.OpUpdate && m.DetailedDiff != nil) || m.Op == deploy.OpDelete) {

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -250,7 +250,7 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 		var resources []ResourceJSON
 		refreshed := map[resource.URN]bool{}
 		for e := range in {
-			switch e.Type { //nolint:exhaustive // we only care about a few event types here
+			switch e.Type { //nolint:exhaustive
 			case engine.ResourcePreEvent:
 				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
 					if payload.Metadata.Op == deploy.OpRefresh {

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -323,6 +323,51 @@ func TestDiffJSONFromStep_CreateAndDelete(t *testing.T) {
 	assert.Equal(t, map[string]PropertyDiffJSON{"acl": {Kind: "delete", Old: "private"}}, got)
 }
 
+func TestDiffJSONFromStep_OutputsPreferredWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors getResourcePropertiesDetails: once new outputs exist (e.g. a
+	// refresh-discovered update), the diff compares outputs, not inputs.
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	meta := engine.StepEventMetadata{
+		Op:  deploy.OpUpdate,
+		URN: urn,
+		Old: &engine.StepEventStateMetadata{URN: urn, Outputs: resource.PropertyMap{
+			"acl": resource.NewProperty("private"),
+		}},
+		New: &engine.StepEventStateMetadata{URN: urn, Outputs: resource.PropertyMap{
+			"acl": resource.NewProperty("public-read"),
+		}},
+	}
+
+	got := diffJSONFromStep(&meta, true, false)
+	assert.Equal(t, map[string]PropertyDiffJSON{"acl": {Kind: "update", Old: "private", New: "public-read"}}, got)
+}
+
+func TestDiffJSONFromStep_RespectsChangedKeys(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the human display: when the provider reports which keys changed
+	// (step.Diffs), other textual differences are not part of the diff.
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	meta := engine.StepEventMetadata{
+		Op:    deploy.OpUpdate,
+		URN:   urn,
+		Diffs: []resource.PropertyKey{"acl"},
+		Old: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl":  resource.NewProperty("private"),
+			"etag": resource.NewProperty("abc"),
+		}},
+		New: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl":  resource.NewProperty("public-read"),
+			"etag": resource.NewProperty("def"),
+		}},
+	}
+
+	got := diffJSONFromStep(&meta, false, false)
+	assert.Equal(t, map[string]PropertyDiffJSON{"acl": {Kind: "update", Old: "private", New: "public-read"}}, got)
+}
+
 func TestDiffJSONFromStep_SameNeverReportsDiff(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -124,7 +124,7 @@ func TestResourceJSONFromEvent_SkipsInternal(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpCreate, urn, "parent-urn", "", true /* internal */)
 
-	got := resourceJSONFromEvent(payload, Options{})
+	got := resourceJSONFromEvent(payload, false)
 	assert.Nil(t, got, "internal events must not surface in the summary")
 }
 
@@ -134,7 +134,7 @@ func TestResourceJSONFromEvent_SkipsSameByDefault(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
 
-	got := resourceJSONFromEvent(payload, Options{})
+	got := resourceJSONFromEvent(payload, false)
 	assert.Nil(t, got, "same resources are filtered out unless --show-sames is set")
 }
 
@@ -144,7 +144,7 @@ func TestResourceJSONFromEvent_IncludesSameWhenShowSames(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
 
-	got := resourceJSONFromEvent(payload, Options{ShowSameResources: true})
+	got := resourceJSONFromEvent(payload, true)
 	require.NotNil(t, got)
 	assert.Equal(t, apitype.OpType("same"), got.Op)
 }
@@ -156,7 +156,7 @@ func TestResourceJSONFromEvent_ExtractsTypeAndName(t *testing.T) {
 	parentURN := resource.NewURN("dev", "myapp", "", "pulumi:pulumi:Stack", "myapp-dev")
 	payload := makePreEvent(deploy.OpUpdate, urn, parentURN, "", false)
 
-	got := resourceJSONFromEvent(payload, Options{})
+	got := resourceJSONFromEvent(payload, false)
 	require.NotNil(t, got)
 	assert.Equal(t, string(urn), got.URN)
 	assert.Equal(t, "aws:s3/bucket:Bucket", got.Type)
@@ -181,7 +181,7 @@ func TestResourceJSONFromEvent_ParentFallsBackToOldOnDelete(t *testing.T) {
 		},
 	}
 
-	got := resourceJSONFromEvent(payload, Options{})
+	got := resourceJSONFromEvent(payload, false)
 	require.NotNil(t, got)
 	assert.Equal(t, string(parentURN), got.Parent)
 	assert.Equal(t, apitype.OpType("delete"), got.Op)
@@ -386,11 +386,11 @@ func TestDiffJSONFromStep_SameNeverReportsDiff(t *testing.T) {
 	assert.Nil(t, diffJSONFromStep(&meta, false, false))
 }
 
-func TestResourceJSONFromEvent_DiffOnlyInDiffMode(t *testing.T) {
+func TestTapSummaryJSON_DiffOnlyInDiffMode(t *testing.T) {
 	t.Parallel()
 
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
-	payload := engine.ResourcePreEventPayload{
+	pre := engine.ResourcePreEventPayload{
 		Metadata: engine.StepEventMetadata{
 			Op:  deploy.OpUpdate,
 			URN: urn,
@@ -403,13 +403,26 @@ func TestResourceJSONFromEvent_DiffOnlyInDiffMode(t *testing.T) {
 		},
 	}
 
-	got := resourceJSONFromEvent(payload, Options{})
-	require.NotNil(t, got)
-	assert.Nil(t, got.Diff, "diff must not be populated without --diff")
+	run := func(opts Options) SummaryJSON {
+		in := make(chan engine.Event, 2)
+		in <- engine.NewEvent(pre)
+		in <- engine.NewEvent(engine.SummaryEventPayload{Result: apitype.OperationResultSucceeded})
+		close(in)
 
-	got = resourceJSONFromEvent(payload, Options{Type: DisplayDiff})
-	require.NotNil(t, got)
-	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "private", New: "public-read"}, got.Diff["acl"])
+		var buf bytes.Buffer
+		opts.Stdout = &buf
+		for range tapSummaryJSON(in, opts) { //nolint:revive // intentional drain
+		}
+		var summary SummaryJSON
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+		require.Len(t, summary.Resources, 1)
+		return summary
+	}
+
+	assert.Nil(t, run(Options{}).Resources[0].Diff, "diff must not be populated without --diff")
+	assert.Equal(t,
+		PropertyDiffJSON{Kind: "update", Old: "private", New: "public-read"},
+		run(Options{Type: DisplayDiff}).Resources[0].Diff["acl"])
 }
 
 func TestTapSummaryJSON_RefreshDiffFromOutputsEvent(t *testing.T) {

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -123,7 +124,7 @@ func TestResourceJSONFromEvent_SkipsInternal(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpCreate, urn, "parent-urn", "", true /* internal */)
 
-	got := resourceJSONFromEvent(payload, false)
+	got := resourceJSONFromEvent(payload, Options{})
 	assert.Nil(t, got, "internal events must not surface in the summary")
 }
 
@@ -133,7 +134,7 @@ func TestResourceJSONFromEvent_SkipsSameByDefault(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
 
-	got := resourceJSONFromEvent(payload, false /* showSames */)
+	got := resourceJSONFromEvent(payload, Options{})
 	assert.Nil(t, got, "same resources are filtered out unless --show-sames is set")
 }
 
@@ -143,7 +144,7 @@ func TestResourceJSONFromEvent_IncludesSameWhenShowSames(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
 
-	got := resourceJSONFromEvent(payload, true /* showSames */)
+	got := resourceJSONFromEvent(payload, Options{ShowSameResources: true})
 	require.NotNil(t, got)
 	assert.Equal(t, apitype.OpType("same"), got.Op)
 }
@@ -155,7 +156,7 @@ func TestResourceJSONFromEvent_ExtractsTypeAndName(t *testing.T) {
 	parentURN := resource.NewURN("dev", "myapp", "", "pulumi:pulumi:Stack", "myapp-dev")
 	payload := makePreEvent(deploy.OpUpdate, urn, parentURN, "", false)
 
-	got := resourceJSONFromEvent(payload, false)
+	got := resourceJSONFromEvent(payload, Options{})
 	require.NotNil(t, got)
 	assert.Equal(t, string(urn), got.URN)
 	assert.Equal(t, "aws:s3/bucket:Bucket", got.Type)
@@ -180,7 +181,7 @@ func TestResourceJSONFromEvent_ParentFallsBackToOldOnDelete(t *testing.T) {
 		},
 	}
 
-	got := resourceJSONFromEvent(payload, false)
+	got := resourceJSONFromEvent(payload, Options{})
 	require.NotNil(t, got)
 	assert.Equal(t, string(parentURN), got.Parent)
 	assert.Equal(t, apitype.OpType("delete"), got.Op)
@@ -246,6 +247,178 @@ func TestTapSummaryJSON_OmitsResourcesFieldWhenEmpty(t *testing.T) {
 	}
 
 	assert.NotContains(t, buf.String(), `"resources"`)
+}
+
+func TestDiffJSONFromStep_UpdateWithoutDetailedDiff(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	meta := engine.StepEventMetadata{
+		Op:  deploy.OpUpdate,
+		URN: urn,
+		Old: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl":    resource.NewProperty("private"),
+			"tags":   resource.NewProperty(resource.PropertyMap{"env": resource.NewProperty("dev")}),
+			"secret": resource.MakeSecret(resource.NewProperty("hunter2")),
+		}},
+		New: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl": resource.NewProperty("public-read"),
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"env":  resource.NewProperty("dev"),
+				"team": resource.NewProperty("infra"),
+			}),
+		}},
+	}
+
+	got := diffJSONFromStep(&meta, false, false)
+	require.NotNil(t, got)
+
+	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "private", New: "public-read"}, got["acl"])
+	assert.Equal(t, PropertyDiffJSON{Kind: "add", New: "infra"}, got["tags.team"])
+	assert.Equal(t, PropertyDiffJSON{Kind: "delete", Old: "[secret]"}, got["secret"])
+	assert.NotContains(t, got, "tags.env", "unchanged nested properties must not appear")
+}
+
+func TestDiffJSONFromStep_DetailedDiff(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	meta := engine.StepEventMetadata{
+		Op:  deploy.OpUpdate,
+		URN: urn,
+		Old: &engine.StepEventStateMetadata{URN: urn, Outputs: resource.PropertyMap{
+			"acl": resource.NewProperty("private"),
+		}},
+		New: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl": resource.NewProperty("public-read"),
+		}},
+		DetailedDiff: map[string]plugin.PropertyDiff{
+			"acl": {Kind: plugin.DiffUpdate},
+		},
+	}
+
+	got := diffJSONFromStep(&meta, false, false)
+	require.NotNil(t, got)
+	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "private", New: "public-read"}, got["acl"])
+}
+
+func TestDiffJSONFromStep_CreateAndDelete(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	inputs := resource.PropertyMap{"acl": resource.NewProperty("private")}
+
+	create := engine.StepEventMetadata{
+		Op: deploy.OpCreate, URN: urn,
+		New: &engine.StepEventStateMetadata{URN: urn, Inputs: inputs},
+	}
+	got := diffJSONFromStep(&create, false, false)
+	assert.Equal(t, map[string]PropertyDiffJSON{"acl": {Kind: "add", New: "private"}}, got)
+
+	del := engine.StepEventMetadata{
+		Op: deploy.OpDelete, URN: urn,
+		Old: &engine.StepEventStateMetadata{URN: urn, Inputs: inputs},
+	}
+	got = diffJSONFromStep(&del, false, false)
+	assert.Equal(t, map[string]PropertyDiffJSON{"acl": {Kind: "delete", Old: "private"}}, got)
+}
+
+func TestDiffJSONFromStep_SameNeverReportsDiff(t *testing.T) {
+	t.Parallel()
+
+	// An OpSame can surface for metadata-only changes (e.g. protect); it must
+	// never carry a property diff even if inputs appear to differ.
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	meta := engine.StepEventMetadata{
+		Op:  deploy.OpSame,
+		URN: urn,
+		Old: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl": resource.NewProperty("private"),
+		}},
+		New: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+			"acl": resource.NewProperty("public-read"),
+		}},
+	}
+
+	assert.Nil(t, diffJSONFromStep(&meta, false, false))
+}
+
+func TestResourceJSONFromEvent_DiffOnlyInDiffMode(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	payload := engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:  deploy.OpUpdate,
+			URN: urn,
+			Old: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+				"acl": resource.NewProperty("private"),
+			}},
+			New: &engine.StepEventStateMetadata{URN: urn, Inputs: resource.PropertyMap{
+				"acl": resource.NewProperty("public-read"),
+			}},
+		},
+	}
+
+	got := resourceJSONFromEvent(payload, Options{})
+	require.NotNil(t, got)
+	assert.Nil(t, got.Diff, "diff must not be populated without --diff")
+
+	got = resourceJSONFromEvent(payload, Options{Type: DisplayDiff})
+	require.NotNil(t, got)
+	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "private", New: "public-read"}, got.Diff["acl"])
+}
+
+func TestTapSummaryJSON_RefreshDiffFromOutputsEvent(t *testing.T) {
+	t.Parallel()
+
+	// Refresh discovers changes after reading the resource: the pre-event has
+	// op `refresh` and no diff; the outputs event is rewritten to an update
+	// carrying the detailed diff, which the tap attaches to the entry.
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	pre := engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:  deploy.OpRefresh,
+			URN: urn,
+			Old: &engine.StepEventStateMetadata{URN: urn},
+			New: &engine.StepEventStateMetadata{URN: urn},
+		},
+	}
+	outputs := engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:  deploy.OpUpdate,
+			URN: urn,
+			Old: &engine.StepEventStateMetadata{URN: urn, Outputs: resource.PropertyMap{
+				"acl": resource.NewProperty("private"),
+			}},
+			New: &engine.StepEventStateMetadata{URN: urn, Outputs: resource.PropertyMap{
+				"acl": resource.NewProperty("public-read"),
+			}},
+			DetailedDiff: map[string]plugin.PropertyDiff{
+				"acl": {Kind: plugin.DiffUpdate},
+			},
+		},
+	}
+
+	in := make(chan engine.Event, 3)
+	in <- engine.NewEvent(pre)
+	in <- engine.NewEvent(outputs)
+	in <- engine.NewEvent(engine.SummaryEventPayload{
+		Result:          apitype.OperationResultSucceeded,
+		ResourceChanges: display.ResourceChanges{"update": 1},
+	})
+	close(in)
+
+	var buf bytes.Buffer
+	out := tapSummaryJSON(in, Options{Stdout: &buf, Type: DisplayDiff})
+	for range out { //nolint:revive // intentional drain
+	}
+
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	require.Len(t, summary.Resources, 1)
+	assert.Equal(t, apitype.OpType("refresh"), summary.Resources[0].Op)
+	assert.Equal(t, PropertyDiffJSON{Kind: "update", Old: "private", New: "public-read"}, summary.Resources[0].Diff["acl"])
 }
 
 func TestTapSummaryJSON_ReturnsOnCancelEvent(t *testing.T) {

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -326,8 +326,6 @@ func TestDiffJSONFromStep_CreateAndDelete(t *testing.T) {
 func TestDiffJSONFromStep_SameNeverReportsDiff(t *testing.T) {
 	t.Parallel()
 
-	// An OpSame can surface for metadata-only changes (e.g. protect); it must
-	// never carry a property diff even if inputs appear to differ.
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	meta := engine.StepEventMetadata{
 		Op:  deploy.OpSame,
@@ -372,9 +370,6 @@ func TestResourceJSONFromEvent_DiffOnlyInDiffMode(t *testing.T) {
 func TestTapSummaryJSON_RefreshDiffFromOutputsEvent(t *testing.T) {
 	t.Parallel()
 
-	// Refresh discovers changes after reading the resource: the pre-event has
-	// op `refresh` and no diff; the outputs event is rewritten to an update
-	// carrying the detailed diff, which the tap attaches to the entry.
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	pre := engine.ResourcePreEventPayload{
 		Metadata: engine.StepEventMetadata{


### PR DESCRIPTION
Part of #24263. This PR allows `--diff` to work with `--output json` for standard operations. Next, we'll implement `--diff` for `stack history events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

```json
{
  "result": "succeeded",
  "duration": 2006662792,
  "summary": {
    "replace": 1,
    "same": 1
  },
  "resources": [
    {
      "urn": "urn:pulumi:dev::echo-demo::testprovider:index:Echo::role-policy",
      "type": "testprovider:index:Echo",
      "name": "role-policy",
      "op": "create-replacement",
      "parent": "urn:pulumi:dev::echo-demo::pulumi:pulumi:Stack::echo-demo-dev",
      "diff": {
        "echo.Statement[0].Condition": {
          "kind": "add",
          "new": {
            "StringEquals": {
              "aws:SourceAccount": "123456789012"
            }
          }
        },
        "echo.Statement[0].Principal.Service": {
          "kind": "update",
          "old": "lambda.amazonaws.com",
          "new": [
            "lambda.amazonaws.com",
            "ecs-tasks.amazonaws.com"
          ]
        }
      }
    },
    {
      "urn": "urn:pulumi:dev::echo-demo::testprovider:index:Echo::role-policy",
      "type": "testprovider:index:Echo",
      "name": "role-policy",
      "op": "replace",
      "parent": "urn:pulumi:dev::echo-demo::pulumi:pulumi:Stack::echo-demo-dev",
      "diff": {
        "echo.Statement[0].Condition": {
          "kind": "add",
          "new": {
            "StringEquals": {
              "aws:SourceAccount": "123456789012"
            }
          }
        },
        "echo.Statement[0].Principal.Service": {
          "kind": "update",
          "old": "lambda.amazonaws.com",
          "new": [
            "lambda.amazonaws.com",
            "ecs-tasks.amazonaws.com"
          ]
        }
      }
    },
    {
      "urn": "urn:pulumi:dev::echo-demo::testprovider:index:Echo::role-policy",
      "type": "testprovider:index:Echo",
      "name": "role-policy",
      "op": "delete-replaced",
      "parent": "urn:pulumi:dev::echo-demo::pulumi:pulumi:Stack::echo-demo-dev",
      "diff": {
        "echo": {
          "kind": "delete",
          "old": {
            "Statement": [
              {
                "Action": "sts:AssumeRole",
                "Effect": "Allow",
                "Principal": {
                  "Service": "lambda.amazonaws.com"
                }
              }
            ]
          }
        }
      }
    }
  ]
}
```