### PR TITLE
Coordinate state migrations with in-flight deployment work

### DIFF
--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -367,6 +367,11 @@ type Deployment struct {
 	// the resource hook registry for this deployment
 	resourceHooks *ResourceHooks
 
+	// stateMigrationRewrites contains reference rewrites from migrations committed during this deployment. They are
+	// used to normalize references retained by the program across a migration.
+	stateMigrationRewritesM sync.RWMutex
+	stateMigrationRewrites  []*stateMigrationRewrite
+
 	// postStepErrors collects errors reported by phases that run after a step's primary cloud operation has succeeded
 	// (e.g. an after-hook callback). The step itself is still treated as successful and its state is committed to the
 	// snapshot, but the deployment as a whole will be cancelled.

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -275,21 +275,57 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context) (_ *Plan, err e
 		// generator is done when its async counter is 0, i.e. for each async event it said it was going to do we've
 		// seen and posted that event back to it.
 		seenNil := false
+		// The source-event select case is disabled while migrationPlanningFence is set, so at most one migration can
+		// be pending here.
+		var pendingMigrationEvent RegisterResourceEvent
+		migrationPlanningFence := false
+
+		handleEvent := func(event SourceEvent) error {
+			if err := ex.handleSingleEvent(ctx, event); err != nil {
+				if !result.IsBail(err) {
+					logging.V(4).Infof("deploymentExecutor.Execute(...): error handling event: %v", err)
+					ex.reportError(ex.deployment.generateEventURN(event), err)
+				}
+				cancel()
+				return result.BailError(err)
+			}
+			return nil
+		}
+
+		// A registration with migrations creates a planning fence. The loop stops accepting source events while it
+		// drains earlier planning continuations, handles the migration registration, and drains any planning work it
+		// starts.
 		for {
+			// Earlier planning has drained, so the pending migration registration can now be handled.
+			if pendingMigrationEvent != nil && ex.asyncEventsExpected == 0 {
+				event := pendingMigrationEvent
+				pendingMigrationEvent = nil
+				if err := handleEvent(event); err != nil {
+					return false, err
+				}
+			}
+			// The migration registration has been handled and no earlier or migration-triggered planning continuations
+			// remain, we can unblock source event consumption.
+			if migrationPlanningFence && pendingMigrationEvent == nil && ex.asyncEventsExpected == 0 {
+				migrationPlanningFence = false
+			}
+
+			sourceEvents := incomingEvents
+			if migrationPlanningFence {
+				// A nil channel disables the select case below. Stop accepting source events until all planning before
+				// and for the migration registration is complete.
+				sourceEvents = nil
+			}
+
 			select {
 			case event := <-stepGenEvents:
 				logging.V(4).Infof("deploymentExecutor.Execute(...): incoming async event")
 
-				if err := ex.handleSingleEvent(ctx, event); err != nil {
-					if !result.IsBail(err) {
-						logging.V(4).Infof("deploymentExecutor.Execute(...): error handling event: %v", err)
-						ex.reportError(ex.deployment.generateEventURN(event), err)
-					}
-					cancel()
-					return false, result.BailError(err)
+				if err := handleEvent(event); err != nil {
+					return false, err
 				}
 
-			case event := <-incomingEvents:
+			case event := <-sourceEvents:
 				logging.V(4).Infof("deploymentExecutor.Execute(...): incoming source event (nil? %v, %v)", event.Event == nil,
 					event.Error)
 
@@ -306,13 +342,18 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context) (_ *Plan, err e
 				if event.Event == nil {
 					seenNil = true
 				} else {
-					if err := ex.handleSingleEvent(ctx, event.Event); err != nil {
-						if !result.IsBail(err) {
-							logging.V(4).Infof("deploymentExecutor.Execute(...): error handling event: %v", err)
-							ex.reportError(ex.deployment.generateEventURN(event.Event), err)
+					registration, hasMigration := event.Event.(RegisterResourceEvent)
+					hasMigration = hasMigration && len(registration.StateMigrations()) != 0
+					if hasMigration {
+						migrationPlanningFence = true
+						if ex.asyncEventsExpected != 0 {
+							pendingMigrationEvent = registration
+							continue
 						}
-						cancel()
-						return false, result.BailError(err)
+					}
+
+					if err := handleEvent(event.Event); err != nil {
+						return false, err
 					}
 				}
 			case <-ctx.Done():
@@ -578,8 +619,14 @@ func doesStepDependOn(step Step, skipped mapset.Set[urn.URN]) bool {
 func (ex *deploymentExecutor) handleSingleEvent(ctx context.Context, event SourceEvent) error {
 	contract.Requiref(event != nil, "event", "must not be nil")
 
+	// A program may still send references that use resource names from before a migration.
+	normalizedEvent, err := ex.deployment.normalizeStateMigrationSourceEvent(event)
+	if err != nil {
+		return err
+	}
+	event = normalizedEvent
+
 	var steps []Step
-	var err error
 	switch e := event.(type) {
 	case ContinueResourceImportEvent:
 		logging.V(4).Infof("deploymentExecutor.handleSingleEvent(...): received ContinueResourceImportEvent")

--- a/pkg/resource/deploy/state_migration_models.go
+++ b/pkg/resource/deploy/state_migration_models.go
@@ -93,14 +93,11 @@ type StateMigrationTransaction struct {
 	currentResourceRewrites map[*pkgresource.State]*pkgresource.State
 }
 
-// A StateMigrationTransaction prepares rewrites for states whose final values are already available, but some states
-// acquire their final values only after the migration has committed. These include states returned by in-flight
-// refresh or import continuations, Step.Apply, RegisterResourceOutputs, and provider-published view steps. Their work
-// may have captured references to predecessor URNs before the migration, so the engine rewrites those references when
-// the states re-enter the deployment.
-//
-// Registration and read states pass through the same boundary because their goals may also contain references
-// captured before the migration. References that already use successor URNs are unchanged.
+// A migration is committed only when no planning or execution work is in flight. The commit rewrites all engine-held
+// state before work resumes, so continuation events are already normalized. However, programs may retain pre-migration
+// references. Read and output events are normalized as the engine receives them. Registration goals are normalized
+// later, after any migrations carried by the registration itself have been applied. Providers and analyzers are
+// expected to derive resource references from the normalized values they receive.
 //
 // stateMigrationRewrite is the part of a committed transaction retained for this later normalization. successorURNs
 // rewrites logical references; successorIdentities supplies the Custom and ID information needed to rebuild typed
@@ -134,8 +131,6 @@ func newStateMigrationRewrite(
 
 // applyToResource rewrites references in state using the successor URNs and identities retained for one committed
 // migration.
-//
-//nolint:unused // Used by state-migration normalization added in the streaming-safety branch.
 func (rewrite *stateMigrationRewrite) applyToResource(state *pkgresource.State) (*pkgresource.State, error) {
 	rewritten, err := rewriteStateMigrationReferences(
 		[]*pkgresource.State{state}, rewrite.successorURNs, rewrite.successorIdentities)

--- a/pkg/resource/deploy/state_migration_normalization.go
+++ b/pkg/resource/deploy/state_migration_normalization.go
@@ -1,0 +1,195 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"fmt"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// rewriteStateMigrationState returns state unchanged if no migration rewrite applies, or a prepared rewritten copy.
+func (d *Deployment) rewriteStateMigrationState(state *pkgresource.State) (*pkgresource.State, error) {
+	if state == nil {
+		return nil, nil
+	}
+
+	d.stateMigrationRewritesM.RLock()
+	defer d.stateMigrationRewritesM.RUnlock()
+
+	rewritten := state
+	var err error
+	for _, rewrite := range d.stateMigrationRewrites {
+		rewritten, err = rewrite.applyToResource(rewritten)
+		if err != nil {
+			return nil, fmt.Errorf("rewriting state for migration of %s: %w", rewrite.rootURN, err)
+		}
+	}
+	return rewritten, nil
+}
+
+// normalizeStateMigrationGoal rewrites state references in a registration goal. Aliases are resolved and rewritten
+// separately.
+func (d *Deployment) normalizeStateMigrationGoal(goal *pkgresource.Goal) error {
+	state := &pkgresource.State{
+		Inputs:               resource.ToResourcePropertyMap(goal.Properties),
+		Parent:               goal.Parent,
+		Dependencies:         goal.Dependencies,
+		Provider:             goal.Provider,
+		PropertyDependencies: goal.PropertyDependencies,
+		DeletedWith:          goal.DeletedWith,
+		ReplaceWith:          goal.ReplaceWith,
+		ReplacementTrigger:   goal.ReplacementTrigger,
+	}
+	rewritten, err := d.rewriteStateMigrationState(state)
+	if err != nil {
+		return err
+	}
+	if rewritten == state {
+		return nil
+	}
+
+	if !rewritten.Inputs.DeepEquals(state.Inputs) {
+		goal.Properties = resource.FromResourcePropertyMap(rewritten.Inputs)
+	}
+	goal.Parent = rewritten.Parent
+	goal.Dependencies = rewritten.Dependencies
+	goal.Provider = rewritten.Provider
+	goal.PropertyDependencies = rewritten.PropertyDependencies
+	goal.DeletedWith = rewritten.DeletedWith
+	goal.ReplaceWith = rewritten.ReplaceWith
+	goal.ReplacementTrigger = rewritten.ReplacementTrigger
+	return nil
+}
+
+// normalizedReadResourceEvent wraps a read event with rewritten state migration references.
+type normalizedReadResourceEvent struct {
+	ReadResourceEvent
+	parent       resource.URN
+	provider     string
+	properties   resource.PropertyMap
+	dependencies []resource.URN
+}
+
+func (e *normalizedReadResourceEvent) Parent() resource.URN             { return e.parent }
+func (e *normalizedReadResourceEvent) Provider() string                 { return e.provider }
+func (e *normalizedReadResourceEvent) Properties() resource.PropertyMap { return e.properties }
+func (e *normalizedReadResourceEvent) Dependencies() []resource.URN     { return e.dependencies }
+
+// normalizedRegisterResourceOutputsEvent wraps an outputs event with rewritten state migration references.
+type normalizedRegisterResourceOutputsEvent struct {
+	RegisterResourceOutputsEvent
+	outputs resource.PropertyMap
+}
+
+func (e *normalizedRegisterResourceOutputsEvent) Outputs() resource.PropertyMap { return e.outputs }
+
+// normalizeStateMigrationSourceEvent applies saved state migration rewrites to program events.
+func (d *Deployment) normalizeStateMigrationSourceEvent(event SourceEvent) (SourceEvent, error) {
+	switch e := event.(type) {
+	case ContinueResourceImportEvent,
+		ContinueResourceRefreshEvent,
+		ContinueExtensionEvent,
+		ContinueResourceDiffEvent:
+		// Continuations contain engine-held state that was already normalized.
+		return event, nil
+	case RegisterResourceEvent:
+		// Registrations are normalized later so migrations they carry can be applied first.
+		return event, nil
+	case ReadResourceEvent:
+		state := &pkgresource.State{
+			Inputs:       e.Properties(),
+			Parent:       e.Parent(),
+			Dependencies: e.Dependencies(),
+			Provider:     e.Provider(),
+		}
+		rewritten, err := d.rewriteStateMigrationState(state)
+		if err != nil {
+			return nil, fmt.Errorf("normalizing read %s after state migration: %w", e.Name(), err)
+		}
+		if rewritten == state {
+			return event, nil
+		}
+		return &normalizedReadResourceEvent{
+			ReadResourceEvent: e,
+			parent:            rewritten.Parent,
+			provider:          rewritten.Provider,
+			properties:        rewritten.Inputs,
+			dependencies:      rewritten.Dependencies,
+		}, nil
+	case RegisterResourceOutputsEvent:
+		state := &pkgresource.State{Outputs: e.Outputs()}
+		rewritten, err := d.rewriteStateMigrationState(state)
+		if err != nil {
+			return nil, fmt.Errorf("normalizing outputs for %s after state migration: %w", e.URN(), err)
+		}
+		if rewritten == state {
+			return event, nil
+		}
+		return &normalizedRegisterResourceOutputsEvent{
+			RegisterResourceOutputsEvent: e,
+			outputs:                      rewritten.Outputs,
+		}, nil
+	default:
+		contract.Failf("unrecognized source event type %T", event)
+		return nil, nil
+	}
+}
+
+func (d *Deployment) rewriteStateMigrationURN(urn resource.URN) resource.URN {
+	if urn == "" {
+		return ""
+	}
+
+	d.stateMigrationRewritesM.RLock()
+	defer d.stateMigrationRewritesM.RUnlock()
+
+	rewritten := urn
+	for _, rewrite := range d.stateMigrationRewrites {
+		rewritten = rewriteStateMigrationSuccessor(rewritten, rewrite.successorURNs)
+	}
+	return rewritten
+}
+
+// rejectStateMigrationPredecessorURN rejects a primary resource URN that was removed by a state migration committed
+// earlier in this deployment. References to such a URN are normalized to its successor, so allowing a later
+// registration or read to reuse it would make those references ambiguous.
+func (d *Deployment) rejectStateMigrationPredecessorURN(urn resource.URN) error {
+	if urn == "" {
+		return nil
+	}
+
+	d.stateMigrationRewritesM.RLock()
+	defer d.stateMigrationRewritesM.RUnlock()
+
+	successor := urn
+	var migrationRoot resource.URN
+	for _, rewrite := range d.stateMigrationRewrites {
+		if next, ok := rewrite.successorURNs[successor]; ok {
+			if migrationRoot == "" {
+				migrationRoot = rewrite.rootURN
+			}
+			successor = next
+		}
+	}
+	if migrationRoot == "" {
+		return nil
+	}
+
+	return fmt.Errorf("resource %s cannot be registered or read because state migration for %s replaced it with %s "+
+		"earlier in this deployment", urn, migrationRoot, successor)
+}

--- a/pkg/resource/deploy/state_migration_normalization_test.go
+++ b/pkg/resource/deploy/state_migration_normalization_test.go
@@ -1,0 +1,279 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
+)
+
+func TestDeploymentNormalizesStateAcrossMigrations(t *testing.T) {
+	t.Parallel()
+
+	const (
+		aURN = resource.URN("urn:pulumi:test::test::pkgA:m:Resource::a")
+		bURN = resource.URN("urn:pulumi:test::test::pkgB:m:Resource::b")
+		cURN = resource.URN("urn:pulumi:test::test::pkgC:m:Resource::c")
+	)
+	d := &Deployment{stateMigrationRewrites: []*stateMigrationRewrite{
+		newStateMigrationRewrite(aURN,
+			map[resource.URN]resource.URN{aURN: bURN},
+			[]*pkgresource.State{{URN: bURN, Custom: true, ID: "physical-id"}}),
+		newStateMigrationRewrite(bURN,
+			map[resource.URN]resource.URN{bURN: cURN},
+			[]*pkgresource.State{{URN: cURN, Custom: true, ID: "physical-id"}}),
+	}}
+	state := &pkgresource.State{
+		URN:     "urn:pulumi:test::test::consumer:m:Resource::consumer",
+		Protect: true,
+		Outputs: resource.PropertyMap{
+			"reference": resource.MakeSecret(resource.MakeCustomResourceReference(aURN, "physical-id", "1.2.3")),
+		},
+	}
+
+	rewritten, err := d.rewriteStateMigrationState(state)
+	require.NoError(t, err)
+	assert.NotSame(t, state, rewritten)
+	ref := rewritten.Outputs["reference"].SecretValue().Element.ResourceReferenceValue()
+	assert.Equal(t, cURN, ref.URN)
+	assert.Equal(t, "physical-id", ref.ID.StringValue())
+	assert.Empty(t, ref.PackageVersion)
+	assert.True(t, rewritten.Protect)
+	assert.Equal(t, cURN, d.rewriteStateMigrationURN(aURN))
+}
+
+func TestDeploymentNormalizesStateMigrationSourceEvents(t *testing.T) {
+	t.Parallel()
+
+	const (
+		predecessorURN         = resource.URN("urn:pulumi:test::test::pkg:m:Resource::a")
+		successorURN           = resource.URN("urn:pulumi:test::test::pkg:m:Resource::b")
+		predecessorProviderURN = resource.URN("urn:pulumi:test::test::pulumi:providers:pkg::provider-a")
+		successorProviderURN   = resource.URN("urn:pulumi:test::test::pulumi:providers:pkg::provider-b")
+		consumerURN            = resource.URN("urn:pulumi:test::test::pkg:m:Resource::consumer")
+	)
+	predecessorProvider, err := sdkproviders.NewReference(predecessorProviderURN, "provider-a-id")
+	require.NoError(t, err)
+	d := &Deployment{stateMigrationRewrites: []*stateMigrationRewrite{
+		newStateMigrationRewrite(
+			"urn:pulumi:test::test::pkg:m:Component::component",
+			map[resource.URN]resource.URN{
+				predecessorURN:         successorURN,
+				predecessorProviderURN: successorProviderURN,
+			},
+			[]*pkgresource.State{
+				{URN: successorURN, Custom: true, ID: "physical-id"},
+				{URN: successorProviderURN, Custom: true, ID: "provider-b-id"},
+			},
+		),
+	}}
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+
+		event := &readResourceEvent{
+			id:           "read-id",
+			name:         "consumer",
+			baseType:     consumerURN.Type(),
+			parent:       predecessorURN,
+			provider:     predecessorProvider.String(),
+			dependencies: []resource.URN{predecessorURN},
+			props: resource.PropertyMap{
+				"reference": resource.MakeCustomResourceReference(predecessorURN, "physical-id", "1.2.3"),
+			},
+		}
+
+		normalized, err := d.normalizeStateMigrationSourceEvent(event)
+		require.NoError(t, err)
+		read, ok := normalized.(ReadResourceEvent)
+		require.True(t, ok)
+		assert.NotSame(t, event, normalized)
+		assert.Equal(t, event.ID(), read.ID())
+		assert.Equal(t, event.Name(), read.Name())
+		assert.Equal(t, event.Type(), read.Type())
+		assert.Equal(t, successorURN, read.Parent())
+		assert.Equal(t, []resource.URN{successorURN}, read.Dependencies())
+
+		provider, err := sdkproviders.ParseReference(read.Provider())
+		require.NoError(t, err)
+		assert.Equal(t, successorProviderURN, provider.URN())
+		assert.Equal(t, resource.ID("provider-b-id"), provider.ID())
+
+		ref := read.Properties()["reference"].ResourceReferenceValue()
+		assert.Equal(t, successorURN, ref.URN)
+		assert.Equal(t, "physical-id", ref.ID.StringValue())
+		assert.Empty(t, ref.PackageVersion)
+	})
+
+	t.Run("outputs", func(t *testing.T) {
+		t.Parallel()
+
+		event := &registerResourceOutputsEvent{
+			urn: consumerURN,
+			outputs: resource.PropertyMap{
+				"reference": resource.MakeCustomResourceReference(predecessorURN, "physical-id", "1.2.3"),
+			},
+		}
+
+		normalized, err := d.normalizeStateMigrationSourceEvent(event)
+		require.NoError(t, err)
+		outputs, ok := normalized.(RegisterResourceOutputsEvent)
+		require.True(t, ok)
+		assert.NotSame(t, event, normalized)
+		assert.Equal(t, consumerURN, outputs.URN())
+		assert.Equal(t, successorURN, outputs.Outputs()["reference"].ResourceReferenceValue().URN)
+	})
+
+	t.Run("engine and registration events pass through", func(t *testing.T) {
+		t.Parallel()
+
+		registration := &registerResourceEvent{goal: &pkgresource.Goal{}}
+		normalized, err := d.normalizeStateMigrationSourceEvent(registration)
+		require.NoError(t, err)
+		assert.Same(t, registration, normalized)
+
+		continuation := &continueResourceRefreshEvent{RegisterResourceEvent: registration}
+		normalized, err = d.normalizeStateMigrationSourceEvent(continuation)
+		require.NoError(t, err)
+		assert.Same(t, continuation, normalized)
+	})
+
+	t.Run("no rewrites preserves event identity", func(t *testing.T) {
+		t.Parallel()
+
+		event := &readResourceEvent{name: "unchanged"}
+		normalized, err := (&Deployment{}).normalizeStateMigrationSourceEvent(event)
+		require.NoError(t, err)
+		assert.Same(t, event, normalized)
+	})
+}
+
+func TestGenerateResourceStepsNormalizesGoalAfterMigration(t *testing.T) {
+	t.Parallel()
+
+	const (
+		predecessorURN         = resource.URN("urn:pulumi:test::test::pkg:m:Resource::a")
+		successorURN           = resource.URN("urn:pulumi:test::test::pkg:m:Resource::b")
+		predecessorProviderURN = resource.URN("urn:pulumi:test::test::pulumi:providers:pkg::provider-a")
+		successorProviderURN   = resource.URN("urn:pulumi:test::test::pulumi:providers:pkg::provider-b")
+		consumerURN            = resource.URN("urn:pulumi:test::test::pkg:m:Component::consumer")
+	)
+	predecessorProvider, err := sdkproviders.NewReference(predecessorProviderURN, "provider-a-id")
+	require.NoError(t, err)
+	d := &Deployment{
+		ctx:   &plugin.Context{Diag: &diag.MockSink{}},
+		opts:  &Options{},
+		goals: &gsync.Map[resource.URN, *pkgresource.Goal]{},
+		stateMigrationRewrites: []*stateMigrationRewrite{
+			newStateMigrationRewrite(
+				consumerURN,
+				map[resource.URN]resource.URN{
+					predecessorURN:         successorURN,
+					predecessorProviderURN: successorProviderURN,
+				},
+				[]*pkgresource.State{
+					{URN: successorURN, Custom: true, ID: "physical-id"},
+					{URN: successorProviderURN, Custom: true, ID: "provider-b-id"},
+				},
+			),
+		},
+	}
+	sg := newStepGenerator(d, false, updateMode, nil)
+	goal := &pkgresource.Goal{
+		Type: consumerURN.Type(),
+		Name: consumerURN.Name(),
+		Properties: resource.FromResourcePropertyMap(resource.PropertyMap{
+			"reference": resource.MakeCustomResourceReference(predecessorURN, "physical-id", "1.2.3"),
+		}),
+		Parent:       predecessorURN,
+		Dependencies: []resource.URN{predecessorURN},
+		Provider:     predecessorProvider.String(),
+		PropertyDependencies: map[resource.PropertyKey][]resource.URN{
+			"reference": {predecessorURN},
+		},
+		DeletedWith: predecessorURN,
+		ReplaceWith: []resource.URN{predecessorURN},
+		ReplacementTrigger: resource.FromResourcePropertyValue(
+			resource.MakeCustomResourceReference(predecessorURN, "physical-id", "1.2.3")),
+	}
+
+	steps, async, err := sg.generateResourceSteps(t.Context(), &registerResourceEvent{goal: goal}, consumerURN)
+	require.NoError(t, err)
+	assert.False(t, async)
+	require.NotEmpty(t, steps)
+	newState := steps[0].New()
+	require.NotNil(t, newState)
+	assert.Equal(t, successorURN, newState.Parent)
+	assert.Equal(t, []resource.URN{successorURN}, newState.Dependencies)
+	assert.Equal(t, []resource.URN{successorURN}, newState.PropertyDependencies["reference"])
+	assert.Equal(t, successorURN, newState.DeletedWith)
+	assert.Equal(t, []resource.URN{successorURN}, newState.ReplaceWith)
+	assert.Equal(t, successorURN, newState.Inputs["reference"].ResourceReferenceValue().URN)
+	assert.Equal(t, successorURN,
+		resource.ToResourcePropertyValue(newState.ReplacementTrigger).ResourceReferenceValue().URN)
+	provider, err := sdkproviders.ParseReference(newState.Provider)
+	require.NoError(t, err)
+	assert.Equal(t, successorProviderURN, provider.URN())
+	assert.Equal(t, resource.ID("provider-b-id"), provider.ID())
+
+	assert.Equal(t, successorURN, goal.Parent)
+	assert.Equal(t, []resource.URN{successorURN}, goal.Dependencies)
+	assert.Equal(t, []resource.URN{successorURN}, goal.PropertyDependencies["reference"])
+	assert.Equal(t, successorURN, goal.DeletedWith)
+	assert.Equal(t, []resource.URN{successorURN}, goal.ReplaceWith)
+	assert.Equal(t, successorURN,
+		resource.ToResourcePropertyMap(goal.Properties)["reference"].ResourceReferenceValue().URN)
+	assert.Equal(t, successorURN,
+		resource.ToResourcePropertyValue(goal.ReplacementTrigger).ResourceReferenceValue().URN)
+	provider, err = sdkproviders.ParseReference(goal.Provider)
+	require.NoError(t, err)
+	assert.Equal(t, successorProviderURN, provider.URN())
+	assert.Equal(t, resource.ID("provider-b-id"), provider.ID())
+}
+
+func TestDeploymentRejectsStateMigrationPredecessorURN(t *testing.T) {
+	t.Parallel()
+
+	const (
+		aURN       = resource.URN("urn:pulumi:test::test::pkgA:m:Resource::a")
+		bURN       = resource.URN("urn:pulumi:test::test::pkgB:m:Resource::b")
+		cURN       = resource.URN("urn:pulumi:test::test::pkgC:m:Resource::c")
+		unrelated  = resource.URN("urn:pulumi:test::test::pkgA:m:Resource::unrelated")
+		firstRoot  = resource.URN("urn:pulumi:test::test::pkgA:m:Component::first")
+		secondRoot = resource.URN("urn:pulumi:test::test::pkgB:m:Component::second")
+	)
+	d := &Deployment{stateMigrationRewrites: []*stateMigrationRewrite{
+		newStateMigrationRewrite(firstRoot,
+			map[resource.URN]resource.URN{aURN: bURN},
+			[]*pkgresource.State{{URN: bURN}}),
+		newStateMigrationRewrite(secondRoot,
+			map[resource.URN]resource.URN{bURN: cURN},
+			[]*pkgresource.State{{URN: cURN}}),
+	}}
+
+	require.Error(t, d.rejectStateMigrationPredecessorURN(aURN))
+	require.Error(t, d.rejectStateMigrationPredecessorURN(bURN))
+	require.NoError(t, d.rejectStateMigrationPredecessorURN(cURN), "a canonical successor URN remains claimable")
+	require.NoError(t, d.rejectStateMigrationPredecessorURN(unrelated))
+}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -279,6 +279,9 @@ func (sg *stepGenerator) generateURN(
 ) (resource.URN, error) {
 	// Generate a URN for this new resource, confirm we haven't seen it before in this deployment.
 	urn := sg.deployment.generateURN(parent, ty, name)
+	if err := sg.deployment.rejectStateMigrationPredecessorURN(urn); err != nil {
+		return "", err
+	}
 	if sg.urns[urn] {
 		// TODO[pulumi/pulumi-framework#19]: improve this error message!
 		return "", sg.bailDiag(diag.GetDuplicateResourceURNError(urn), urn)
@@ -652,12 +655,25 @@ func (sg *stepGenerator) generateAliases(
 	return result
 }
 
+// generateRewrittenAliases resolves registration aliases through state migration rewrites committed earlier in the
+// update. A program may continue to name a predecessor URN even though a migration has already replaced that state
+// with its successor in the deployment's old-resource map.
+func (sg *stepGenerator) generateRewrittenAliases(
+	name string, typ tokens.Type, parent resource.URN, resAliases []resource.Alias,
+) []resource.URN {
+	aliases := sg.generateAliases(name, typ, parent, resAliases)
+	for i, alias := range aliases {
+		aliases[i] = sg.deployment.rewriteStateMigrationURN(alias)
+	}
+	return aliases
+}
+
 func (sg *stepGenerator) getOldResource(
 	urn resource.URN, name string, typ tokens.Type, parent resource.URN, resAliases []resource.Alias,
 ) (*pkgresource.State, bool, resource.URN) {
 	invalid := false
 	// Generate the aliases for this resource.
-	aliases := sg.generateAliases(name, typ, parent, resAliases)
+	aliases := sg.generateRewrittenAliases(name, typ, parent, resAliases)
 	// Log the aliases we're going to use to help with debugging aliasing issues.
 	logging.V(7).Infof("Generated aliases for %s: %v", urn, aliases)
 
@@ -715,8 +731,10 @@ func (sg *stepGenerator) getOldResource(
 func (sg *stepGenerator) generateSteps(ctx context.Context, event RegisterResourceEvent) ([]Step, bool, error) {
 	goal := event.Goal()
 
+	parent := sg.deployment.rewriteStateMigrationURN(goal.Parent)
+
 	// Some goal settings are based on the parent settings so make sure our parent is correct.
-	parent, err := sg.checkParent(goal.Parent, goal.Type)
+	parent, err := sg.checkParent(parent, goal.Type)
 	if err != nil {
 		return nil, false, err
 	}
@@ -768,6 +786,9 @@ func (sg *stepGenerator) generateResourceSteps(
 	ctx context.Context, event RegisterResourceEvent, urn resource.URN,
 ) ([]Step, bool, error) {
 	goal := event.Goal()
+	if err := sg.deployment.normalizeStateMigrationGoal(goal); err != nil {
+		return nil, false, fmt.Errorf("normalizing resource goal for %s after state migration: %w", urn, err)
+	}
 	old, invalid, alias := sg.getOldResource(urn, goal.Name, goal.Type, goal.Parent, goal.Aliases)
 
 	var aliasUrns []resource.URN

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -857,7 +857,8 @@ func TestStepGenerator(t *testing.T) {
 		t.Run("could not find parent resource", func(t *testing.T) {
 			t.Parallel()
 			sg := &stepGenerator{
-				urns: map[resource.URN]bool{},
+				deployment: &Deployment{},
+				urns:       map[resource.URN]bool{},
 			}
 			_, err := sg.GenerateReadSteps(&readResourceEvent{
 				parent: "does-not-exist",


### PR DESCRIPTION
A state migration changes the prior state used by later planning. When a registration declares migrations, stop accepting new source events until earlier asynchronous planning has completed, and keep the fence in place until the registration's own planning also finishes.

A migration commit rewrites all engine-held state. However, the program may still send references using names from before the migration. These are normalized in two places:

- ReadResource and RegisterResourceOutputs events are normalized when they enter the engine in `handleSingleEvent`.
- Registration goals are normalized when their steps are generated, after applying any migrations carried by that registration itself. It would be too early to normalize these in `handleSingleEvent`.

Parents and aliases are also rewritten before URN lookup.

[Draft dev docs for state migrations](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html)

Ref https://github.com/pulumi/pulumi/issues/24045