### PR TITLE
Rewrite `pulumi login` and `pulumi logout` help text

### DIFF
--- a/changelog/pending/20260813--cli--login-help-text.yaml
+++ b/changelog/pending/20260813--cli--login-help-text.yaml
@@ -3,3 +3,5 @@ kind: chore
 body: Rewrite the `pulumi login` and `pulumi logout` help text to cover all supported
     state backends and document `PULUMI_ACCESS_TOKEN`, `--default-org`, and `--interactive`
 time: 2026-08-13T12:00:00Z
+custom:
+    PR: "24319"

--- a/changelog/pending/20260813--cli--login-help-text.yaml
+++ b/changelog/pending/20260813--cli--login-help-text.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: chore
+body: Rewrite the `pulumi login` and `pulumi logout` help text to cover all supported
+    state backends and document `PULUMI_ACCESS_TOKEN`, `--default-org`, and `--interactive`
+time: 2026-08-13T12:00:00Z

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -57,57 +57,34 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Log in to the Pulumi Cloud",
-		Long: "Log in to the Pulumi Cloud.\n" +
+		Short: "Log in to a Pulumi state backend",
+		Long: "Log in to a Pulumi state backend.\n" +
 			"\n" +
-			"The Pulumi Cloud manages your stack's state reliably. Simply run\n" +
+			"With no arguments, this command logs in to Pulumi Cloud:\n" +
 			"\n" +
 			"    $ pulumi login\n" +
 			"\n" +
-			"and this command will prompt you for an access token, including a way to launch your web browser to\n" +
-			"easily obtain one. You can script by using `PULUMI_ACCESS_TOKEN` environment variable.\n" +
+			"If `PULUMI_ACCESS_TOKEN` is set, that token is used. Otherwise, the command prompts for an\n" +
+			"access token and offers to open a browser where you can create one.\n" +
 			"\n" +
-			"By default, this will log in to the managed Pulumi Cloud backend.\n" +
-			"If you prefer to log in to a self-hosted Pulumi Cloud backend, specify a URL. For example, run\n" +
+			"To log in to a self-hosted Pulumi Cloud, pass its API URL:\n" +
 			"\n" +
 			"    $ pulumi login https://api.pulumi.acmecorp.com\n" +
 			"\n" +
-			"to log in to a self-hosted Pulumi Cloud running at the api.pulumi.acmecorp.com domain.\n" +
+			"For either, `--default-org` sets the organization to use when a command doesn't name one, and\n" +
+			"`--interactive` lists the accounts you're already logged in to so you can choose among them.\n" +
 			"\n" +
-			"For `https://` URLs, the CLI will speak REST to a Pulumi Cloud that manages state and concurrency control.\n" +
-			"You can specify a default org to use when logging into the Pulumi Cloud backend or a " +
-			"self-hosted Pulumi Cloud.\n" +
+			"To manage state yourself, pass the URL of a supported storage backend instead. Pulumi stores\n" +
+			"state under a `.pulumi` directory at that location, and backing it up and coordinating access\n" +
+			"across a team is then up to you:\n" +
 			"\n" +
-			"If you prefer to operate Pulumi independently of a Pulumi Cloud, and entirely local to your computer,\n" +
-			"pass `file://<path>`, where `<path>` will be where state checkpoints will be stored. For instance,\n" +
+			"    $ pulumi login file://~                                    # local filesystem\n" +
+			"    $ pulumi login s3://my-pulumi-state-bucket                 # AWS S3\n" +
+			"    $ pulumi login gs://my-pulumi-state-bucket                 # Google Cloud Storage\n" +
+			"    $ pulumi login azblob://my-pulumi-state-bucket             # Azure Blob Storage\n" +
+			"    $ pulumi login postgres://user:password@host:5432/database # PostgreSQL\n" +
 			"\n" +
-			"    $ pulumi login file://~\n" +
-			"\n" +
-			"will store your state information on your computer underneath `~/.pulumi`. It is then up to you to\n" +
-			"manage this state, including backing it up, using it in a team environment, and so on.\n" +
-			"\n" +
-			"As a shortcut, you may pass --local to use your home directory (this is an alias for `file://~`):\n" +
-			"\n" +
-			"    $ pulumi login --local\n" +
-			"\n" +
-			"Additionally, you may leverage supported object storage backends from one of the cloud providers " +
-			"to manage the state independent of the Pulumi Cloud. For instance,\n" +
-			"\n" +
-			"AWS S3:\n" +
-			"\n" +
-			"    $ pulumi login s3://my-pulumi-state-bucket\n" +
-			"\n" +
-			"GCP GCS:\n" +
-			"\n" +
-			"    $ pulumi login gs://my-pulumi-state-bucket\n" +
-			"\n" +
-			"Azure Blob:\n" +
-			"\n" +
-			"    $ pulumi login azblob://my-pulumi-state-bucket\n" +
-			"\n" +
-			"PostgreSQL:\n" +
-			"\n" +
-			"    $ pulumi login postgres://username:password@hostname:5432/database\n",
+			"`--local` is a shortcut for `file://~`, which stores state under `~/.pulumi`.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			displayOptions := display.Options{

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -35,17 +35,25 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Log out of the Pulumi Cloud",
-		Long: "Log out of the Pulumi Cloud.\n" +
+		Short: "Log out of a Pulumi state backend",
+		Long: "Log out of a Pulumi state backend.\n" +
 			"\n" +
-			"This command deletes stored credentials on the local machine for a single login.\n" +
+			"This command deletes the credentials stored on this machine for a single login. With no\n" +
+			"arguments, it logs you out of the current backend:\n" +
 			"\n" +
-			"Because you may be logged into multiple backends simultaneously, you can optionally pass\n" +
-			"a specific URL argument, formatted just as you logged in, to log out of a specific one.\n" +
-			"If no URL is provided, you will be logged out of the current backend." +
-			"\n\n" +
-			"If you would like to log out of all backends simultaneously, you can pass `--all`,\n\n" +
-			"    $ pulumi logout --all",
+			"    $ pulumi logout\n" +
+			"\n" +
+			"You can be logged in to several backends at once. To choose one, pass its URL, written the\n" +
+			"same way you wrote it when logging in:\n" +
+			"\n" +
+			"    $ pulumi logout https://api.pulumi.acmecorp.com\n" +
+			"    $ pulumi logout s3://my-pulumi-state-bucket\n" +
+			"\n" +
+			"To log out of every backend at once, pass `--all`:\n" +
+			"\n" +
+			"    $ pulumi logout --all\n" +
+			"\n" +
+			"`--local` is a shortcut for `file://~`, matching `pulumi login --local`.\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If a <cloud> was specified as an argument, use it.
 			if len(args) > 0 {
@@ -106,11 +114,11 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 	})
 
 	cmd.PersistentFlags().BoolVar(&all, "all", false,
-		"Logout of all backends")
+		"Log out of all backends")
 	cmd.PersistentFlags().StringVarP(&cloudURL, "cloud-url", "c", "",
-		"A cloud URL to log out of (defaults to current cloud)")
+		"A cloud URL to log out of (defaults to the current backend)")
 	cmd.PersistentFlags().BoolVarP(&localMode, "local", "l", false,
-		"Log out of using local mode")
+		"Log out of local-only mode (an alias for `file://~`)")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #24315.

The `pulumi login` long help was outdated and incomplete. It described only Pulumi Cloud despite the command supporting DIY state backends, advertised Pulumi Cloud's virtues in what should be reference documentation, and left `--interactive` and `--default-org` undocumented. It also instructed the reader to run the very command they had just asked for help about.

`pulumi logout` is updated to match, since it shared the same framing.

Both now follow the [Pulumi docs style guide](https://github.com/pulumi/docs/blob/master/STYLE-GUIDE.md): second person, present tense, no "simply"/"easily" (the guide bans terms that judge difficulty), and no marketing copy. "State backend" is the term the docs use throughout, and the concept page is titled *State & backends*.

### `pulumi login`

```
Log in to a Pulumi state backend.

With no arguments, this command logs in to Pulumi Cloud:

    $ pulumi login

If `PULUMI_ACCESS_TOKEN` is set, that token is used. Otherwise, the command prompts for an
access token and offers to open a browser where you can create one.

To log in to a self-hosted Pulumi Cloud, pass its API URL:

    $ pulumi login https://api.pulumi.acmecorp.com

For either, `--default-org` sets the organization to use when a command doesn't name one, and
`--interactive` lists the accounts you're already logged in to so you can choose among them.

To manage state yourself, pass the URL of a supported storage backend instead. Pulumi stores
state under a `.pulumi` directory at that location, and backing it up and coordinating access
across a team is then up to you:

    $ pulumi login file://~                                    # local filesystem
    $ pulumi login s3://my-pulumi-state-bucket                 # AWS S3
    $ pulumi login gs://my-pulumi-state-bucket                 # Google Cloud Storage
    $ pulumi login azblob://my-pulumi-state-bucket             # Azure Blob Storage
    $ pulumi login postgres://user:password@host:5432/database # PostgreSQL

`--local` is a shortcut for `file://~`, which stores state under `~/.pulumi`.
```

Notable changes:

- `PULUMI_ACCESS_TOKEN` is stated as the default path with the browser prompt as the fallback, rather than buried as a scripting afterthought.
- `--interactive` and `--default-org` are now documented.
- The five one-per-heading object-storage sections collapse into a single aligned block.

### `pulumi logout`

```
Log out of a Pulumi state backend.

This command deletes the credentials stored on this machine for a single login. With no
arguments, it logs you out of the current backend:

    $ pulumi logout

You can be logged in to several backends at once. To choose one, pass its URL, written the
same way you wrote it when logging in:

    $ pulumi logout https://api.pulumi.acmecorp.com
    $ pulumi logout s3://my-pulumi-state-bucket

To log out of every backend at once, pass `--all`:

    $ pulumi logout --all

`--local` is a shortcut for `file://~`, matching `pulumi login --local`.
```

Notable changes:

- Adds the bare `pulumi logout` example so the no-argument default is shown, not just described.
- Adds a DIY-backend example; the old text said "formatted just as you logged in" without showing that a bucket URL counts.
- Documents `--local`, which the long help didn't mention.

Three `pulumi logout` flag descriptions are also fixed: `--all` said "Logout of all backends" (noun for verb), `--local` said "Log out of using local mode", and `--cloud-url` said "current cloud" where the rest of the text now says "backend".

### Notes

- This is help text only — no behavior, flag, or argument changes. `Short` does change, so the one-line descriptions in `pulumi --help` change too.
- The examples stay `$`-prefixed and indented rather than becoming fenced code blocks: this string renders in a terminal, where fences would show literally, and indentation matches the other CLI commands that carry examples. The generated docs page at `content/docs/iac/cli/commands/pulumi_login.md` will pick the new text up on the next sync.

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works — n/a, documentation-only change
- [x] I have added a changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
