### PR TITLE
TestNewDefaultOrgResolution: make sure promises are done

### DIFF
--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -1614,6 +1614,12 @@ func TestNewDefaultOrgResolution(t *testing.T) {
 			b, err := New(ctx, diagtest.LogSink(t), server.URL, nil, false)
 			require.NoError(t, err)
 
+			// New spawns goroutines that may log to the test's diag sink;
+			// wait for them before the test finishes.
+			cb := b.(*cloudBackend)
+			_, _ = cb.capabilities.Result(ctx)
+			_, _ = cb.userInfo.Result(ctx)
+
 			org, err := b.GetDefaultOrg(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedOrg, org)


### PR DESCRIPTION
This test currently triggers the race detector occasionally, because we are still writing to `diagtest.LogSink` (which in turn calls `t.Logf`, which is not allowed after the test is done).  This comes from goroutines not being finished before the test exits.

Wait for these goroutines to avoid this issue.

Noticed this in https://github.com/pulumi/pulumi/actions/runs/31688936692/job/94412993439