### PR TITLE
Refactor the Python feature support helpers

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,3 @@ build:
 
 sphinx:
   configuration: docs/sphinx/conf.py
-
-formats:
-  - pdf

--- a/changelog/pending/sdk-python-improvement-20260813-145100.yaml
+++ b/changelog/pending/sdk-python-improvement-20260813-145100.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: improvement
+body: Use the resource monitor's advertised feature set consistently throughout the Python SDK
+time: 2026-08-13T14:51:00.438832+02:00

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -41,7 +41,7 @@ from .settings import (
     get_monitor,
     grpc_error_to_exception,
     handle_grpc_error,
-    monitor_supports_invoke_depends_on,
+    monitor_supports_feature,
 )
 from .sync_await import _sync_await
 
@@ -291,7 +291,9 @@ def _invoke(
                 resources_to_wait_for = resources_to_wait_for.union(deps)
             # The expanded set of dependencies, including children of components.
             expanded_deps = await rpc._expand_dependencies(resources_to_wait_for, None)
-            if monitor_supports_invoke_depends_on():
+            if monitor_supports_feature(
+                resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON
+            ):
                 invoke_depends_on = list(expanded_deps.keys())
             else:
                 # Older engines cannot gate invokes: if we depend on any

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -291,7 +291,7 @@ def _invoke(
                 resources_to_wait_for = resources_to_wait_for.union(deps)
             # The expanded set of dependencies, including children of components.
             expanded_deps = await rpc._expand_dependencies(resources_to_wait_for, None)
-            if await monitor_supports_invoke_depends_on():
+            if monitor_supports_invoke_depends_on():
                 invoke_depends_on = list(expanded_deps.keys())
             else:
                 # Older engines cannot gate invokes: if we depend on any

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -340,8 +340,13 @@ def set_mocks(
     """
     set_mocks configures the Pulumi runtime to use the given mocks for testing.
     """
+    monitor = MockMonitor(mocks) if monitor is None else monitor
+    monitor_features = set(
+        monitor.GetDeploymentInfo(empty_pb2.Empty()).supportedFeatures
+    )
     settings = MockSettings(
-        monitor=MockMonitor(mocks) if not monitor else monitor,
+        monitor=monitor,
+        monitor_features=monitor_features,
         engine=MockEngine(logger),
         project=project if project is not None else "project",
         stack=stack if stack is not None else "stack",

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -40,7 +40,7 @@ from .rpc import _expand_dependencies, serialize_property
 from .settings import (
     _get_callbacks,
     _get_rpc_manager,
-    _sync_monitor_supports_transforms,
+    monitor_supports_transforms,
     monitor_supports_error_hooks,
     monitor_supports_resource_hooks,
     handle_grpc_error,
@@ -265,7 +265,7 @@ async def prepare_resource(
     if opts is not None and opts.replacement_trigger is not None:
         replacement_trigger = opts.replacement_trigger
 
-    supports_alias_specs = await settings.monitor_supports_alias_specs()
+    supports_alias_specs = settings.monitor_supports_alias_specs()
     aliases = await prepare_aliases(res, opts, supports_alias_specs)
     deleted_with_urn: Optional[str] = ""
     if opts is not None and opts.deleted_with is not None:
@@ -1048,7 +1048,7 @@ def register_resource(
 
             callbacks: list[callback_pb2.Callback] = []
             if opts.transforms:
-                if not _sync_monitor_supports_transforms():
+                if not monitor_supports_transforms():
                     raise Exception(
                         "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
                     )
@@ -1079,7 +1079,7 @@ def register_resource(
 
             if (
                 resolver.deleted_with_urn
-                and not await settings.monitor_supports_deleted_with()
+                and not settings.monitor_supports_deleted_with()
             ):
                 raise Exception(
                     "The Pulumi CLI does not support the DeletedWith option. Please update the Pulumi CLI."
@@ -1087,7 +1087,7 @@ def register_resource(
 
             if (
                 resolver.replace_with_urns
-                and not await settings.monitor_supports_replace_with()
+                and not settings.monitor_supports_replace_with()
             ):
                 raise Exception(
                     "The Pulumi CLI does not support the ReplaceWith option. Please update the Pulumi CLI."
@@ -1404,7 +1404,7 @@ async def _prepare_resource_hooks(
             hooks, hook_type, []
         )
         for i, _hook in enumerate(hooks_for_type or []):
-            if not await monitor_supports_resource_hooks():
+            if not monitor_supports_resource_hooks():
                 raise Exception(
                     "The Pulumi CLI does not support resource hooks. Please update the Pulumi CLI."
                 )
@@ -1426,7 +1426,7 @@ async def _prepare_resource_hooks(
 
     on_error_hooks_list: list[ErrorHook] = getattr(hooks, "on_error", []) or []
     if on_error_hooks_list:
-        if not await monitor_supports_error_hooks():
+        if not monitor_supports_error_hooks():
             raise Exception(
                 "The Pulumi CLI does not support error hooks. Please update the Pulumi CLI."
             )
@@ -1448,7 +1448,7 @@ def register_resource_hook(hook: "ResourceHook") -> asyncio.Future[None]:
         return callbacks.register_resource_hook(hook)
 
     async def wrapper() -> None:
-        if not await monitor_supports_resource_hooks():
+        if not monitor_supports_resource_hooks():
             raise Exception(
                 "The Pulumi CLI does not support resource hooks. Please update the Pulumi CLI."
             )
@@ -1471,7 +1471,7 @@ def register_error_hook(hook: "ErrorHook") -> asyncio.Future[None]:
         return callbacks.register_error_hook(hook)
 
     async def wrapper() -> None:
-        if not await monitor_supports_error_hooks():
+        if not monitor_supports_error_hooks():
             raise Exception(
                 "The Pulumi CLI does not support error hooks. Please update the Pulumi CLI."
             )

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -40,10 +40,8 @@ from .rpc import _expand_dependencies, serialize_property
 from .settings import (
     _get_callbacks,
     _get_rpc_manager,
-    monitor_supports_transforms,
-    monitor_supports_error_hooks,
-    monitor_supports_resource_hooks,
     handle_grpc_error,
+    monitor_supports_feature,
 )
 
 if TYPE_CHECKING:
@@ -265,7 +263,9 @@ async def prepare_resource(
     if opts is not None and opts.replacement_trigger is not None:
         replacement_trigger = opts.replacement_trigger
 
-    supports_alias_specs = settings.monitor_supports_alias_specs()
+    supports_alias_specs = monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS
+    )
     aliases = await prepare_aliases(res, opts, supports_alias_specs)
     deleted_with_urn: Optional[str] = ""
     if opts is not None and opts.deleted_with is not None:
@@ -1048,7 +1048,9 @@ def register_resource(
 
             callbacks: list[callback_pb2.Callback] = []
             if opts.transforms:
-                if not monitor_supports_transforms():
+                if not monitor_supports_feature(
+                    resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS
+                ):
                     raise Exception(
                         "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
                     )
@@ -1077,17 +1079,15 @@ def register_resource(
             if opts.custom_timeouts is not None:
                 custom_timeouts = _create_custom_timeouts(opts.custom_timeouts)
 
-            if (
-                resolver.deleted_with_urn
-                and not settings.monitor_supports_deleted_with()
+            if resolver.deleted_with_urn and not monitor_supports_feature(
+                resource_pb2.RESOURCE_MONITOR_FEATURE_DELETED_WITH
             ):
                 raise Exception(
                     "The Pulumi CLI does not support the DeletedWith option. Please update the Pulumi CLI."
                 )
 
-            if (
-                resolver.replace_with_urns
-                and not settings.monitor_supports_replace_with()
+            if resolver.replace_with_urns and not monitor_supports_feature(
+                resource_pb2.RESOURCE_MONITOR_FEATURE_REPLACE_WITH
             ):
                 raise Exception(
                     "The Pulumi CLI does not support the ReplaceWith option. Please update the Pulumi CLI."
@@ -1404,7 +1404,9 @@ async def _prepare_resource_hooks(
             hooks, hook_type, []
         )
         for i, _hook in enumerate(hooks_for_type or []):
-            if not monitor_supports_resource_hooks():
+            if not monitor_supports_feature(
+                resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS
+            ):
                 raise Exception(
                     "The Pulumi CLI does not support resource hooks. Please update the Pulumi CLI."
                 )
@@ -1426,7 +1428,9 @@ async def _prepare_resource_hooks(
 
     on_error_hooks_list: list[ErrorHook] = getattr(hooks, "on_error", []) or []
     if on_error_hooks_list:
-        if not monitor_supports_error_hooks():
+        if not monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS
+        ):
             raise Exception(
                 "The Pulumi CLI does not support error hooks. Please update the Pulumi CLI."
             )
@@ -1448,7 +1452,9 @@ def register_resource_hook(hook: "ResourceHook") -> asyncio.Future[None]:
         return callbacks.register_resource_hook(hook)
 
     async def wrapper() -> None:
-        if not monitor_supports_resource_hooks():
+        if not monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS
+        ):
             raise Exception(
                 "The Pulumi CLI does not support resource hooks. Please update the Pulumi CLI."
             )
@@ -1471,7 +1477,9 @@ def register_error_hook(hook: "ErrorHook") -> asyncio.Future[None]:
         return callbacks.register_error_hook(hook)
 
     async def wrapper() -> None:
-        if not monitor_supports_error_hooks():
+        if not monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS
+        ):
             raise Exception(
                 "The Pulumi CLI does not support error hooks. Please update the Pulumi CLI."
             )

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -41,6 +41,7 @@ from semver import Version
 from .. import _types, log
 from .. import urn as urn_util
 from . import known_types, settings
+from .proto import resource_pb2
 from .resource_cycle_breaker import declare_dependency
 
 if TYPE_CHECKING:
@@ -474,9 +475,8 @@ async def serialize_property(
         is_custom = known_types.is_custom_resource(value)
         resource_id = cast("CustomResource", value).id if is_custom else None
 
-        if (
-            exclude_resource_refs_from_deps
-            and settings.monitor_supports_resource_references()
+        if exclude_resource_refs_from_deps and settings.monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
         ):
             # If excluding resource references from dependencies and the monitor supports resource
             # references, we don't want to track this dependency, so we set `deps` to `None` so when
@@ -484,7 +484,9 @@ async def serialize_property(
             deps = None
 
         # If we're retaining resources, serialize the resource as a reference.
-        if settings.monitor_supports_resource_references():
+        if settings.monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
+        ):
             res = {
                 _special_sig_key: _special_resource_sig,
                 "urn": await serialize_property(
@@ -654,7 +656,9 @@ async def serialize_property(
             deps.extend(promise_deps)
         value_resources.update(promise_deps)
 
-        if keep_output_values and settings.monitor_supports_output_values():
+        if keep_output_values and settings.monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES
+        ):
             urn_deps: list[Resource] = []
             for resource in value_resources:
                 await serialize_property(
@@ -683,7 +687,9 @@ async def serialize_property(
 
         if not is_known:
             return UNKNOWN
-        if is_secret and settings.monitor_supports_secrets():
+        if is_secret and settings.monitor_supports_feature(
+            resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS
+        ):
             # Serializing an output with a secret value requires the use of a magical signature key,
             # which the engine detects.
             return {_special_sig_key: _special_secret_sig, "value": value}

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -476,7 +476,7 @@ async def serialize_property(
 
         if (
             exclude_resource_refs_from_deps
-            and await settings.monitor_supports_resource_references()
+            and settings.monitor_supports_resource_references()
         ):
             # If excluding resource references from dependencies and the monitor supports resource
             # references, we don't want to track this dependency, so we set `deps` to `None` so when
@@ -484,7 +484,7 @@ async def serialize_property(
             deps = None
 
         # If we're retaining resources, serialize the resource as a reference.
-        if await settings.monitor_supports_resource_references():
+        if settings.monitor_supports_resource_references():
             res = {
                 _special_sig_key: _special_resource_sig,
                 "urn": await serialize_property(
@@ -654,7 +654,7 @@ async def serialize_property(
             deps.extend(promise_deps)
         value_resources.update(promise_deps)
 
-        if keep_output_values and await settings.monitor_supports_output_values():
+        if keep_output_values and settings.monitor_supports_output_values():
             urn_deps: list[Resource] = []
             for resource in value_resources:
                 await serialize_property(
@@ -683,7 +683,7 @@ async def serialize_property(
 
         if not is_known:
             return UNKNOWN
-        if is_secret and await settings.monitor_supports_secrets():
+        if is_secret and settings.monitor_supports_secrets():
             # Serializing an output with a secret value requires the use of a magical signature key,
             # which the engine detects.
             return {_special_sig_key: _special_secret_sig, "value": value}

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -325,7 +325,7 @@ def require_pulumi_version(rg: str) -> None:
             raise grpc_error_to_exception(exn) from None
 
 
-def _monitor_supports_feature(feature: int) -> bool:
+def monitor_supports_feature(feature: int) -> bool:
     return feature in SETTINGS.monitor_features
 
 
@@ -347,50 +347,6 @@ def grpc_error_to_exception(exn: grpc.RpcError) -> Exception:
 
 def handle_grpc_error(exn: grpc.RpcError) -> NoReturn:
     raise grpc_error_to_exception(exn)
-
-
-def monitor_supports_secrets() -> bool:
-    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS)
-
-
-def monitor_supports_resource_references() -> bool:
-    return _monitor_supports_feature(
-        resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
-    )
-
-
-def monitor_supports_output_values() -> bool:
-    return _monitor_supports_feature(
-        resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES
-    )
-
-
-def monitor_supports_deleted_with() -> bool:
-    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_DELETED_WITH)
-
-
-def monitor_supports_replace_with() -> bool:
-    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_REPLACE_WITH)
-
-
-def monitor_supports_alias_specs() -> bool:
-    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS)
-
-
-def monitor_supports_transforms() -> bool:
-    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS)
-
-
-def monitor_supports_invoke_transforms() -> bool:
-    return _monitor_supports_feature(
-        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS
-    )
-
-
-def monitor_supports_parameterization() -> bool:
-    return _monitor_supports_feature(
-        resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION
-    )
 
 
 async def register_package(
@@ -426,7 +382,9 @@ async def register_package(
     if existing is not None:
         return existing
 
-    if not monitor_supports_parameterization():
+    if not monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION
+    ):
         raise Exception(
             "The Pulumi CLI does not support parameterization. Please update the Pulumi CLI."
         )
@@ -453,23 +411,6 @@ async def register_package(
     ref = response.ref
     package_refs[key] = ref
     return ref
-
-
-def monitor_supports_resource_hooks() -> bool:
-    return _monitor_supports_feature(
-        resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS
-    )
-
-
-def monitor_supports_error_hooks() -> bool:
-    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS)
-
-
-def monitor_supports_invoke_depends_on() -> bool:
-    # Advertised by GetDeploymentInfo only, so an engine that predates that RPC never has it.
-    return _monitor_supports_feature(
-        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON
-    )
 
 
 def reset_options(

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -72,7 +72,7 @@ class Settings:
         self.parallel = parallel
         self.dry_run = dry_run
         self.legacy_apply_enabled = legacy_apply_enabled
-        self.feature_support = {}
+        self.monitor_features = set()
         self.organization = organization
         # Caches package references returned by `RegisterPackage` for
         # parameterized providers. Scoped to the deployment so concurrent inline
@@ -146,7 +146,7 @@ class Settings:
     def legacy_apply_enabled(self) -> Optional[bool]: ...
 
     @contextproperty
-    def feature_support(self) -> Optional[dict]: ...
+    def monitor_features(self) -> set[int]: ...  # type: ignore
 
     @contextproperty
     def package_refs(self) -> Optional[dict]: ...
@@ -325,16 +325,8 @@ def require_pulumi_version(rg: str) -> None:
             raise grpc_error_to_exception(exn) from None
 
 
-async def monitor_supports_feature(feature: str) -> bool:
-    if feature not in SETTINGS.feature_support:
-        monitor = SETTINGS.monitor
-        if not monitor:
-            return False
-
-        result = await _monitor_supports_feature(monitor, feature)
-        SETTINGS.feature_support[feature] = result
-
-    return SETTINGS.feature_support[feature]
+def _monitor_supports_feature(feature: int) -> bool:
+    return feature in SETTINGS.monitor_features
 
 
 def grpc_error_to_exception(exn: grpc.RpcError) -> Exception:
@@ -357,40 +349,48 @@ def handle_grpc_error(exn: grpc.RpcError) -> NoReturn:
     raise grpc_error_to_exception(exn)
 
 
-async def monitor_supports_secrets() -> bool:
-    return await monitor_supports_feature("secrets")
+def monitor_supports_secrets() -> bool:
+    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS)
 
 
-async def monitor_supports_resource_references() -> bool:
-    return await monitor_supports_feature("resourceReferences")
+def monitor_supports_resource_references() -> bool:
+    return _monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
+    )
 
 
-async def monitor_supports_output_values() -> bool:
-    return await monitor_supports_feature("outputValues")
+def monitor_supports_output_values() -> bool:
+    return _monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES
+    )
 
 
-async def monitor_supports_deleted_with() -> bool:
-    return await monitor_supports_feature("deletedWith")
+def monitor_supports_deleted_with() -> bool:
+    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_DELETED_WITH)
 
 
-async def monitor_supports_replace_with() -> bool:
-    return await monitor_supports_feature("replaceWith")
+def monitor_supports_replace_with() -> bool:
+    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_REPLACE_WITH)
 
 
-async def monitor_supports_alias_specs() -> bool:
-    return await monitor_supports_feature("aliasSpecs")
+def monitor_supports_alias_specs() -> bool:
+    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS)
 
 
-def _sync_monitor_supports_transforms() -> bool:
-    return SETTINGS.feature_support.get("transforms", False)
+def monitor_supports_transforms() -> bool:
+    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS)
 
 
-def _sync_monitor_supports_invoke_transforms() -> bool:
-    return SETTINGS.feature_support.get("invokeTransforms", False)
+def monitor_supports_invoke_transforms() -> bool:
+    return _monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS
+    )
 
 
-def _sync_monitor_supports_parameterization() -> bool:
-    return SETTINGS.feature_support.get("parameterization", False)
+def monitor_supports_parameterization() -> bool:
+    return _monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION
+    )
 
 
 async def register_package(
@@ -426,7 +426,7 @@ async def register_package(
     if existing is not None:
         return existing
 
-    if not _sync_monitor_supports_parameterization():
+    if not monitor_supports_parameterization():
         raise Exception(
             "The Pulumi CLI does not support parameterization. Please update the Pulumi CLI."
         )
@@ -455,17 +455,21 @@ async def register_package(
     return ref
 
 
-async def monitor_supports_resource_hooks() -> bool:
-    return await monitor_supports_feature("resourceHooks")
+def monitor_supports_resource_hooks() -> bool:
+    return _monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS
+    )
 
 
-async def monitor_supports_error_hooks() -> bool:
-    return await monitor_supports_feature("errorHooks")
+def monitor_supports_error_hooks() -> bool:
+    return _monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS)
 
 
-async def monitor_supports_invoke_depends_on() -> bool:
+def monitor_supports_invoke_depends_on() -> bool:
     # Advertised by GetDeploymentInfo only, so an engine that predates that RPC never has it.
-    return SETTINGS.feature_support.get(_INVOKE_DEPENDS_ON, False)
+    return _monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON
+    )
 
 
 def reset_options(
@@ -496,7 +500,7 @@ def reset_options(
     )
 
 
-async def _monitor_supports_feature(
+async def _probe_monitor_feature(
     monitor: resource_pb2_grpc.ResourceMonitorStub, feature: str
 ) -> bool:
     req = resource_pb2.SupportsFeatureRequest(id=feature)
@@ -532,14 +536,6 @@ _LEGACY_FEATURE_MAPPING = {
     "errorHooks": resource_pb2.RESOURCE_MONITOR_FEATURE_ERROR_HOOKS,
 }
 
-# Features that have no legacy ID, keyed in feature_support by their own name.
-_INVOKE_DEPENDS_ON = "invokeDependsOn"
-
-_FEATURE_MAPPING = {
-    **_LEGACY_FEATURE_MAPPING,
-    _INVOKE_DEPENDS_ON: resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON,
-}
-
 
 async def _load_monitor_feature_support():
     if not SETTINGS.monitor:
@@ -552,17 +548,20 @@ async def _load_monitor_feature_support():
                 lambda: SETTINGS.monitor.GetDeploymentInfo(empty_pb2.Empty())
             ),
         )
-        for feature, value in _FEATURE_MAPPING.items():
-            SETTINGS.feature_support[feature] = (
-                value in deployment_info.supportedFeatures
-            )
+        SETTINGS.monitor_features = set(deployment_info.supportedFeatures)
 
     except grpc.RpcError as exn:
         if exn.code() != grpc.StatusCode.UNIMPLEMENTED:
             handle_grpc_error(exn)
-        await asyncio.gather(
+        legacy_features = list(_LEGACY_FEATURE_MAPPING)
+        supported = await asyncio.gather(
             *(
-                monitor_supports_feature(feature)
-                for feature in sorted(_LEGACY_FEATURE_MAPPING)
+                _probe_monitor_feature(SETTINGS.monitor, feature)
+                for feature in legacy_features
             )
         )
+        SETTINGS.monitor_features = {
+            _LEGACY_FEATURE_MAPPING[feature]
+            for feature, has_support in zip(legacy_features, supported)
+            if has_support
+        }

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -44,8 +44,8 @@ from .settings import (
     _get_rpc_manager,
     _load_monitor_feature_support,
     _shutdown_callbacks,
-    _sync_monitor_supports_transforms,
-    _sync_monitor_supports_invoke_transforms,
+    monitor_supports_transforms,
+    monitor_supports_invoke_transforms,
     get_monitor,
     get_project,
     get_root_resource,
@@ -486,7 +486,7 @@ def register_resource_transform(t: ResourceTransform) -> None:
     """
     Add a transform to all future resources constructed in this Pulumi stack.
     """
-    if not _sync_monitor_supports_transforms():
+    if not monitor_supports_transforms():
         raise Exception(
             "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
         )
@@ -518,7 +518,7 @@ def register_invoke_transform(t: InvokeTransform) -> None:
     Add a transforms to all future invokes called in this Pulumi stack.
     """
 
-    if not _sync_monitor_supports_invoke_transforms():
+    if not monitor_supports_invoke_transforms():
         raise Exception(
             "The Pulumi CLI does not support invoke transforms. Please update the Pulumi CLI."
         )

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -27,6 +27,7 @@ import grpc
 
 from . import settings
 from ._instrumentation import wrap_with_context
+from .proto import resource_pb2
 from .. import log
 from ..resource import (
     ComponentResource,
@@ -44,8 +45,7 @@ from .settings import (
     _get_rpc_manager,
     _load_monitor_feature_support,
     _shutdown_callbacks,
-    monitor_supports_transforms,
-    monitor_supports_invoke_transforms,
+    monitor_supports_feature,
     get_monitor,
     get_project,
     get_root_resource,
@@ -486,7 +486,7 @@ def register_resource_transform(t: ResourceTransform) -> None:
     """
     Add a transform to all future resources constructed in this Pulumi stack.
     """
-    if not monitor_supports_transforms():
+    if not monitor_supports_feature(resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS):
         raise Exception(
             "The Pulumi CLI does not support transforms. Please update the Pulumi CLI."
         )
@@ -518,7 +518,9 @@ def register_invoke_transform(t: InvokeTransform) -> None:
     Add a transforms to all future invokes called in this Pulumi stack.
     """
 
-    if not monitor_supports_invoke_transforms():
+    if not monitor_supports_feature(
+        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS
+    ):
         raise Exception(
             "The Pulumi CLI does not support invoke transforms. Please update the Pulumi CLI."
         )

--- a/sdk/python/lib/test/runtime/test_feature_support.py
+++ b/sdk/python/lib/test/runtime/test_feature_support.py
@@ -58,7 +58,6 @@ class LegacyMonitor:
 def configure_monitor(monitor):
     s = Settings(project="project", stack="stack")
     s.monitor = monitor
-    s.feature_support = {}
     settings.configure(s)
 
 
@@ -80,19 +79,14 @@ async def test_loads_features_from_get_deployment_info():
 
     await _load_monitor_feature_support()
 
-    assert settings.SETTINGS.feature_support.fget() == {
-        "secrets": True,
-        "resourceReferences": True,
-        "outputValues": False,
-        "deletedWith": False,
-        "replaceWith": False,
-        "aliasSpecs": True,
-        "transforms": True,
-        "invokeTransforms": False,
-        "parameterization": False,
-        "resourceHooks": True,
-        "errorHooks": False,
-        "invokeDependsOn": True,
+    assert settings.SETTINGS.monitor_features == {
+        resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_ALIAS_SPECS,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_BYTE_STRING,
     }
     assert monitor.supports_feature_calls == 0
 
@@ -104,18 +98,10 @@ async def test_falls_back_to_supports_feature_when_unimplemented():
 
     await _load_monitor_feature_support()
 
-    assert settings.SETTINGS.feature_support.fget() == {
-        "secrets": True,
-        "resourceReferences": False,
-        "outputValues": True,
-        "deletedWith": False,
-        "replaceWith": False,
-        "aliasSpecs": False,
-        "transforms": False,
-        "invokeTransforms": True,
-        "parameterization": False,
-        "resourceHooks": False,
-        "errorHooks": False,
+    assert settings.SETTINGS.monitor_features == {
+        resource_pb2.RESOURCE_MONITOR_FEATURE_SECRETS,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES,
+        resource_pb2.RESOURCE_MONITOR_FEATURE_INVOKE_TRANSFORMS,
     }
     assert sorted(monitor.probed) == [
         "aliasSpecs",

--- a/sdk/python/lib/test/runtime/test_register_package.py
+++ b/sdk/python/lib/test/runtime/test_register_package.py
@@ -35,7 +35,11 @@ def configure_monitor(ref, supports_parameterization=True):
     monitor = MockMonitor(ref)
     s = Settings(project="project", stack="stack")
     s.monitor = monitor
-    s.feature_support = {"parameterization": supports_parameterization}
+    s.monitor_features = (
+        {resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION}
+        if supports_parameterization
+        else set()
+    )
     settings.configure(s)
     return monitor
 
@@ -109,7 +113,7 @@ async def test_raises_when_parameterization_is_not_supported():
 async def test_raises_when_there_is_no_monitor():
     s = Settings(project="project", stack="stack")
     s.monitor = None
-    s.feature_support = {"parameterization": True}
+    s.monitor_features = {resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION}
     settings.configure(s)
     with pytest.raises(Exception, match="No monitor available"):
         await register_package(**BASE_ARGS)

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -43,6 +43,7 @@ from pulumi.runtime import (
     set_mocks,
     settings,
 )
+from pulumi.runtime.proto import resource_pb2
 
 import pulumi
 from pulumi import UNKNOWN, Input, Output, input_type
@@ -198,13 +199,15 @@ class NextSerializationTests(unittest.IsolatedAsyncioTestCase):
         urn = await res.urn.future()
         id = await res.id.future()
 
-        settings.SETTINGS.feature_support["resourceReferences"] = False
+        settings.SETTINGS.monitor_features = set()
         deps = []
         prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(id, prop)
 
-        settings.SETTINGS.feature_support["resourceReferences"] = True
+        settings.SETTINGS.monitor_features = {
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
+        }
         deps = []
         prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res, res], deps)
@@ -228,13 +231,15 @@ class NextSerializationTests(unittest.IsolatedAsyncioTestCase):
         urn = await res.urn.future()
         id = await res.id.future()
 
-        settings.SETTINGS.feature_support["resourceReferences"] = False
+        settings.SETTINGS.monitor_features = set()
         deps = []
         prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(id, prop)
 
-        settings.SETTINGS.feature_support["resourceReferences"] = True
+        settings.SETTINGS.monitor_features = {
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
+        }
         deps = []
         prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res, res], deps)
@@ -257,13 +262,15 @@ class NextSerializationTests(unittest.IsolatedAsyncioTestCase):
         res = MyComponentResource("test")
         urn = await res.urn.future()
 
-        settings.SETTINGS.feature_support["resourceReferences"] = False
+        settings.SETTINGS.monitor_features = set()
         deps = []
         prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
         self.assertEqual(urn, prop)
 
-        settings.SETTINGS.feature_support["resourceReferences"] = True
+        settings.SETTINGS.monitor_features = {
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES
+        }
         deps = []
         prop = await rpc.serialize_property(res, deps, None)
         self.assertListEqual([res], deps)
@@ -1692,7 +1699,9 @@ class OutputValueSerializationTests(unittest.IsolatedAsyncioTestCase):
 
     @pulumi_test
     async def test_serialize(self):
-        settings.SETTINGS.feature_support["outputValues"] = True
+        settings.SETTINGS.monitor_features = {
+            resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES
+        }
 
         def gen_test_parameters():
             for value in [None, 0, 1, "", "hi", {}, []]:
@@ -1746,7 +1755,9 @@ class OutputValueSerializationTests(unittest.IsolatedAsyncioTestCase):
 
     @pulumi_test
     async def test_serialize_nested_dict(self):
-        settings.SETTINGS.feature_support["outputValues"] = True
+        settings.SETTINGS.monitor_features = {
+            resource_pb2.RESOURCE_MONITOR_FEATURE_OUTPUT_VALUES
+        }
 
         inputs = {
             "value": {
@@ -1791,7 +1802,11 @@ async def test_serialize_resource_references_dependencies():
         yield (False, False, {custom1, custom2})
 
     for supports, exclude, expected in gen_test_parameters():
-        settings.SETTINGS.feature_support["resourceReferences"] = supports
+        settings.SETTINGS.monitor_features = (
+            {resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES}
+            if supports
+            else set()
+        )
         property_deps = {}
         await rpc.serialize_properties(
             inputs, property_deps, exclude_resource_refs_from_deps=exclude

--- a/tests/integration/component_provider/python/features/provider/src/provider/component.py
+++ b/tests/integration/component_provider/python/features/provider/src/provider/component.py
@@ -15,6 +15,7 @@
 from typing import TypedDict
 
 import pulumi
+from pulumi.runtime.proto import resource_pb2
 
 
 class Args(TypedDict):
@@ -28,12 +29,15 @@ class MyComponent(pulumi.ComponentResource):
 
     def __init__(self, name: str, args: Args, opts: pulumi.ResourceOptions):
         super().__init__("provider:index:MyComponent", name, {}, opts)
-        self.parameterization = pulumi.runtime.settings.SETTINGS.feature_support.get(
-            "parameterization"
+        self.parameterization = (
+            resource_pb2.RESOURCE_MONITOR_FEATURE_PARAMETERIZATION
+            in pulumi.runtime.settings.SETTINGS.monitor_features
         )
-        self.transforms = pulumi.runtime.settings.SETTINGS.feature_support.get(
-            "transforms"
+        self.transforms = (
+            resource_pb2.RESOURCE_MONITOR_FEATURE_TRANSFORMS
+            in pulumi.runtime.settings.SETTINGS.monitor_features
         )
-        self.resourceHooks = pulumi.runtime.settings.SETTINGS.feature_support.get(
-            "resourceHooks"
+        self.resourceHooks = (
+            resource_pb2.RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS
+            in pulumi.runtime.settings.SETTINGS.monitor_features
         )


### PR DESCRIPTION
Refactor the feature support helpers now that it's all coming from GetDeploymentInfo. On old engines we still backfill via SupportsFeatureRequest.
