### PR TITLE
fix(cli): suggest terraform destroy when removing terraform-cli stacks

### DIFF
--- a/changelog/pending/cli-fix-stack-rm-terraform-cli-destroy-hint.yaml
+++ b/changelog/pending/cli-fix-stack-rm-terraform-cli-destroy-hint.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Suggest terraform destroy instead of pulumi destroy when removing a terraform-cli stack that still has resources
+time: 2026-08-05T00:00:00Z

--- a/pkg/cmd/pulumi/stack/stack_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_remove.go
@@ -23,6 +23,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
@@ -36,6 +37,41 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+// terraformCLIRuntime is the Pulumi.yaml runtime for stacks whose resources are
+// managed by the Terraform CLI rather than by `pulumi destroy`.
+const terraformCLIRuntime = "terraform-cli"
+
+// stackRuntimeName returns the project's language runtime for s.
+// Prefer a matching local Pulumi.yaml, then fall back to the stack's runtime tag.
+func stackRuntimeName(s backend.Stack) string {
+	if proj, err := workspace.DetectProject(); err == nil {
+		stackProj, has := s.Ref().Project()
+		if !has || stackProj == tokens.Name(proj.Name) {
+			return proj.Runtime.Name()
+		}
+	}
+	if tags := s.Tags(); tags != nil {
+		return tags[apitype.ProjectRuntimeTag]
+	}
+	return ""
+}
+
+// stackRemoveHasResourcesError is the user-facing error when stack removal is
+// rejected because the stack still has resources. terraform-cli stacks must be
+// cleaned up with `terraform destroy`, not `pulumi destroy`.
+func stackRemoveHasResourcesError(stackRef, runtime string) error {
+	destroyHint := "Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`"
+	if runtime == terraformCLIRuntime {
+		destroyHint = "Run `terraform destroy` to delete the resources, then run `pulumi stack rm`"
+	}
+	return fmt.Errorf(
+		"'%s' still has resources; removal rejected. Possible actions:\n"+
+			"- Make sure that '%[1]s' is the stack that you want to destroy\n"+
+			"- %s\n"+
+			"- Run `pulumi stack rm --force` to override this error",
+		stackRef, destroyHint)
+}
 
 func newStackRemoveCmd() *cobra.Command {
 	var stack string
@@ -94,11 +130,7 @@ func newStackRemoveCmd() *cobra.Command {
 			hasResources, err := backend.RemoveStack(ctx, s, force, removeBackups)
 			if err != nil {
 				if hasResources {
-					return fmt.Errorf(
-						"'%s' still has resources; removal rejected. Possible actions:\n"+
-							"- Make sure that '%[1]s' is the stack that you want to destroy\n"+
-							"- Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`\n"+
-							"- Run `pulumi stack rm --force` to override this error", s.Ref())
+					return stackRemoveHasResourcesError(s.Ref().String(), stackRuntimeName(s))
 				}
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_remove.go
@@ -38,31 +38,35 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// terraformCLIRuntime is the Pulumi.yaml runtime for stacks whose resources are
-// managed by the Terraform CLI rather than by `pulumi destroy`.
+// terraformCLIRuntime is the pulumi:runtime value named in issue 24139 for
+// Terraform-managed stacks. Those stacks have no Pulumi.yaml.
 const terraformCLIRuntime = "terraform-cli"
 
-// stackRuntimeName returns the project's language runtime for s.
-// Prefer a matching local Pulumi.yaml, then fall back to the stack's runtime tag.
-func stackRuntimeName(s backend.Stack) string {
-	if proj, err := workspace.DetectProject(); err == nil {
-		stackProj, has := s.Ref().Project()
-		if !has || stackProj == tokens.Name(proj.Name) {
-			return proj.Runtime.Name()
-		}
+// terraformExecutionModeTag is set on Terraform-managed Pulumi Cloud stacks
+// (local or remote). See https://www.pulumi.com/docs/iac/get-started/terraform/terraform-remote-execution/
+const terraformExecutionModeTag apitype.StackTagName = "terraform:execution-mode"
+
+// isTerraformCLIStack reports whether s is a Terraform-managed stack.
+// Detection uses backend tags only: these stacks are Terraform workspaces
+// stored in Pulumi Cloud and do not have a Pulumi.yaml.
+func isTerraformCLIStack(s backend.Stack) bool {
+	tags := s.Tags()
+	if tags == nil {
+		return false
 	}
-	if tags := s.Tags(); tags != nil {
-		return tags[apitype.ProjectRuntimeTag]
+	if tags[apitype.ProjectRuntimeTag] == terraformCLIRuntime {
+		return true
 	}
-	return ""
+	_, ok := tags[terraformExecutionModeTag]
+	return ok
 }
 
 // stackRemoveHasResourcesError is the user-facing error when stack removal is
-// rejected because the stack still has resources. terraform-cli stacks must be
-// cleaned up with `terraform destroy`, not `pulumi destroy`.
-func stackRemoveHasResourcesError(stackRef, runtime string) error {
+// rejected because the stack still has resources. Terraform-managed stacks
+// must be cleaned up with `terraform destroy`, not `pulumi destroy`.
+func stackRemoveHasResourcesError(stackRef string, terraformCLI bool) error {
 	destroyHint := "Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`"
-	if runtime == terraformCLIRuntime {
+	if terraformCLI {
 		destroyHint = "Run `terraform destroy` to delete the resources, then run `pulumi stack rm`"
 	}
 	return fmt.Errorf(
@@ -130,7 +134,7 @@ func newStackRemoveCmd() *cobra.Command {
 			hasResources, err := backend.RemoveStack(ctx, s, force, removeBackups)
 			if err != nil {
 				if hasResources {
-					return stackRemoveHasResourcesError(s.Ref().String(), stackRuntimeName(s))
+					return stackRemoveHasResourcesError(s.Ref().String(), isTerraformCLIStack(s))
 				}
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_remove_test.go
+++ b/pkg/cmd/pulumi/stack/stack_remove_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +26,7 @@ import (
 func TestStackRemoveHasResourcesError_DefaultSuggestsPulumiDestroy(t *testing.T) {
 	t.Parallel()
 
-	err := stackRemoveHasResourcesError("org/project/stack", "nodejs")
+	err := stackRemoveHasResourcesError("org/project/stack", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "still has resources; removal rejected")
 	assert.Contains(t, err.Error(), "Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`")
@@ -37,30 +36,79 @@ func TestStackRemoveHasResourcesError_DefaultSuggestsPulumiDestroy(t *testing.T)
 func TestStackRemoveHasResourcesError_TerraformCLISuggestsTerraformDestroy(t *testing.T) {
 	t.Parallel()
 
-	err := stackRemoveHasResourcesError("org/project/stack", terraformCLIRuntime)
+	err := stackRemoveHasResourcesError("org/project/stack", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "still has resources; removal rejected")
 	assert.Contains(t, err.Error(), "Run `terraform destroy` to delete the resources, then run `pulumi stack rm`")
 	assert.NotContains(t, err.Error(), "pulumi destroy")
 }
 
-func TestStackRuntimeName_FromTags(t *testing.T) {
+func TestIsTerraformCLIStack(t *testing.T) {
 	t.Parallel()
 
-	s := &backend.MockStack{
-		RefF: func() backend.StackReference {
-			return &backend.MockStackReference{
-				StringV:  "org/project/stack",
-				NameV:    tokens.MustParseStackName("stack"),
-				ProjectV: "project",
-			}
+	tests := []struct {
+		name string
+		tags map[apitype.StackTagName]string
+		want bool
+	}{
+		{
+			name: "nil tags",
+			tags: nil,
+			want: false,
 		},
-		TagsF: func() map[apitype.StackTagName]string {
-			return map[apitype.StackTagName]string{
+		{
+			name: "empty tags",
+			tags: map[apitype.StackTagName]string{},
+			want: false,
+		},
+		{
+			name: "pulumi language runtime",
+			tags: map[apitype.StackTagName]string{
+				apitype.ProjectRuntimeTag: "nodejs",
+			},
+			want: false,
+		},
+		{
+			name: "pulumi:runtime terraform-cli",
+			tags: map[apitype.StackTagName]string{
 				apitype.ProjectRuntimeTag: terraformCLIRuntime,
-			}
+			},
+			want: true,
+		},
+		{
+			name: "terraform:execution-mode local",
+			tags: map[apitype.StackTagName]string{
+				terraformExecutionModeTag: "local",
+			},
+			want: true,
+		},
+		{
+			name: "terraform:execution-mode remote",
+			tags: map[apitype.StackTagName]string{
+				terraformExecutionModeTag: "remote",
+			},
+			want: true,
+		},
+		{
+			name: "both runtime and execution-mode",
+			tags: map[apitype.StackTagName]string{
+				apitype.ProjectRuntimeTag: terraformCLIRuntime,
+				terraformExecutionModeTag: "remote",
+			},
+			want: true,
 		},
 	}
 
-	assert.Equal(t, terraformCLIRuntime, stackRuntimeName(s))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &backend.MockStack{
+				TagsF: func() map[apitype.StackTagName]string {
+					return tt.tags
+				},
+			}
+			assert.Equal(t, tt.want, isTerraformCLIStack(s))
+		})
+	}
 }

--- a/pkg/cmd/pulumi/stack/stack_remove_test.go
+++ b/pkg/cmd/pulumi/stack/stack_remove_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackRemoveHasResourcesError_DefaultSuggestsPulumiDestroy(t *testing.T) {
+	t.Parallel()
+
+	err := stackRemoveHasResourcesError("org/project/stack", "nodejs")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has resources; removal rejected")
+	assert.Contains(t, err.Error(), "Run `pulumi destroy` to delete the resources, then run `pulumi stack rm`")
+	assert.NotContains(t, err.Error(), "terraform destroy")
+}
+
+func TestStackRemoveHasResourcesError_TerraformCLISuggestsTerraformDestroy(t *testing.T) {
+	t.Parallel()
+
+	err := stackRemoveHasResourcesError("org/project/stack", terraformCLIRuntime)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still has resources; removal rejected")
+	assert.Contains(t, err.Error(), "Run `terraform destroy` to delete the resources, then run `pulumi stack rm`")
+	assert.NotContains(t, err.Error(), "pulumi destroy")
+}
+
+func TestStackRuntimeName_FromTags(t *testing.T) {
+	t.Parallel()
+
+	s := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				StringV:  "org/project/stack",
+				NameV:    tokens.MustParseStackName("stack"),
+				ProjectV: "project",
+			}
+		},
+		TagsF: func() map[apitype.StackTagName]string {
+			return map[apitype.StackTagName]string{
+				apitype.ProjectRuntimeTag: terraformCLIRuntime,
+			}
+		},
+	}
+
+	assert.Equal(t, terraformCLIRuntime, stackRuntimeName(s))
+}


### PR DESCRIPTION
## What

When `pulumi stack rm` rejects a stack that still has resources, suggest `terraform destroy` for Terraform-managed stacks instead of `pulumi destroy`.

## Why

Fixes #24139. Terraform-managed Pulumi Cloud stacks are Terraform workspaces. `pulumi destroy` is the wrong next step.

## How

Do **not** read `Pulumi.yaml`. Those stacks do not have one.

Detect from backend stack tags, which the Cloud API already attaches when the stack is loaded:

- `pulumi:runtime=terraform-cli` (the runtime named in #24139)
- or `terraform:execution-mode` set (`local` or `remote`, [docs](https://www.pulumi.com/docs/iac/get-started/terraform/terraform-remote-execution/))

Other stacks keep the existing `pulumi destroy` hint.

## Tests

```
=== RUN   TestStackRemoveHasResourcesError_DefaultSuggestsPulumiDestroy
--- PASS: TestStackRemoveHasResourcesError_DefaultSuggestsPulumiDestroy (0.00s)
=== RUN   TestStackRemoveHasResourcesError_TerraformCLISuggestsTerraformDestroy
--- PASS: TestStackRemoveHasResourcesError_TerraformCLISuggestsTerraformDestroy (0.00s)
=== RUN   TestIsTerraformCLIStack
--- PASS: TestIsTerraformCLIStack (0.00s)
    --- PASS: TestIsTerraformCLIStack/both_runtime_and_execution-mode (0.00s)
    --- PASS: TestIsTerraformCLIStack/terraform:execution-mode_remote (0.00s)
    --- PASS: TestIsTerraformCLIStack/nil_tags (0.00s)
    --- PASS: TestIsTerraformCLIStack/terraform:execution-mode_local (0.00s)
    --- PASS: TestIsTerraformCLIStack/pulumi:runtime_terraform-cli (0.00s)
    --- PASS: TestIsTerraformCLIStack/empty_tags (0.00s)
    --- PASS: TestIsTerraformCLIStack/pulumi_language_runtime (0.00s)
PASS
ok  	github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack	0.045s
```