### PR TITLE
Support kebab-case property names across code generators

### DIFF
--- a/changelog/pending/20260812--programgen-go--kebab-property-names.yaml
+++ b/changelog/pending/20260812--programgen-go--kebab-property-names.yaml
@@ -1,0 +1,4 @@
+component: programgen/go
+kind: fix
+body: Generate valid struct field names for properties whose names contain hyphens
+time: 2026-08-12T00:00:00Z

--- a/changelog/pending/20260812--programgen-python--kebab-property-names.yaml
+++ b/changelog/pending/20260812--programgen-python--kebab-property-names.yaml
@@ -1,0 +1,5 @@
+component: programgen/python
+kind: fix
+body: Access schema properties whose names contain hyphens as attributes under their
+    Python names instead of subscripting
+time: 2026-08-12T00:00:00Z

--- a/changelog/pending/20260812--sdkgen-nodejs--kebab-property-names.yaml
+++ b/changelog/pending/20260812--sdkgen-nodejs--kebab-property-names.yaml
@@ -1,0 +1,5 @@
+component: sdkgen/nodejs
+kind: fix
+body: Quote property names that are not legal identifiers (e.g. kebab-case) in generated
+    declarations and use bracket access for them
+time: 2026-08-12T00:00:00Z

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -2191,7 +2191,7 @@ func (g *generator) genComponent(w io.Writer, r *pcl.Component) {
 		if len(componentInputs) > 0 {
 			g.Fgenf(w, "&%sArgs{\n", componentName)
 			for _, attr := range componentInputs {
-				g.Fgenf(w, "%s: %.v,\n", strings.Title(attr.Name), attr.Value)
+				g.Fgenf(w, "%s: %.v,\n", Title(attr.Name), attr.Value)
 			}
 			g.Fprint(w, "}")
 		} else {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -486,7 +486,7 @@ func (mod *modContext) genPlainType(w io.Writer, name, comment string,
 		}
 
 		typ := mod.typeString(propertyType, input, p.ConstValue)
-		fmt.Fprintf(w, "%s    %s%s%s: %s;\n", indent, prefix, p.Name, sigil, typ)
+		fmt.Fprintf(w, "%s    %s%s%s: %s;\n", indent, prefix, propertyName(p.Name), sigil, typ)
 	}
 	fmt.Fprintf(w, "%s}\n", indent)
 	return nil
@@ -760,7 +760,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		if mod.compatibility == kubernetes20 {
 			propertyType = codegen.RequiredType(prop)
 		}
-		fmt.Fprintf(w, "    declare public %sreadonly %s: pulumi.Output<%s>;\n", outcomment, prop.Name, mod.typeString(propertyType, false, prop.ConstValue))
+		fmt.Fprintf(w, "    declare public %sreadonly %s: pulumi.Output<%s>;\n", outcomment, propertyName(prop.Name), mod.typeString(propertyType, false, prop.ConstValue))
 	}
 	fmt.Fprintf(w, "\n")
 
@@ -804,7 +804,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 	genInputProps := func() error {
 		for _, prop := range r.InputProperties {
 			if prop.IsRequired() {
-				fmt.Fprintf(w, "            if (args?.%s === undefined && !opts.urn) {\n", prop.Name)
+				fmt.Fprintf(w, "            if (args%s === undefined && !opts.urn) {\n", optionalPropertyAccessor(prop.Name))
 				fmt.Fprintf(w, "                throw new Error(\"Missing required property '%s'\");\n", prop.Name)
 				fmt.Fprintf(w, "            }\n")
 			}
@@ -827,13 +827,14 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 				return arg
 			}
 
-			argRef := "args." + prop.Name
+			argRef := "args" + propertyAccessor(prop.Name)
 			argValue := applyDefaults(argRef)
 			if prop.Secret {
-				arg = fmt.Sprintf("args?.%[1]s ? pulumi.secret(%[2]s) : undefined", prop.Name, argValue)
+				arg = fmt.Sprintf("args%[1]s ? pulumi.secret(%[2]s) : undefined",
+					optionalPropertyAccessor(prop.Name), argValue)
 			} else {
 				if argRef == argValue {
-					arg = "args?." + prop.Name
+					arg = "args" + optionalPropertyAccessor(prop.Name)
 				} else {
 					arg = fmt.Sprintf("args ? %[1]s : undefined", argValue)
 				}
@@ -899,7 +900,8 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 			stateInputNames := codegen.NewStringSet()
 			for _, prop := range r.StateInputs.Properties {
 				stateInputNames.Add(prop.Name)
-				fmt.Fprintf(w, "            resourceInputs[\"%[1]s\"] = state?.%[1]s;\n", prop.Name)
+				fmt.Fprintf(w, "            resourceInputs[\"%s\"] = state%s;\n",
+					prop.Name, optionalPropertyAccessor(prop.Name))
 			}
 			// Add resolvers for output-only properties so that they resolve to unknown
 			// during a preview when the id is unknown.

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -67,10 +67,10 @@ func isLegalIdentifierPart(c rune) bool {
 
 // isLegalIdentifier returns true if s is a legal JavaScript identifier as per ECMA-262.
 func isLegalIdentifier(s string) bool {
-	if isReservedWord(s) {
-		return false
-	}
+	return !isReservedWord(s) && isLegalIdentifierName(s)
+}
 
+func isLegalIdentifierName(s string) bool {
 	reader := strings.NewReader(s)
 	c, _, _ := reader.ReadRune()
 	if !isLegalIdentifierStart(c) {
@@ -106,6 +106,27 @@ func makeValidIdentifier(name string) string {
 		return "_" + name
 	}
 	return name
+}
+
+func propertyName(name string) string {
+	if isLegalIdentifierName(name) {
+		return name
+	}
+	return fmt.Sprintf("%q", name)
+}
+
+func propertyAccessor(name string) string {
+	if isLegalIdentifierName(name) {
+		return "." + name
+	}
+	return fmt.Sprintf("[%q]", name)
+}
+
+func optionalPropertyAccessor(name string) string {
+	if isLegalIdentifierName(name) {
+		return "?." + name
+	}
+	return fmt.Sprintf("?.[%q]", name)
 }
 
 // makeValidModuleSegment converts one `/`-separated segment of a module path into the (possibly

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -82,7 +82,7 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 			}
 		}
 
-		if objectKey && isLegalIdentifier(keyVal) {
+		if objectKey && isLegalIdentifier(PyName(keyVal)) {
 			currentTraversal = append(currentTraversal, traverser)
 			currentParts = append(currentParts, parts[i+1])
 			continue

--- a/pkg/testing/pulumi-test-language/providers/kebab_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/kebab_names_provider.go
@@ -29,9 +29,8 @@ import (
 )
 
 // KebabNamesProvider is used to test that kebab-case names are handled correctly across sdk-gen and
-// program-gen: in the package name and module names. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// program-gen: in the package name, module names and property names. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 type KebabNamesProvider struct {
 	plugin.UnimplementedProvider
 }
@@ -59,22 +58,22 @@ func (p *KebabNamesProvider) GetSchema(
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
-						"nestedValue": {
+						"nested-value": {
 							TypeSpec: schema.TypeSpec{Type: "string"},
 						},
 					},
-					Required: []string{"nestedValue"},
+					Required: []string{"nested-value"},
 				},
 			},
 			"kebab-names:kebab-module:outputItem": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
-						"nestedOutput": {
+						"nested-output": {
 							TypeSpec: schema.TypeSpec{Type: "string"},
 						},
 					},
-					Required: []string{"nestedOutput"},
+					Required: []string{"nested-output"},
 				},
 			},
 		},
@@ -83,16 +82,16 @@ func (p *KebabNamesProvider) GetSchema(
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
-						"theOutput": {
+						"the-output": {
 							TypeSpec: schema.TypeSpec{
 								Ref: "#/types/kebab-names:kebab-module:outputItem",
 							},
 						},
 					},
-					Required: []string{"theOutput"},
+					Required: []string{"the-output"},
 				},
 				InputProperties: map[string]schema.PropertySpec{
-					"theInput": {
+					"the-input": {
 						TypeSpec: schema.TypeSpec{Type: "boolean"},
 					},
 					"nested": {
@@ -101,24 +100,24 @@ func (p *KebabNamesProvider) GetSchema(
 						},
 					},
 				},
-				RequiredInputs: []string{"theInput", "nested"},
+				RequiredInputs: []string{"the-input", "nested"},
 			},
 			"kebab-names:kebab-module:anotherResource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
-						"theInput": {
+						"the-input": {
 							TypeSpec: schema.TypeSpec{Type: "string"},
 						},
 					},
-					Required: []string{"theInput"},
+					Required: []string{"the-input"},
 				},
 				InputProperties: map[string]schema.PropertySpec{
-					"theInput": {
+					"the-input": {
 						TypeSpec: schema.TypeSpec{Type: "string"},
 					},
 				},
-				RequiredInputs: []string{"theInput"},
+				RequiredInputs: []string{"the-input"},
 			},
 		},
 	}
@@ -159,9 +158,9 @@ func (p *KebabNamesProvider) Check(
 ) (plugin.CheckResponse, error) {
 	switch typ := req.URN.Type(); typ {
 	case "kebab-names:kebab-module:someResource":
-		if _, ok := req.News["theInput"]; !ok {
+		if _, ok := req.News["the-input"]; !ok {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("theInput", "missing theInput"),
+				Failures: makeCheckFailure("the-input", "missing the-input"),
 			}, nil
 		}
 		if _, ok := req.News["nested"]; !ok {
@@ -176,9 +175,9 @@ func (p *KebabNamesProvider) Check(
 		}
 		return plugin.CheckResponse{Properties: req.News}, nil
 	case "kebab-names:kebab-module:anotherResource":
-		if _, ok := req.News["theInput"]; !ok {
+		if _, ok := req.News["the-input"]; !ok {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("theInput", "missing theInput"),
+				Failures: makeCheckFailure("the-input", "missing the-input"),
 			}, nil
 		}
 		if len(req.News) != 1 {
@@ -210,25 +209,25 @@ func (p *KebabNamesProvider) Create(
 		if !ok {
 			return plugin.CreateResponse{Status: resource.StatusUnknown}, errors.New("missing nested property")
 		}
-		nestedValue := nested.ObjectValue()["nestedValue"].StringValue()
+		nestedValue := nested.ObjectValue()["nested-value"].StringValue()
 		return plugin.CreateResponse{
 			ID: resource.ID(id),
 			Properties: resource.PropertyMap{
-				"theOutput": resource.NewProperty(resource.PropertyMap{
-					"nestedOutput": resource.NewProperty(nestedValue),
+				"the-output": resource.NewProperty(resource.PropertyMap{
+					"nested-output": resource.NewProperty(nestedValue),
 				}),
 			},
 			Status: resource.StatusOK,
 		}, nil
 	case "kebab-names:kebab-module:anotherResource":
-		theInput, ok := req.Properties["theInput"]
+		theInput, ok := req.Properties["the-input"]
 		if !ok {
-			return plugin.CreateResponse{Status: resource.StatusUnknown}, errors.New("missing theInput property")
+			return plugin.CreateResponse{Status: resource.StatusUnknown}, errors.New("missing the-input property")
 		}
 		return plugin.CreateResponse{
 			ID: resource.ID(id),
 			Properties: resource.PropertyMap{
-				"theInput": theInput,
+				"the-input": theInput,
 			},
 			Status: resource.StatusOK,
 		}, nil

--- a/pkg/testing/pulumi-test-language/tests/l2_kebab_names.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_kebab_names.go
@@ -38,29 +38,29 @@ func init() {
 					second := RequireSingleNamedResource(l, res.Snap.Resources, "second")
 
 					assert.Equal(l, resource.PropertyMap{
-						"theInput": resource.NewProperty(true),
+						"the-input": resource.NewProperty(true),
 						"nested": resource.NewProperty(resource.PropertyMap{
-							"nestedValue": resource.NewProperty("nested"),
+							"nested-value": resource.NewProperty("nested"),
 						}),
 					}, first.Inputs)
 
 					assert.Equal(l, resource.PropertyMap{
-						"theOutput": resource.NewProperty(resource.PropertyMap{
-							"nestedOutput": resource.NewProperty("nested"),
+						"the-output": resource.NewProperty(resource.PropertyMap{
+							"nested-output": resource.NewProperty("nested"),
 						}),
 					}, first.Outputs)
 
 					assert.Equal(l, resource.PropertyMap{
-						"theInput": resource.NewProperty("nested"),
+						"the-input": resource.NewProperty("nested"),
 					}, second.Inputs)
 
 					assert.Equal(l, resource.PropertyMap{
-						"theInput": resource.NewProperty("nested"),
+						"the-input": resource.NewProperty("nested"),
 					}, second.Outputs)
 
 					stack := RequireSingleResource(l, res.Snap.Resources, "pulumi:pulumi:Stack")
 					AssertPropertyMapMember(l, stack.Outputs, "theOutput", resource.NewProperty(resource.PropertyMap{
-						"nestedOutput": resource.NewProperty("nested"),
+						"nested-output": resource.NewProperty("nested"),
 					}))
 				},
 			},

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-kebab-names/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-kebab-names/main.pp
@@ -1,18 +1,17 @@
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 resource "first" "kebab-names:kebab-module:someResource" {
-    theInput = true
+    the-input = true
     nested = {
-        nestedValue = "nested"
+        nested-value = "nested"
     }
 }
 
 resource "second" "kebab-names:kebab-module:anotherResource" {
-    theInput = first.theOutput.nestedOutput
+    the-input = first.the-output.nested-output
 }
 
 // Whole objects in stack outputs keep their wire-format keys
 output "theOutput" {
-    value = first.theOutput
+    value = first.the-output
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-kebab-names/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-kebab-names/main.go
@@ -7,9 +7,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		// The package name and module name are kebab-case. Resource and object type names cannot be
-		// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-		// property names are not yet handled by all code generators.
+		// The package name, module name and property names are kebab-case. Resource and object type names
+		// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 		first, err := kebabmodule.NewSomeResource(ctx, "first", &kebabmodule.SomeResourceArgs{
 			TheInput: pulumi.Bool(true),
 			Nested: &kebabmodule.NestedInputArgs{

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/kebab-names-52.0.0/kebabnames/kebab-module/anotherResource.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/kebab-names-52.0.0/kebabnames/kebab-module/anotherResource.go
@@ -15,7 +15,7 @@ import (
 type AnotherResource struct {
 	pulumi.CustomResourceState
 
-	TheInput pulumi.StringOutput `pulumi:"theInput"`
+	TheInput pulumi.StringOutput `pulumi:"the-input"`
 }
 
 // NewAnotherResource registers a new resource with the given unique name, arguments, and options.
@@ -61,7 +61,7 @@ func (AnotherResourceState) ElementType() reflect.Type {
 }
 
 type anotherResourceArgs struct {
-	TheInput string `pulumi:"theInput"`
+	TheInput string `pulumi:"the-input"`
 }
 
 // The set of arguments for constructing a AnotherResource resource.

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/kebab-names-52.0.0/kebabnames/kebab-module/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/kebab-names-52.0.0/kebabnames/kebab-module/pulumiTypes.go
@@ -14,7 +14,7 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type NestedInput struct {
-	NestedValue string `pulumi:"nestedValue"`
+	NestedValue string `pulumi:"nested-value"`
 }
 
 // NestedInputInput is an input type that accepts NestedInputArgs and NestedInputOutput values.
@@ -29,7 +29,7 @@ type NestedInputInput interface {
 }
 
 type NestedInputArgs struct {
-	NestedValue pulumi.StringInput `pulumi:"nestedValue"`
+	NestedValue pulumi.StringInput `pulumi:"nested-value"`
 }
 
 func (NestedInputArgs) ElementType() reflect.Type {
@@ -63,7 +63,7 @@ func (o NestedInputOutput) NestedValue() pulumi.StringOutput {
 }
 
 type OutputItem struct {
-	NestedOutput string `pulumi:"nestedOutput"`
+	NestedOutput string `pulumi:"nested-output"`
 }
 
 type OutputItemOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/kebab-names-52.0.0/kebabnames/kebab-module/someResource.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/kebab-names-52.0.0/kebabnames/kebab-module/someResource.go
@@ -15,7 +15,7 @@ import (
 type SomeResource struct {
 	pulumi.CustomResourceState
 
-	TheOutput OutputItemOutput `pulumi:"theOutput"`
+	TheOutput OutputItemOutput `pulumi:"the-output"`
 }
 
 // NewSomeResource registers a new resource with the given unique name, arguments, and options.
@@ -65,7 +65,7 @@ func (SomeResourceState) ElementType() reflect.Type {
 
 type someResourceArgs struct {
 	Nested   NestedInput `pulumi:"nested"`
-	TheInput bool        `pulumi:"theInput"`
+	TheInput bool        `pulumi:"the-input"`
 }
 
 // The set of arguments for constructing a SomeResource resource.

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/main.go
@@ -7,9 +7,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		// The package name and module name are kebab-case. Resource and object type names cannot be
-		// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-		// property names are not yet handled by all code generators.
+		// The package name, module name and property names are kebab-case. Resource and object type names
+		// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 		first, err := kebabmodule.NewSomeResource(ctx, "first", &kebabmodule.SomeResourceArgs{
 			TheInput: pulumi.Bool(true),
 			Nested: &kebabmodule.NestedInputArgs{

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/sdks/kebab-names-52.0.0/kebabnames/kebab-module/anotherResource.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/sdks/kebab-names-52.0.0/kebabnames/kebab-module/anotherResource.go
@@ -15,7 +15,7 @@ import (
 type AnotherResource struct {
 	pulumi.CustomResourceState
 
-	TheInput pulumi.StringOutput `pulumi:"theInput"`
+	TheInput pulumi.StringOutput `pulumi:"the-input"`
 }
 
 // NewAnotherResource registers a new resource with the given unique name, arguments, and options.
@@ -61,7 +61,7 @@ func (AnotherResourceState) ElementType() reflect.Type {
 }
 
 type anotherResourceArgs struct {
-	TheInput string `pulumi:"theInput"`
+	TheInput string `pulumi:"the-input"`
 }
 
 // The set of arguments for constructing a AnotherResource resource.

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/sdks/kebab-names-52.0.0/kebabnames/kebab-module/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/sdks/kebab-names-52.0.0/kebabnames/kebab-module/pulumiTypes.go
@@ -14,7 +14,7 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type NestedInput struct {
-	NestedValue string `pulumi:"nestedValue"`
+	NestedValue string `pulumi:"nested-value"`
 }
 
 // NestedInputInput is an input type that accepts NestedInputArgs and NestedInputOutput values.
@@ -29,7 +29,7 @@ type NestedInputInput interface {
 }
 
 type NestedInputArgs struct {
-	NestedValue pulumi.StringInput `pulumi:"nestedValue"`
+	NestedValue pulumi.StringInput `pulumi:"nested-value"`
 }
 
 func (NestedInputArgs) ElementType() reflect.Type {
@@ -63,7 +63,7 @@ func (o NestedInputOutput) NestedValue() pulumi.StringOutput {
 }
 
 type OutputItem struct {
-	NestedOutput string `pulumi:"nestedOutput"`
+	NestedOutput string `pulumi:"nested-output"`
 }
 
 type OutputItemOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/sdks/kebab-names-52.0.0/kebabnames/kebab-module/someResource.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-kebab-names/sdks/kebab-names-52.0.0/kebabnames/kebab-module/someResource.go
@@ -15,7 +15,7 @@ import (
 type SomeResource struct {
 	pulumi.CustomResourceState
 
-	TheOutput OutputItemOutput `pulumi:"theOutput"`
+	TheOutput OutputItemOutput `pulumi:"the-output"`
 }
 
 // NewSomeResource registers a new resource with the given unique name, arguments, and options.
@@ -65,7 +65,7 @@ func (SomeResourceState) ElementType() reflect.Type {
 
 type someResourceArgs struct {
 	Nested   NestedInput `pulumi:"nested"`
-	TheInput bool        `pulumi:"theInput"`
+	TheInput bool        `pulumi:"the-input"`
 }
 
 // The set of arguments for constructing a SomeResource resource.

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-kebab-names/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-kebab-names/main.go
@@ -7,9 +7,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		// The package name and module name are kebab-case. Resource and object type names cannot be
-		// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-		// property names are not yet handled by all code generators.
+		// The package name, module name and property names are kebab-case. Resource and object type names
+		// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 		first, err := kebabmodule.NewSomeResource(ctx, "first", &kebabmodule.SomeResourceArgs{
 			TheInput: pulumi.Bool(true),
 			Nested: &kebabmodule.NestedInputArgs{

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/kebab-names-52.0.0/kebabnames/kebab-module/anotherResource.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/kebab-names-52.0.0/kebabnames/kebab-module/anotherResource.go
@@ -15,7 +15,7 @@ import (
 type AnotherResource struct {
 	pulumi.CustomResourceState
 
-	TheInput pulumi.StringOutput `pulumi:"theInput"`
+	TheInput pulumi.StringOutput `pulumi:"the-input"`
 }
 
 // NewAnotherResource registers a new resource with the given unique name, arguments, and options.
@@ -61,7 +61,7 @@ func (AnotherResourceState) ElementType() reflect.Type {
 }
 
 type anotherResourceArgs struct {
-	TheInput string `pulumi:"theInput"`
+	TheInput string `pulumi:"the-input"`
 }
 
 // The set of arguments for constructing a AnotherResource resource.

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/kebab-names-52.0.0/kebabnames/kebab-module/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/kebab-names-52.0.0/kebabnames/kebab-module/pulumiTypes.go
@@ -14,7 +14,7 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type NestedInput struct {
-	NestedValue string `pulumi:"nestedValue"`
+	NestedValue string `pulumi:"nested-value"`
 }
 
 // NestedInputInput is an input type that accepts NestedInputArgs and NestedInputOutput values.
@@ -29,7 +29,7 @@ type NestedInputInput interface {
 }
 
 type NestedInputArgs struct {
-	NestedValue pulumi.StringInput `pulumi:"nestedValue"`
+	NestedValue pulumi.StringInput `pulumi:"nested-value"`
 }
 
 func (NestedInputArgs) ElementType() reflect.Type {
@@ -63,7 +63,7 @@ func (o NestedInputOutput) NestedValue() pulumi.StringOutput {
 }
 
 type OutputItem struct {
-	NestedOutput string `pulumi:"nestedOutput"`
+	NestedOutput string `pulumi:"nested-output"`
 }
 
 type OutputItemOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/kebab-names-52.0.0/kebabnames/kebab-module/someResource.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/kebab-names-52.0.0/kebabnames/kebab-module/someResource.go
@@ -15,7 +15,7 @@ import (
 type SomeResource struct {
 	pulumi.CustomResourceState
 
-	TheOutput OutputItemOutput `pulumi:"theOutput"`
+	TheOutput OutputItemOutput `pulumi:"the-output"`
 }
 
 // NewSomeResource registers a new resource with the given unique name, arguments, and options.
@@ -65,7 +65,7 @@ func (SomeResourceState) ElementType() reflect.Type {
 
 type someResourceArgs struct {
 	Nested   NestedInput `pulumi:"nested"`
-	TheInput bool        `pulumi:"theInput"`
+	TheInput bool        `pulumi:"the-input"`
 }
 
 // The set of arguments for constructing a SomeResource resource.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-kebab-names/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-kebab-names/index.ts
@@ -1,14 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as kebab_names from "@pulumi/kebab-names";
 
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 const first = new kebab_names.kebab_module.SomeResource("first", {
-    theInput: true,
+    "the-input": true,
     nested: {
-        nestedValue: "nested",
+        "nested-value": "nested",
     },
 });
-const second = new kebab_names.kebab_module.AnotherResource("second", {theInput: first.theOutput.nestedOutput});
-export const theOutput = first.theOutput;
+const second = new kebab_names.kebab_module.AnotherResource("second", {"the-input": first["the-output"]["nested-output"]});
+export const theOutput = first["the-output"];

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/kebab-module/anotherResource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/kebab-module/anotherResource.ts
@@ -31,7 +31,7 @@ export class AnotherResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === AnotherResource.__pulumiType;
     }
 
-    declare public readonly theInput: pulumi.Output<string>;
+    declare public readonly "the-input": pulumi.Output<string>;
 
     /**
      * Create a AnotherResource resource with the given unique name, arguments, and options.
@@ -44,12 +44,12 @@ export class AnotherResource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if (args?.theInput === undefined && !opts.urn) {
-                throw new Error("Missing required property 'theInput'");
+            if (args?.["the-input"] === undefined && !opts.urn) {
+                throw new Error("Missing required property 'the-input'");
             }
-            resourceInputs["theInput"] = args?.theInput;
+            resourceInputs["the-input"] = args?.["the-input"];
         } else {
-            resourceInputs["theInput"] = undefined /*out*/;
+            resourceInputs["the-input"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(AnotherResource.__pulumiType, name, resourceInputs, opts);
@@ -60,5 +60,5 @@ export class AnotherResource extends pulumi.CustomResource {
  * The set of arguments for constructing a AnotherResource resource.
  */
 export interface AnotherResourceArgs {
-    theInput: pulumi.Input<string>;
+    "the-input": pulumi.Input<string>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/kebab-module/someResource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/kebab-module/someResource.ts
@@ -33,7 +33,7 @@ export class SomeResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === SomeResource.__pulumiType;
     }
 
-    declare public /*out*/ readonly theOutput: pulumi.Output<outputs.kebab_module.OutputItem>;
+    declare public /*out*/ readonly "the-output": pulumi.Output<outputs.kebab_module.OutputItem>;
 
     /**
      * Create a SomeResource resource with the given unique name, arguments, and options.
@@ -49,14 +49,14 @@ export class SomeResource extends pulumi.CustomResource {
             if (args?.nested === undefined && !opts.urn) {
                 throw new Error("Missing required property 'nested'");
             }
-            if (args?.theInput === undefined && !opts.urn) {
-                throw new Error("Missing required property 'theInput'");
+            if (args?.["the-input"] === undefined && !opts.urn) {
+                throw new Error("Missing required property 'the-input'");
             }
             resourceInputs["nested"] = args?.nested;
-            resourceInputs["theInput"] = args?.theInput;
-            resourceInputs["theOutput"] = undefined /*out*/;
+            resourceInputs["the-input"] = args?.["the-input"];
+            resourceInputs["the-output"] = undefined /*out*/;
         } else {
-            resourceInputs["theOutput"] = undefined /*out*/;
+            resourceInputs["the-output"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(SomeResource.__pulumiType, name, resourceInputs, opts);
@@ -68,5 +68,5 @@ export class SomeResource extends pulumi.CustomResource {
  */
 export interface SomeResourceArgs {
     nested: pulumi.Input<inputs.kebab_module.NestedInputArgs>;
-    theInput: pulumi.Input<boolean>;
+    "the-input": pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/types/input.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/types/input.ts
@@ -7,7 +7,7 @@ import * as outputs from "../types/output";
 
 export namespace kebab_module {
     export interface NestedInputArgs {
-        nestedValue: pulumi.Input<string>;
+        "nested-value": pulumi.Input<string>;
     }
 
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/types/output.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/kebab-names-52.0.0/types/output.ts
@@ -7,7 +7,7 @@ import * as outputs from "../types/output";
 
 export namespace kebab_module {
     export interface OutputItem {
-        nestedOutput: string;
+        "nested-output": string;
     }
 
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-kebab-names/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-kebab-names/index.ts
@@ -1,14 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as kebab_names from "@pulumi/kebab-names";
 
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 const first = new kebab_names.kebab_module.SomeResource("first", {
-    theInput: true,
+    "the-input": true,
     nested: {
-        nestedValue: "nested",
+        "nested-value": "nested",
     },
 });
-const second = new kebab_names.kebab_module.AnotherResource("second", {theInput: first.theOutput.nestedOutput});
-export const theOutput = first.theOutput;
+const second = new kebab_names.kebab_module.AnotherResource("second", {"the-input": first["the-output"]["nested-output"]});
+export const theOutput = first["the-output"];

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/kebab-module/anotherResource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/kebab-module/anotherResource.ts
@@ -31,7 +31,7 @@ export class AnotherResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === AnotherResource.__pulumiType;
     }
 
-    declare public readonly theInput: pulumi.Output<string>;
+    declare public readonly "the-input": pulumi.Output<string>;
 
     /**
      * Create a AnotherResource resource with the given unique name, arguments, and options.
@@ -44,12 +44,12 @@ export class AnotherResource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if (args?.theInput === undefined && !opts.urn) {
-                throw new Error("Missing required property 'theInput'");
+            if (args?.["the-input"] === undefined && !opts.urn) {
+                throw new Error("Missing required property 'the-input'");
             }
-            resourceInputs["theInput"] = args?.theInput;
+            resourceInputs["the-input"] = args?.["the-input"];
         } else {
-            resourceInputs["theInput"] = undefined /*out*/;
+            resourceInputs["the-input"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(AnotherResource.__pulumiType, name, resourceInputs, opts);
@@ -60,5 +60,5 @@ export class AnotherResource extends pulumi.CustomResource {
  * The set of arguments for constructing a AnotherResource resource.
  */
 export interface AnotherResourceArgs {
-    theInput: pulumi.Input<string>;
+    "the-input": pulumi.Input<string>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/kebab-module/someResource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/kebab-module/someResource.ts
@@ -33,7 +33,7 @@ export class SomeResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === SomeResource.__pulumiType;
     }
 
-    declare public /*out*/ readonly theOutput: pulumi.Output<outputs.kebab_module.OutputItem>;
+    declare public /*out*/ readonly "the-output": pulumi.Output<outputs.kebab_module.OutputItem>;
 
     /**
      * Create a SomeResource resource with the given unique name, arguments, and options.
@@ -49,14 +49,14 @@ export class SomeResource extends pulumi.CustomResource {
             if (args?.nested === undefined && !opts.urn) {
                 throw new Error("Missing required property 'nested'");
             }
-            if (args?.theInput === undefined && !opts.urn) {
-                throw new Error("Missing required property 'theInput'");
+            if (args?.["the-input"] === undefined && !opts.urn) {
+                throw new Error("Missing required property 'the-input'");
             }
             resourceInputs["nested"] = args?.nested;
-            resourceInputs["theInput"] = args?.theInput;
-            resourceInputs["theOutput"] = undefined /*out*/;
+            resourceInputs["the-input"] = args?.["the-input"];
+            resourceInputs["the-output"] = undefined /*out*/;
         } else {
-            resourceInputs["theOutput"] = undefined /*out*/;
+            resourceInputs["the-output"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(SomeResource.__pulumiType, name, resourceInputs, opts);
@@ -68,5 +68,5 @@ export class SomeResource extends pulumi.CustomResource {
  */
 export interface SomeResourceArgs {
     nested: pulumi.Input<inputs.kebab_module.NestedInputArgs>;
-    theInput: pulumi.Input<boolean>;
+    "the-input": pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/types/input.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/types/input.ts
@@ -7,7 +7,7 @@ import * as outputs from "../types/output";
 
 export namespace kebab_module {
     export interface NestedInputArgs {
-        nestedValue: pulumi.Input<string>;
+        "nested-value": pulumi.Input<string>;
     }
 
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/types/output.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/kebab-names-52.0.0/types/output.ts
@@ -7,7 +7,7 @@ import * as outputs from "../types/output";
 
 export namespace kebab_module {
     export interface OutputItem {
-        nestedOutput: string;
+        "nested-output": string;
     }
 
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-kebab-names/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-kebab-names/index.ts
@@ -1,14 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as kebab_names from "@pulumi/kebab-names";
 
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 const first = new kebab_names.kebab_module.SomeResource("first", {
-    theInput: true,
+    "the-input": true,
     nested: {
-        nestedValue: "nested",
+        "nested-value": "nested",
     },
 });
-const second = new kebab_names.kebab_module.AnotherResource("second", {theInput: first.theOutput.nestedOutput});
-export const theOutput = first.theOutput;
+const second = new kebab_names.kebab_module.AnotherResource("second", {"the-input": first["the-output"]["nested-output"]});
+export const theOutput = first["the-output"];

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/kebab-module/anotherResource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/kebab-module/anotherResource.ts
@@ -31,7 +31,7 @@ export class AnotherResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === AnotherResource.__pulumiType;
     }
 
-    declare public readonly theInput: pulumi.Output<string>;
+    declare public readonly "the-input": pulumi.Output<string>;
 
     /**
      * Create a AnotherResource resource with the given unique name, arguments, and options.
@@ -44,12 +44,12 @@ export class AnotherResource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if (args?.theInput === undefined && !opts.urn) {
-                throw new Error("Missing required property 'theInput'");
+            if (args?.["the-input"] === undefined && !opts.urn) {
+                throw new Error("Missing required property 'the-input'");
             }
-            resourceInputs["theInput"] = args?.theInput;
+            resourceInputs["the-input"] = args?.["the-input"];
         } else {
-            resourceInputs["theInput"] = undefined /*out*/;
+            resourceInputs["the-input"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(AnotherResource.__pulumiType, name, resourceInputs, opts);
@@ -60,5 +60,5 @@ export class AnotherResource extends pulumi.CustomResource {
  * The set of arguments for constructing a AnotherResource resource.
  */
 export interface AnotherResourceArgs {
-    theInput: pulumi.Input<string>;
+    "the-input": pulumi.Input<string>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/kebab-module/someResource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/kebab-module/someResource.ts
@@ -33,7 +33,7 @@ export class SomeResource extends pulumi.CustomResource {
         return obj['__pulumiType'] === SomeResource.__pulumiType;
     }
 
-    declare public /*out*/ readonly theOutput: pulumi.Output<outputs.kebab_module.OutputItem>;
+    declare public /*out*/ readonly "the-output": pulumi.Output<outputs.kebab_module.OutputItem>;
 
     /**
      * Create a SomeResource resource with the given unique name, arguments, and options.
@@ -49,14 +49,14 @@ export class SomeResource extends pulumi.CustomResource {
             if (args?.nested === undefined && !opts.urn) {
                 throw new Error("Missing required property 'nested'");
             }
-            if (args?.theInput === undefined && !opts.urn) {
-                throw new Error("Missing required property 'theInput'");
+            if (args?.["the-input"] === undefined && !opts.urn) {
+                throw new Error("Missing required property 'the-input'");
             }
             resourceInputs["nested"] = args?.nested;
-            resourceInputs["theInput"] = args?.theInput;
-            resourceInputs["theOutput"] = undefined /*out*/;
+            resourceInputs["the-input"] = args?.["the-input"];
+            resourceInputs["the-output"] = undefined /*out*/;
         } else {
-            resourceInputs["theOutput"] = undefined /*out*/;
+            resourceInputs["the-output"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(SomeResource.__pulumiType, name, resourceInputs, opts);
@@ -68,5 +68,5 @@ export class SomeResource extends pulumi.CustomResource {
  */
 export interface SomeResourceArgs {
     nested: pulumi.Input<inputs.kebab_module.NestedInputArgs>;
-    theInput: pulumi.Input<boolean>;
+    "the-input": pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/types/input.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/types/input.ts
@@ -7,7 +7,7 @@ import * as outputs from "../types/output";
 
 export namespace kebab_module {
     export interface NestedInputArgs {
-        nestedValue: pulumi.Input<string>;
+        "nested-value": pulumi.Input<string>;
     }
 
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/types/output.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/kebab-names-52.0.0/types/output.ts
@@ -7,7 +7,7 @@ import * as outputs from "../types/output";
 
 export namespace kebab_module {
     export interface OutputItem {
-        nestedOutput: string;
+        "nested-output": string;
     }
 
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-kebab-names/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-kebab-names/main.pp
@@ -1,18 +1,17 @@
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 resource "first" "kebab-names:kebab-module:someResource" {
-    theInput = true
+    the-input = true
     nested = {
-        nestedValue = "nested"
+        nested-value = "nested"
     }
 }
 
 resource "second" "kebab-names:kebab-module:anotherResource" {
-    theInput = first.theOutput.nestedOutput
+    the-input = first.the-output.nested-output
 }
 
 // Whole objects in stack outputs keep their wire-format keys
 output "theOutput" {
-    value = first.theOutput
+    value = first.the-output
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-kebab-names/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-kebab-names/main.pp
@@ -1,18 +1,17 @@
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 resource "first" "kebab-names:kebab-module:someResource" {
-    theInput = true
+    the-input = true
     nested = {
-        nestedValue = "nested"
+        nested-value = "nested"
     }
 }
 
 resource "second" "kebab-names:kebab-module:anotherResource" {
-    theInput = first.theOutput.nestedOutput
+    the-input = first.the-output.nested-output
 }
 
 // Whole objects in stack outputs keep their wire-format keys
 output "theOutput" {
-    value = first.theOutput
+    value = first.the-output
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-kebab-names/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-kebab-names/main.pp
@@ -1,18 +1,17 @@
-// The package name and module name are kebab-case. Resource and object type names cannot be
-// kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-// property names are not yet handled by all code generators.
+// The package name, module name and property names are kebab-case. Resource and object type names
+// cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 resource "first" "kebab-names:kebab-module:someResource" {
-    theInput = true
+    the-input = true
     nested = {
-        nestedValue = "nested"
+        nested-value = "nested"
     }
 }
 
 resource "second" "kebab-names:kebab-module:anotherResource" {
-    theInput = first.theOutput.nestedOutput
+    the-input = first.the-output.nested-output
 }
 
 // Whole objects in stack outputs keep their wire-format keys
 output "theOutput" {
-    value = first.theOutput
+    value = first.the-output
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-kebab-names/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-kebab-names/__main__.py
@@ -1,9 +1,8 @@
 import pulumi
 import pulumi_kebab_names as kebab_names
 
-# The package name and module name are kebab-case. Resource and object type names cannot be
-# kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-# property names are not yet handled by all code generators.
+# The package name, module name and property names are kebab-case. Resource and object type names
+# cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 first = kebab_names.kebab_module.SomeResource("first",
     the_input=True,
     nested=kebab_names.kebab_module.NestedInputArgs(

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
@@ -20,7 +20,7 @@ class NestedInputArgs:
         pulumi.set(__self__, "nested_value", nested_value)
 
     @_builtins.property
-    @pulumi.getter(name="nestedValue")
+    @pulumi.getter(name="nested-value")
     def nested_value(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "nested_value")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
@@ -21,7 +21,7 @@ class AnotherResourceArgs:
         pulumi.set(__self__, "the_input", the_input)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "the_input")
 
@@ -107,7 +107,7 @@ class AnotherResource(pulumi.CustomResource):
         return AnotherResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Output[_builtins.str]:
         return pulumi.get(self, "the_input")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
@@ -18,7 +18,7 @@ class OutputItem(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "nestedOutput":
+        if key == "nested-output":
             suggest = "nested_output"
 
         if suggest:
@@ -37,7 +37,7 @@ class OutputItem(dict):
         pulumi.set(__self__, "nested_output", nested_output)
 
     @_builtins.property
-    @pulumi.getter(name="nestedOutput")
+    @pulumi.getter(name="nested-output")
     def nested_output(self) -> _builtins.str:
         return pulumi.get(self, "nested_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
@@ -34,7 +34,7 @@ class SomeResourceArgs:
         pulumi.set(self, "nested", value)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.bool]:
         return pulumi.get(self, "the_input")
 
@@ -126,7 +126,7 @@ class SomeResource(pulumi.CustomResource):
         return SomeResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theOutput")
+    @pulumi.getter(name="the-output")
     def the_output(self) -> pulumi.Output['outputs.OutputItem']:
         return pulumi.get(self, "the_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-kebab-names/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-kebab-names/__main__.py
@@ -1,9 +1,8 @@
 import pulumi
 import pulumi_kebab_names as kebab_names
 
-# The package name and module name are kebab-case. Resource and object type names cannot be
-# kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-# property names are not yet handled by all code generators.
+# The package name, module name and property names are kebab-case. Resource and object type names
+# cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 first = kebab_names.kebab_module.SomeResource("first",
     the_input=True,
     nested=kebab_names.kebab_module.NestedInputArgs(

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
@@ -20,7 +20,7 @@ class NestedInputArgs:
         pulumi.set(__self__, "nested_value", nested_value)
 
     @_builtins.property
-    @pulumi.getter(name="nestedValue")
+    @pulumi.getter(name="nested-value")
     def nested_value(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "nested_value")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
@@ -21,7 +21,7 @@ class AnotherResourceArgs:
         pulumi.set(__self__, "the_input", the_input)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "the_input")
 
@@ -107,7 +107,7 @@ class AnotherResource(pulumi.CustomResource):
         return AnotherResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Output[_builtins.str]:
         return pulumi.get(self, "the_input")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
@@ -18,7 +18,7 @@ class OutputItem(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "nestedOutput":
+        if key == "nested-output":
             suggest = "nested_output"
 
         if suggest:
@@ -37,7 +37,7 @@ class OutputItem(dict):
         pulumi.set(__self__, "nested_output", nested_output)
 
     @_builtins.property
-    @pulumi.getter(name="nestedOutput")
+    @pulumi.getter(name="nested-output")
     def nested_output(self) -> _builtins.str:
         return pulumi.get(self, "nested_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
@@ -34,7 +34,7 @@ class SomeResourceArgs:
         pulumi.set(self, "nested", value)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.bool]:
         return pulumi.get(self, "the_input")
 
@@ -126,7 +126,7 @@ class SomeResource(pulumi.CustomResource):
         return SomeResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theOutput")
+    @pulumi.getter(name="the-output")
     def the_output(self) -> pulumi.Output['outputs.OutputItem']:
         return pulumi.get(self, "the_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-kebab-names/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-kebab-names/__main__.py
@@ -1,9 +1,8 @@
 import pulumi
 import pulumi_kebab_names as kebab_names
 
-# The package name and module name are kebab-case. Resource and object type names cannot be
-# kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-# property names are not yet handled by all code generators.
+# The package name, module name and property names are kebab-case. Resource and object type names
+# cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 first = kebab_names.kebab_module.SomeResource("first",
     the_input=True,
     nested={

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
@@ -29,7 +29,7 @@ class NestedInputArgs:
         pulumi.set(__self__, "nested_value", nested_value)
 
     @_builtins.property
-    @pulumi.getter(name="nestedValue")
+    @pulumi.getter(name="nested-value")
     def nested_value(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "nested_value")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
@@ -26,7 +26,7 @@ class AnotherResourceArgs:
         pulumi.set(__self__, "the_input", the_input)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "the_input")
 
@@ -112,7 +112,7 @@ class AnotherResource(pulumi.CustomResource):
         return AnotherResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Output[_builtins.str]:
         return pulumi.get(self, "the_input")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
@@ -23,7 +23,7 @@ class OutputItem(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "nestedOutput":
+        if key == "nested-output":
             suggest = "nested_output"
 
         if suggest:
@@ -42,7 +42,7 @@ class OutputItem(dict):
         pulumi.set(__self__, "nested_output", nested_output)
 
     @_builtins.property
-    @pulumi.getter(name="nestedOutput")
+    @pulumi.getter(name="nested-output")
     def nested_output(self) -> _builtins.str:
         return pulumi.get(self, "nested_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
@@ -39,7 +39,7 @@ class SomeResourceArgs:
         pulumi.set(self, "nested", value)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.bool]:
         return pulumi.get(self, "the_input")
 
@@ -131,7 +131,7 @@ class SomeResource(pulumi.CustomResource):
         return SomeResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theOutput")
+    @pulumi.getter(name="the-output")
     def the_output(self) -> pulumi.Output['outputs.OutputItem']:
         return pulumi.get(self, "the_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-kebab-names/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-kebab-names/__main__.py
@@ -1,9 +1,8 @@
 import pulumi
 import pulumi_kebab_names as kebab_names
 
-# The package name and module name are kebab-case. Resource and object type names cannot be
-# kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-# property names are not yet handled by all code generators.
+# The package name, module name and property names are kebab-case. Resource and object type names
+# cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 first = kebab_names.kebab_module.SomeResource("first",
     the_input=True,
     nested={

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
@@ -29,7 +29,7 @@ class NestedInputArgs:
         pulumi.set(__self__, "nested_value", nested_value)
 
     @_builtins.property
-    @pulumi.getter(name="nestedValue")
+    @pulumi.getter(name="nested-value")
     def nested_value(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "nested_value")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
@@ -26,7 +26,7 @@ class AnotherResourceArgs:
         pulumi.set(__self__, "the_input", the_input)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "the_input")
 
@@ -112,7 +112,7 @@ class AnotherResource(pulumi.CustomResource):
         return AnotherResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Output[_builtins.str]:
         return pulumi.get(self, "the_input")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
@@ -23,7 +23,7 @@ class OutputItem(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "nestedOutput":
+        if key == "nested-output":
             suggest = "nested_output"
 
         if suggest:
@@ -42,7 +42,7 @@ class OutputItem(dict):
         pulumi.set(__self__, "nested_output", nested_output)
 
     @_builtins.property
-    @pulumi.getter(name="nestedOutput")
+    @pulumi.getter(name="nested-output")
     def nested_output(self) -> _builtins.str:
         return pulumi.get(self, "nested_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
@@ -39,7 +39,7 @@ class SomeResourceArgs:
         pulumi.set(self, "nested", value)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.bool]:
         return pulumi.get(self, "the_input")
 
@@ -131,7 +131,7 @@ class SomeResource(pulumi.CustomResource):
         return SomeResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theOutput")
+    @pulumi.getter(name="the-output")
     def the_output(self) -> pulumi.Output['outputs.OutputItem']:
         return pulumi.get(self, "the_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-kebab-names/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-kebab-names/__main__.py
@@ -1,9 +1,8 @@
 import pulumi
 import pulumi_kebab_names as kebab_names
 
-# The package name and module name are kebab-case. Resource and object type names cannot be
-# kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-# property names are not yet handled by all code generators.
+# The package name, module name and property names are kebab-case. Resource and object type names
+# cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 first = kebab_names.kebab_module.SomeResource("first",
     the_input=True,
     nested={

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
@@ -29,7 +29,7 @@ class NestedInputArgs:
         pulumi.set(__self__, "nested_value", nested_value)
 
     @_builtins.property
-    @pulumi.getter(name="nestedValue")
+    @pulumi.getter(name="nested-value")
     def nested_value(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "nested_value")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
@@ -26,7 +26,7 @@ class AnotherResourceArgs:
         pulumi.set(__self__, "the_input", the_input)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "the_input")
 
@@ -112,7 +112,7 @@ class AnotherResource(pulumi.CustomResource):
         return AnotherResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Output[_builtins.str]:
         return pulumi.get(self, "the_input")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
@@ -23,7 +23,7 @@ class OutputItem(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "nestedOutput":
+        if key == "nested-output":
             suggest = "nested_output"
 
         if suggest:
@@ -42,7 +42,7 @@ class OutputItem(dict):
         pulumi.set(__self__, "nested_output", nested_output)
 
     @_builtins.property
-    @pulumi.getter(name="nestedOutput")
+    @pulumi.getter(name="nested-output")
     def nested_output(self) -> _builtins.str:
         return pulumi.get(self, "nested_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
@@ -39,7 +39,7 @@ class SomeResourceArgs:
         pulumi.set(self, "nested", value)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.bool]:
         return pulumi.get(self, "the_input")
 
@@ -131,7 +131,7 @@ class SomeResource(pulumi.CustomResource):
         return SomeResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theOutput")
+    @pulumi.getter(name="the-output")
     def the_output(self) -> pulumi.Output['outputs.OutputItem']:
         return pulumi.get(self, "the_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-kebab-names/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-kebab-names/__main__.py
@@ -1,9 +1,8 @@
 import pulumi
 import pulumi_kebab_names as kebab_names
 
-# The package name and module name are kebab-case. Resource and object type names cannot be
-# kebab-case yet (the metaschema forbids hyphens in the member segment of a token), and kebab-case
-# property names are not yet handled by all code generators.
+# The package name, module name and property names are kebab-case. Resource and object type names
+# cannot be kebab-case yet: the metaschema forbids hyphens in the member segment of a token.
 first = kebab_names.kebab_module.SomeResource("first",
     the_input=True,
     nested={

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/_inputs.py
@@ -29,7 +29,7 @@ class NestedInputArgs:
         pulumi.set(__self__, "nested_value", nested_value)
 
     @_builtins.property
-    @pulumi.getter(name="nestedValue")
+    @pulumi.getter(name="nested-value")
     def nested_value(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "nested_value")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/another_resource.py
@@ -26,7 +26,7 @@ class AnotherResourceArgs:
         pulumi.set(__self__, "the_input", the_input)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.str]:
         return pulumi.get(self, "the_input")
 
@@ -112,7 +112,7 @@ class AnotherResource(pulumi.CustomResource):
         return AnotherResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Output[_builtins.str]:
         return pulumi.get(self, "the_input")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/outputs.py
@@ -23,7 +23,7 @@ class OutputItem(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "nestedOutput":
+        if key == "nested-output":
             suggest = "nested_output"
 
         if suggest:
@@ -42,7 +42,7 @@ class OutputItem(dict):
         pulumi.set(__self__, "nested_output", nested_output)
 
     @_builtins.property
-    @pulumi.getter(name="nestedOutput")
+    @pulumi.getter(name="nested-output")
     def nested_output(self) -> _builtins.str:
         return pulumi.get(self, "nested_output")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/kebab_module/some_resource.py
@@ -39,7 +39,7 @@ class SomeResourceArgs:
         pulumi.set(self, "nested", value)
 
     @_builtins.property
-    @pulumi.getter(name="theInput")
+    @pulumi.getter(name="the-input")
     def the_input(self) -> pulumi.Input[_builtins.bool]:
         return pulumi.get(self, "the_input")
 
@@ -131,7 +131,7 @@ class SomeResource(pulumi.CustomResource):
         return SomeResource(resource_name, opts=opts, __props__=__props__)
 
     @_builtins.property
-    @pulumi.getter(name="theOutput")
+    @pulumi.getter(name="the-output")
     def the_output(self) -> pulumi.Output['outputs.OutputItem']:
         return pulumi.get(self, "the_output")
 


### PR DESCRIPTION
Extends the l2-kebab-names conformance test to use kebab-case property
names, which the metaschema permits. It fixes code generation for Python, NodeJS & Go. Resource and object type names still cannot be kebab-case: the
metaschema forbids hyphens in the member segment of a token.