### PR TITLE
Fix Neo TUI stuck busy after cancelling a local tool call

### DIFF
--- a/changelog/pending/cli-fix-20260813-000000.yaml
+++ b/changelog/pending/cli-fix-20260813-000000.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: fix
+body: '`pulumi neo`: cancelling a local tool call no longer leaves the TUI stuck
+    on "Thinking..." with input blocked'
+time: 2026-08-13T00:00:00+03:00

--- a/changelog/pending/cli-fix-20260813-000000.yaml
+++ b/changelog/pending/cli-fix-20260813-000000.yaml
@@ -1,5 +1,5 @@
-component: cli
+component: cli/neo
 kind: fix
-body: '`pulumi neo`: cancelling a local tool call no longer leaves the TUI stuck
-    on "Thinking..." with input blocked'
+body: Cancelling a local tool call no longer leaves the TUI stuck on "Thinking..."
+    with input blocked
 time: 2026-08-13T00:00:00+03:00

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -1657,10 +1657,9 @@ func (m *Model) applyBusyForEvent(ev UIEvent) tea.Cmd {
 		return nil
 	}
 	// Tool lifecycle events relabel an existing busy indicator but never
-	// start one from idle: a cancelled local tool reports UIToolCompleted
-	// after the server's cancelled event has already ended the turn, and
-	// resurrecting the spinner then would leave it on — and input blocked —
-	// with no further event ever arriving to clear it.
+	// start one from idle: a killed tool's late UIToolCompleted arrives
+	// after the cancelled event already ended the turn, and resurrecting
+	// the spinner then would block input forever.
 	switch ev.(type) {
 	case UIToolStarted, UIToolProgress, UIToolCompleted:
 		if !m.busy {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -1656,6 +1656,17 @@ func (m *Model) applyBusyForEvent(ev UIEvent) tea.Cmd {
 		// non-final tick): leave the busy state exactly as it is.
 		return nil
 	}
+	// Tool lifecycle events relabel an existing busy indicator but never
+	// start one from idle: a cancelled local tool reports UIToolCompleted
+	// after the server's cancelled event has already ended the turn, and
+	// resurrecting the spinner then would leave it on — and input blocked —
+	// with no further event ever arriving to clear it.
+	switch ev.(type) {
+	case UIToolStarted, UIToolProgress, UIToolCompleted:
+		if !m.busy {
+			return nil
+		}
+	}
 	return m.showBusy(label, shim)
 }
 

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -182,6 +182,48 @@ func TestBusy_CancellingSubstate(t *testing.T) {
 	assert.Equal(t, -1, m.findBlockKind(blockBusy))
 }
 
+// TestBusy_LateToolCompletionAfterCancelStaysIdle — cancelling a local tool
+// delivers the backend's cancelled event before the killed tool's
+// UIToolCompleted (the session cancels the batch context only after
+// forwarding UICancelled, and the tool worker reports once the process
+// dies). The late completion must not resurrect the spinner: no further
+// event will ever arrive to clear it, and Enter is swallowed while busy, so
+// the session would be stuck on "Thinking..." with input blocked forever.
+func TestBusy_LateToolCompletionAfterCancelStaysIdle(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 8)
+	outCh := make(chan outboundEvent, 4)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: true}))
+
+	// Hand-off with pending CLI work, then the tool starts locally.
+	model, _ = model.Update(UIAssistantMessage{IsFinal: true, HasPendingCLIWork: true})
+	model, _ = model.Update(UIToolStarted{Name: "shell__shell_execute", Args: json.RawMessage(`{"command":"sleep 180"}`)})
+	require.True(t, model.(Model).busy)
+
+	// ESC → backend confirms the cancel.
+	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	model, _ = model.Update(UICancelled{})
+	require.False(t, model.(Model).busy, "cancelled event must clear busy")
+
+	// The killed tool's completion lands after the turn already ended.
+	model, _ = model.Update(UIToolCompleted{
+		Name:    "shell__shell_execute",
+		Args:    json.RawMessage(`{"command":"sleep 180"}`),
+		IsError: true,
+	})
+	m := model.(Model)
+	assert.False(t, m.busy, "late tool completion must not resurrect the spinner")
+	assert.Equal(t, -1, m.findBlockKind(blockBusy))
+
+	// Same rule for a straggling start or progress event from the cancelled
+	// batch: relabel-only events never start the spinner from idle.
+	model, _ = model.Update(UIToolStarted{Name: "shell__shell_execute"})
+	assert.False(t, model.(Model).busy, "late tool start must not resurrect the spinner")
+	model, _ = model.Update(UIToolProgress{Name: "shell__shell_execute", Message: "tick"})
+	assert.False(t, model.(Model).busy, "late tool progress must not resurrect the spinner")
+}
+
 // TestBusy_EscIgnoredWhenIdle — ESC while the TUI is idle is a no-op. We
 // don't want to post a spurious user_cancel.
 func TestBusy_EscIgnoredWhenIdle(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -182,13 +182,9 @@ func TestBusy_CancellingSubstate(t *testing.T) {
 	assert.Equal(t, -1, m.findBlockKind(blockBusy))
 }
 
-// TestBusy_LateToolCompletionAfterCancelStaysIdle — cancelling a local tool
-// delivers the backend's cancelled event before the killed tool's
-// UIToolCompleted (the session cancels the batch context only after
-// forwarding UICancelled, and the tool worker reports once the process
-// dies). The late completion must not resurrect the spinner: no further
-// event will ever arrive to clear it, and Enter is swallowed while busy, so
-// the session would be stuck on "Thinking..." with input blocked forever.
+// TestBusy_LateToolCompletionAfterCancelStaysIdle — a killed tool's
+// UIToolCompleted lands after the backend's cancelled event has ended the
+// turn; it must not resurrect the spinner, or the TUI stays busy forever.
 func TestBusy_LateToolCompletionAfterCancelStaysIdle(t *testing.T) {
 	t.Parallel()
 
@@ -196,17 +192,14 @@ func TestBusy_LateToolCompletionAfterCancelStaysIdle(t *testing.T) {
 	outCh := make(chan outboundEvent, 4)
 	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: true}))
 
-	// Hand-off with pending CLI work, then the tool starts locally.
 	model, _ = model.Update(UIAssistantMessage{IsFinal: true, HasPendingCLIWork: true})
 	model, _ = model.Update(UIToolStarted{Name: "shell__shell_execute", Args: json.RawMessage(`{"command":"sleep 180"}`)})
 	require.True(t, model.(Model).busy)
 
-	// ESC → backend confirms the cancel.
 	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
 	model, _ = model.Update(UICancelled{})
 	require.False(t, model.(Model).busy, "cancelled event must clear busy")
 
-	// The killed tool's completion lands after the turn already ended.
 	model, _ = model.Update(UIToolCompleted{
 		Name:    "shell__shell_execute",
 		Args:    json.RawMessage(`{"command":"sleep 180"}`),
@@ -216,8 +209,6 @@ func TestBusy_LateToolCompletionAfterCancelStaysIdle(t *testing.T) {
 	assert.False(t, m.busy, "late tool completion must not resurrect the spinner")
 	assert.Equal(t, -1, m.findBlockKind(blockBusy))
 
-	// Same rule for a straggling start or progress event from the cancelled
-	// batch: relabel-only events never start the spinner from idle.
 	model, _ = model.Update(UIToolStarted{Name: "shell__shell_execute"})
 	assert.False(t, model.(Model).busy, "late tool start must not resurrect the spinner")
 	model, _ = model.Update(UIToolProgress{Name: "shell__shell_execute", Message: "tick"})

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1444,10 +1444,8 @@ func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T
 func TestModel_Update_UIToolStarted_ShowsBusyBlock(t *testing.T) {
 	t.Parallel()
 
-	// Busy is already true when a tool starts in real flows (the hand-off
-	// assistant_message set it); tool lifecycle events only relabel the
-	// spinner, they never start it from idle (see
-	// TestBusy_LateToolCompletionAfterCancelStaysIdle).
+	// Tool lifecycle events never start the spinner from idle, so start
+	// busy, as the hand-off assistant_message leaves it in real flows.
 	ch := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{EventCh: ch, Busy: true})
 	updated, _ := m.Update(UIToolStarted{

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1444,8 +1444,12 @@ func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T
 func TestModel_Update_UIToolStarted_ShowsBusyBlock(t *testing.T) {
 	t.Parallel()
 
+	// Busy is already true when a tool starts in real flows (the hand-off
+	// assistant_message set it); tool lifecycle events only relabel the
+	// spinner, they never start it from idle (see
+	// TestBusy_LateToolCompletionAfterCancelStaysIdle).
 	ch := make(chan UIEvent, 4)
-	m := NewModel(ModelConfig{EventCh: ch})
+	m := NewModel(ModelConfig{EventCh: ch, Busy: true})
 	updated, _ := m.Update(UIToolStarted{
 		Name: "filesystem__read",
 		Args: json.RawMessage(`{"file_path":"/x"}`),


### PR DESCRIPTION
Cancelling a local tool call left the Neo TUI stuck on "Thinking..." with input blocked: the killed tool's `UIToolCompleted` arrives after the server's `cancelled` event and resurrected the busy spinner, and with the turn already over no further event ever clears it.

Make tool lifecycle events (`UIToolStarted`/`UIToolProgress`/`UIToolCompleted`) relabel-only in `applyBusyForEvent`: they update the spinner's label when it is already showing but never start it from idle.

## Test plan

Regression test `TestBusy_LateToolCompletionAfterCancelStaysIdle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
