### PR TITLE
Remove pdf format from Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,3 @@ build:
 
 sphinx:
   configuration: docs/sphinx/conf.py
-
-formats:
-  - pdf


### PR DESCRIPTION
Read the Docs PDF builds fail because RTD's default PDF builder runs Sphinx from the conf.py directory (docs/sphinx), while our docs use the repo root as the source directory, so the master document resolves to a path that doesn't exist.

This surfaced with #22243, which switched from `build.commands` (where RTD ignores `formats:` entirely) to `build.jobs` (where RTD runs its default PDF pipeline for declared formats). Since no PDF was ever
actually published, drop the `pdf` format to get this all working again.
