### PR TITLE
Decompose config prompting into a reusable pipeline

### DIFF
--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -366,6 +366,26 @@ func parseKeyValuePair(pair string, path bool) (config.Key, string, error) {
 // foo.bar:buzz is a (namespace: foo.bar, key: buzz) if not path, and
 // (namespace: <project-name>, key: foo.bar:buzz) if path.
 func ParseConfigKey(ws pkgWorkspace.Context, key string, path bool) (config.Key, error) {
+	return parseConfigKey(key, path, func() (tokens.PackageName, error) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getting current working directory: %w", err)
+		}
+
+		proj, _, err := ws.ReadProject(cwd)
+		if err != nil {
+			return "", err
+		}
+		return proj.Name, nil
+	})
+}
+
+// ParseConfigKeyForProject is [ParseConfigKey] for callers that already know the project name.
+func ParseConfigKeyForProject(projectName tokens.PackageName, key string, path bool) (config.Key, error) {
+	return parseConfigKey(key, path, func() (tokens.PackageName, error) { return projectName, nil })
+}
+
+func parseConfigKey(key string, path bool, projectName func() (tokens.PackageName, error)) (config.Key, error) {
 	// If the key is a path, the namespacing requirement only applies to the
 	// top-level key, while sub-keys may have arbitrary names.
 	if path {
@@ -375,7 +395,7 @@ func ParseConfigKey(ws pkgWorkspace.Context, key string, path bool) (config.Key,
 		bracketOrDotIndex := strings.IndexAny(key, "[.")
 		if bracketOrDotIndex > 0 {
 			topSegment := key[:bracketOrDotIndex]
-			topKey, err := ParseConfigKey(ws, topSegment, false)
+			topKey, err := parseConfigKey(topSegment, false, projectName)
 			if err != nil {
 				return config.Key{}, err
 			}
@@ -386,17 +406,12 @@ func ParseConfigKey(ws pkgWorkspace.Context, key string, path bool) (config.Key,
 	// As a convenience, we'll treat any key with no delimiter as if:
 	// <program-name>:<key> had been written instead
 	if !strings.Contains(key, tokens.TokenDelimiter) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return config.Key{}, fmt.Errorf("getting current working directory: %w", err)
-		}
-
-		proj, _, err := ws.ReadProject(cwd)
+		name, err := projectName()
 		if err != nil {
 			return config.Key{}, err
 		}
 
-		return config.ParseKey(fmt.Sprintf("%s:%s", proj.Name, key))
+		return config.ParseKey(fmt.Sprintf("%s:%s", name, key))
 	}
 
 	return config.ParseKey(key)
@@ -408,11 +423,12 @@ func PrettyKey(k config.Key) string {
 		return fmt.Sprintf("%s:%s", k.Namespace(), k.Name())
 	}
 
-	return prettyKeyForProject(k, proj)
+	return PrettyKeyForProject(k, proj.Name)
 }
 
-func prettyKeyForProject(k config.Key, proj *workspace.Project) string {
-	if k.Namespace() == string(proj.Name) {
+// PrettyKeyForProject is [PrettyKey] for callers that already know the project name.
+func PrettyKeyForProject(k config.Key, projectName tokens.PackageName) string {
+	if k.Namespace() == string(projectName) {
 		return k.Name()
 	}
 

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -39,13 +39,10 @@ import (
 func TestPrettyKeyForProject(t *testing.T) {
 	t.Parallel()
 
-	proj := &workspace.Project{
-		Name:    tokens.PackageName("test-package"),
-		Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
-	}
+	projectName := tokens.PackageName("test-package")
 
-	assert.Equal(t, "foo", prettyKeyForProject(config.MustMakeKey("test-package", "foo"), proj))
-	assert.Equal(t, "other-package:bar", prettyKeyForProject(config.MustMakeKey("other-package", "bar"), proj))
+	assert.Equal(t, "foo", PrettyKeyForProject(config.MustMakeKey("test-package", "foo"), projectName))
+	assert.Equal(t, "other-package:bar", PrettyKeyForProject(config.MustMakeKey("other-package", "bar"), projectName))
 	assert.Panics(t, func() { config.MustMakeKey("other:package", "bar") })
 }
 

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -202,7 +202,7 @@ func promptForConfig(
 		return nil, err
 	}
 
-	values, err := resolveTemplateDefaults(project.Name, templateConfig, commandLineConfig, stackConfig, decrypter)
+	values, err := resolveTemplateConfig(project.Name, templateConfig, commandLineConfig, stackConfig, decrypter)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (v templateConfigValue) unset() bool {
 	return !v.fromFlag && v.value == ""
 }
 
-func resolveTemplateDefaults(
+func resolveTemplateConfig(
 	projectName tokens.PackageName,
 	templateConfig map[string]workspace.ProjectTemplateConfigValue,
 	commandLineConfig config.Map,

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
@@ -196,116 +197,174 @@ func promptForConfig(
 	opts display.Options,
 	configFile string,
 ) (config.Map, error) {
+	encrypter, decrypter, err := stackCrypters(ctx, sink, ssml, project, stack, configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := resolveTemplateDefaults(project.Name, templateConfig, commandLineConfig, stackConfig, decrypter)
+	if err != nil {
+		return nil, err
+	}
+	if err := askTemplateConfig(values, prompt, yes, askAll, opts); err != nil {
+		return nil, err
+	}
+
+	return encryptTemplateConfig(ctx, encrypter, values, commandLineConfig)
+}
+
+// A template config entry, held as plaintext so values can be gathered before a stack exists to
+// encrypt secrets.
+type templateConfigValue struct {
+	// As the template declared it; stable when the project name changes.
+	templateKey string
+	key         config.Key
+	value       string
+	secret      bool
+	promptText  string // "Description (pretty:key)"
+	// Never re-asked: the answer would lose to the --config value at save time.
+	fromFlag bool
+}
+
+func (v templateConfigValue) unset() bool {
+	return !v.fromFlag && v.value == ""
+}
+
+func resolveTemplateDefaults(
+	projectName tokens.PackageName,
+	templateConfig map[string]workspace.ProjectTemplateConfigValue,
+	commandLineConfig config.Map,
+	stackConfig config.Map,
+	decrypter config.Decrypter,
+) ([]templateConfigValue, error) {
 	// Convert `string` keys to `config.Key`. If a string key is missing a delimiter,
 	// the project name will be prepended.
-	parsedTemplateConfig := make(map[config.Key]workspace.ProjectTemplateConfigValue)
-	for k, v := range templateConfig {
-		parsedKey, parseErr := cmdConfig.ParseConfigKey(pkgWorkspace.Instance, k, false)
-		if parseErr != nil {
-			return nil, parseErr
+	templateKeys := make(map[config.Key]string, len(templateConfig))
+	keys := make(config.KeyArray, 0, len(templateConfig))
+	for k := range templateConfig {
+		parsedKey, err := cmdConfig.ParseConfigKeyForProject(projectName, k, false)
+		if err != nil {
+			return nil, err
 		}
-		parsedTemplateConfig[parsedKey] = v
+		templateKeys[parsedKey] = k
+		keys = append(keys, parsedKey)
 	}
 
 	// Sort keys. Note that we use the fully qualified module member here instead of a `prettyKey` so that
 	// all config values for the current program are prompted one after another.
-	var keys config.KeyArray
-	for k := range parsedTemplateConfig {
-		keys = append(keys, k)
-	}
 	sort.Sort(keys)
 
-	// We need to load the stack config here for the secret manager
-	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
-	if err != nil {
-		return nil, fmt.Errorf("loading stack config: %w", err)
-	}
-
-	sm, state, err := ssml.GetSecretsManager(ctx, stack, ps)
-	if err != nil {
-		return nil, err
-	}
-	if state != cmdStack.SecretsManagerUnchanged {
-		if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
-			return nil, fmt.Errorf("saving stack config: %w", err)
-		}
-	}
-	encrypter := sm.Encrypter()
-	decrypter := sm.Decrypter()
-
-	c := make(config.Map)
-
+	values := make([]templateConfigValue, 0, len(keys))
 	for _, k := range keys {
-		// If it was passed as a command line flag, use it without prompting.
-		if val, ok := commandLineConfig[k]; ok {
-			c[k] = val
-			continue
+		templateKey := templateKeys[k]
+		tcv := templateConfig[templateKey]
+
+		promptText := cmdConfig.PrettyKeyForProject(k, projectName)
+		if tcv.Description != "" {
+			promptText = tcv.Description + " (" + promptText + ")"
+		}
+		entry := templateConfigValue{
+			templateKey: templateKey,
+			key:         k,
+			secret:      tcv.Secret,
+			promptText:  promptText,
 		}
 
-		templateConfigValue := parsedTemplateConfig[k]
-
-		// Prepare a default value.
-		var defaultValue string
-		var secret bool
-		if stackConfig != nil {
-			// Use the stack's existing value as the default.
-			if val, ok := stackConfig[k]; ok {
-				// It's OK to pass a nil or non-nil crypter for non-secret values.
-				value, err := val.Value(decrypter)
-				if err != nil {
-					return nil, err
-				}
-				defaultValue = value
-			}
-		}
-		if defaultValue == "" {
-			defaultValue = templateConfigValue.Default
-		}
-		if !secret {
-			secret = templateConfigValue.Secret
-		}
-
-		// Prepare the prompt.
-		promptText := cmdConfig.PrettyKey(k)
-		if templateConfigValue.Description != "" {
-			promptText = templateConfigValue.Description + " (" + promptText + ")"
-		}
-
-		// Prompt.
-		value, err := prompt(yes, promptText, defaultValue, secret, nil, opts)
-		if err != nil {
-			return nil, err
-		}
-
-		if value == "" {
-			// Don't add empty values to the config.
-			continue
-		}
-
-		// Encrypt the value if needed.
-		var v config.Value
-		if secret {
-			enc, err := encrypter.EncryptValue(ctx, value)
+		if flagValue, ok := commandLineConfig[k]; ok {
+			plain, err := flagValue.Value(config.NopDecrypter)
 			if err != nil {
 				return nil, err
 			}
-			v = config.NewSecureValue(enc)
+			entry.value, entry.fromFlag = plain, true
+		} else if stackValue, ok := stackConfig[k]; ok {
+			// It's OK to pass a nil or non-nil crypter for non-secret values.
+			plain, err := stackValue.Value(decrypter)
+			if err != nil {
+				return nil, err
+			}
+			entry.value = plain
+		}
+		if entry.value == "" && !entry.fromFlag {
+			entry.value = tcv.Default
+		}
+		values = append(values, entry)
+	}
+	return values, nil
+}
+
+// The scope of keys askTemplateConfig prompts for; keys fixed by a --config flag are never asked.
+type askScope int
+
+const (
+	askAll askScope = iota
+	askUnset
+)
+
+func askTemplateConfig(
+	values []templateConfigValue, prompt promptForValueFunc,
+	yes bool, scope askScope, opts display.Options,
+) error {
+	for i, v := range values {
+		if v.fromFlag || (scope == askUnset && !v.unset()) {
+			continue
+		}
+		answer, err := prompt(yes, v.promptText, v.value, v.secret, nil, opts)
+		if err != nil {
+			return err
+		}
+		values[i].value = answer
+	}
+	return nil
+}
+
+// commandLineConfig is merged as-is so --config values keep their parsed structure and win even
+// for keys the template does not declare.
+func encryptTemplateConfig(
+	ctx context.Context, encrypter config.Encrypter,
+	values []templateConfigValue, commandLineConfig config.Map,
+) (config.Map, error) {
+	c := make(config.Map, len(values)+len(commandLineConfig))
+	maps.Copy(c, commandLineConfig)
+	for _, v := range values {
+		if _, ok := c[v.key]; ok {
+			continue
+		}
+		if v.value == "" {
+			// Don't add empty values to the config.
+			continue
+		}
+		if v.secret {
+			enc, err := encrypter.EncryptValue(ctx, v.value)
+			if err != nil {
+				return nil, err
+			}
+			c[v.key] = config.NewSecureValue(enc)
 		} else {
-			v = config.NewValue(value)
-		}
-
-		// Save it.
-		c[k] = v
-	}
-
-	// Add any other config values from the command line.
-	for k, v := range commandLineConfig {
-		if _, ok := c[k]; !ok {
-			c[k] = v
+			c[v.key] = config.NewValue(v.value)
 		}
 	}
-
 	return c, nil
+}
+
+func stackCrypters(
+	ctx context.Context, sink diag.Sink, ssml cmdStack.SecretsManagerLoader,
+	project *workspace.Project, s backend.Stack, configFile string,
+) (config.Encrypter, config.Decrypter, error) {
+	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, s, configFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading stack config: %w", err)
+	}
+
+	sm, state, err := ssml.GetSecretsManager(ctx, s, ps)
+	if err != nil {
+		return nil, nil, err
+	}
+	if state != cmdStack.SecretsManagerUnchanged {
+		if err = cmdStack.SaveProjectStack(ctx, s, ps, configFile); err != nil {
+			return nil, nil, fmt.Errorf("saving stack config: %w", err)
+		}
+	}
+	return sm.Encrypter(), sm.Decrypter(), nil
 }
 
 // ParseConfig parses the config values passed via command line flags.
@@ -313,11 +372,28 @@ func promptForConfig(
 // in configArray as ["aws:region=us-east-1", "foo:bar=blah"].
 // This function converts the array into a config.Map.
 func ParseConfig(configArray []string, path bool) (config.Map, error) {
+	return parseConfig(configArray, path, func(key string) (config.Key, error) {
+		return cmdConfig.ParseConfigKey(pkgWorkspace.Instance, key, path)
+	})
+}
+
+// ParseConfigForProject is [ParseConfig] for callers that already know the project name.
+func ParseConfigForProject(
+	projectName tokens.PackageName, configArray []string, path bool,
+) (config.Map, error) {
+	return parseConfig(configArray, path, func(key string) (config.Key, error) {
+		return cmdConfig.ParseConfigKeyForProject(projectName, key, path)
+	})
+}
+
+func parseConfig(
+	configArray []string, path bool, parseKey func(string) (config.Key, error),
+) (config.Map, error) {
 	configMap := make(config.Map)
 	for _, c := range configArray {
 		kvp := strings.SplitN(c, "=", 2)
 
-		key, err := cmdConfig.ParseConfigKey(pkgWorkspace.Instance, kvp[0], path)
+		key, err := parseKey(kvp[0])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/project/newcmd/config_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/config_test.go
@@ -16,9 +16,12 @@ package newcmd
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -300,4 +303,137 @@ func TestSetFail(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestTemplateConfigResolvesWithoutPrompting(t *testing.T) {
+	t.Parallel()
+
+	values, err := resolveTemplateDefaults(
+		"proj",
+		map[string]workspace.ProjectTemplateConfigValue{
+			"aws:region":  {Description: "The AWS region to deploy into", Default: "us-east-1"},
+			"gcp:zone":    {Description: "The zone"},
+			"gcp:project": {Description: "The Google Cloud project to deploy into"},
+			"auth0:token": {Description: "The token", Secret: true},
+		},
+		config.Map{config.MustMakeKey("gcp", "zone"): config.NewValue("z")},
+		nil, nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, slices.ContainsFunc(values, templateConfigValue.unset),
+		"the no-default keys are unset, which is what earns a question")
+
+	prompts := 0
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		prompts++
+		return "typed:" + valueType, nil
+	}
+	require.NoError(t, askTemplateConfig(values, prompt, false, askUnset, display.Options{}))
+
+	byKey := map[string]templateConfigValue{}
+	for _, v := range values {
+		byKey[v.key.String()] = v
+	}
+	assert.Equal(t, "us-east-1", byKey["aws:region"].value, "a default is filled in silently")
+	assert.Equal(t, "z", byKey["gcp:zone"].value, "a flag value is filled in silently")
+	assert.True(t, byKey["gcp:zone"].fromFlag)
+	assert.Equal(t,
+		"typed:The Google Cloud project to deploy into (gcp:project)",
+		byKey["gcp:project"].value, "no default means a prompt, with promptForConfig's prompt text")
+	assert.True(t, byKey["auth0:token"].secret)
+	assert.Equal(t, 2, prompts, "only the two no-default keys prompt")
+}
+
+func TestTemplateConfigAsksForEveryKey(t *testing.T) {
+	t.Parallel()
+
+	values, err := resolveTemplateDefaults(
+		"proj",
+		map[string]workspace.ProjectTemplateConfigValue{
+			"aws:region": {Default: "us-east-1"},
+			"gcp:zone":   {Default: "a"},
+		},
+		config.Map{config.MustMakeKey("gcp", "zone"): config.NewValue("z")},
+		nil, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, values, 2)
+	// Overlay a prior value, as the decline path does with what its confirmation showed.
+	values[0].value = "eu-west-1"
+
+	defaults := map[string]string{}
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		defaults[valueType] = defaultValue
+		return "typed", nil
+	}
+	require.NoError(t, askTemplateConfig(values, prompt, false, askAll, display.Options{}))
+
+	assert.Equal(t, map[string]string{"aws:region": "eu-west-1"}, defaults,
+		"the resolved value pre-fills the prompt, and a key fixed by --config is never asked")
+	byKey := map[string]templateConfigValue{}
+	for _, v := range values {
+		byKey[v.key.String()] = v
+	}
+	assert.Equal(t, "typed", byKey["aws:region"].value)
+	assert.Equal(t, "z", byKey["gcp:zone"].value, "the flag value survives, unasked")
+}
+
+func TestTemplateConfigNamespacesBareKeys(t *testing.T) {
+	t.Parallel()
+
+	// A bare key takes the project's namespace. Resolving it must not depend on a Pulumi.yaml
+	// being on disk, which it is not when the guided flow gathers config before creating one.
+	values, err := resolveTemplateDefaults(
+		"my-proj",
+		map[string]workspace.ProjectTemplateConfigValue{
+			"bucketName": {Description: "The bucket"},
+		},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Equal(t, "my-proj:bucketName", values[0].key.String())
+	assert.Equal(t, "bucketName", values[0].templateKey)
+
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		return "typed:" + valueType, nil
+	}
+	require.NoError(t, askTemplateConfig(values, prompt, false, askUnset, display.Options{}))
+	assert.Equal(t, "typed:The bucket (bucketName)", values[0].value,
+		"the prompt elides the namespace when it is the project's own")
+}
+
+func TestTemplateConfigOrdersKeys(t *testing.T) {
+	t.Parallel()
+
+	values, err := resolveTemplateDefaults(
+		"proj",
+		map[string]workspace.ProjectTemplateConfigValue{
+			"b:two": {Default: "2"}, "a:one": {Default: "1"},
+		},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, values, 2)
+	assert.Equal(t, "a:one", values[0].key.String())
+	assert.Equal(t, "b:two", values[1].key.String())
+	assert.False(t, slices.ContainsFunc(values, templateConfigValue.unset),
+		"every key had a default, so nothing would be asked")
+}
+
+func TestParseConfigForProjectNamespacesBareKeys(t *testing.T) {
+	t.Parallel()
+
+	c, err := ParseConfigForProject("my-proj", []string{"bucketName=b", "aws:region=us-east-1"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, config.Map{
+		config.MustMakeKey("my-proj", "bucketName"): config.NewValue("b"),
+		config.MustMakeKey("aws", "region"):         config.NewValue("us-east-1"),
+	}, c)
 }

--- a/pkg/cmd/pulumi/project/newcmd/config_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/config_test.go
@@ -308,7 +308,7 @@ func TestSetFail(t *testing.T) {
 func TestTemplateConfigResolvesWithoutPrompting(t *testing.T) {
 	t.Parallel()
 
-	values, err := resolveTemplateDefaults(
+	values, err := resolveTemplateConfig(
 		"proj",
 		map[string]workspace.ProjectTemplateConfigValue{
 			"aws:region":  {Description: "The AWS region to deploy into", Default: "us-east-1"},
@@ -349,7 +349,7 @@ func TestTemplateConfigResolvesWithoutPrompting(t *testing.T) {
 func TestTemplateConfigAsksForEveryKey(t *testing.T) {
 	t.Parallel()
 
-	values, err := resolveTemplateDefaults(
+	values, err := resolveTemplateConfig(
 		"proj",
 		map[string]workspace.ProjectTemplateConfigValue{
 			"aws:region": {Default: "us-east-1"},
@@ -387,7 +387,7 @@ func TestTemplateConfigNamespacesBareKeys(t *testing.T) {
 
 	// A bare key takes the project's namespace. Resolving it must not depend on a Pulumi.yaml
 	// being on disk, which it is not when the guided flow gathers config before creating one.
-	values, err := resolveTemplateDefaults(
+	values, err := resolveTemplateConfig(
 		"my-proj",
 		map[string]workspace.ProjectTemplateConfigValue{
 			"bucketName": {Description: "The bucket"},
@@ -412,7 +412,7 @@ func TestTemplateConfigNamespacesBareKeys(t *testing.T) {
 func TestTemplateConfigOrdersKeys(t *testing.T) {
 	t.Parallel()
 
-	values, err := resolveTemplateDefaults(
+	values, err := resolveTemplateConfig(
 		"proj",
 		map[string]workspace.ProjectTemplateConfigValue{
 			"b:two": {Default: "2"}, "a:one": {Default: "1"},

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -77,12 +77,12 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		return createStack(ctx, sink, ws, b, stack, root, createOpts)
 	}
 
-	// Helper used by multiple commands, with no writer of its own; the blurb goes to process stdout.
 	stackName, err := promptStackName(os.Stdout, b, prompt, defaultStackName, yes, opts) //nolint:forbidigo
 	if err != nil {
 		return nil, err
 	}
-	s, _, err := createStackWithRetry(ctx, sink, ws, b, prompt, stackName, root, yes, opts, createOpts)
+	s, _, err := createStackWithRetry(ctx, sink, os.Stdout, ws, b, prompt, //nolint:forbidigo
+		stackName, root, yes, opts, createOpts)
 	return s, err
 }
 
@@ -110,9 +110,8 @@ func createStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b
 	return cmdStack.InitStack(ctx, sink, ws, b, formatted, root, opts)
 }
 
-// The returned name is org-resolved; [backend.StackReference.String] elides the org when it is
-// the default.
-func createStackWithRetry(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
+// The returned name includes the organization, which the passed-in name may not.
+func createStackWithRetry(ctx context.Context, sink diag.Sink, w io.Writer, ws pkgWorkspace.Context,
 	b backend.Backend, prompt promptForValueFunc, stackName, root string, yes bool,
 	opts display.Options, createOpts cmdStack.CreateStackOptions,
 ) (backend.Stack, string, error) {
@@ -129,7 +128,7 @@ func createStackWithRetry(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 			return nil, "", err
 		}
 		// Let the user know about the error and loop around to try again.
-		fmt.Printf("Sorry, could not create stack '%s': %v\n", stackName, err) //nolint:forbidigo
+		fmt.Fprintf(w, "Sorry, could not create stack '%s': %v\n", stackName, err)
 		if stackName, err = prompt(yes, "Stack name", defaultStackName, false, b.ValidateStackName, opts); err != nil {
 			return nil, "", err
 		}

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -17,6 +17,8 @@ package newcmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -72,43 +74,65 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		ConfigFile:      configFile,
 	}
 	if stack != "" {
-		stackName, err := buildStackName(ctx, b, stack)
-		if err != nil {
-			return nil, err
-		}
-		s, err := cmdStack.InitStack(ctx, sink, ws, b, stackName, root, createOpts)
-		if err != nil {
-			return nil, err
-		}
-		return s, nil
+		return createStack(ctx, sink, ws, b, stack, root, createOpts)
 	}
 
+	// Helper used by multiple commands, with no writer of its own; the blurb goes to process stdout.
+	stackName, err := promptStackName(os.Stdout, b, prompt, defaultStackName, yes, opts) //nolint:forbidigo
+	if err != nil {
+		return nil, err
+	}
+	s, _, err := createStackWithRetry(ctx, sink, ws, b, prompt, stackName, root, yes, opts, createOpts)
+	return s, err
+}
+
+const defaultStackName = "dev"
+
+func promptStackName(
+	w io.Writer, b backend.Backend, prompt promptForValueFunc, defaultName string,
+	yes bool, opts display.Options,
+) (string, error) {
 	if b.SupportsOrganizations() {
-		// Helper used by multiple commands; uses process stdout.
-		fmt.Print("Please enter your desired stack name.\n" + //nolint:forbidigo
-			"To create a stack in an organization, " +
+		fmt.Fprint(w, "Please enter your desired stack name.\n"+
+			"To create a stack in an organization, "+
 			"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
 	}
+	return prompt(yes, "Stack name", defaultName, false, b.ValidateStackName, opts)
+}
 
+func createStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b backend.Backend,
+	stackName, root string, opts cmdStack.CreateStackOptions,
+) (backend.Stack, error) {
+	formatted, err := buildStackName(ctx, b, stackName)
+	if err != nil {
+		return nil, err
+	}
+	return cmdStack.InitStack(ctx, sink, ws, b, formatted, root, opts)
+}
+
+// The returned name is org-resolved; [backend.StackReference.String] elides the org when it is
+// the default.
+func createStackWithRetry(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
+	b backend.Backend, prompt promptForValueFunc, stackName, root string, yes bool,
+	opts display.Options, createOpts cmdStack.CreateStackOptions,
+) (backend.Stack, string, error) {
 	for {
-		stackName, err := prompt(yes, "Stack name", "dev", false, b.ValidateStackName, opts)
+		formatted, err := buildStackName(ctx, b, stackName)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		formattedStackName, err := buildStackName(ctx, b, stackName)
-		if err != nil {
-			return nil, err
+		s, err := cmdStack.InitStack(ctx, sink, ws, b, formatted, root, createOpts)
+		if err == nil {
+			return s, formatted, nil
 		}
-		s, err := cmdStack.InitStack(ctx, sink, ws, b, formattedStackName, root, createOpts)
-		if err != nil {
-			if !yes {
-				// Let the user know about the error and loop around to try again.
-				fmt.Printf("Sorry, could not create stack '%s': %v\n", stackName, err) //nolint:forbidigo
-				continue
-			}
-			return nil, err
+		if yes {
+			return nil, "", err
 		}
-		return s, nil
+		// Let the user know about the error and loop around to try again.
+		fmt.Printf("Sorry, could not create stack '%s': %v\n", stackName, err) //nolint:forbidigo
+		if stackName, err = prompt(yes, "Stack name", defaultStackName, false, b.ValidateStackName, opts); err != nil {
+			return nil, "", err
+		}
 	}
 }
 

--- a/pkg/cmd/pulumi/project/newcmd/stack_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+)
+
+// stackCreationBackend fails CreateStack a set number of times, then keeps failing or
+// succeeding per the remaining count, recording each attempted name.
+func stackCreationBackend(t *testing.T, failures int, created *[]string) *backend.MockBackend {
+	return &backend.MockBackend{
+		SupportsOrganizationsF: func() bool { return false },
+		GetDefaultOrgF:         func(ctx context.Context) (string, error) { return "", nil },
+		ValidateStackNameF:     func(s string) error { return nil },
+		ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+			return &backend.MockStackReference{
+				NameV:   tokens.MustParseStackName(s),
+				StringV: s,
+			}, nil
+		},
+		DefaultSecretManagerF: func(ctx context.Context, ps *workspace.ProjectStack) (secrets.Manager, error) {
+			return nil, nil
+		},
+		CreateStackF: func(ctx context.Context, ref backend.StackReference, root string,
+			initialState *apitype.UntypedDeployment, opts *backend.CreateStackOptions,
+		) (backend.Stack, error) {
+			*created = append(*created, ref.String())
+			if len(*created) <= failures {
+				return nil, errors.New("stack exists")
+			}
+			return &backend.MockStack{RefF: func() backend.StackReference { return ref }}, nil
+		},
+	}
+}
+
+//nolint:paralleltest // uses process stdout
+func TestPromptAndCreateStackNamedStackHardErrors(t *testing.T) {
+	var created []string
+	b := stackCreationBackend(t, 1, &created)
+	prompts := 0
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		prompts++
+		return defaultValue, nil
+	}
+
+	_, err := PromptAndCreateStack(t.Context(), cmdutil.Diag(), pkgWorkspace.Instance,
+		b, prompt, "named", t.TempDir(), false, false, display.Options{}, "default", false, "")
+
+	assert.Error(t, err, "a pre-decided stack name must not retry")
+	assert.Equal(t, 0, prompts, "a pre-decided stack name must not prompt")
+	assert.Equal(t, []string{"named"}, created)
+}
+
+//nolint:paralleltest // uses process stdout
+func TestCreateStackWithRetryRepromptsOnFailure(t *testing.T) {
+	var created []string
+	b := stackCreationBackend(t, 1, &created)
+	names := []string{"second"}
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		require.NotEmpty(t, names, "unexpected extra prompt")
+		name := names[0]
+		names = names[1:]
+		return name, nil
+	}
+
+	s, resolved, err := createStackWithRetry(t.Context(), cmdutil.Diag(), pkgWorkspace.Instance,
+		b, prompt, "first", t.TempDir(), false, display.Options{},
+		cmdStack.CreateStackOptions{SecretsProvider: "default", Quiet: true})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"first", "second"}, created)
+	assert.Equal(t, "second", resolved)
+	require.NotNil(t, s)
+}
+
+//nolint:paralleltest // uses process stdout
+func TestCreateStackWithRetryDefaultOrgFailureIsFatal(t *testing.T) {
+	var created []string
+	b := stackCreationBackend(t, 1, &created)
+	b.GetDefaultOrgF = func(ctx context.Context) (string, error) {
+		return "", errors.New("could not determine default org")
+	}
+	prompt := func(yes bool, valueType, defaultValue string, secret bool,
+		isValidFn func(string) error, opts display.Options,
+	) (string, error) {
+		t.Fatal("unexpected prompt: a buildStackName failure must not retry")
+		return "", nil
+	}
+
+	s, resolved, err := createStackWithRetry(t.Context(), cmdutil.Diag(), pkgWorkspace.Instance,
+		b, prompt, "first", t.TempDir(), false, display.Options{},
+		cmdStack.CreateStackOptions{SecretsProvider: "default", Quiet: true})
+
+	assert.Error(t, err, "a buildStackName failure must be fatal")
+	assert.Empty(t, created, "CreateStack must not be attempted when buildStackName fails")
+	assert.Empty(t, resolved)
+	assert.Nil(t, s)
+}

--- a/pkg/cmd/pulumi/project/newcmd/stack_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack_test.go
@@ -17,6 +17,7 @@ package newcmd
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,8 +83,9 @@ func TestPromptAndCreateStackNamedStackHardErrors(t *testing.T) {
 	assert.Equal(t, []string{"named"}, created)
 }
 
-//nolint:paralleltest // uses process stdout
 func TestCreateStackWithRetryRepromptsOnFailure(t *testing.T) {
+	t.Parallel()
+
 	var created []string
 	b := stackCreationBackend(t, 1, &created)
 	names := []string{"second"}
@@ -96,7 +98,7 @@ func TestCreateStackWithRetryRepromptsOnFailure(t *testing.T) {
 		return name, nil
 	}
 
-	s, resolved, err := createStackWithRetry(t.Context(), cmdutil.Diag(), pkgWorkspace.Instance,
+	s, resolved, err := createStackWithRetry(t.Context(), cmdutil.Diag(), io.Discard, pkgWorkspace.Instance,
 		b, prompt, "first", t.TempDir(), false, display.Options{},
 		cmdStack.CreateStackOptions{SecretsProvider: "default", Quiet: true})
 
@@ -106,8 +108,9 @@ func TestCreateStackWithRetryRepromptsOnFailure(t *testing.T) {
 	require.NotNil(t, s)
 }
 
-//nolint:paralleltest // uses process stdout
 func TestCreateStackWithRetryDefaultOrgFailureIsFatal(t *testing.T) {
+	t.Parallel()
+
 	var created []string
 	b := stackCreationBackend(t, 1, &created)
 	b.GetDefaultOrgF = func(ctx context.Context) (string, error) {
@@ -120,7 +123,7 @@ func TestCreateStackWithRetryDefaultOrgFailureIsFatal(t *testing.T) {
 		return "", nil
 	}
 
-	s, resolved, err := createStackWithRetry(t.Context(), cmdutil.Diag(), pkgWorkspace.Instance,
+	s, resolved, err := createStackWithRetry(t.Context(), cmdutil.Diag(), io.Discard, pkgWorkspace.Instance,
 		b, prompt, "first", t.TempDir(), false, display.Options{},
 		cmdStack.CreateStackOptions{SecretsProvider: "default", Quiet: true})
 


### PR DESCRIPTION
## What

Split `promptForConfig` into `resolveTemplateDefaults` → `askTemplateConfig` → `encryptTemplateConfig` stages, add project-aware config key helpers to `pkg/cmd/pulumi/config`, and extract `createStackWithRetry` from `PromptAndCreateStack`. No behavior changes.

## Why

`promptForConfig` was a single ~120-line pass that parsed template keys, resolved defaults, prompted, and encrypted, so exercising any part of it required a live backend and stack. The guided `pulumi new` confirmation (#24223) needs to resolve config defaults and prompt before a stack — or even a `Pulumi.yaml` — exists, and the stack-creation retry loop needs to run against a name chosen up front rather than always prompting first.

## How

The stages work on plain `templateConfigValue` slices, with `stackCrypters` isolating the secrets-manager plumbing; `promptForConfig` keeps its signature and behavior as a thin composition of them. The new helpers (`ParseConfigKeyForProject`, `PrettyKeyForProject`, `ParseConfigForProject`) namespace bare keys from a known project name instead of reading `Pulumi.yaml` off disk. Unit tests pin the existing behavior: flag values are never re-asked, defaults fill silently, prompting scope, bare-key namespacing, key ordering, and the create-then-reprompt retry loop.

## References

- Based on #24280
- #24223 builds on these pieces


