### PR TITLE
Reserve complete step execution chains

### DIFF
--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -146,10 +146,18 @@ func (se *stepExecutor) ExecuteSerial(chain chain) completionToken {
 	// If one is pending, we should exit early - we will shortly be tearing down the engine and exiting.
 
 	completion := make(chan bool)
+
+	// Acquire a reader before publishing the chain. The worker that receives the chain releases it in executeChain
+	// after the whole chain finishes. This uses the "read" side of the lock because we're ok with as many workers as
+	// possible executing steps in parallel.
+	se.workerLock.RLock()
 	select {
 	case se.incomingChains <- incomingChain{Chain: chain, CompletionChan: completion}:
+		// The matching RUnlock is deferred by executeChain.
+		return completionToken{channel: completion}
 	case <-se.ctx.Done():
 		close(completion)
+		se.workerLock.RUnlock()
 	}
 
 	return completionToken{channel: completion}
@@ -394,6 +402,8 @@ func (se *stepExecutor) WaitForCompletion() {
 // executeChain executes a chain, one step at a time. If any step in the chain fails to execute, or if the
 // context is canceled, the chain stops execution.
 func (se *stepExecutor) executeChain(workerID int, chain chain) {
+	defer se.workerLock.RUnlock()
+
 	for _, step := range chain {
 		select {
 		case <-se.ctx.Done():
@@ -402,13 +412,7 @@ func (se *stepExecutor) executeChain(workerID int, chain chain) {
 		default:
 		}
 
-		// Take the work lock before executing the step, this uses the "read" side of the lock because we're ok with as
-		// many workers as possible executing steps in parallel.
-		se.workerLock.RLock()
 		err := se.executeStep(workerID, step)
-		// Regardless of error we need to release the lock here.
-		se.workerLock.RUnlock()
-
 		if err != nil {
 			se.log(workerID, "step %v on %v failed, signalling cancellation", step.Op(), step.URN())
 			se.cancelDueToError(err, step)

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -149,7 +149,7 @@ func (se *stepExecutor) ExecuteSerial(chain chain) completionToken {
 
 	// Acquire a reader before publishing the chain. The worker that receives the chain releases it in executeChain
 	// after the whole chain finishes. This uses the "read" side of the lock because we're ok with as many workers as
-	// possible executing steps in parallel.
+	// possible executing chains in parallel.
 	se.workerLock.RLock()
 	select {
 	case se.incomingChains <- incomingChain{Chain: chain, CompletionChan: completion}:
@@ -163,12 +163,12 @@ func (se *stepExecutor) ExecuteSerial(chain chain) completionToken {
 	return completionToken{channel: completion}
 }
 
-// Locks the step executor from executing any more steps. This is used to synchronize with the step executor.
+// Locks the step executor from executing any more chains. This is used to synchronize with the step executor.
 func (se *stepExecutor) Lock() {
 	se.workerLock.Lock()
 }
 
-// Unlocks the step executor to allow it to execute more steps. This is used to synchronize with the step executor.
+// Unlocks the step executor to allow it to execute more chains. This is used to synchronize with the step executor.
 func (se *stepExecutor) Unlock() {
 	se.workerLock.Unlock()
 }

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -16,6 +16,8 @@ package deploy
 
 import (
 	"errors"
+	"runtime"
+	"sync"
 	"testing"
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
@@ -40,6 +42,163 @@ func TestRegisterResourceErrorsOnMissingPendingNew(t *testing.T) {
 	})
 	// Should error, but not panic since the resource is being registered twice.
 	assert.Error(t, err)
+}
+
+type stepGate struct {
+	entered chan struct{}
+	finish  chan struct{}
+}
+
+func newStepGate() *stepGate {
+	return &stepGate{entered: make(chan struct{}), finish: make(chan struct{})}
+}
+
+func (g *stepGate) enter() {
+	close(g.entered)
+	<-g.finish
+}
+
+func (g *stepGate) waitUntilEntered() { <-g.entered }
+
+func (g *stepGate) release() { close(g.finish) }
+
+type pendingWriter struct {
+	lock     *sync.RWMutex
+	acquired chan struct{}
+	release  chan struct{}
+	done     chan struct{}
+}
+
+func (w *pendingWriter) start() {
+	w.acquired = make(chan struct{})
+	w.release = make(chan struct{})
+	w.done = make(chan struct{})
+	go func() {
+		w.lock.Lock()
+		close(w.acquired)
+		<-w.release
+		w.lock.Unlock()
+		close(w.done)
+	}()
+}
+
+func (w *pendingWriter) waitUntilPending() {
+	// Go's RWMutex blocks new readers once a writer is waiting. TryRLock therefore
+	// distinguishes a pending writer from the reader already held by the chain.
+	for w.lock.TryRLock() {
+		w.lock.RUnlock()
+		runtime.Gosched()
+	}
+}
+
+func (w *pendingWriter) assertNotAcquired(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-w.acquired:
+		t.Fatal("writer unexpectedly acquired the executor lock")
+	default:
+	}
+}
+
+func (w *pendingWriter) finish(t *testing.T) {
+	t.Helper()
+
+	<-w.acquired
+	close(w.release)
+	<-w.done
+}
+
+func TestStepExecutorWriterCannotOvertakeQueuedChain(t *testing.T) {
+	t.Parallel()
+
+	executor := &stepExecutor{
+		incomingChains: make(chan incomingChain, 1),
+		ctx:            t.Context(),
+	}
+
+	// The chain has been accepted but no worker has picked it up.
+	executor.ExecuteSerial(chain{})
+	<-executor.incomingChains
+
+	if executor.workerLock.TryLock() {
+		executor.workerLock.Unlock()
+		t.Fatal("writer overtook a queued chain")
+	}
+	// No worker exists in this test, so release the reservation it would own.
+	executor.workerLock.RUnlock()
+}
+
+func TestStepExecutorReservationSpansStepsWithinChain(t *testing.T) {
+	t.Parallel()
+
+	firstURN := resource.URN("urn:pulumi:stack::project::test:index:Resource::first")
+	secondURN := resource.URN("urn:pulumi:stack::project::test:index:Resource::second")
+	first, second := newStepGate(), newStepGate()
+	gates := map[resource.URN]*stepGate{
+		firstURN:  first,
+		secondURN: second,
+	}
+	deployment := &Deployment{
+		opts: &Options{},
+		events: &mockEvents{
+			OnResourceStepPreF: func(step Step) (any, error) {
+				gates[step.URN()].enter()
+				return nil, nil
+			},
+			OnResourceStepPostF: func(any, Step, resource.Status, error) error {
+				return nil
+			},
+		},
+		news: &gsync.Map[resource.URN, *pkgresource.State]{},
+	}
+	executor := &stepExecutor{
+		deployment:     deployment,
+		incomingChains: make(chan incomingChain, 1),
+		ctx:            t.Context(),
+	}
+
+	newSameStep := func(urn resource.URN) Step {
+		return &SameStep{
+			deployment: deployment,
+			old:        &pkgresource.State{URN: urn},
+			new:        &pkgresource.State{URN: urn},
+		}
+	}
+
+	token := executor.ExecuteSerial(chain{
+		newSameStep(firstURN),
+		newSameStep(secondURN),
+	})
+	request := <-executor.incomingChains
+
+	go func() {
+		executor.executeChain(0, request.Chain)
+		close(request.CompletionChan)
+	}()
+
+	// Step 1 is running with the chain reservation.
+	first.waitUntilEntered()
+
+	// Queue an exclusive writer while step 1 is still blocked.
+	writer := &pendingWriter{lock: &executor.workerLock}
+	writer.start()
+	writer.waitUntilPending()
+
+	// Let step 1 finish. Since the lock is for the whole chain, the writer should not acquire it.
+	first.release()
+
+	select {
+	case <-second.entered:
+		writer.assertNotAcquired(t)
+	case <-writer.acquired:
+		writer.finish(t)
+		t.Fatal("writer acquired the executor lock between steps in the same chain")
+	}
+	second.release()
+
+	token.Wait(t.Context())
+	writer.finish(t)
 }
 
 type mockRegisterResourceOutputsEvent struct {


### PR DESCRIPTION
Acquire the step executor read lock before publishing a chain and keep it until the worker finishes the chain. Per-step locking leaves two windows for exclusive work: a writer can overtake a chain before worker pickup or enter between its steps.

For component state migrations (https://github.com/pulumi/pulumi/issues/24045), we will need to take the writer lock before reading and rewriting live state. That lock must form a boundary between complete chains; otherwise a migration could overtake an accepted chain or observe a chain halfway through.

This does not serialize ordinary chain execution: workers still run concurrently under reader reservations, with one lock acquisition per chain instead of per step. Before migrations, performPostSteps is the only caller that acquires the exclusive side of workerLock. It holds the lock while generating post-program delete or refresh steps. Language runtimes drain outstanding resource RPCs before calling SignalAndWaitForShutdown, so the lock will normally find no registration work in progress. The only exception is a trailing ReplaceStep: in a create-before-delete replacement chain, the create step completes the RegisterResource RPC before the logical replacement step finishes.

[Draft dev docs for state migrations](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html)

Ref https://github.com/pulumi/pulumi/issues/24045