### PR TITLE
Add a `pulumi self-update` command

### DIFF
--- a/changelog/pending/20260814--cli--self-update-command.yaml
+++ b/changelog/pending/20260814--cli--self-update-command.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Add a `pulumi self-update` command that updates a get.pulumi.com install in place, verifying the release against its published checksum before replacing anything
+time: 2026-08-14T00:00:00Z

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -970,6 +970,13 @@ func getUpgradeCommand(isDevVersion bool) string {
 		return "$ brew update && brew upgrade pulumi"
 	}
 
+	// Reinstalling is only worth suggesting when the CLI cannot replace itself. This covers installs made with a
+	// custom root as well, which the check below does not. Dev builds are not published with the checksums that
+	// `pulumi self-update` verifies, so those still go through the install script.
+	if !isDevVersion && selfupdate.CanUpdateInPlace() {
+		return "$ pulumi self-update"
+	}
+
 	if filepath.Dir(exe) != filepath.Join(curUser.HomeDir, workspace.BookkeepingDir, "bin") {
 		return ""
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -77,6 +77,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/rattler"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schema"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/selfupdate"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templatecmd"
@@ -541,6 +542,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				cmdVersion.NewVersionCmd(),
 				about.NewAboutCmd(pkgWorkspace.Instance),
 				completion.NewGenCompletionCmd(cmd),
+				selfupdate.NewSelfUpdateCmd(),
 			},
 		},
 

--- a/pkg/cmd/pulumi/selfupdate/download.go
+++ b/pkg/cmd/pulumi/selfupdate/download.go
@@ -1,0 +1,286 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selfupdate
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
+)
+
+// These are variables rather than constants so that tests can point them at a local server.
+var (
+	// latestVersionURL reports the newest released CLI version. The install scripts read the same endpoint, and
+	// third parties such as the GitHub Actions runner images depend on it, so it is effectively a stable API.
+	latestVersionURL = "https://www.pulumi.com/latest-version"
+
+	// releaseBaseURL and fallbackBaseURL mirror the order the install scripts try: GitHub first, then the CDN.
+	releaseBaseURL  = "https://github.com/pulumi/pulumi/releases/download"
+	fallbackBaseURL = "https://get.pulumi.com/releases/sdk"
+)
+
+// latestVersion fetches the newest released version of the CLI.
+func latestVersion(ctx context.Context) (semver.Version, error) {
+	body, err := get(ctx, latestVersionURL)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("could not determine the latest Pulumi version: %w", err)
+	}
+	defer contract.IgnoreClose(body)
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	v, err := semver.ParseTolerant(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("could not parse the latest Pulumi version %q: %w", raw, err)
+	}
+	return v, nil
+}
+
+// artifactName returns the name of the release archive for the running platform.
+func artifactName(v semver.Version) (string, error) {
+	return artifactNameFor(v, runtime.GOOS, runtime.GOARCH)
+}
+
+// artifactNameFor builds a release archive name for an explicit platform. Releases label x86-64 as x64 rather than
+// the amd64 Go reports, and ship a zip rather than a tarball for Windows.
+func artifactNameFor(v semver.Version, goos, goarch string) (string, error) {
+	var arch string
+	switch goarch {
+	case "amd64":
+		arch = "x64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		return "", fmt.Errorf("unsupported architecture %q", goarch)
+	}
+
+	switch goos {
+	case "linux", "darwin":
+		return fmt.Sprintf("pulumi-v%s-%s-%s.tar.gz", v, goos, arch), nil
+	case "windows":
+		return fmt.Sprintf("pulumi-v%s-windows-%s.zip", v, arch), nil
+	default:
+		return "", fmt.Errorf("unsupported operating system %q", goos)
+	}
+}
+
+// fetchChecksum returns the published SHA256 for artifact, taken from the checksums file attached to the release.
+func fetchChecksum(ctx context.Context, v semver.Version, artifact string) (string, error) {
+	url := fmt.Sprintf("%s/v%s/pulumi-%s-checksums.txt", releaseBaseURL, v, v)
+	body, err := get(ctx, url)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch checksums for v%s: %w", v, err)
+	}
+	defer contract.IgnoreClose(body)
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+
+	sum, err := findChecksum(string(raw), artifact)
+	if err != nil {
+		return "", fmt.Errorf("the checksums for v%s %w", v, err)
+	}
+	return sum, nil
+}
+
+// findChecksum picks the digest for artifact out of a file in sha256sum format: the digest, whitespace, then the
+// file name.
+func findChecksum(contents, artifact string) (string, error) {
+	for line := range strings.SplitSeq(contents, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == artifact {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("do not list %s", artifact)
+}
+
+// downloadVerified downloads artifact for the given version into dir and checks it against the published checksum.
+func downloadVerified(ctx context.Context, v semver.Version, artifact, dir string) (string, error) {
+	want, err := fetchChecksum(ctx, v, artifact)
+	if err != nil {
+		return "", err
+	}
+
+	dest := filepath.Join(dir, artifact)
+	urls := []string{
+		fmt.Sprintf("%s/v%s/%s", releaseBaseURL, v, artifact),
+		fmt.Sprintf("%s/%s", fallbackBaseURL, artifact),
+	}
+
+	var lastErr error
+	for _, url := range urls {
+		lastErr = downloadTo(ctx, url, dest)
+		if lastErr == nil {
+			break
+		}
+	}
+	if lastErr != nil {
+		return "", fmt.Errorf("could not download %s: %w", artifact, lastErr)
+	}
+
+	got, err := sha256File(dest)
+	if err != nil {
+		return "", err
+	}
+	if got != want {
+		// Do not leave an archive we could not vouch for lying around.
+		_ = os.Remove(dest)
+		return "", fmt.Errorf("checksum mismatch for %s: expected %s, got %s", artifact, want, got)
+	}
+	return dest, nil
+}
+
+func downloadTo(ctx context.Context, url, dest string) error {
+	body, err := get(ctx, url)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(body)
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(f)
+
+	_, err = io.Copy(f, body)
+	return err
+}
+
+func get(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httputil.DoWithRetry(req, http.DefaultClient)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		contract.IgnoreClose(resp.Body)
+		return nil, fmt.Errorf("GET %s returned %s", url, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer contract.IgnoreClose(f)
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// extract unpacks a downloaded release archive into dir and returns the directory holding the binaries. Archives
+// used to carry a top level bin folder, so that older layout is still recognised.
+func extract(archivePath, dir string) (string, error) {
+	var err error
+	if strings.HasSuffix(archivePath, ".zip") {
+		err = extractZip(archivePath, dir)
+	} else {
+		var f *os.File
+		if f, err = os.Open(archivePath); err == nil {
+			defer contract.IgnoreClose(f)
+			err = archive.ExtractTGZ(f, dir)
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("could not extract %s: %w", filepath.Base(archivePath), err)
+	}
+
+	root := filepath.Join(dir, "pulumi")
+	if info, err := os.Stat(filepath.Join(root, "bin")); err == nil && info.IsDir() {
+		return filepath.Join(root, "bin"), nil
+	}
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		return "", fmt.Errorf("%s did not contain the expected pulumi directory", filepath.Base(archivePath))
+	}
+	return root, nil
+}
+
+func extractZip(archivePath, dir string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(r)
+
+	for _, f := range r.File {
+		// Reject entries that would escape the destination directory.
+		dest := filepath.Join(dir, filepath.FromSlash(f.Name)) //nolint:gosec // checked immediately below
+		if !strings.HasPrefix(dest, filepath.Clean(dir)+string(os.PathSeparator)) {
+			return fmt.Errorf("archive entry %q would write outside the destination directory", f.Name)
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(dest, 0o700); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+			return err
+		}
+		if err := writeZipEntry(f, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeZipEntry(f *zip.File, dest string) error {
+	src, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(src)
+
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(out)
+
+	//nolint:gosec // the archive is checked against its published checksum before it is extracted
+	_, err = io.Copy(out, src)
+	return err
+}

--- a/pkg/cmd/pulumi/selfupdate/download.go
+++ b/pkg/cmd/pulumi/selfupdate/download.go
@@ -127,11 +127,15 @@ func findChecksum(contents, artifact string) (string, error) {
 }
 
 // downloadVerified downloads artifact for the given version into dir and checks it against the published checksum.
+// A partially downloaded archive left in dir by an earlier run is resumed rather than fetched again.
 func downloadVerified(ctx context.Context, v semver.Version, artifact, dir string) (string, error) {
 	want, err := fetchChecksum(ctx, v, artifact)
 	if err != nil {
 		return "", err
 	}
+
+	// Only one archive is ever worth keeping, so anything left over for another version is dropped.
+	pruneDownloads(dir, artifact)
 
 	dest := filepath.Join(dir, artifact)
 	urls := []string{
@@ -162,30 +166,74 @@ func downloadVerified(ctx context.Context, v semver.Version, artifact, dir strin
 	return dest, nil
 }
 
-func downloadTo(ctx context.Context, url, dest string) error {
-	body, err := get(ctx, url)
+// pruneDownloads removes archives in dir other than keep, so an abandoned download cannot accumulate.
+func pruneDownloads(dir, keep string) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return err
+		return
 	}
-	defer contract.IgnoreClose(body)
+	for _, entry := range entries {
+		if !entry.IsDir() && entry.Name() != keep {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
+}
 
-	f, err := os.Create(dest)
+// downloadTo fetches url into dest, continuing from whatever is already there. Anything it writes is checked
+// against the published checksum afterwards, so a partial file that turns out to be unusable is caught there
+// rather than trusted here.
+func downloadTo(ctx context.Context, url, dest string) error {
+	f, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return err
 	}
 	defer contract.IgnoreClose(f)
 
-	_, err = io.Copy(f, body)
+	have, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+
+	resp, err := request(ctx, url, have)
+	if err != nil {
+		return err
+	}
+	defer contract.IgnoreClose(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		// The server is sending the remainder, which appends onto what is already on disk.
+	case http.StatusOK:
+		// Range was ignored, or there was nothing to resume, so the response is the whole archive.
+		if err := f.Truncate(0); err != nil {
+			return err
+		}
+	case http.StatusRequestedRangeNotSatisfiable:
+		// Nothing left to fetch. Either the archive is complete or the local copy is too long, and the checksum
+		// decides which.
+		return nil
+	default:
+		return fmt.Errorf("GET %s returned %s", url, resp.Status)
+	}
+
+	_, err = io.Copy(f, resp.Body)
 	return err
 }
 
-func get(ctx context.Context, url string) (io.ReadCloser, error) {
+// request performs a GET, asking for everything from the given offset when resuming a download.
+func request(ctx context.Context, url string, from int64) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
+	if from > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", from))
+	}
+	return httputil.DoWithRetry(req, http.DefaultClient)
+}
 
-	resp, err := httputil.DoWithRetry(req, http.DefaultClient)
+func get(ctx context.Context, url string) (io.ReadCloser, error) {
+	resp, err := request(ctx, url, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/selfupdate/download.go
+++ b/pkg/cmd/pulumi/selfupdate/download.go
@@ -183,7 +183,9 @@ func pruneDownloads(dir, keep string) {
 // against the published checksum afterwards, so a partial file that turns out to be unusable is caught there
 // rather than trusted here.
 func downloadTo(ctx context.Context, url, dest string) error {
-	f, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	// Opened without O_APPEND, which on Windows withholds the write access that truncating the file needs, and
+	// seeking to the end instead leaves the handle positioned to carry on from what is already there.
+	f, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
@@ -206,6 +208,9 @@ func downloadTo(ctx context.Context, url, dest string) error {
 	case http.StatusOK:
 		// Range was ignored, or there was nothing to resume, so the response is the whole archive.
 		if err := f.Truncate(0); err != nil {
+			return err
+		}
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
 			return err
 		}
 	case http.StatusRequestedRangeNotSatisfiable:

--- a/pkg/cmd/pulumi/selfupdate/download_test.go
+++ b/pkg/cmd/pulumi/selfupdate/download_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checksums is a copy of the format published alongside a release.
+const checksums = `a8bb6c8828bb6c716ed1d08cc3d94ca7a2435ed9c7d208705f422529d39614a0  pulumi-v3.257.0-darwin-arm64.tar.gz
+d5e2155d59cf65fadedd63d8af28e82b286d94a4c2b80cfaaedd76418b840298  pulumi-v3.257.0-darwin-x64.tar.gz
+e5c22687e56f77ac094d4b74c0c48a2de0da699ce72644c9bf173d98980946a6  pulumi-v3.257.0-linux-arm64.tar.gz
+a99c21521eb5ac74849f5ea55f46fdc3e93006633d0d3ae6862a2e83325f7a92  pulumi-v3.257.0-windows-x64.zip
+`
+
+func TestFindChecksum(t *testing.T) {
+	t.Parallel()
+
+	sum, err := findChecksum(checksums, "pulumi-v3.257.0-linux-arm64.tar.gz")
+
+	require.NoError(t, err)
+	assert.Equal(t, "e5c22687e56f77ac094d4b74c0c48a2de0da699ce72644c9bf173d98980946a6", sum)
+}
+
+func TestFindChecksumReportsMissingArtifact(t *testing.T) {
+	t.Parallel()
+
+	_, err := findChecksum(checksums, "pulumi-v3.257.0-plan9-x64.tar.gz")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pulumi-v3.257.0-plan9-x64.tar.gz")
+}
+
+func TestArtifactNameMatchesThePublishedNames(t *testing.T) {
+	t.Parallel()
+
+	v := semver.MustParse("3.257.0")
+	tests := []struct {
+		goos, goarch, want string
+	}{
+		{"darwin", "arm64", "pulumi-v3.257.0-darwin-arm64.tar.gz"},
+		{"darwin", "amd64", "pulumi-v3.257.0-darwin-x64.tar.gz"},
+		{"linux", "arm64", "pulumi-v3.257.0-linux-arm64.tar.gz"},
+		{"linux", "amd64", "pulumi-v3.257.0-linux-x64.tar.gz"},
+		{"windows", "amd64", "pulumi-v3.257.0-windows-x64.zip"},
+		{"windows", "arm64", "pulumi-v3.257.0-windows-arm64.zip"},
+	}
+
+	for _, tt := range tests {
+		// These are exactly the names listed in the checksums file published with each release.
+		got, err := artifactNameFor(v, tt.goos, tt.goarch)
+		require.NoError(t, err, "%s/%s", tt.goos, tt.goarch)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func TestArtifactNameRejectsUnsupportedPlatforms(t *testing.T) {
+	t.Parallel()
+
+	v := semver.MustParse("3.257.0")
+
+	_, err := artifactNameFor(v, "linux", "386")
+	assert.ErrorContains(t, err, "unsupported architecture")
+
+	_, err = artifactNameFor(v, "plan9", "amd64")
+	assert.ErrorContains(t, err, "unsupported operating system")
+}
+
+func TestSHA256File(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "artifact")
+	require.NoError(t, os.WriteFile(path, []byte("pulumi"), 0o600))
+
+	sum, err := sha256File(path)
+
+	require.NoError(t, err)
+	// echo -n pulumi | shasum -a 256
+	assert.Equal(t, "fbe2a04069387628783a3f90b947236e6ff8b1c099e710871356a6381a4e20b2", sum)
+}
+
+func TestExtractReadsATarball(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pulumi-v3.257.0-linux-x64.tar.gz")
+	writeTarball(t, path, map[string]string{
+		"pulumi/pulumi":                 "the cli",
+		"pulumi/pulumi-language-nodejs": "the nodejs plugin",
+	})
+
+	staged, err := extract(path, t.TempDir())
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(staged, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "the cli", string(contents))
+}
+
+func TestExtractReadsTheOlderBinLayout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pulumi-v3.257.0-linux-x64.tar.gz")
+	writeTarball(t, path, map[string]string{"pulumi/bin/pulumi": "the cli"})
+
+	staged, err := extract(path, t.TempDir())
+
+	require.NoError(t, err)
+	assert.Equal(t, "bin", filepath.Base(staged))
+	assert.FileExists(t, filepath.Join(staged, "pulumi"))
+}
+
+func TestExtractReadsAZip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pulumi-v3.257.0-windows-x64.zip")
+	writeZip(t, path, map[string]string{"pulumi/pulumi.exe": "the cli"})
+
+	staged, err := extract(path, t.TempDir())
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(staged, "pulumi.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "the cli", string(contents))
+}
+
+func TestExtractZipRejectsEntriesEscapingTheDestination(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "evil.zip")
+	writeZip(t, path, map[string]string{"../escaped": "should not be written"})
+
+	err := extractZip(path, t.TempDir())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside the destination directory")
+}
+
+func writeTarball(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	for name, contents := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o700,
+			Size: int64(len(contents)),
+		}))
+		_, err := tw.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+}
+
+func writeZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	for name, contents := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+}

--- a/pkg/cmd/pulumi/selfupdate/install.go
+++ b/pkg/cmd/pulumi/selfupdate/install.go
@@ -175,10 +175,12 @@ func swapIn(stagedDir, installDir string) error {
 	}
 
 	stamp := strconv.Itoa(os.Getpid())
+	installed := make(map[string]bool, len(staged))
 	for _, entry := range staged {
 		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "pulumi") {
 			continue
 		}
+		installed[entry.Name()] = true
 
 		target := filepath.Join(installDir, entry.Name())
 		if _, err := os.Lstat(target); err == nil {
@@ -201,10 +203,36 @@ func swapIn(stagedDir, installDir string) error {
 		}
 	}
 
+	// A binary the new release no longer ships would otherwise sit on $PATH indefinitely.
+	sweepOrphans(installDir, installed, stamp)
+
 	// The update is committed, so the displaced binaries are safe to drop. The running executable is among them on
 	// Windows and cannot be deleted yet; removeStale picks it up next time.
 	removeStale(installDir)
 	return nil
+}
+
+// sweepOrphans displaces binaries belonging to an earlier release that the new one no longer contains, so that the
+// install directory ends up holding what the archive held and nothing more. Both install scripts delete every
+// pulumi* file before they extract, and this keeps that behaviour. Orphans are renamed rather than deleted because
+// one of them may still be running, which Windows will not allow us to remove.
+func sweepOrphans(installDir string, installed map[string]bool, stamp string) {
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, "pulumi") || installed[name] {
+			continue
+		}
+		// Binaries displaced moments ago by the swap itself carry the same prefix.
+		if strings.Contains(name, staleSuffix) {
+			continue
+		}
+		//nolint:forbidigo // renaming within one directory, which is also how a running executable is displaced
+		_ = os.Rename(filepath.Join(installDir, name), filepath.Join(installDir, name+staleSuffix+"."+stamp))
+	}
 }
 
 // removeStale deletes binaries displaced by this or an earlier update, ignoring the ones still held open.

--- a/pkg/cmd/pulumi/selfupdate/install.go
+++ b/pkg/cmd/pulumi/selfupdate/install.go
@@ -1,0 +1,219 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selfupdate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// staleSuffix marks binaries displaced by an update. Windows refuses to delete a running executable, so the old
+// binary is renamed out of the way and cleaned up by a later run instead.
+const staleSuffix = ".pulumi-old"
+
+// stagingPrefix names the directory an update downloads and unpacks into. Windows can hold a handle to a freshly
+// written executable for a moment, which makes removing that directory fail, so leftovers are swept by a later run.
+const stagingPrefix = ".pulumi-update-"
+
+// managedPathMarkers are path segments belonging to package managers that own their own copy of the CLI. Updating
+// underneath one leaves the manager's metadata describing a version that is no longer on disk.
+var managedPathMarkers = []string{
+	"/cellar/",      // Homebrew
+	"/nix/store/",   // Nix
+	"node_modules/", // npm / npx shim
+	"/.asdf/",       // asdf
+	"/mise/",        // mise
+}
+
+// errNotUpdatable reports that the running CLI cannot be updated in place. Hint carries the command the user should
+// run instead, when we know it.
+type errNotUpdatable struct {
+	reason string
+	hint   string
+}
+
+func (e *errNotUpdatable) Error() string {
+	if e.hint == "" {
+		return e.reason
+	}
+	return e.reason + "\nTo upgrade, run:\n    " + e.hint
+}
+
+// detectInstallDir returns the directory holding the running CLI, provided it looks like an install produced by
+// get.pulumi.com and is safe to replace.
+func detectInstallDir() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("could not locate the running executable: %w", err)
+	}
+	return installDirFor(exe)
+}
+
+// installDirFor applies the update eligibility rules to a given executable path.
+func installDirFor(exe string) (string, error) {
+	// Resolve symlinks so that a link on $PATH is judged by where it actually points.
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve %s: %w", exe, err)
+	}
+	dir := filepath.Dir(resolved)
+
+	if marker := managedPathMarker(dir); marker != "" {
+		return "", &errNotUpdatable{
+			reason: fmt.Sprintf("%s looks like it was installed by a package manager, so it should be upgraded "+
+				"with that package manager rather than replaced in place.", resolved),
+			hint: managedPathHint(marker),
+		}
+	}
+
+	// Both installers lay the bundle out flat, so the language plugins sit alongside the CLI. A directory without
+	// them is a shim or a development build, neither of which this command should overwrite.
+	siblings, err := filepath.Glob(filepath.Join(dir, "pulumi-language-*"))
+	if err != nil {
+		return "", err
+	}
+	if len(siblings) == 0 {
+		return "", &errNotUpdatable{
+			reason: fmt.Sprintf("%s does not look like a Pulumi CLI install: the bundled language plugins are "+
+				"not present alongside it.", resolved),
+		}
+	}
+
+	if err := checkWritable(dir); err != nil {
+		return "", &errNotUpdatable{
+			reason: fmt.Sprintf("%s is not writable by the current user: %v", dir, err),
+		}
+	}
+
+	return dir, nil
+}
+
+// managedPathMarker returns the package manager marker found in dir, or the empty string if there is none.
+func managedPathMarker(dir string) string {
+	// Normalise separators directly rather than with filepath.ToSlash, which only rewrites them on Windows.
+	needle := strings.ToLower(strings.ReplaceAll(dir, `\`, "/")) + "/"
+	for _, marker := range managedPathMarkers {
+		if strings.Contains(needle, marker) {
+			return marker
+		}
+	}
+	return ""
+}
+
+func managedPathHint(marker string) string {
+	switch marker {
+	case "/cellar/":
+		return "brew update && brew upgrade pulumi"
+	case "node_modules/":
+		return "npm update @pulumi/pulumi"
+	default:
+		return ""
+	}
+}
+
+// checkWritable reports whether new files can be created in dir.
+func checkWritable(dir string) error {
+	probe, err := os.CreateTemp(dir, ".pulumi-update-probe-*")
+	if err != nil {
+		return err
+	}
+	name := probe.Name()
+	if err := probe.Close(); err != nil {
+		return err
+	}
+	return os.Remove(name)
+}
+
+// swapIn replaces every pulumi binary in installDir with its counterpart from stagedDir. Each file is moved into
+// place individually after the existing one is renamed aside, so a failure part way through can be rolled back and
+// no window exists in which the CLI is missing entirely.
+func swapIn(stagedDir, installDir string) error {
+	staged, err := os.ReadDir(stagedDir)
+	if err != nil {
+		return err
+	}
+
+	// A displaced binary from an earlier update may still be on disk if it was running at the time.
+	removeStale(installDir)
+
+	type swapped struct{ from, to string }
+	var displaced []swapped
+
+	rollback := func() {
+		for _, s := range displaced {
+			// Best effort: the update already failed, so surface the original error rather than this one.
+			//nolint:forbidigo // staging sits alongside the install directory, so this rename stays on one file system
+			_ = os.Rename(s.to, s.from)
+		}
+	}
+
+	stamp := strconv.Itoa(os.Getpid())
+	for _, entry := range staged {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "pulumi") {
+			continue
+		}
+
+		target := filepath.Join(installDir, entry.Name())
+		if _, err := os.Lstat(target); err == nil {
+			aside := target + staleSuffix + "." + stamp
+			//nolint:forbidigo // renaming within one directory, which is also how a running executable is displaced
+			if err := os.Rename(target, aside); err != nil {
+				rollback()
+				return fmt.Errorf("could not move the existing %s aside: %w", entry.Name(), err)
+			}
+			displaced = append(displaced, swapped{from: target, to: aside})
+		} else if !errors.Is(err, os.ErrNotExist) {
+			rollback()
+			return err
+		}
+
+		//nolint:forbidigo // staging sits alongside the install directory, so this rename stays on one file system
+		if err := os.Rename(filepath.Join(stagedDir, entry.Name()), target); err != nil {
+			rollback()
+			return fmt.Errorf("could not install %s: %w", entry.Name(), err)
+		}
+	}
+
+	// The update is committed, so the displaced binaries are safe to drop. The running executable is among them on
+	// Windows and cannot be deleted yet; removeStale picks it up next time.
+	removeStale(installDir)
+	return nil
+}
+
+// removeStale deletes binaries displaced by this or an earlier update, ignoring the ones still held open.
+func removeStale(installDir string) {
+	stale, err := filepath.Glob(filepath.Join(installDir, "*"+staleSuffix+".*"))
+	if err != nil {
+		return
+	}
+	for _, path := range stale {
+		_ = os.Remove(path)
+	}
+}
+
+// removeOrphanedStaging deletes staging directories an earlier update could not remove.
+func removeOrphanedStaging(parentDir string) {
+	orphans, err := filepath.Glob(filepath.Join(parentDir, stagingPrefix+"*"))
+	if err != nil {
+		return
+	}
+	for _, path := range orphans {
+		_ = os.RemoveAll(path)
+	}
+}

--- a/pkg/cmd/pulumi/selfupdate/install.go
+++ b/pkg/cmd/pulumi/selfupdate/install.go
@@ -55,6 +55,13 @@ func (e *errNotUpdatable) Error() string {
 	return e.reason + "\nTo upgrade, run:\n    " + e.hint
 }
 
+// CanUpdateInPlace reports whether the running CLI is one `pulumi self-update` is able to replace, so that callers
+// can offer that command in preference to reinstalling.
+func CanUpdateInPlace() bool {
+	_, err := detectInstallDir()
+	return err == nil
+}
+
 // detectInstallDir returns the directory holding the running CLI, provided it looks like an install produced by
 // get.pulumi.com and is safe to replace.
 func detectInstallDir() (string, error) {

--- a/pkg/cmd/pulumi/selfupdate/install.go
+++ b/pkg/cmd/pulumi/selfupdate/install.go
@@ -27,9 +27,13 @@ import (
 // binary is renamed out of the way and cleaned up by a later run instead.
 const staleSuffix = ".pulumi-old"
 
-// stagingPrefix names the directory an update downloads and unpacks into. Windows can hold a handle to a freshly
-// written executable for a moment, which makes removing that directory fail, so leftovers are swept by a later run.
+// stagingPrefix names the directory an update unpacks into. Windows can hold a handle to a freshly written
+// executable for a moment, which makes removing that directory fail, so leftovers are swept by a later run.
 const stagingPrefix = ".pulumi-update-"
+
+// downloadDirName holds the archive while it is being fetched. It outlives a run, unlike the staging directory, so
+// that a download interrupted part way through can be resumed rather than started again.
+const downloadDirName = ".pulumi-download"
 
 // managedPathMarkers are path segments belonging to package managers that own their own copy of the CLI. Updating
 // underneath one leaves the manager's metadata describing a version that is no longer on disk.

--- a/pkg/cmd/pulumi/selfupdate/install_test.go
+++ b/pkg/cmd/pulumi/selfupdate/install_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bundle lays out a directory the way the install scripts do, with the language plugins next to the CLI.
+func bundle(t *testing.T, contents string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, name := range []string{"pulumi", "pulumi-language-nodejs", "pulumi-language-python"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents+" "+name), 0o600))
+	}
+
+	// The temp directory may itself sit behind a symlink, and the code under test resolves those.
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	return resolved
+}
+
+func TestManagedPathMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dir  string
+		want string
+	}{
+		{"/opt/homebrew/Cellar/pulumi/3.100.0/bin", "/cellar/"},
+		{"/nix/store/abc123-pulumi-3.100.0/bin", "/nix/store/"},
+		{"/home/me/project/node_modules/.bin", "node_modules/"},
+		{"/home/me/.asdf/installs/pulumi/3.100.0/bin", "/.asdf/"},
+		{"/home/me/.local/share/mise/installs/pulumi/3.100.0", "/mise/"},
+		{"/home/me/.pulumi/bin", ""},
+		{"/usr/local/pulumi/bin", ""},
+		// Windows installs use backslashes, and the npm shim is the package manager that reaches them.
+		{`C:\Users\me\project\node_modules\.bin`, "node_modules/"},
+		{`C:\Users\me\.pulumi\bin`, ""},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, managedPathMarker(tt.dir), "dir %s", tt.dir)
+	}
+}
+
+func TestInstallDirForRejectsPackageManagerInstalls(t *testing.T) {
+	t.Parallel()
+
+	dir := bundle(t, "old")
+	// A Cellar segment anywhere in the resolved path is enough to disqualify the install.
+	cellar := filepath.Join(dir, "Cellar", "pulumi", "bin")
+	require.NoError(t, os.MkdirAll(cellar, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(cellar, "pulumi"), []byte("old"), 0o600))
+
+	_, err := installDirFor(filepath.Join(cellar, "pulumi"))
+
+	var notUpdatable *errNotUpdatable
+	require.ErrorAs(t, err, &notUpdatable)
+	assert.Contains(t, err.Error(), "brew update && brew upgrade pulumi")
+}
+
+func TestInstallDirForRejectsDirectoryWithoutLanguagePlugins(t *testing.T) {
+	t.Parallel()
+
+	// A lone binary is a development build or a shim, not an install we should replace.
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "pulumi")
+	require.NoError(t, os.WriteFile(exe, []byte("built from source"), 0o600))
+
+	_, err := installDirFor(exe)
+
+	var notUpdatable *errNotUpdatable
+	require.ErrorAs(t, err, &notUpdatable)
+	assert.Contains(t, err.Error(), "language plugins")
+}
+
+func TestInstallDirForAcceptsBundledInstall(t *testing.T) {
+	t.Parallel()
+
+	dir := bundle(t, "old")
+
+	got, err := installDirFor(filepath.Join(dir, "pulumi"))
+
+	require.NoError(t, err)
+	assert.Equal(t, dir, got)
+}
+
+func TestInstallDirForResolvesSymlinks(t *testing.T) {
+	t.Parallel()
+
+	dir := bundle(t, "old")
+	link := filepath.Join(t.TempDir(), "pulumi")
+	require.NoError(t, os.Symlink(filepath.Join(dir, "pulumi"), link))
+
+	// A link on $PATH should be judged by the directory it points into, not the one holding the link.
+	got, err := installDirFor(link)
+
+	require.NoError(t, err)
+	assert.Equal(t, dir, got)
+}
+
+func TestSwapInReplacesEveryBinary(t *testing.T) {
+	t.Parallel()
+
+	install := bundle(t, "old")
+	staged := bundle(t, "new")
+
+	require.NoError(t, swapIn(staged, install))
+
+	for _, name := range []string{"pulumi", "pulumi-language-nodejs", "pulumi-language-python"} {
+		contents, err := os.ReadFile(filepath.Join(install, name))
+		require.NoError(t, err)
+		assert.Equal(t, "new "+name, string(contents))
+	}
+}
+
+func TestSwapInLeavesNoDisplacedBinariesBehind(t *testing.T) {
+	t.Parallel()
+
+	install := bundle(t, "old")
+	staged := bundle(t, "new")
+
+	require.NoError(t, swapIn(staged, install))
+
+	stale, err := filepath.Glob(filepath.Join(install, "*"+staleSuffix+".*"))
+	require.NoError(t, err)
+	assert.Empty(t, stale)
+}
+
+func TestSwapInRemovesBinariesDisplacedByAnEarlierUpdate(t *testing.T) {
+	t.Parallel()
+
+	install := bundle(t, "old")
+	staged := bundle(t, "new")
+
+	// Windows cannot delete the executable it is running, so one may survive until the following update.
+	leftover := filepath.Join(install, "pulumi"+staleSuffix+".999")
+	require.NoError(t, os.WriteFile(leftover, []byte("older still"), 0o600))
+
+	require.NoError(t, swapIn(staged, install))
+
+	assert.NoFileExists(t, leftover)
+}
+
+func TestSwapInRestoresTheOldBinariesWhenOneCannotBeInstalled(t *testing.T) {
+	t.Parallel()
+
+	install := bundle(t, "old")
+	staged := bundle(t, "new")
+
+	// Binaries are swapped in name order, so blocking the last one fails the swap once the earlier two are done.
+	// A non-empty directory cannot be renamed over, which is what makes moving the old binary aside fail.
+	blocked := filepath.Join(install, "pulumi-language-python"+staleSuffix+"."+strconv.Itoa(os.Getpid()))
+	require.NoError(t, os.MkdirAll(blocked, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(blocked, "blocker"), []byte("x"), 0o600))
+
+	err := swapIn(staged, install)
+
+	require.Error(t, err)
+	// Every binary displaced before the failure must be back where it started.
+	for _, name := range []string{"pulumi", "pulumi-language-nodejs"} {
+		contents, readErr := os.ReadFile(filepath.Join(install, name))
+		require.NoError(t, readErr, "%s should have been restored", name)
+		assert.Equal(t, "old "+name, string(contents))
+	}
+}
+
+func TestRemoveOrphanedStagingClearsLeftoverDirectories(t *testing.T) {
+	t.Parallel()
+
+	// Windows may hold a handle to a freshly written executable, so an update can fail to remove its own staging
+	// directory and leave it for a later run to clear.
+	parent := t.TempDir()
+	orphan := filepath.Join(parent, stagingPrefix+"2600156136")
+	require.NoError(t, os.MkdirAll(orphan, 0o700))
+	keep := filepath.Join(parent, "bin")
+	require.NoError(t, os.MkdirAll(keep, 0o700))
+
+	removeOrphanedStaging(parent)
+
+	assert.NoDirExists(t, orphan)
+	assert.DirExists(t, keep)
+}
+
+func TestSwapInIgnoresUnrelatedFiles(t *testing.T) {
+	t.Parallel()
+
+	install := bundle(t, "old")
+	staged := bundle(t, "new")
+
+	// The install directory may be on $PATH and hold binaries Pulumi does not own.
+	unrelated := filepath.Join(install, "something-else")
+	require.NoError(t, os.WriteFile(unrelated, []byte("not ours"), 0o600))
+
+	require.NoError(t, swapIn(staged, install))
+
+	contents, err := os.ReadFile(unrelated)
+	require.NoError(t, err)
+	assert.Equal(t, "not ours", string(contents))
+}

--- a/pkg/cmd/pulumi/selfupdate/install_test.go
+++ b/pkg/cmd/pulumi/selfupdate/install_test.go
@@ -202,6 +202,26 @@ func TestRemoveOrphanedStagingClearsLeftoverDirectories(t *testing.T) {
 	assert.DirExists(t, keep)
 }
 
+func TestSwapInRemovesBinariesTheNewReleaseNoLongerShips(t *testing.T) {
+	t.Parallel()
+
+	install := bundle(t, "old")
+	staged := bundle(t, "new")
+
+	// The set of bundled binaries changes between releases, and one that is left behind stays on $PATH.
+	dropped := filepath.Join(install, "pulumi-language-dropped")
+	require.NoError(t, os.WriteFile(dropped, []byte("old pulumi-language-dropped"), 0o600))
+
+	require.NoError(t, swapIn(staged, install))
+
+	assert.NoFileExists(t, dropped)
+	for _, name := range []string{"pulumi", "pulumi-language-nodejs", "pulumi-language-python"} {
+		contents, err := os.ReadFile(filepath.Join(install, name))
+		require.NoError(t, err)
+		assert.Equal(t, "new "+name, string(contents))
+	}
+}
+
 func TestSwapInIgnoresUnrelatedFiles(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/selfupdate/selfupdate.go
+++ b/pkg/cmd/pulumi/selfupdate/selfupdate.go
@@ -1,0 +1,145 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/blang/semver"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+)
+
+func NewSelfUpdateCmd() *cobra.Command {
+	var targetVersion string
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "self-update",
+		Short: "Update the Pulumi CLI to the latest version",
+		Long: "Update the Pulumi CLI to the latest version.\n" +
+			"\n" +
+			"This replaces the running CLI, and the language plugins bundled with it, with the newest released\n" +
+			"version. The release archive is checked against its published SHA256 checksum before anything is\n" +
+			"replaced, and the previous binaries are only discarded once the new ones are in place.\n" +
+			"\n" +
+			"This only applies to installs produced by https://get.pulumi.com. If the CLI came from a package\n" +
+			"manager such as Homebrew, upgrade it with that package manager instead.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return selfUpdate(cmd.Context(), cmd.OutOrStdout(), targetVersion, dryRun)
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&targetVersion, "version", "",
+		"Install this version instead of the latest release")
+	cmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false,
+		"Report what would be installed without changing anything")
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	return cmd
+}
+
+func selfUpdate(ctx context.Context, out io.Writer, targetVersion string, dryRun bool) error {
+	installDir, err := detectInstallDir()
+	if err != nil {
+		return err
+	}
+
+	current, err := semver.ParseTolerant(version.Version)
+	if err != nil {
+		return fmt.Errorf("could not parse the running version %q: %w", version.Version, err)
+	}
+
+	return update(ctx, out, installDir, current, targetVersion, dryRun)
+}
+
+// update installs targetVersion into installDir, replacing the binaries of the currently running version.
+func update(
+	ctx context.Context, out io.Writer, installDir string, current semver.Version, targetVersion string, dryRun bool,
+) error {
+	// Windows cannot delete the executable it is running, and may briefly hold a handle to a freshly written one, so
+	// the previous update can leave both its binary and its staging directory behind. Clear them here rather than
+	// only during a swap, so that a run which has nothing to install still tidies up.
+	removeStale(installDir)
+	removeOrphanedStaging(filepath.Dir(installDir))
+
+	target, err := resolveTarget(ctx, targetVersion)
+	if err != nil {
+		return err
+	}
+
+	if current.EQ(target) {
+		fmt.Fprintf(out, "Pulumi v%s is already up to date.\n", current)
+		return nil
+	}
+
+	artifact, err := artifactName(target)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		fmt.Fprintf(out, "Would update Pulumi v%s to v%s in %s, using %s.\n", current, target, installDir, artifact)
+		return nil
+	}
+
+	// Stage alongside the install directory so that the binaries can be moved into place with a rename rather than
+	// a copy, which keeps the swap quick and avoids a partially written executable.
+	staging, err := os.MkdirTemp(filepath.Dir(installDir), stagingPrefix+"*")
+	if err != nil {
+		return fmt.Errorf("could not create a staging directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(staging)
+	}()
+
+	fmt.Fprintf(out, "Updating Pulumi v%s to v%s...\n", current, target)
+
+	downloaded, err := downloadVerified(ctx, target, artifact, staging)
+	if err != nil {
+		return err
+	}
+
+	staged, err := extract(downloaded, staging)
+	if err != nil {
+		return err
+	}
+
+	if err := swapIn(staged, installDir); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Pulumi is now at v%s.\n", target)
+	return nil
+}
+
+func resolveTarget(ctx context.Context, targetVersion string) (semver.Version, error) {
+	if targetVersion == "" {
+		return latestVersion(ctx)
+	}
+
+	v, err := semver.ParseTolerant(targetVersion)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("could not parse the requested version %q: %w", targetVersion, err)
+	}
+	return v, nil
+}

--- a/pkg/cmd/pulumi/selfupdate/selfupdate.go
+++ b/pkg/cmd/pulumi/selfupdate/selfupdate.go
@@ -104,7 +104,8 @@ func update(
 
 	// Stage alongside the install directory so that the binaries can be moved into place with a rename rather than
 	// a copy, which keeps the swap quick and avoids a partially written executable.
-	staging, err := os.MkdirTemp(filepath.Dir(installDir), stagingPrefix+"*")
+	parent := filepath.Dir(installDir)
+	staging, err := os.MkdirTemp(parent, stagingPrefix+"*")
 	if err != nil {
 		return fmt.Errorf("could not create a staging directory: %w", err)
 	}
@@ -112,9 +113,16 @@ func update(
 		_ = os.RemoveAll(staging)
 	}()
 
+	// The archive is kept outside the staging directory, which is discarded when this run ends, so that an
+	// interrupted download is still on disk to resume from next time.
+	downloads := filepath.Join(parent, downloadDirName)
+	if err := os.MkdirAll(downloads, 0o700); err != nil {
+		return fmt.Errorf("could not create a download directory: %w", err)
+	}
+
 	fmt.Fprintf(out, "Updating Pulumi v%s to v%s...\n", current, target)
 
-	downloaded, err := downloadVerified(ctx, target, artifact, staging)
+	downloaded, err := downloadVerified(ctx, target, artifact, downloads)
 	if err != nil {
 		return err
 	}
@@ -127,6 +135,10 @@ func update(
 	if err := swapIn(staged, installDir); err != nil {
 		return err
 	}
+
+	// The archive has served its purpose, so there is nothing left to resume.
+	_ = os.Remove(downloaded)
+	_ = os.Remove(downloads)
 
 	fmt.Fprintf(out, "Pulumi is now at v%s.\n", target)
 	return nil

--- a/pkg/cmd/pulumi/selfupdate/update_test.go
+++ b/pkg/cmd/pulumi/selfupdate/update_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,10 @@ type release struct {
 	corruptChecksum bool
 	// omitFromGitHub forces the download to fall back to the secondary host.
 	omitFromGitHub bool
+	// ignoreRange answers the whole archive even when a range was asked for, as some mirrors do.
+	ignoreRange bool
+	// ranges collects the Range headers the server was sent.
+	ranges *[]string
 }
 
 func serveRelease(t *testing.T, r release) {
@@ -60,17 +65,28 @@ func serveRelease(t *testing.T, r release) {
 		func(w http.ResponseWriter, _ *http.Request) {
 			fmt.Fprintf(w, "%s  %s\n", digest, r.artifact)
 		})
+	// http.ServeContent answers Range requests, which is what makes an interrupted download resumable.
+	serve := func(w http.ResponseWriter, req *http.Request) {
+		if got := req.Header.Get("Range"); got != "" && r.ranges != nil {
+			*r.ranges = append(*r.ranges, got)
+		}
+		http.ServeContent(w, req, r.artifact, time.Time{}, bytes.NewReader(r.archive))
+	}
+
 	mux.HandleFunc(fmt.Sprintf("/releases/v%s/%s", r.version, r.artifact),
-		func(w http.ResponseWriter, _ *http.Request) {
+		func(w http.ResponseWriter, req *http.Request) {
 			if r.omitFromGitHub {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			_, _ = w.Write(r.archive)
+			if r.ignoreRange {
+				// Some mirrors answer the whole body regardless of what was asked for.
+				_, _ = w.Write(r.archive)
+				return
+			}
+			serve(w, req)
 		})
-	mux.HandleFunc("/cdn/"+r.artifact, func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(r.archive)
-	})
+	mux.HandleFunc("/cdn/"+r.artifact, serve)
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -252,6 +268,113 @@ func TestUpdateReportsAVersionThatWasNeverPublished(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not fetch checksums for v9.99.9")
+}
+
+// partialDownload writes the first n bytes of the release archive where the next run will look for it, standing in
+// for a download that was interrupted.
+func partialDownload(t *testing.T, installDir string, r release, n int) string {
+	t.Helper()
+
+	dir := filepath.Join(filepath.Dir(installDir), downloadDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	path := filepath.Join(dir, r.artifact)
+	require.NoError(t, os.WriteFile(path, r.archive[:n], 0o600))
+	return path
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateResumesAnInterruptedDownload(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	var ranges []string
+	r.ranges = &ranges
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	have := len(r.archive) / 2
+	partialDownload(t, install, r, have)
+
+	err := update(t.Context(), new(bytes.Buffer), install, semver.MustParse("3.200.0"), "", false)
+
+	require.NoError(t, err)
+	// Only the part that was missing should have been requested.
+	require.Len(t, ranges, 1)
+	assert.Equal(t, fmt.Sprintf("bytes=%d-", have), ranges[0])
+
+	contents, err := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "new pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateStartsOverWhenTheServerIgnoresTheRange(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	r.ignoreRange = true
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	partialDownload(t, install, r, len(r.archive)/2)
+
+	// Appending a whole archive onto a partial one would corrupt it, so the file has to be truncated first.
+	err := update(t.Context(), new(bytes.Buffer), install, semver.MustParse("3.200.0"), "", false)
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "new pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateDiscardsAPartialDownloadThatDoesNotVerify(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	// A partial file holding the wrong bytes resumes into an archive that cannot match the published checksum.
+	path := partialDownload(t, install, r, len(r.archive)/2)
+	require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), len(r.archive)/2), 0o600))
+
+	err := update(t.Context(), new(bytes.Buffer), install, semver.MustParse("3.200.0"), "", false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+	// The bad archive must not be left behind for the next run to resume from.
+	assert.NoFileExists(t, path)
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateDropsADownloadForAnotherVersion(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	downloads := filepath.Join(filepath.Dir(install), downloadDirName)
+	require.NoError(t, os.MkdirAll(downloads, 0o700))
+	stale := filepath.Join(downloads, "pulumi-v3.100.0-linux-x64.tar.gz")
+	require.NoError(t, os.WriteFile(stale, []byte("abandoned"), 0o600))
+
+	err := update(t.Context(), new(bytes.Buffer), install, semver.MustParse("3.200.0"), "", false)
+
+	require.NoError(t, err)
+	assert.NoFileExists(t, stale)
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateRemovesTheArchiveOnceInstalled(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+
+	err := update(t.Context(), new(bytes.Buffer), install, semver.MustParse("3.200.0"), "", false)
+
+	require.NoError(t, err)
+	// Nothing is left to resume, so the archive and its directory should be gone.
+	assert.NoDirExists(t, filepath.Join(filepath.Dir(install), downloadDirName))
 }
 
 func TestNewSelfUpdateCmdAcceptsItsFlags(t *testing.T) {

--- a/pkg/cmd/pulumi/selfupdate/update_test.go
+++ b/pkg/cmd/pulumi/selfupdate/update_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selfupdate
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// release serves the subset of the release endpoints the updater reads: the latest version, a checksums file, and
+// the archive itself. These tests must not run in parallel, since they repoint the package level URLs.
+type release struct {
+	version  semver.Version
+	artifact string
+	archive  []byte
+	// corruptChecksum publishes a digest that does not match the archive, standing in for a tampered download.
+	corruptChecksum bool
+	// omitFromGitHub forces the download to fall back to the secondary host.
+	omitFromGitHub bool
+}
+
+func serveRelease(t *testing.T, r release) {
+	t.Helper()
+
+	sum := sha256.Sum256(r.archive)
+	digest := hex.EncodeToString(sum[:])
+	if r.corruptChecksum {
+		digest = strings.Repeat("0", len(digest))
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/latest-version", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, r.version.String())
+	})
+	mux.HandleFunc(fmt.Sprintf("/releases/v%s/pulumi-%s-checksums.txt", r.version, r.version),
+		func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, "%s  %s\n", digest, r.artifact)
+		})
+	mux.HandleFunc(fmt.Sprintf("/releases/v%s/%s", r.version, r.artifact),
+		func(w http.ResponseWriter, _ *http.Request) {
+			if r.omitFromGitHub {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write(r.archive)
+		})
+	mux.HandleFunc("/cdn/"+r.artifact, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(r.archive)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	latestVersionURL, releaseBaseURL, fallbackBaseURL = srv.URL+"/latest-version", srv.URL+"/releases", srv.URL+"/cdn"
+	t.Cleanup(func() {
+		latestVersionURL = "https://www.pulumi.com/latest-version"
+		releaseBaseURL = "https://github.com/pulumi/pulumi/releases/download"
+		fallbackBaseURL = "https://get.pulumi.com/releases/sdk"
+	})
+}
+
+// newRelease builds a release archive laid out the way the real ones are, holding the given binaries.
+func newRelease(t *testing.T, v semver.Version, contents string) release {
+	t.Helper()
+
+	artifact, err := artifactName(v)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, artifact)
+	files := map[string]string{}
+	for _, name := range []string{"pulumi", "pulumi-language-nodejs", "pulumi-language-python"} {
+		files["pulumi/"+name] = contents + " " + name
+	}
+	if strings.HasSuffix(artifact, ".zip") {
+		writeZip(t, path, files)
+	} else {
+		writeTarball(t, path, files)
+	}
+
+	archive, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return release{version: v, artifact: artifact, archive: archive}
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateInstallsTheLatestRelease(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	var out bytes.Buffer
+
+	err := update(t.Context(), &out, install, semver.MustParse("3.200.0"), "", false)
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Pulumi is now at v3.257.0.")
+	for _, name := range []string{"pulumi", "pulumi-language-nodejs", "pulumi-language-python"} {
+		contents, err := os.ReadFile(filepath.Join(install, name))
+		require.NoError(t, err)
+		assert.Equal(t, "new "+name, string(contents))
+	}
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateRejectsAnArchiveThatFailsItsChecksum(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "tampered")
+	r.corruptChecksum = true
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	var out bytes.Buffer
+
+	err := update(t.Context(), &out, install, semver.MustParse("3.200.0"), "", false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	// Nothing may be replaced when the download cannot be vouched for.
+	contents, readErr := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "old pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateFallsBackToTheSecondaryHost(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	r := newRelease(t, target, "new")
+	r.omitFromGitHub = true
+	serveRelease(t, r)
+
+	install := bundle(t, "old")
+	var out bytes.Buffer
+
+	err := update(t.Context(), &out, install, semver.MustParse("3.200.0"), "", false)
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "new pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateDoesNothingWhenAlreadyCurrent(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	serveRelease(t, newRelease(t, target, "new"))
+
+	install := bundle(t, "old")
+	var out bytes.Buffer
+
+	err := update(t.Context(), &out, install, target, "", false)
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "already up to date")
+	contents, err := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "old pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateDryRunChangesNothing(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	serveRelease(t, newRelease(t, target, "new"))
+
+	install := bundle(t, "old")
+	var out bytes.Buffer
+
+	err := update(t.Context(), &out, install, semver.MustParse("3.200.0"), "", true)
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Would update Pulumi v3.200.0 to v3.257.0")
+	contents, err := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "old pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateClearsLeftoversFromAnEarlierRun(t *testing.T) {
+	target := semver.MustParse("3.257.0")
+	serveRelease(t, newRelease(t, target, "new"))
+
+	install := bundle(t, "old")
+	stale := filepath.Join(install, "pulumi"+staleSuffix+".999")
+	require.NoError(t, os.WriteFile(stale, []byte("older"), 0o600))
+	orphan := filepath.Join(filepath.Dir(install), stagingPrefix+"999")
+	require.NoError(t, os.MkdirAll(orphan, 0o700))
+
+	// Even a run with nothing to install should tidy up after the previous one.
+	err := update(t.Context(), new(bytes.Buffer), install, target, "", false)
+
+	require.NoError(t, err)
+	assert.NoFileExists(t, stale)
+	assert.NoDirExists(t, orphan)
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateInstallsAnExplicitlyRequestedVersion(t *testing.T) {
+	target := semver.MustParse("3.250.0")
+	serveRelease(t, newRelease(t, target, "pinned"))
+
+	install := bundle(t, "old")
+
+	err := update(t.Context(), new(bytes.Buffer), install, semver.MustParse("3.200.0"), "3.250.0", false)
+
+	require.NoError(t, err)
+	contents, err := os.ReadFile(filepath.Join(install, "pulumi"))
+	require.NoError(t, err)
+	assert.Equal(t, "pinned pulumi", string(contents))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateReportsAnUnparseableRequestedVersion(t *testing.T) {
+	serveRelease(t, newRelease(t, semver.MustParse("3.257.0"), "new"))
+
+	err := update(t.Context(), new(bytes.Buffer), bundle(t, "old"), semver.MustParse("3.200.0"), "banana", false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `could not parse the requested version "banana"`)
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestUpdateReportsAVersionThatWasNeverPublished(t *testing.T) {
+	serveRelease(t, newRelease(t, semver.MustParse("3.257.0"), "new"))
+
+	err := update(t.Context(), new(bytes.Buffer), bundle(t, "old"), semver.MustParse("3.200.0"), "9.99.9", false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not fetch checksums for v9.99.9")
+}
+
+func TestNewSelfUpdateCmdAcceptsItsFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewSelfUpdateCmd()
+
+	assert.Equal(t, "self-update", cmd.Use)
+	require.NoError(t, cmd.PersistentFlags().Parse([]string{"--version", "3.250.0", "--dry-run"}))
+	assert.Equal(t, "3.250.0", cmd.PersistentFlags().Lookup("version").Value.String())
+	assert.Equal(t, "true", cmd.PersistentFlags().Lookup("dry-run").Value.String())
+	// The command takes no positional arguments.
+	require.Error(t, cmd.Args(cmd, []string{"unexpected"}))
+}
+
+//nolint:paralleltest // serveRelease repoints package level URLs, so these cannot run alongside each other
+func TestLatestVersionReadsThePublishedVersion(t *testing.T) {
+	serveRelease(t, newRelease(t, semver.MustParse("3.257.0"), "new"))
+
+	v, err := latestVersion(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "3.257.0", v.String())
+}

--- a/tests/integration/selfupdate_test.go
+++ b/tests/integration/selfupdate_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// fakeInstall lays a directory out the way get.pulumi.com does, with the CLI under test and stand-ins for the
+// language plugins that ship beside it. withPlugins controls whether those stand-ins are created, which is what
+// tells `pulumi self-update` the directory is a real install rather than a shim or a development build.
+func fakeInstall(t *testing.T, withPlugins bool) string {
+	t.Helper()
+
+	pulumiName := "pulumi"
+	if runtime.GOOS == "windows" {
+		pulumiName = "pulumi.exe"
+	}
+
+	pulumiBin, err := exec.LookPath(pulumiName)
+	require.NoError(t, err, "the CLI under test must be on $PATH")
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o700))
+
+	source, err := os.ReadFile(pulumiBin)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, pulumiName), source, 0o700)) //nolint:gosec // an executable
+
+	if withPlugins {
+		for _, runtimeName := range []string{"nodejs", "python", "go", "dotnet", "yaml", "java"} {
+			name := "pulumi-language-" + runtimeName
+			if runtime.GOOS == "windows" {
+				name += ".exe"
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(binDir, name), []byte("stub"), 0o700)) //nolint:gosec
+		}
+	}
+
+	return filepath.Join(binDir, pulumiName)
+}
+
+// TestSelfUpdateRefusesAnInstallItDoesNotOwn checks that a CLI which is not part of a get.pulumi.com bundle is left
+// alone, so that a copy managed by a package manager is never replaced underneath it.
+func TestSelfUpdateRefusesAnInstallItDoesNotOwn(t *testing.T) {
+	t.Parallel()
+
+	cli := fakeInstall(t, false)
+
+	//nolint:gosec // the path is built by the test
+	out, err := exec.Command(cli, "self-update", "--dry-run").CombinedOutput()
+
+	require.Error(t, err, "expected a non-zero exit, got: %s", out)
+	assert.Contains(t, string(out), "does not look like a Pulumi CLI install")
+}
+
+// TestSelfUpdateDryRunResolvesARealRelease exercises the command against the live release endpoints. It reports the
+// version and archive it would install without downloading or replacing anything.
+func TestSelfUpdateDryRunResolvesARealRelease(t *testing.T) {
+	t.Parallel()
+
+	cli := fakeInstall(t, true)
+
+	//nolint:gosec // the path is built by the test
+	stdout, err := exec.Command(cli, "self-update", "--dry-run").CombinedOutput()
+	require.NoError(t, err, "self-update --dry-run failed: %s", stdout)
+
+	// The CLI under test carries a development version, so there is always a newer release to report.
+	assert.Contains(t, string(stdout), "Would update Pulumi")
+
+	artifact := artifactFromDryRun(t, string(stdout))
+	assertPublishedArtifact(t, artifact)
+}
+
+// artifactFromDryRun pulls the archive name out of the dry run report.
+func artifactFromDryRun(t *testing.T, out string) string {
+	t.Helper()
+
+	matches := regexp.MustCompile(`using (pulumi-v\S+?)\.\s*$`).FindStringSubmatch(strings.TrimSpace(out))
+	require.Len(t, matches, 2, "could not find the archive name in: %s", out)
+	return matches[1]
+}
+
+// assertPublishedArtifact confirms the archive the CLI intends to fetch is one the release actually publishes. The
+// unit tests serve their own archives, so this is what keeps the naming convention honest against the real releases.
+func assertPublishedArtifact(t *testing.T, artifact string) {
+	t.Helper()
+
+	version := regexp.MustCompile(`^pulumi-v(\d+\.\d+\.\d+\S*?)-`).FindStringSubmatch(artifact)
+	require.Len(t, version, 2, "could not read a version out of %q", artifact)
+
+	url := fmt.Sprintf(
+		"https://github.com/pulumi/pulumi/releases/download/v%s/pulumi-%s-checksums.txt", version[1], version[1])
+	resp, err := http.Get(url) //nolint:gosec,noctx // a fixed release URL
+	require.NoError(t, err)
+	defer contract.IgnoreClose(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s", url)
+
+	checksums, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(checksums), artifact,
+		"the release for v%s does not publish %s", version[1], artifact)
+}

--- a/tools/automation/automation-overrides.json
+++ b/tools/automation/automation-overrides.json
@@ -341,6 +341,12 @@
             "flags": {}
         },
         {
+            "path": ["self-update"],
+            "propagate": true,
+            "exclude": true,
+            "flags": {}
+        },
+        {
             "path": ["stack"],
             "propagate": true,
             "exclude": true,


### PR DESCRIPTION
Adds `pulumi self-update`, which updates a get.pulumi.com install in place.

## Why

Today the CLI detects that it is out of date and prints the command you should run, but you still have to go and run it. #19997 asks for the CLI to upgrade itself. This does the smaller half of that: the mechanism, invoked explicitly, with no background behaviour and no change to any default.

Two things about the current upgrade path made this worth doing properly rather than shelling out to the install script:

1. Neither install script verifies anything it downloads. `install.sh` does `curl` then `tar zxf`, `install.ps1` does `Invoke-WebRequest` then `Expand-Archive`. Every release publishes a checksums file next to the archive and nothing reads it. This command does.
2. Both install scripts delete your binaries before they download the new ones (`rm "${PULUMI_INSTALL_ROOT}/bin"/pulumi*` in `install.sh`, the equivalent `Remove-Item` loop in `install.ps1`). Ctrl-C or a failed download in that window leaves you with no working `pulumi`. This command downloads and verifies first, then swaps.

## What it does

```
$ pulumi self-update
Updating Pulumi v3.200.0 to v3.257.0...
Pulumi is now at v3.257.0.
```

`--dry-run` reports what it would install. `--version` pins a specific release.

It only touches installs it owns. An install is eligible when the resolved binary has the bundled `pulumi-language-*` plugins beside it and the directory is writable, and it is refused outright under a package manager path (Homebrew, Nix, npm, asdf, mise), with a pointer to the right command instead:

```
$ pulumi self-update
error: /opt/homebrew/Cellar/pulumi/3.257.0/bin/pulumi looks like it was installed by a
package manager, so it should be upgraded with that package manager rather than replaced
in place.
To upgrade, run:
    brew update && brew upgrade pulumi
```

Detection is off the resolved path of `os.Executable()` rather than `$PULUMI_HOME`, so `--install-root` installs and a `PULUMI_HOME` pointing somewhere else both work.

The out of date warning now points at the command on installs where it works, instead of telling you to re-run the install script:

```
warning: You are running a very old version of Pulumi and should upgrade as soon as
possible. To upgrade from version '3.100.0' to '3.257.0', run
   $ pulumi self-update
or visit https://pulumi.com/docs/install/ for manual instructions and release notes.
```

Homebrew still gets the brew command, dev builds still get the install script, and an install that is not eligible is unchanged.

## Downloads

The archive is a little over 100MB, so a connection lost part way through should not mean fetching all of it again. It is kept outside the staging directory, which is discarded when the run ends, and the next run asks for the remainder with a range request. GitHub answers those:

```
$ curl -sSL -o /dev/null -D - -r 18515486-18515586 \
    https://github.com/pulumi/pulumi/releases/download/v3.257.0/pulumi-v3.257.0-darwin-arm64.tar.gz
HTTP/2 206
accept-ranges: bytes
content-range: bytes 18515486-18515586/116267521
```

A server that ignores the range and sends the whole archive is handled by truncating first. An archive that resumes into something which no longer matches its published checksum is deleted rather than left to poison the next run, and only one archive is kept, so switching target version does not accumulate them.

The file is opened without `O_APPEND` and seeked to the end instead. Windows grants an append handle `FILE_APPEND_DATA` but not `FILE_WRITE_DATA`, so truncating one is denied, which every download hits and not just a resumed one.

## How the swap works

Binaries are replaced one at a time. The existing one is renamed aside first, then the new one is moved in, so at no point is a binary missing. If one fails part way through, the ones already swapped are put back.

The set of bundled binaries changes between releases, so once the swap is committed anything named `pulumi*` that the new archive did not contain is removed too. That keeps the install directory holding what the release holds and nothing more, which is what the install scripts do when they `rm "${PULUMI_INSTALL_ROOT}/bin"/pulumi*` before extracting. Files Pulumi does not own are left alone.

On Windows a running `.exe` cannot be deleted but can be renamed, which is what makes this work there. The displaced binary is left behind and cleaned up by the next run. Windows also intermittently holds a handle on freshly written executables long enough that removing the staging directory fails, so leftovers from an earlier run get swept at the start of each run too.

## Testing

Unit tests cover the swap and rollback, install detection, archive handling, and the download path against a local server, including an archive whose checksum does not match (the update aborts and the old binaries are untouched). Package coverage is 78.2%.

Resuming is covered by killing a download part way, overwriting what was fetched with zeroes, and running again. The update fails on the checksum, which is only possible if the remainder was appended to what was already there rather than the archive being fetched from the start.

The integration tests run the real binary. One checks that a CLI without the bundled plugins beside it is refused. The other runs `--dry-run` against the live release endpoints and then fetches the published checksums file to confirm the archive name the CLI resolved is one that release actually ships, since the unit tests serve their own archives and would not catch a change to the naming convention.

I also ran real updates end to end on macOS arm64, Windows amd64, linux amd64 and linux arm64, against a copy of a real install rather than a synthetic one. Those runs are what caught the Windows truncate above, and they confirm that a binary the new release does not ship is removed while a file Pulumi does not own is left alone.

## Not in this change

- Dev channel versions. Checksums are only published for GitHub releases, so `--version dev` is not supported.
- Anything automatic. No background download, no new default behaviour.
- There is no lock, so two `self-update` runs at once against the same install will fight.

## References

- #19997
- #19088 by @tgummerer prototyped the background version of this. I have not reused the code, but the design questions it ran into (the bundle is not one binary, Windows) are the ones this is trying to answer. Happy to close this if you would rather take that further instead.
