### PR TITLE
Fix do help text about delete not needing stateless

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -484,8 +484,7 @@ expression in the input format (e.g. YAML interpolations or fn:: invocations).`,
 	cmd.Flags().StringVar(&output, "output", "",
 		"Output format for resource operation results (supported: default, json)")
 	cmd.Flags().BoolVar(&stateless, "stateless", false,
-		"Run create/patch/delete directly against the provider without persisting state. "+
-			"Required for delete until stateful delete is implemented.")
+		"Run create/patch/delete directly against the provider without persisting state.")
 	cmd.Flags().StringVar(
 		&pkg, "package", "", "The package to load, in the form 'name@version' or "+
 			"a path to a plugin binary or folder. If the package supports "+

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -145,7 +145,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for delete until stateful delete is implemented.
+      --stateless              Run create/patch/delete directly against the provider without persisting state.
 `
 	assert.Equal(t, expected, stdout.String())
 }

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -154,7 +154,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for delete until stateful delete is implemented.
+      --stateless              Run create/patch/delete directly against the provider without persisting state.
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `
@@ -209,7 +209,7 @@ Flags:
       --provider string        The URN of a provider resource in the current stack whose inputs to use as the base of the provider configuration (requires a stack context)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
-      --stateless              Run create/patch/delete directly against the provider without persisting state. Required for delete until stateful delete is implemented.
+      --stateless              Run create/patch/delete directly against the provider without persisting state.
 
 Use "do azure:index:myResource [command] --help" for more information about a command.
 `


### PR DESCRIPTION
Minor fixup, delete can run without --stateless so fix up the help text.