### PR TITLE
Validate and prepare state migration transactions

### DIFF
--- a/pkg/resource/deploy/state_migration_transaction.go
+++ b/pkg/resource/deploy/state_migration_transaction.go
@@ -50,7 +50,6 @@ func (sg *stepGenerator) prepareStateMigrationTransaction(
 	for _, state := range d.prev.Resources {
 		if priorSubtreeSet[state] {
 			if state == lastPriorResource {
-				// Insert the result
 				preparedPriorResources = append(preparedPriorResources, resultSubtree...)
 			}
 			continue // The state is part of the prior subtree; skip it.

--- a/pkg/resource/deploy/state_migration_transaction.go
+++ b/pkg/resource/deploy/state_migration_transaction.go
@@ -1,0 +1,151 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"fmt"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// prepareStateMigrationTransaction validates a migration result and prepares every rewrite that must be persisted.
+//
+//nolint:unused // Used by state-migration orchestration added in the engine transaction branch.
+func (sg *stepGenerator) prepareStateMigrationTransaction(
+	registrationURN resource.URN, priorRoot *pkgresource.State, priorSubtree, resultSubtree []*pkgresource.State,
+	successors map[resource.URN]resource.URN,
+) (*StateMigrationTransaction, error) {
+	if err := sg.validateStateMigrationResult(
+		registrationURN, priorRoot, priorSubtree, resultSubtree,
+	); err != nil {
+		return nil, err
+	}
+	d := sg.deployment
+	priorSubtreeSet := make(map[*pkgresource.State]bool, len(priorSubtree))
+	for _, state := range priorSubtree {
+		priorSubtreeSet[state] = true
+	}
+	lastPriorResource := priorSubtree[len(priorSubtree)-1]
+
+	// Put ResultSubtree at the last prior resource's position so it remains after anything it may reference.
+	preparedPriorResources := make(
+		[]*pkgresource.State, 0, len(d.prev.Resources)-len(priorSubtree)+len(resultSubtree))
+	retainedResources := make([]*pkgresource.State, 0, len(d.prev.Resources)-len(priorSubtree))
+	preparedPriorIndices := make(map[*pkgresource.State]int, len(d.prev.Resources)-len(priorSubtree))
+	for _, state := range d.prev.Resources {
+		if priorSubtreeSet[state] {
+			if state == lastPriorResource {
+				// Insert the result
+				preparedPriorResources = append(preparedPriorResources, resultSubtree...)
+			}
+			continue // The state is part of the prior subtree; skip it.
+		}
+		preparedPriorIndices[state] = len(preparedPriorResources)
+		retainedResources = append(retainedResources, state)
+		preparedPriorResources = append(preparedPriorResources, state)
+	}
+
+	// Resources outside PriorSubtree remain in the snapshot, but their references to removed subtree resources must
+	// follow those resources to their final successors.
+	rewrittenRetainedResources, err := rewriteStateMigrationReferences(
+		retainedResources, successors, stateMigrationSuccessorIdentities(resultSubtree))
+	if err != nil {
+		return nil, fmt.Errorf("state migration for %s: rewriting successor references: %w", registrationURN, err)
+	}
+	retainedRewrites, err := mapResourcesToPreparedRewrites(
+		registrationURN, retainedResources, rewrittenRetainedResources, "retained from prior state")
+	if err != nil {
+		return nil, err
+	}
+
+	// Put each changed prepared copy into the candidate prior-resource list. Also remember the live resource's index so
+	// the migration commit can copy the prepared fields back into that object without changing its pointer identity.
+	retainedRewriteIndices := make(map[*pkgresource.State]int, len(retainedRewrites))
+	for old, rewritten := range retainedRewrites {
+		index := preparedPriorIndices[old]
+		preparedPriorResources[index] = rewritten
+		retainedRewriteIndices[old] = index
+	}
+
+	verifySnap := &Snapshot{Manifest: d.prev.Manifest, Resources: preparedPriorResources}
+	if err := verifySnap.VerifyIntegrity(); err != nil {
+		return nil, fmt.Errorf(
+			"state migration for %s produced an invalid state; no changes were made: %w", registrationURN, err)
+	}
+
+	transaction := &StateMigrationTransaction{
+		RootURN:                  registrationURN,
+		PriorSubtree:             priorSubtree,
+		ResultSubtree:            resultSubtree,
+		SuccessorURNs:            successors,
+		PreparedPriorResources:   preparedPriorResources,
+		RetainedResourceRewrites: retainedRewrites,
+		retainedRewriteIndices:   retainedRewriteIndices,
+	}
+
+	// Deployment.news and Deployment.reads may already contain live states that reference migrated resources.
+	currentResourceSet := make(map[*pkgresource.State]struct{})
+	if d.news != nil {
+		d.news.Range(func(_ resource.URN, state *pkgresource.State) bool {
+			currentResourceSet[state] = struct{}{}
+			return true
+		})
+	}
+	if d.reads != nil {
+		d.reads.Range(func(_ resource.URN, state *pkgresource.State) bool {
+			currentResourceSet[state] = struct{}{}
+			return true
+		})
+	}
+	currentResources := make([]*pkgresource.State, 0, len(currentResourceSet))
+	for state := range currentResourceSet {
+		currentResources = append(currentResources, state)
+	}
+	rewrittenCurrentResources, err := transaction.RewriteResources(currentResources)
+	if err != nil {
+		return nil, fmt.Errorf("state migration for %s: rewriting current resources: %w", registrationURN, err)
+	}
+	transaction.currentResourceRewrites, err = mapResourcesToPreparedRewrites(
+		registrationURN, currentResources, rewrittenCurrentResources, "created or updated earlier in this deployment")
+	if err != nil {
+		return nil, err
+	}
+	return transaction, nil
+}
+
+// mapResourcesToPreparedRewrites maps each live resource whose references changed to its prepared rewritten state.
+// Provider states must remain unchanged and are rejected if normalization produced a rewrite for one.
+//
+//nolint:unused // Used by state-migration orchestration added in the engine transaction branch.
+func mapResourcesToPreparedRewrites(
+	urn resource.URN, before, after []*pkgresource.State, origin string,
+) (map[*pkgresource.State]*pkgresource.State, error) {
+	contract.Assertf(len(before) == len(after), "state migration reference rewrite changed resource count")
+	rewrites := make(map[*pkgresource.State]*pkgresource.State)
+	for i, state := range before {
+		if after[i] == state {
+			continue
+		}
+		if sdkproviders.IsProviderType(state.Type) {
+			return nil, fmt.Errorf("state migration for %s rewrites references in provider state %s %s; "+
+				"provider states must remain unchanged", urn, state.URN, origin)
+		}
+		rewrites[state] = after[i]
+	}
+	return rewrites, nil
+}

--- a/pkg/resource/deploy/state_migration_validation.go
+++ b/pkg/resource/deploy/state_migration_validation.go
@@ -39,7 +39,7 @@ func validateStateMigrationContext(
 	}
 	if len(snap.PendingOperations) > 0 {
 		return fmt.Errorf("state migration for %s cannot change state while the snapshot has %d pending "+
-			"operation(s); resolve them before migrating %s", urn, len(snap.PendingOperations), urn)
+			"operation(s); resolve them before migrating %s, by running 'pulumi refresh'", urn, len(snap.PendingOperations), urn)
 	}
 	// Snippet references are persisted separately from resource state and are not part of StateMigrationTransaction.
 	for _, snippet := range snap.Snippets {

--- a/pkg/resource/deploy/state_migration_validation.go
+++ b/pkg/resource/deploy/state_migration_validation.go
@@ -1,0 +1,373 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+var ErrStateMigrationsUnsupported = errors.New("state migrations are not supported by this deployment")
+
+// validateStateMigrationContext rejects state migrations during partial updates, or when pending operations or
+// persisted snippets prevent the snapshot from being rewritten safely.
+func validateStateMigrationContext(
+	urn resource.URN, opts *Options, snap *Snapshot, successors map[resource.URN]resource.URN,
+) error {
+	if opts.Targets.IsConstrained() || opts.Excludes.IsConstrained() ||
+		opts.ReplaceTargets.IsConstrained() || len(opts.TargetSnippets) > 0 {
+		return fmt.Errorf("state migration for %s cannot change state during a targeted or excluded update; "+
+			"run a full update without --target, --exclude, --replace, or --target-snippet", urn)
+	}
+	if len(snap.PendingOperations) > 0 {
+		return fmt.Errorf("state migration for %s cannot change state while the snapshot has %d pending "+
+			"operation(s); resolve them before migrating %s", urn, len(snap.PendingOperations), urn)
+	}
+	// Snippet references are persisted separately from resource state and are not part of StateMigrationTransaction.
+	for _, snippet := range snap.Snippets {
+		for name, referenced := range snippet.References {
+			predecessor := resource.URN(referenced)
+			if successor, ok := successors[predecessor]; ok {
+				return fmt.Errorf("state migration for %s cannot rewrite snippet %q reference %q from %s to %s; "+
+					"remove or update the persisted snippet before migrating %s",
+					urn, snippet.UUID, name, predecessor, successor, urn)
+			}
+		}
+	}
+	return nil
+}
+
+// validateStateMigrationManagedIdentity ensures a migration cannot abandon one managed object and silently make a
+// different object its successor. A successor mapping may change a resource's logical Pulumi identity (its URN and
+// type), but a migration only rewrites checkpoint state, it does not ask a provider to import, read, or replace the
+// underlying object. A custom resource's physical ID, provider and extension identity, whether Pulumi owns its
+// lifecycle (External), and its PendingReplacement and Taint flags must therefore follow its successor. Protect and
+// RetainOnDelete are engine-owned safety metadata and must be inherited conservatively by any custom or component
+// successor: when multiple resources are folded together, the successor must carry either flag if any predecessor did.
+// The provider identity restrictions do not apply to components because they have no provider-managed physical
+// identity.
+func validateStateMigrationManagedIdentity(
+	urn resource.URN,
+	original, final []apitype.ResourceV3,
+	successors map[resource.URN]resource.URN,
+) error {
+	finalByURN := make(map[resource.URN]apitype.ResourceV3, len(final))
+	for _, state := range final {
+		finalByURN[state.URN] = state
+	}
+
+	type inheritedState struct {
+		hasCustomPredecessor bool
+		protect              bool
+		retainOnDelete       bool
+		pendingReplacement   bool
+		taint                bool
+	}
+	inheritedByURN := make(map[resource.URN]inheritedState, len(final))
+	for _, old := range original {
+		targetURN := old.URN
+		target, retained := finalByURN[targetURN]
+		if !retained {
+			var ok bool
+			targetURN, ok = successors[old.URN]
+			if !ok {
+				continue
+			}
+			target, ok = finalByURN[targetURN]
+			if !ok {
+				continue
+			}
+		}
+
+		inherited := inheritedByURN[targetURN]
+		inherited.protect = inherited.protect || old.Protect
+		inherited.retainOnDelete = inherited.retainOnDelete || old.RetainOnDelete
+		if !old.Custom {
+			inheritedByURN[targetURN] = inherited
+			continue
+		}
+
+		inherited.hasCustomPredecessor = true
+		if !target.Custom {
+			return fmt.Errorf("state migration for %s maps managed custom resource %s to component successor %s; "+
+				"migrations must preserve managed resource identity", urn, old.URN, targetURN)
+		}
+		if old.ID != target.ID {
+			return fmt.Errorf("state migration for %s changes the physical ID of managed custom resource %s "+
+				"from %q to %q on successor %s; migrations must preserve managed resource identity",
+				urn, old.URN, old.ID, target.ID, targetURN)
+		}
+		if old.Provider != target.Provider {
+			return fmt.Errorf("state migration for %s changes the provider reference of managed custom resource %s "+
+				"from %q to %q on successor %s; migrations must preserve managed resource provider identity",
+				urn, old.URN, old.Provider, target.Provider, targetURN)
+		}
+		if old.ExtensionRef != target.ExtensionRef {
+			return fmt.Errorf("state migration for %s changes the extension reference of managed custom resource %s "+
+				"from %q to %q on successor %s; migrations must preserve managed resource extension identity",
+				urn, old.URN, old.ExtensionRef, target.ExtensionRef, targetURN)
+		}
+		if old.External != target.External {
+			return fmt.Errorf("state migration for %s changes ownership of custom resource %s "+
+				"from external=%t to external=%t on successor %s; migrations must preserve managed resource ownership",
+				urn, old.URN, old.External, target.External, targetURN)
+		}
+		if old.PendingReplacement != target.PendingReplacement {
+			return fmt.Errorf("state migration for %s changes PendingReplacement for custom resource %s "+
+				"from %t to %t on successor %s; migrations must preserve provider lifecycle state",
+				urn, old.URN, old.PendingReplacement, target.PendingReplacement, targetURN)
+		}
+		if old.Taint != target.Taint {
+			return fmt.Errorf("state migration for %s changes Taint for custom resource %s "+
+				"from %t to %t on successor %s; migrations must preserve provider lifecycle state",
+				urn, old.URN, old.Taint, target.Taint, targetURN)
+		}
+		if old.PendingReplacement {
+			inherited.pendingReplacement = true
+		}
+		if old.Taint {
+			inherited.taint = true
+		}
+		inheritedByURN[targetURN] = inherited
+	}
+
+	// The checks above validate retained custom resources and their successors. Now reject custom states without a
+	// managed predecessor, and reject safety or lifecycle flags that were not inherited from their predecessors. This
+	// includes states newly introduced by the migration.
+	for _, state := range final {
+		inherited := inheritedByURN[state.URN]
+		if state.PendingReplacement && (!state.Custom || !inherited.pendingReplacement) {
+			return fmt.Errorf("state migration for %s returns resource %s with PendingReplacement set "+
+				"without a pending-replacement custom predecessor", urn, state.URN)
+		}
+		if state.Taint && (!state.Custom || !inherited.taint) {
+			return fmt.Errorf("state migration for %s returns resource %s with Taint set "+
+				"without a tainted custom predecessor", urn, state.URN)
+		}
+		if state.Custom && !inherited.hasCustomPredecessor {
+			return fmt.Errorf("state migration for %s introduces custom resource %s with ID %q without a "+
+				"managed custom predecessor; migrations cannot import resources", urn, state.URN, state.ID)
+		}
+		if state.Protect != inherited.protect {
+			return fmt.Errorf("state migration for %s changes Protect for resource %s from inherited value %t to %t; "+
+				"migrations must preserve resource protection", urn, state.URN, inherited.protect, state.Protect)
+		}
+		if state.RetainOnDelete != inherited.retainOnDelete {
+			return fmt.Errorf("state migration for %s changes RetainOnDelete for resource %s from inherited value %t "+
+				"to %t; migrations must preserve resource retention", urn, state.URN,
+				inherited.retainOnDelete, state.RetainOnDelete)
+		}
+	}
+	return nil
+}
+
+// validateStateMigrationProviderStates prevents migrations from adding, removing, renaming, or reconfiguring provider
+// resources. A provider state corresponds to a configured plugin instance in the deployment's provider registry, which
+// custom resources identify by the provider's URN and ID. Rewriting checkpoint state alone cannot make the matching
+// registry change. A migration may therefore carry provider state through only with its exact normalized checkpoint
+// representation and URN unchanged.
+func validateStateMigrationProviderStates(
+	urn resource.URN,
+	original, final []apitype.ResourceV3,
+) error {
+	originalProviders := make(map[resource.URN]apitype.ResourceV3)
+	for _, state := range original {
+		if sdkproviders.IsProviderType(state.Type) {
+			originalProviders[state.URN] = state
+		}
+	}
+
+	finalProviders := make(map[resource.URN]apitype.ResourceV3)
+	for _, state := range final {
+		if sdkproviders.IsProviderType(state.Type) {
+			finalProviders[state.URN] = state
+		}
+	}
+
+	for providerURN, originalState := range originalProviders {
+		finalState, ok := finalProviders[providerURN]
+		if !ok {
+			return fmt.Errorf("state migration for %s removes or renames provider state %s; "+
+				"provider states must be returned unchanged", urn, providerURN)
+		}
+		if !reflect.DeepEqual(originalState, finalState) {
+			return fmt.Errorf("state migration for %s changes provider state %s; "+
+				"provider states must be returned unchanged", urn, providerURN)
+		}
+	}
+	for providerURN := range finalProviders {
+		if _, ok := originalProviders[providerURN]; !ok {
+			return fmt.Errorf("state migration for %s introduces provider state %s; "+
+				"provider states cannot be created by a state migration", urn, providerURN)
+		}
+	}
+	return nil
+}
+
+// validateStateMigrationResult checks that ResultSubtree is well-formed before using it to rewrite the prior snapshot:
+// the registering resource's state must be present, all result states must be parented transitively to it, and no
+// result state may introduce an unresolved structural reference. ResourceReference values in inputs and outputs are not
+// structural dependencies and may legitimately identify resources in another stack.
+//
+// registrationURN is the current-program URN derived for the registration. priorRoot is the matched prior-state root;
+// it may have a different URN when the registration found it through an alias after a rename.
+func (sg *stepGenerator) validateStateMigrationResult(
+	registrationURN resource.URN, priorRoot *pkgresource.State, priorSubtree, resultSubtree []*pkgresource.State,
+) error {
+	errorf := func(format string, args ...any) error {
+		prefix := fmt.Sprintf("state migration for %s: ", registrationURN)
+		return fmt.Errorf(prefix+format, args...)
+	}
+
+	priorURNs := make(map[resource.URN]bool, len(priorSubtree))
+	for _, state := range priorSubtree {
+		priorURNs[state.URN] = true
+	}
+
+	resultByURN := make(map[resource.URN]*pkgresource.State, len(resultSubtree))
+	for _, state := range resultSubtree {
+		resultByURN[state.URN] = state
+	}
+	resultRootURN := registrationURN
+	rootCount := 0
+	if _, ok := resultByURN[registrationURN]; ok {
+		rootCount++
+	}
+	if priorRoot.URN != registrationURN {
+		if _, ok := resultByURN[priorRoot.URN]; ok {
+			rootCount++
+			resultRootURN = priorRoot.URN
+		}
+	}
+	if rootCount == 0 {
+		return errorf("the migration result must include the state for %s (the resource being registered) "+
+			"under its new URN or its prior URN %s", registrationURN, priorRoot.URN)
+	}
+	if rootCount != 1 {
+		return errorf("the migration result includes both the new root %s and its prior root %s; "+
+			"it must include exactly one logical root", registrationURN, priorRoot.URN)
+	}
+	isRoot := func(u resource.URN) bool { return u == resultRootURN }
+
+	// resolvableOutside is the set of prior resources outside PriorSubtree that ResultSubtree may
+	// still reference (providers, dependencies, and so on).
+	resolvable := func(target resource.URN) bool {
+		if _, ok := resultByURN[target]; ok {
+			return true
+		}
+		if priorURNs[target] {
+			// Successor references have already been rewritten. A missing former member at this point would dangle.
+			return false
+		}
+		_, ok := sg.deployment.Olds()[target]
+		return ok
+	}
+
+	for _, state := range resultSubtree {
+		if !state.URN.IsValid() {
+			return errorf("returned resource has invalid URN %q", state.URN)
+		}
+		if state.URN.Stack() != registrationURN.Stack() || state.URN.Project() != registrationURN.Project() {
+			return errorf("returned resource %s belongs to stack %q and project %q; migration results must remain "+
+				"in registration stack %q and project %q", state.URN, state.URN.Stack(), state.URN.Project(),
+				registrationURN.Stack(), registrationURN.Project())
+		}
+		if state.URN != registrationURN {
+			if claimant, claimed := sg.aliased[state.URN]; claimed {
+				return errorf("returned resource %s was already claimed as an alias by %s earlier in this deployment",
+					state.URN, claimant)
+			}
+			if sg.urns[state.URN] {
+				return errorf("returned resource %s was already registered earlier in this deployment", state.URN)
+			}
+		}
+		if state.Delete {
+			return errorf("returned resource %s is marked for pending deletion; migrations may not return "+
+				"pending-delete resources", state.URN)
+		}
+		if state.ViewOf != "" {
+			return errorf("returned resource %s is a view; state migrations do not support views", state.URN)
+		}
+		if state.Custom && state.ID == "" {
+			return errorf("returned custom resource %s has no ID", state.URN)
+		}
+		if state.ExtensionRef != "" {
+			if _, ok := sg.deployment.prev.Extensions[state.ExtensionRef]; !ok {
+				return errorf("returned resource %s references unknown extension %s",
+					state.URN, state.ExtensionRef)
+			}
+		}
+		if state.Parent != "" && !state.Parent.IsValid() {
+			return errorf("returned resource %s has invalid parent URN %q", state.URN, state.Parent)
+		}
+		expectedQualifiedType := state.Type
+		if state.Parent != "" && state.Parent.QualifiedType() != resource.RootStackType {
+			expectedQualifiedType = state.Parent.QualifiedType() + resource.URNTypeDelimiter + state.Type
+		}
+		if state.URN.QualifiedType() != expectedQualifiedType {
+			return errorf("resource %s has parent %s but qualified type %s; expected %s",
+				state.URN, state.Parent, state.URN.QualifiedType(), expectedQualifiedType)
+		}
+
+		if isRoot(state.URN) {
+			if state.Parent != priorRoot.Parent {
+				return errorf("the parent of %s may not be changed by a migration (got %q, expected %q)",
+					state.URN, state.Parent, priorRoot.Parent)
+			}
+		} else {
+			// Walk the parent chain within ResultSubtree: it must terminate at the root.
+			seen := 0
+			parent := state.Parent
+			for !isRoot(parent) {
+				if seen++; seen > len(resultSubtree) {
+					return errorf("resource %s has a cyclic parent chain", state.URN)
+				}
+				next, ok := resultByURN[parent]
+				if !ok {
+					return errorf("resource %s is parented to %s which is not part of the migration result",
+						state.URN, parent)
+				}
+				parent = next.Parent
+			}
+		}
+
+		provider, allDeps := state.GetAllDependencies()
+		if provider != "" {
+			ref, err := sdkproviders.ParseReference(provider)
+			if err != nil {
+				return errorf("resource %s has an invalid provider reference %q: %w", state.URN, provider, err)
+			}
+			if !resolvable(ref.URN()) {
+				return errorf("resource %s refers to unknown provider %s", state.URN, ref)
+			}
+		}
+		for _, dep := range allDeps {
+			if dep.Type == pkgresource.ResourceParent {
+				continue
+			}
+			if !resolvable(dep.URN) {
+				return errorf("resource %s refers to unknown resource %s", state.URN, dep.URN)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/resource/deploy/state_migration_validation_test.go
+++ b/pkg/resource/deploy/state_migration_validation_test.go
@@ -1,0 +1,553 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestValidateStateMigrationContext(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rootURN = resource.URN("urn:pulumi:test::test::pkg:m:Component::component")
+		oldURN  = resource.URN("urn:pulumi:test::test::pkg:m:Resource::old")
+		newURN  = resource.URN("urn:pulumi:test::test::pkg:m:Resource::new")
+	)
+	successors := map[resource.URN]resource.URN{oldURN: newURN}
+
+	t.Run("clean full update", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateStateMigrationContext(rootURN, &Options{}, &Snapshot{}, successors))
+	})
+
+	for name, opts := range map[string]*Options{
+		"target": {
+			Targets: NewUrnTargets([]string{string(rootURN)}),
+		},
+		"exclude": {
+			Excludes: NewUrnTargets([]string{string(rootURN)}),
+		},
+		"replace target": {
+			ReplaceTargets: NewUrnTargets([]string{string(rootURN)}),
+		},
+		"target snippet": {
+			TargetSnippets: []string{"snippet-id"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := validateStateMigrationContext(rootURN, opts, &Snapshot{}, successors)
+			require.ErrorContains(t, err, "cannot change state during a targeted or excluded update")
+		})
+	}
+
+	t.Run("pending operation", func(t *testing.T) {
+		t.Parallel()
+		snap := &Snapshot{PendingOperations: []pkgresource.Operation{pkgresource.NewOperation(
+			&pkgresource.State{URN: "urn:pulumi:test::test::pkg:m:Resource::pending"},
+			pkgresource.OperationTypeCreating,
+		)}}
+		err := validateStateMigrationContext(rootURN, &Options{}, snap, successors)
+		require.ErrorContains(t, err, "snapshot has 1 pending operation")
+	})
+
+	t.Run("snippet reference", func(t *testing.T) {
+		t.Parallel()
+		snap := &Snapshot{Snippets: []resource.Snippet{{
+			UUID:       "snippet-id",
+			References: map[string]string{"dependency": string(oldURN)},
+		}}}
+		err := validateStateMigrationContext(rootURN, &Options{}, snap, successors)
+		require.ErrorContains(t, err, `cannot rewrite snippet "snippet-id" reference "dependency"`)
+	})
+
+	t.Run("unrelated snippet reference", func(t *testing.T) {
+		t.Parallel()
+		snap := &Snapshot{Snippets: []resource.Snippet{{
+			UUID: "snippet-id",
+			References: map[string]string{
+				"dependency": "urn:pulumi:test::test::pkg:m:Resource::unrelated",
+			},
+		}}}
+		require.NoError(t, validateStateMigrationContext(rootURN, &Options{}, snap, successors))
+	})
+}
+
+func TestValidateStateMigrationManagedIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rootURN  = resource.URN("urn:pulumi:test::test::pkg:m:Component::component")
+		oldURN   = resource.URN("urn:pulumi:test::test::pkg:m:Resource::old")
+		newURN   = resource.URN("urn:pulumi:test::test::pkg:m:Resource::new")
+		otherURN = resource.URN("urn:pulumi:test::test::pkg:m:Resource::other")
+	)
+	state := func(urn resource.URN, custom, pendingReplacement bool, id ...resource.ID) apitype.ResourceV3 {
+		resourceID := resource.ID("id")
+		if len(id) > 0 {
+			resourceID = id[0]
+		}
+		return apitype.ResourceV3{
+			URN:                urn,
+			Type:               urn.Type(),
+			Custom:             custom,
+			ID:                 resourceID,
+			PendingReplacement: pendingReplacement,
+		}
+	}
+
+	t.Run("renamed successor preserves flag", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(oldURN, true /* custom */, true /* pendingReplacement */)},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, true /* pendingReplacement */)},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("cannot clear flag", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(oldURN, true /* custom */, true /* pendingReplacement */)},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, false /* pendingReplacement */)},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes PendingReplacement")
+	})
+
+	t.Run("cannot forge flag", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(oldURN, true /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, true /* pendingReplacement */)},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes PendingReplacement")
+	})
+
+	t.Run("new resource cannot invent flag", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(rootURN, false /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{
+				state(rootURN, false /* custom */, false /* pendingReplacement */),
+				state(newURN, true /* custom */, true /* pendingReplacement */),
+			},
+			nil,
+		)
+		require.ErrorContains(t, err, "without a pending-replacement custom predecessor")
+	})
+
+	t.Run("cannot clear taint", func(t *testing.T) {
+		t.Parallel()
+		old := state(oldURN, true /* custom */, false /* pendingReplacement */)
+		old.Taint = true
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{old},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, false /* pendingReplacement */)},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes Taint")
+	})
+
+	t.Run("cannot forge taint", func(t *testing.T) {
+		t.Parallel()
+		successor := state(newURN, true /* custom */, false /* pendingReplacement */)
+		successor.Taint = true
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(oldURN, true /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{successor},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes Taint")
+	})
+
+	t.Run("new resource cannot invent taint", func(t *testing.T) {
+		t.Parallel()
+		added := state(newURN, true /* custom */, false /* pendingReplacement */)
+		added.Taint = true
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(rootURN, false /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{
+				state(rootURN, false /* custom */, false /* pendingReplacement */),
+				added,
+			},
+			nil,
+		)
+		require.ErrorContains(t, err, "without a tainted custom predecessor")
+	})
+
+	t.Run("component does not constrain custom successor", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{
+				state(rootURN, false /* custom */, false /* pendingReplacement */),
+				state(oldURN, true /* custom */, true /* pendingReplacement */),
+			},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, true /* pendingReplacement */)},
+			map[resource.URN]resource.URN{
+				rootURN: newURN,
+				oldURN:  newURN,
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("many-to-one successor conservatively inherits safety flags", func(t *testing.T) {
+		t.Parallel()
+		protected := state(oldURN, true /* custom */, false /* pendingReplacement */)
+		protected.Protect = true
+		retained := state(otherURN, true /* custom */, false /* pendingReplacement */)
+		retained.RetainOnDelete = true
+		successor := state(newURN, true /* custom */, false /* pendingReplacement */)
+		successor.Protect = true
+		successor.RetainOnDelete = true
+
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{protected, retained},
+			[]apitype.ResourceV3{successor},
+			map[resource.URN]resource.URN{oldURN: newURN, otherURN: newURN},
+		)
+		require.NoError(t, err)
+	})
+
+	for _, flag := range []struct {
+		name      string
+		set       func(*apitype.ResourceV3, bool)
+		wantError string
+	}{
+		{
+			name:      "Protect",
+			set:       func(state *apitype.ResourceV3, value bool) { state.Protect = value },
+			wantError: "changes Protect",
+		},
+		{
+			name:      "RetainOnDelete",
+			set:       func(state *apitype.ResourceV3, value bool) { state.RetainOnDelete = value },
+			wantError: "changes RetainOnDelete",
+		},
+	} {
+		t.Run("cannot clear "+flag.name, func(t *testing.T) {
+			t.Parallel()
+			old := state(oldURN, true /* custom */, false /* pendingReplacement */)
+			flag.set(&old, true)
+			successor := state(newURN, true /* custom */, false /* pendingReplacement */)
+			err := validateStateMigrationManagedIdentity(
+				rootURN,
+				[]apitype.ResourceV3{old},
+				[]apitype.ResourceV3{successor},
+				map[resource.URN]resource.URN{oldURN: newURN},
+			)
+			require.ErrorContains(t, err, flag.wantError)
+		})
+
+		t.Run("cannot forge "+flag.name, func(t *testing.T) {
+			t.Parallel()
+			old := state(oldURN, true /* custom */, false /* pendingReplacement */)
+			successor := state(newURN, true /* custom */, false /* pendingReplacement */)
+			flag.set(&successor, true)
+			err := validateStateMigrationManagedIdentity(
+				rootURN,
+				[]apitype.ResourceV3{old},
+				[]apitype.ResourceV3{successor},
+				map[resource.URN]resource.URN{oldURN: newURN},
+			)
+			require.ErrorContains(t, err, flag.wantError)
+		})
+	}
+
+	t.Run("introduced custom resource requires managed predecessor", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(rootURN, false /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{
+				state(rootURN, false /* custom */, false /* pendingReplacement */),
+				state(newURN, true /* custom */, false /* pendingReplacement */),
+			},
+			nil,
+		)
+		require.ErrorContains(t, err, "without a managed custom predecessor")
+	})
+
+	t.Run("component predecessor alone cannot authorize custom successor", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(rootURN, false /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, false /* pendingReplacement */)},
+			map[resource.URN]resource.URN{rootURN: newURN},
+		)
+		require.ErrorContains(t, err, "without a managed custom predecessor")
+	})
+
+	t.Run("cannot change physical ID", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(oldURN, true /* custom */, false /* pendingReplacement */, "old-id")},
+			[]apitype.ResourceV3{state(newURN, true /* custom */, false /* pendingReplacement */, "new-id")},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes the physical ID")
+	})
+
+	t.Run("cannot change extension reference", func(t *testing.T) {
+		t.Parallel()
+		old := state(oldURN, true /* custom */, false /* pendingReplacement */)
+		old.ExtensionRef = "old-extension"
+		successor := state(newURN, true /* custom */, false /* pendingReplacement */)
+		successor.ExtensionRef = "new-extension"
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{old},
+			[]apitype.ResourceV3{successor},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes the extension reference")
+	})
+
+	t.Run("cannot change ownership", func(t *testing.T) {
+		t.Parallel()
+		old := state(oldURN, true /* custom */, false /* pendingReplacement */)
+		successor := state(newURN, true /* custom */, false /* pendingReplacement */)
+		successor.External = true
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{old},
+			[]apitype.ResourceV3{successor},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "changes ownership")
+	})
+
+	t.Run("cannot map custom resource to component", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{state(oldURN, true /* custom */, false /* pendingReplacement */)},
+			[]apitype.ResourceV3{state(newURN, false /* custom */, false /* pendingReplacement */)},
+			map[resource.URN]resource.URN{oldURN: newURN},
+		)
+		require.ErrorContains(t, err, "maps managed custom resource")
+	})
+
+	t.Run("cannot merge distinct managed IDs", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationManagedIdentity(
+			rootURN,
+			[]apitype.ResourceV3{
+				state(oldURN, true /* custom */, false /* pendingReplacement */, "old-id"),
+				state(newURN, true /* custom */, false /* pendingReplacement */, "new-id"),
+			},
+			[]apitype.ResourceV3{state(rootURN, true /* custom */, false /* pendingReplacement */, "old-id")},
+			map[resource.URN]resource.URN{
+				oldURN: rootURN,
+				newURN: rootURN,
+			},
+		)
+		require.ErrorContains(t, err, "changes the physical ID")
+	})
+}
+
+func TestValidateStateMigrationProviderStates(t *testing.T) {
+	t.Parallel()
+
+	const rootURN = resource.URN("urn:pulumi:test::test::pkg:m:Component::component")
+	providerURN := resource.NewURN("test", "test", "", "pulumi:providers:pkg", "default")
+	provider := apitype.ResourceV3{
+		URN:    providerURN,
+		Type:   providerURN.Type(),
+		Custom: true,
+		ID:     "provider-id",
+		Inputs: map[string]any{"region": "us-west-2"},
+	}
+
+	t.Run("unchanged", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateStateMigrationProviderStates(
+			rootURN, []apitype.ResourceV3{provider}, []apitype.ResourceV3{provider}))
+	})
+
+	t.Run("removed or renamed", func(t *testing.T) {
+		t.Parallel()
+		renamed := provider
+		renamed.URN = resource.NewURN("test", "test", "", "pulumi:providers:pkg", "renamed")
+		err := validateStateMigrationProviderStates(
+			rootURN, []apitype.ResourceV3{provider}, []apitype.ResourceV3{renamed})
+		require.ErrorContains(t, err, "removes or renames provider state")
+	})
+
+	t.Run("reconfigured", func(t *testing.T) {
+		t.Parallel()
+		reconfigured := provider
+		reconfigured.Inputs = map[string]any{"region": "eu-west-1"}
+		err := validateStateMigrationProviderStates(
+			rootURN, []apitype.ResourceV3{provider}, []apitype.ResourceV3{reconfigured})
+		require.ErrorContains(t, err, "changes provider state")
+	})
+
+	t.Run("introduced", func(t *testing.T) {
+		t.Parallel()
+		err := validateStateMigrationProviderStates(rootURN, nil, []apitype.ResourceV3{provider})
+		require.ErrorContains(t, err, "introduces provider state")
+	})
+}
+
+func TestValidateMigratedStatesRejectsAlreadyRegisteredURN(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rootURN      = resource.URN("urn:pulumi:test::test::pkg:m:Component::component")
+		collisionURN = resource.URN("urn:pulumi:test::test::pkg:m:Component$pkg:m:Component::collision")
+	)
+	root := &pkgresource.State{URN: rootURN, Type: rootURN.Type()}
+	collision := &pkgresource.State{
+		URN:    collisionURN,
+		Type:   collisionURN.Type(),
+		Parent: rootURN,
+	}
+	sg := &stepGenerator{
+		deployment: &Deployment{olds: map[resource.URN]*pkgresource.State{rootURN: root}},
+		urns: map[resource.URN]bool{
+			rootURN:      true,
+			collisionURN: true,
+		},
+		aliased: map[resource.URN]resource.URN{},
+	}
+
+	err := sg.validateStateMigrationResult(rootURN, root, []*pkgresource.State{root},
+		[]*pkgresource.State{root, collision})
+	require.ErrorContains(t, err, "was already registered earlier in this deployment")
+}
+
+func TestValidateStateMigrationResultRoot(t *testing.T) {
+	t.Parallel()
+
+	registrationURN := resource.NewURN("test", "test", "", "pkg:m:NewComponent", "component")
+	priorURN := resource.NewURN("test", "test", "", "pkg:m:OldComponent", "component")
+	priorRoot := &pkgresource.State{URN: priorURN, Type: priorURN.Type()}
+	registrationRoot := &pkgresource.State{URN: registrationURN, Type: registrationURN.Type()}
+	sg := &stepGenerator{
+		deployment: &Deployment{olds: map[resource.URN]*pkgresource.State{priorURN: priorRoot}},
+		aliased:    map[resource.URN]resource.URN{},
+		urns:       map[resource.URN]bool{},
+	}
+
+	t.Run("new root only", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, sg.validateStateMigrationResult(
+			registrationURN, priorRoot, []*pkgresource.State{priorRoot},
+			[]*pkgresource.State{registrationRoot}))
+	})
+
+	t.Run("prior root only", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, sg.validateStateMigrationResult(
+			registrationURN, priorRoot, []*pkgresource.State{priorRoot},
+			[]*pkgresource.State{priorRoot}))
+	})
+
+	t.Run("both roots", func(t *testing.T) {
+		t.Parallel()
+		err := sg.validateStateMigrationResult(
+			registrationURN, priorRoot, []*pkgresource.State{priorRoot},
+			[]*pkgresource.State{priorRoot, registrationRoot})
+		require.ErrorContains(t, err, "must include exactly one logical root")
+	})
+}
+
+func TestValidateStateMigrationResultURNScope(t *testing.T) {
+	t.Parallel()
+
+	rootURN := resource.NewURN("test", "test", "", "pkg:m:Component", "component")
+	root := &pkgresource.State{URN: rootURN, Type: rootURN.Type()}
+	sg := &stepGenerator{
+		deployment: &Deployment{olds: map[resource.URN]*pkgresource.State{rootURN: root}},
+		aliased:    map[resource.URN]resource.URN{},
+		urns:       map[resource.URN]bool{},
+	}
+
+	for _, tt := range []struct {
+		name     string
+		childURN resource.URN
+		want     string
+	}{
+		{
+			name:     "different stack",
+			childURN: resource.NewURN("other", "test", rootURN.QualifiedType(), "pkg:m:Resource", "child"),
+			want:     `migration results must remain in registration stack "test"`,
+		},
+		{
+			name:     "different project",
+			childURN: resource.NewURN("test", "other", rootURN.QualifiedType(), "pkg:m:Resource", "child"),
+			want:     `and project "test"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			child := &pkgresource.State{URN: tt.childURN, Type: tt.childURN.Type(), Parent: rootURN}
+			err := sg.validateStateMigrationResult(
+				rootURN, root, []*pkgresource.State{root}, []*pkgresource.State{root, child})
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestValidateStateMigrationResultParentQualifiedType(t *testing.T) {
+	t.Parallel()
+
+	rootURN := resource.NewURN("test", "test", "", "pkg:m:Component", "component")
+	root := &pkgresource.State{URN: rootURN, Type: rootURN.Type()}
+	sg := &stepGenerator{
+		deployment: &Deployment{olds: map[resource.URN]*pkgresource.State{rootURN: root}},
+		aliased:    map[resource.URN]resource.URN{},
+		urns:       map[resource.URN]bool{},
+	}
+
+	t.Run("consistent", func(t *testing.T) {
+		t.Parallel()
+		childURN := resource.NewURN("test", "test", rootURN.QualifiedType(), "pkg:m:Resource", "child")
+		child := &pkgresource.State{URN: childURN, Type: childURN.Type(), Parent: rootURN}
+		require.NoError(t, sg.validateStateMigrationResult(
+			rootURN, root, []*pkgresource.State{root}, []*pkgresource.State{root, child}))
+	})
+
+	t.Run("inconsistent", func(t *testing.T) {
+		t.Parallel()
+		childURN := resource.NewURN("test", "test", "", "pkg:m:Resource", "child")
+		child := &pkgresource.State{URN: childURN, Type: childURN.Type(), Parent: rootURN}
+		err := sg.validateStateMigrationResult(
+			rootURN, root, []*pkgresource.State{root}, []*pkgresource.State{root, child})
+		require.ErrorContains(t, err, "but qualified type pkg:m:Resource; expected pkg:m:Component$pkg:m:Resource")
+	})
+}


### PR DESCRIPTION
Validate migration callback results against deployment and resource lifecycle invariants, then prepare the resulting prior-state and live-resource rewrites as a StateMigrationTransaction.

[Draft dev docs for state migrations](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html)

Ref https://github.com/pulumi/pulumi/issues/24045