### PR TITLE
Execute component state migrations

### DIFF
--- a/changelog/pending/engine-feat-state-migrations.yaml
+++ b/changelog/pending/engine-feat-state-migrations.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: feat
+body: Support state migration callbacks on resource registrations
+time: 2026-07-21T17:16:58.868913+02:00

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1368,6 +1368,9 @@ func (b *diyBackend) apply(
 		Cancel:        scope.Context(),
 		Events:        engineEvents,
 		BackendClient: backend.NewBackendClient(b, op.SecretsProvider),
+		SnapshotManagerCapabilities: engine.SnapshotManagerCapabilities{
+			StateMigrations: true,
+		},
 	}
 	// Create the management machinery.
 	// We only need a snapshot manager if we're doing an update.

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -26,8 +26,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
@@ -180,6 +182,9 @@ type deploymentOptions struct {
 	// operation preceding e.g. a refresh or destroy.
 	DryRun bool
 
+	// true if the resource monitor may accept state migration callbacks for this deployment.
+	supportsStateMigrations bool
+
 	// LoadedAnalyzers is populated by loadPolicyPlugins after policy packs are loaded
 	// and configured. This is the list that the step generator will run for policy checks.
 	LoadedAnalyzers []plugin.Analyzer
@@ -210,6 +215,19 @@ func ensureHost(ctx context.Context, opts *deploymentOptions, span opentracing.S
 	return nil
 }
 
+type stateMigrationResourceSerializer struct{}
+
+func (stateMigrationResourceSerializer) Serialize(
+	ctx context.Context, state *pkgresource.State,
+) (apitype.ResourceV3, error) {
+	serialized, _, err := stack.SerializeResource(ctx, state, config.NopEncrypter, true /* showSecrets */)
+	return serialized, err
+}
+
+func (stateMigrationResourceSerializer) Deserialize(state apitype.ResourceV3) (*pkgresource.State, error) {
+	return stack.DeserializeResource(state, config.NopDecrypter)
+}
+
 // newDeployment creates a new deployment with the given context and options.
 func newDeployment(
 	ctx *Context,
@@ -228,7 +246,7 @@ func newDeployment(
 	projinfo := &Projinfo{Proj: proj, Root: info.Update.Root}
 
 	// Decrypt the configuration.
-	config, err := target.Config.Decrypt(target.Decrypter)
+	decryptedConfig, err := target.Config.Decrypt(target.Decrypter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt config: %w", err)
 	}
@@ -238,7 +256,7 @@ func newDeployment(
 	// Create a context for plugins.
 	baseCtx := trace.ContextWithSpan(ctx.Cancel.Base(), info.otelSpan)
 	pwd, main, plugctx, err := ProjectInfoContext(baseCtx, projinfo, opts.host,
-		opts.Diag, opts.StatusDiag, opts.DisableProviderPreview, info.TracingSpan, config)
+		opts.Diag, opts.StatusDiag, opts.DisableProviderPreview, info.TracingSpan, decryptedConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -260,6 +278,8 @@ func newDeployment(
 	})
 
 	resourceHooks := deploy.NewResourceHooks(plugctx.DialOptions)
+
+	opts.supportsStateMigrations = ctx.SnapshotManagerCapabilities.StateMigrations
 
 	// Now create the state source.  This may issue an error if it can't create the source.  This entails,
 	// for example, loading any plugins which will be required to execute a program, among other things.
@@ -302,6 +322,7 @@ func newDeployment(
 		Autonamer:                 opts.Autonamer,
 		ShowSecrets:               opts.ShowSecrets,
 		Analyzers:                 opts.LoadedAnalyzers,
+		StateMigrationSerializer:  stateMigrationResourceSerializer{},
 	}
 
 	var depl *deploy.Deployment

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -38,12 +38,13 @@ type UpdateInfo struct {
 // Context provides cancellation, termination, and eventing options for an engine operation. It also provides
 // a way for the engine to persist snapshots, using the `SnapshotManager`.
 type Context struct {
-	Cancel          *cancel.Context
-	Events          chan<- Event
-	SnapshotManager SnapshotManager
-	BackendClient   deploy.BackendClient
-	ParentSpan      opentracing.SpanContext
-	PluginManager   PluginManager
+	Cancel                      *cancel.Context
+	Events                      chan<- Event
+	SnapshotManager             SnapshotManager
+	SnapshotManagerCapabilities SnapshotManagerCapabilities
+	BackendClient               deploy.BackendClient
+	ParentSpan                  opentracing.SpanContext
+	PluginManager               PluginManager
 	// FinalizeUpdateFunc is an optional function that is called at the end of an update. It can be used to
 	// perform any finalization steps, including sending engine events.
 	FinalizeUpdateFunc func()

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -274,7 +274,8 @@ func (op TestOp) runWithContext(
 		require.NoErrorf(opts.T, err, "got error setting up journaler")
 
 		snapshotManager := backend.NewSnapshotManager(persister, secretsManager, target.Snapshot, nil)
-		journalSnapshotManager, err := engine.NewJournalSnapshotManager(journaler, target.Snapshot, secretsManager)
+		journalSnapshotManager, err := engine.NewJournalSnapshotManagerWithVersion(
+			journaler, target.Snapshot, secretsManager, apitype.LatestJournalVersion)
 		require.NoError(opts.T, err)
 
 		combined = &engine.CombinedManager{
@@ -287,11 +288,12 @@ func (op TestOp) runWithContext(
 		pluginManager = NopPluginManager{}
 	}
 	ctx := &engine.Context{
-		Cancel:          cancelCtx,
-		Events:          events,
-		SnapshotManager: combined,
-		BackendClient:   backendClient,
-		PluginManager:   pluginManager,
+		Cancel:                      cancelCtx,
+		Events:                      events,
+		SnapshotManager:             combined,
+		BackendClient:               backendClient,
+		PluginManager:               pluginManager,
+		SnapshotManagerCapabilities: opts.SnapshotManagerCapabilities,
 	}
 
 	updateOpts := opts.Options()
@@ -793,9 +795,11 @@ type TestUpdateOptions struct {
 	// a factory to produce a plugin host for an update operation.
 	HostF deploytest.PluginHostFactory
 	// PluginManager overrides the engine.Context.PluginManager used by the run. Defaults to NopPluginManager{}.
-	PluginManager    engine.PluginManager
-	T                TB
-	SkipDisplayTests bool
+	PluginManager engine.PluginManager
+	// SnapshotManagerCapabilities configures the test backend's persistence capabilities.
+	SnapshotManagerCapabilities engine.SnapshotManagerCapabilities
+	T                           TB
+	SkipDisplayTests            bool
 }
 
 // Options produces UpdateOptions for an update operation.

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -1,0 +1,1968 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	. "github.com/pulumi/pulumi/pkg/v3/engine"
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// stateMigrationFunction adapts a typed Go function into the raw callback shape expected by
+// deploytest.CallbackServer.Allocate for state migration callbacks.
+func stateMigrationFunction(
+	f func(
+		urn resource.URN, resources []apitype.ResourceV3,
+	) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error),
+) func([]byte) (proto.Message, error) {
+	return func(request []byte) (proto.Message, error) {
+		var migrationRequest pulumirpc.StateMigrationRequest
+		if err := proto.Unmarshal(request, &migrationRequest); err != nil {
+			return nil, fmt.Errorf("unmarshaling request: %w", err)
+		}
+
+		var resources []apitype.ResourceV3
+		if err := json.Unmarshal(migrationRequest.OldState, &resources); err != nil {
+			return nil, fmt.Errorf("unmarshaling old state: %w", err)
+		}
+
+		newResources, successors, err := f(resource.URN(migrationRequest.Urn), resources)
+		if err != nil {
+			return nil, err
+		}
+
+		response := &pulumirpc.StateMigrationResponse{}
+		if newResources != nil {
+			newState, err := json.Marshal(newResources)
+			if err != nil {
+				return nil, fmt.Errorf("marshaling new state: %w", err)
+			}
+			response.NewState = newState
+		}
+		if len(successors) > 0 {
+			response.Successors = make(map[string]string, len(successors))
+			for source, target := range successors {
+				response.Successors[string(source)] = string(target)
+			}
+		}
+		return response, nil
+	}
+}
+
+// countSuccessfulOps counts successful resource steps by operation type. For example, three unchanged resources and
+// one deletion produce {same: 3, delete: 1}.
+func countSuccessfulOps(entries JournalEntries) map[display.StepOp]int {
+	ops := map[display.StepOp]int{}
+	for _, entry := range entries {
+		if entry.Kind == TestJournalEntrySuccess {
+			ops[entry.Step.Op()]++
+		}
+	}
+	return ops
+}
+
+// validateOps returns a lifecycle test validation function asserting the given step operation counts.
+func validateOps(t *testing.T, expected map[display.StepOp]int) lt.ValidateFunc {
+	return func(
+		project workspace.Project, target deploy.Target, entries JournalEntries, events []Event, err error,
+	) error {
+		assert.Equal(t, expected, countSuccessfulOps(entries))
+		return err
+	}
+}
+
+// runUpdate runs a single update of the given plan against the given prior snapshot.
+func runUpdate(
+	t *testing.T, p *lt.TestPlan, snap *deploy.Snapshot, validate lt.ValidateFunc,
+) (*deploy.Snapshot, error) {
+	return lt.TestOp(Update).Run(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, validate)
+}
+
+func stateMigrationTestOptions(t *testing.T, hostF deploytest.PluginHostFactory) lt.TestUpdateOptions {
+	return lt.TestUpdateOptions{
+		T:                t,
+		HostF:            hostF,
+		SkipDisplayTests: true,
+		SnapshotManagerCapabilities: SnapshotManagerCapabilities{
+			StateMigrations: true,
+		},
+	}
+}
+
+// renameByName renames the resources with the given name in a serialized resource list.
+func renameByName(resources []apitype.ResourceV3, oldName, newName string) []apitype.ResourceV3 {
+	oldSuffix, newSuffix := "::"+oldName, "::"+newName
+	for i, res := range resources {
+		if prefix, ok := strings.CutSuffix(string(res.URN), oldSuffix); ok {
+			resources[i].URN = resource.URN(prefix + newSuffix)
+		}
+	}
+	return resources
+}
+
+// stateMigrationEnv wires up the shared scaffolding for state migration lifecycle tests: a pkgA provider and a
+// program consisting of a component "comp" with a custom child resource parented to it. The child's name and the
+// migrations attached to the component are controlled per-update via the returned struct's fields.
+type stateMigrationEnv struct {
+	plan *lt.TestPlan
+
+	// childName is the name the program registers the child resource under.
+	childName string
+	// childInputs are the inputs the program registers the child resource with.
+	childInputs resource.PropertyMap
+	// childProtect marks the child resource as protected.
+	childProtect bool
+	// childRetainOnDelete marks the child resource as retained when deleted.
+	childRetainOnDelete bool
+	// registerChild controls whether the child resource is registered at all.
+	registerChild bool
+	// migrations builds the migration callbacks to attach to the component, given a callback server.
+	migrations func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback
+}
+
+func newStateMigrationEnv(t *testing.T) *stateMigrationEnv {
+	env := &stateMigrationEnv{
+		childName:     "childA",
+		childInputs:   resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		registerChild: true,
+	}
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		var migrations []*pulumirpc.Callback
+		if env.migrations != nil {
+			migrations = env.migrations(t, callbacks)
+		}
+
+		resp, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{
+			StateMigrations: migrations,
+		})
+		if err != nil {
+			return err
+		}
+
+		if env.registerChild {
+			_, err = monitor.RegisterResource("pkgA:m:typA", env.childName, true, deploytest.ResourceOptions{
+				Parent:         resp.URN,
+				Inputs:         env.childInputs,
+				Protect:        &env.childProtect,
+				RetainOnDelete: &env.childRetainOnDelete,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+	env.plan = &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+	return env
+}
+
+// TestStateMigrationRejectsSafetyMetadataChanges verifies that a callback cannot clear engine-owned safety metadata
+// while renaming a managed resource.
+func TestStateMigrationRejectsSafetyMetadataChanges(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		clear func(*apitype.ResourceV3)
+		want  string
+	}{
+		{
+			name: "protect",
+			clear: func(state *apitype.ResourceV3) {
+				state.Protect = false
+			},
+			want: "changes Protect",
+		},
+		{
+			name: "retain on delete",
+			clear: func(state *apitype.ResourceV3) {
+				state.RetainOnDelete = false
+			},
+			want: "changes RetainOnDelete",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newStateMigrationEnv(t)
+			env.childProtect = true
+			env.childRetainOnDelete = true
+			snap, err := runUpdate(t, env.plan, nil, nil)
+			require.NoError(t, err)
+
+			env.childName = "childB"
+			env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+				callback, err := callbacks.Allocate(
+					stateMigrationFunction(func(
+						urn resource.URN, resources []apitype.ResourceV3,
+					) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+						for i := range resources {
+							if resources[i].URN != childAURN {
+								continue
+							}
+							resources[i].URN = childBURN
+							tt.clear(&resources[i])
+							return resources, map[resource.URN]resource.URN{childAURN: childBURN}, nil
+						}
+						return nil, nil, nil
+					}))
+				require.NoError(t, err)
+				return []*pulumirpc.Callback{callback}
+			}
+
+			_, err = runUpdate(t, env.plan, snap, nil)
+			require.ErrorContains(t, err, tt.want)
+			assert.Contains(t, snapURNs(snap), childAURN)
+			assert.NotContains(t, snapURNs(snap), childBURN)
+		})
+	}
+}
+
+const (
+	compURN   = resource.URN("urn:pulumi:test::test::my:module:Comp::comp")
+	childAURN = resource.URN("urn:pulumi:test::test::my:module:Comp$pkgA:m:typA::childA")
+	childBURN = resource.URN("urn:pulumi:test::test::my:module:Comp$pkgA:m:typA::childB")
+	childCURN = resource.URN("urn:pulumi:test::test::my:module:Comp$pkgA:m:typA::childC")
+)
+
+// snapURNs returns the URNs of all resources in the snapshot.
+func snapURNs(snap *deploy.Snapshot) []resource.URN {
+	urns := make([]resource.URN, len(snap.Resources))
+	for i, res := range snap.Resources {
+		urns[i] = res.URN
+	}
+	return urns
+}
+
+// renameMigration returns a migration callback that renames the child resource and maps its old URN to the new one.
+func renameMigration(t *testing.T, callbacks *deploytest.CallbackServer, oldName, newName string) *pulumirpc.Callback {
+	callback, err := callbacks.Allocate(
+		stateMigrationFunction(func(
+			urn resource.URN, resources []apitype.ResourceV3,
+		) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+			successors := make(map[resource.URN]resource.URN)
+			for _, res := range resources {
+				if strings.HasSuffix(string(res.URN), "::"+oldName) {
+					renamed := renameByName([]apitype.ResourceV3{res}, oldName, newName)
+					successors[res.URN] = renamed[0].URN
+				}
+			}
+			if len(successors) == 0 {
+				// Already migrated: return the state unchanged.
+				return nil, nil, nil
+			}
+			return renameByName(resources, oldName, newName), successors, nil
+		}))
+	require.NoError(t, err)
+	return callback
+}
+
+// setRenameMigration attaches the common rename migration used by lifecycle tests.
+func (env *stateMigrationEnv) setRenameMigration(oldName, newName string) {
+	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+		return []*pulumirpc.Callback{renameMigration(t, callbacks, oldName, newName)}
+	}
+}
+
+// TestStateMigrationRenameChild exercises the basic migration:
+//
+//	childA (managed) -> childB (managed, retaining childA's ID and protection)
+//
+// Version 2 registers childB and ships a migration that renames the prior state to match, producing only same steps.
+func TestStateMigrationRenameChild(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	env.childProtect = true
+
+	// Version 1: component with child "childA".
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+	require.Contains(t, snapURNs(snap), childAURN)
+	var childID resource.ID
+	for _, res := range snap.Resources {
+		if res.URN == childAURN {
+			childID = res.ID
+			require.True(t, res.Protect)
+		}
+	}
+	require.NotEmpty(t, childID)
+
+	// Version 2: the child is renamed to "childB" and a migration renames the prior state.
+	env.childName = "childB"
+	env.setRenameMigration("childA", "childB")
+
+	// A preview must reject the callback when the backend says the corresponding update could not persist it.
+	unsupportedPreviewOpts := env.plan.Options
+	unsupportedPreviewOpts.SnapshotManagerCapabilities.StateMigrations = false
+	_, err = lt.TestOp(Update).Run(
+		env.plan.GetProject(), env.plan.GetTarget(t, snap), unsupportedPreviewOpts, true, env.plan.BackendClient, nil)
+	require.ErrorContains(t, err, "state migrations are not supported by this deployment")
+
+	// Lifecycle previews have plan generation enabled. Since a changing migration cannot be represented in a plan,
+	// the preview must fail without modifying the prior snapshot.
+	_, err = lt.TestOp(Update).Run(
+		env.plan.GetProject(), env.plan.GetTarget(t, snap), env.plan.Options, true, env.plan.BackendClient, nil)
+	require.ErrorContains(t, err, "cannot change state while generating an update plan")
+	assert.Contains(t, snapURNs(snap), childAURN)
+	assert.NotContains(t, snapURNs(snap), childBURN)
+
+	snap, err = runUpdate(t, env.plan, snap,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries, events []Event, err error) error {
+			assert.Equal(t, map[display.StepOp]int{deploy.OpSame: 3}, countSuccessfulOps(entries))
+			return err
+		})
+	require.NoError(t, err)
+
+	urns := snapURNs(snap)
+	assert.Contains(t, urns, childBURN)
+	assert.NotContains(t, urns, childAURN)
+	for _, res := range snap.Resources {
+		if res.URN == childBURN {
+			// The renamed resource keeps its identity and resource options.
+			assert.Equal(t, childID, res.ID)
+			assert.Equal(t, compURN, res.Parent)
+			assert.True(t, res.Protect)
+		}
+	}
+
+	// A third update is a steady-state no-op: the migration sees the new shape and returns nil.
+	snap, err = runUpdate(t, env.plan, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+	assert.Contains(t, snapURNs(snap), childBURN)
+}
+
+// TestStateMigrationNormalizesProgramReferences verifies that references retained by the program are rewritten after
+// a migration commits. It covers the registration carrying the migration, a later registration, and outputs for a
+// component registered before the migration.
+func TestStateMigrationNormalizesProgramReferences(t *testing.T) {
+	t.Parallel()
+
+	const (
+		holderURN   = resource.URN("urn:pulumi:test::test::my:module:Holder::holder")
+		consumerURN = resource.URN("urn:pulumi:test::test::pkgA:m:consumer::consumer")
+	)
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	var upgrade bool
+	var predecessorID resource.ID
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		holder, err := monitor.RegisterResource("my:module:Holder", "holder", false)
+		if err != nil {
+			return err
+		}
+
+		componentOptions := deploytest.ResourceOptions{}
+		if upgrade {
+			componentOptions.Inputs = resource.PropertyMap{
+				"ref": resource.MakeCustomResourceReference(childAURN, predecessorID, ""),
+			}
+			componentOptions.StateMigrations = []*pulumirpc.Callback{
+				renameMigration(t, callbacks, "childA", "childB"),
+			}
+		}
+		component, err := monitor.RegisterResource("my:module:Comp", "comp", false, componentOptions)
+		if err != nil {
+			return err
+		}
+
+		childName := "childA"
+		if upgrade {
+			childName = "childB"
+		}
+		child, err := monitor.RegisterResource("pkgA:m:typA", childName, true, deploytest.ResourceOptions{
+			Parent: component.URN,
+			Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		})
+		if err != nil {
+			return err
+		}
+
+		referenceURN, referenceID := child.URN, child.ID
+		if upgrade {
+			// Model a program value captured before the migration committed.
+			referenceURN, referenceID = childAURN, predecessorID
+		}
+		ref := resource.MakeCustomResourceReference(referenceURN, referenceID, "")
+		_, err = monitor.RegisterResource("pkgA:m:consumer", "consumer", true, deploytest.ResourceOptions{
+			Inputs:       resource.PropertyMap{"ref": ref},
+			Dependencies: []resource.URN{referenceURN},
+			PropertyDeps: map[resource.PropertyKey][]resource.URN{"ref": {referenceURN}},
+		})
+		if err != nil {
+			return err
+		}
+
+		return monitor.RegisterResourceOutputs(holder.URN, resource.PropertyMap{"ref": ref})
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, plan, nil, nil)
+	require.NoError(t, err)
+	for _, state := range snap.Resources {
+		if state.URN == childAURN {
+			predecessorID = state.ID
+		}
+	}
+	require.NotEmpty(t, predecessorID)
+
+	upgrade = true
+	snap, err = runUpdate(t, plan, snap, nil)
+	require.NoError(t, err)
+
+	assertReference := func(properties resource.PropertyMap) {
+		t.Helper()
+		require.True(t, properties["ref"].IsResourceReference())
+		ref := properties["ref"].ResourceReferenceValue()
+		assert.Equal(t, childBURN, ref.URN)
+		assert.Equal(t, predecessorID, resource.ID(ref.ID.StringValue()))
+	}
+
+	states := make(map[resource.URN]*pkgresource.State, len(snap.Resources))
+	for _, state := range snap.Resources {
+		states[state.URN] = state
+	}
+	require.Contains(t, states, compURN)
+	require.Contains(t, states, childBURN)
+	require.Contains(t, states, consumerURN)
+	require.Contains(t, states, holderURN)
+
+	assertReference(states[compURN].Inputs)
+	assert.Equal(t, predecessorID, states[childBURN].ID)
+	assertReference(states[consumerURN].Inputs)
+	assert.Equal(t, []resource.URN{childBURN}, states[consumerURN].Dependencies)
+	assert.Equal(t, []resource.URN{childBURN}, states[consumerURN].PropertyDependencies["ref"])
+	assertReference(states[holderURN].Outputs)
+}
+
+// TestStateMigrationAfterRefresh exercises this refresh-and-migrate sequence:
+//
+//	childA -> refreshed childA -> childB (retaining the refreshed ID)
+//
+// `pulumi up --refresh` must rebuild the journal base before applying the migration in the update phase.
+func TestStateMigrationAfterRefresh(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+
+	var childID resource.ID
+	for _, state := range snap.Resources {
+		if state.URN == childAURN {
+			childID = state.ID
+		}
+	}
+	require.NotEmpty(t, childID)
+
+	env.childName = "childB"
+	env.setRenameMigration("childA", "childB")
+	options := env.plan.Options
+	options.Refresh = true
+	snap, err = lt.TestOp(Update).Run(
+		env.plan.GetProject(), env.plan.GetTarget(t, snap), options, false, env.plan.BackendClient,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries, events []Event, err error) error {
+			require.NoError(t, err)
+			lastRefresh, migration := -1, -1
+			for i, entry := range entries {
+				if entry.Kind == TestJournalEntrySuccess && entry.Step.Op() == deploy.OpRefresh {
+					lastRefresh = i
+				}
+				if entry.Kind == TestJournalEntryStateMigration {
+					migration = i
+				}
+			}
+			require.NotEqual(t, -1, lastRefresh, "expected refresh entries")
+			require.NotEqual(t, -1, migration, "expected a state migration entry")
+			assert.Less(t, lastRefresh, migration, "the refresh must complete before the migration")
+			return err
+		})
+	require.NoError(t, err)
+
+	assert.NotContains(t, snapURNs(snap), childAURN)
+	for _, state := range snap.Resources {
+		if state.URN == childBURN {
+			assert.Equal(t, childID, state.ID)
+			return
+		}
+	}
+	t.Fatal("migrated child is missing from the snapshot")
+}
+
+// TestStateMigrationChained exercises two callbacks in sequence:
+//
+//	childA -> childB -> childC
+//
+// Each migration receives the previous migration's output.
+func TestStateMigrationChained(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+
+	env.childName = "childC"
+	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+		return []*pulumirpc.Callback{
+			renameMigration(t, callbacks, "childA", "childB"),
+			renameMigration(t, callbacks, "childB", "childC"),
+		}
+	}
+
+	snap, err = runUpdate(t, env.plan, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+	urns := snapURNs(snap)
+	assert.Contains(t, urns, childCURN)
+	assert.NotContains(t, urns, childAURN)
+	assert.NotContains(t, urns, childBURN)
+}
+
+// TestStateMigrationErrors tests that any callback error or validation failure fails the update and leaves the prior
+// state untouched.
+func TestStateMigrationErrors(t *testing.T) {
+	t.Parallel()
+
+	run := func(
+		t *testing.T, expectedError string,
+		migration func(
+			urn resource.URN, resources []apitype.ResourceV3,
+		) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error),
+		prepare func(env *stateMigrationEnv),
+	) {
+		env := newStateMigrationEnv(t)
+		if prepare != nil {
+			prepare(env)
+		}
+
+		snap, err := lt.TestOp(Update).Run(
+			env.plan.GetProject(), env.plan.GetTarget(t, nil), env.plan.Options, false, env.plan.BackendClient, nil)
+		require.NoError(t, err)
+		before := snapURNs(snap)
+
+		env.childName = "childB"
+		env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+			callback, err := callbacks.Allocate(stateMigrationFunction(migration))
+			require.NoError(t, err)
+			return []*pulumirpc.Callback{callback}
+		}
+
+		snap, err = lt.TestOp(Update).Run(
+			env.plan.GetProject(), env.plan.GetTarget(t, snap), env.plan.Options, false, env.plan.BackendClient, nil)
+		require.ErrorContains(t, err, expectedError)
+		// The prior state is untouched by the failed migration.
+		assert.Equal(t, before, snapURNs(snap))
+	}
+
+	t.Run("callback error", func(t *testing.T) {
+		t.Parallel()
+		run(t, "state migration 1 of 1 for "+string(compURN),
+			func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				return nil, nil, errors.New("bad migration")
+			}, nil)
+	})
+
+	t.Run("custom resource changes provider", func(t *testing.T) {
+		t.Parallel()
+		run(t, "changes the provider reference",
+			func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				for i := range resources {
+					if resources[i].URN == childAURN {
+						resources[i].URN = childBURN
+						oldProvider, err := sdkproviders.ParseReference(resources[i].Provider)
+						require.NoError(t, err)
+						newProvider, err := sdkproviders.NewReference(oldProvider.URN(), "different-provider-id")
+						require.NoError(t, err)
+						resources[i].Provider = newProvider.String()
+					}
+				}
+				return resources, map[resource.URN]resource.URN{childAURN: childBURN}, nil
+			}, nil)
+	})
+}
+
+// TestStateMigrationSecrets exercises this migration:
+//
+//	childA (managed, secret input) -> childB (managed, same secret input)
+//
+// Secret values in the prior state must survive the callback serialization round-trip.
+func TestStateMigrationSecrets(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	env.childInputs = resource.PropertyMap{
+		"foo":    resource.NewProperty("bar"),
+		"secret": resource.MakeSecret(resource.NewProperty("shh")),
+	}
+
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+
+	env.childName = "childB"
+	env.setRenameMigration("childA", "childB")
+
+	snap, err = runUpdate(t, env.plan, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+
+	var child *pkgresource.State
+	for _, res := range snap.Resources {
+		if res.URN == childBURN {
+			child = res
+		}
+	}
+	require.NotNil(t, child)
+	assert.True(t, child.Inputs["secret"].IsSecret(), "expected the secret input to stay secret")
+	assert.Equal(t, "shh", child.Inputs["secret"].SecretValue().Element.StringValue())
+}
+
+// TestStateMigrationRejectsSplit verifies that a one-to-many migration cannot fabricate managed state. A final custom
+// resource must have a custom predecessor whose provider-managed identity the engine can verify.
+func TestStateMigrationRejectsSplit(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+
+	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+		callback, err := callbacks.Allocate(
+			stateMigrationFunction(func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				var child apitype.ResourceV3
+				for _, res := range resources {
+					if res.URN == childAURN {
+						child = res
+					}
+				}
+				split := child
+				split.URN = childBURN
+				split.Inputs = map[string]any{"foo": "bar"}
+				split.Outputs = map[string]any{"foo": "bar"}
+				return append(resources, split), nil, nil
+			}))
+		require.NoError(t, err)
+		return []*pulumirpc.Callback{callback}
+	}
+
+	_, err = runUpdate(t, env.plan, snap, nil)
+	require.ErrorContains(t, err, "without a managed custom predecessor")
+	assert.Contains(t, snapURNs(snap), childAURN)
+	assert.NotContains(t, snapURNs(snap), childBURN)
+}
+
+// TestStateMigrationFold exercises this many-to-one migration:
+//
+//	childA (managed)   -> childC (managed, retaining childA's ID)
+//	childB (component) -> childC
+//
+// References from a resource outside the component subtree are rewritten to childC and deduplicated.
+func TestStateMigrationFold(t *testing.T) {
+	t.Parallel()
+
+	const consumerURN = resource.URN("urn:pulumi:test::test::pkgA:m:consumer::consumer")
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	var migrate bool
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		options := deploytest.ResourceOptions{}
+		if migrate {
+			callback, err := callbacks.Allocate(
+				stateMigrationFunction(func(
+					urn resource.URN, resources []apitype.ResourceV3,
+				) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+					for _, state := range resources {
+						if state.URN == childCURN {
+							// We've already migrated
+							return nil, nil, nil
+						}
+					}
+
+					folded := make([]apitype.ResourceV3, 0, len(resources)-1)
+					successors := make(map[resource.URN]resource.URN)
+					for _, state := range resources {
+						switch state.URN {
+						case childAURN:
+							successors[state.URN] = childCURN
+							state.URN = childCURN
+							folded = append(folded, state)
+						case childBURN:
+							successors[state.URN] = childCURN
+						default:
+							folded = append(folded, state)
+						}
+					}
+					return folded, successors, nil
+				}))
+			require.NoError(t, err)
+			options.StateMigrations = []*pulumirpc.Callback{callback}
+		}
+
+		comp, err := monitor.RegisterResource("my:module:Comp", "comp", false, options)
+		if err != nil {
+			return err
+		}
+
+		var canonicalURN resource.URN
+		var canonicalID resource.ID
+		var dependencies []resource.URN
+		if migrate {
+			child, err := monitor.RegisterResource("pkgA:m:typA", "childC", true, deploytest.ResourceOptions{
+				Parent: comp.URN,
+				Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+			})
+			if err != nil {
+				return err
+			}
+			canonicalURN, canonicalID = child.URN, child.ID
+			dependencies = []resource.URN{child.URN}
+		} else {
+			childA, err := monitor.RegisterResource("pkgA:m:typA", "childA", true, deploytest.ResourceOptions{
+				Parent: comp.URN,
+				Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+			})
+			if err != nil {
+				return err
+			}
+			childB, err := monitor.RegisterResource("pkgA:m:typA", "childB", false, deploytest.ResourceOptions{
+				Parent: comp.URN,
+				Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+			})
+			if err != nil {
+				return err
+			}
+			canonicalURN, canonicalID = childA.URN, childA.ID
+			dependencies = []resource.URN{childA.URN, childB.URN}
+		}
+
+		_, err = monitor.RegisterResource("pkgA:m:consumer", "consumer", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"ref": resource.MakeCustomResourceReference(canonicalURN, canonicalID, ""),
+			},
+			Dependencies: dependencies,
+			PropertyDeps: map[resource.PropertyKey][]resource.URN{
+				"ref": dependencies,
+			},
+			DeletedWith: canonicalURN,
+			ReplaceWith: dependencies,
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, p, nil, nil)
+	require.NoError(t, err)
+	var canonicalID resource.ID
+	for _, state := range snap.Resources {
+		if state.URN == childAURN {
+			canonicalID = state.ID
+		}
+	}
+	require.NotEmpty(t, canonicalID)
+
+	migrate = true
+	snap, err = runUpdate(t, p, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 4}))
+	require.NoError(t, err)
+	assert.NotContains(t, snapURNs(snap), childAURN)
+	assert.NotContains(t, snapURNs(snap), childBURN)
+	assert.Contains(t, snapURNs(snap), childCURN)
+
+	var consumer *pkgresource.State
+	for _, state := range snap.Resources {
+		if state.URN == childCURN {
+			assert.Equal(t, canonicalID, state.ID)
+		}
+		if state.URN == consumerURN {
+			consumer = state
+		}
+	}
+	require.NotNil(t, consumer)
+	assert.Equal(t, []resource.URN{childCURN}, consumer.Dependencies)
+	assert.Equal(t, []resource.URN{childCURN}, consumer.PropertyDependencies["ref"])
+	assert.Equal(t, childCURN, consumer.DeletedWith)
+	assert.Equal(t, []resource.URN{childCURN}, consumer.ReplaceWith)
+	require.True(t, consumer.Inputs["ref"].IsResourceReference())
+	ref := consumer.Inputs["ref"].ResourceReferenceValue()
+	assert.Equal(t, childCURN, ref.URN)
+	assert.Equal(t, canonicalID, resource.ID(ref.ID.StringValue()))
+}
+
+// TestStateMigrationS3BucketFold exercises a component upgrade built around the Pulumi AWS v6-to-v7 S3 bucket
+// unification. It replaces BucketV2 and its separately managed versioning sidecar with one Bucket:
+//
+//	BucketV2 (managed) ───────────┐
+//	                              ├─> Bucket (managed, retaining the shared bucket ID)
+//	BucketVersioningV2 (managed) ─┘
+//
+// The migration moves the sidecar's versioning value onto the surviving bucket.
+func TestStateMigrationS3BucketFold(t *testing.T) {
+	t.Parallel()
+
+	const (
+		componentType     = "example:storage:BucketComponent"
+		oldBucketType     = "aws:s3/bucketV2:BucketV2"
+		oldVersioningType = "aws:s3/bucketVersioningV2:BucketVersioningV2"
+		newBucketType     = "aws:s3/bucket:Bucket"
+
+		componentURN = resource.URN("urn:pulumi:test::test::example:storage:BucketComponent::bucket")
+		oldBucketURN = resource.URN(
+			"urn:pulumi:test::test::example:storage:BucketComponent$aws:s3/bucketV2:BucketV2::bucket")
+		oldVersioningURN = resource.URN(
+			"urn:pulumi:test::test::example:storage:BucketComponent$" +
+				"aws:s3/bucketVersioningV2:BucketVersioningV2::bucket-versioning")
+		newBucketURN = resource.URN(
+			"urn:pulumi:test::test::example:storage:BucketComponent$aws:s3/bucket:Bucket::bucket")
+	)
+
+	oldBucketInputs := resource.NewPropertyMapFromMap(map[string]any{
+		"bucket": "bucket-name",
+	})
+	versioningInputs := resource.NewPropertyMapFromMap(map[string]any{
+		"enabled": true,
+	})
+	newBucketInputs := resource.NewPropertyMapFromMap(map[string]any{
+		"bucket":     "bucket-name",
+		"versioning": true,
+	})
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("aws", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					// The bucket and sidecar have the same provider identity, allowing them to share a successor.
+					return plugin.CreateResponse{
+						ID:         "bucket-name",
+						Properties: req.Properties,
+						Status:     resource.StatusOK,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	var upgrade bool
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		var migrations []*pulumirpc.Callback
+		if upgrade {
+			callback, err := callbacks.Allocate(
+				stateMigrationFunction(func(
+					urn resource.URN, resources []apitype.ResourceV3,
+				) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+					var component, oldBucket, oldVersioning *apitype.ResourceV3
+					for i := range resources {
+						state := &resources[i]
+						switch state.URN {
+						case componentURN:
+							component = state
+						case oldBucketURN:
+							oldBucket = state
+						case oldVersioningURN:
+							oldVersioning = state
+						}
+					}
+					if component == nil || oldBucket == nil || oldVersioning == nil {
+						return nil, nil, errors.New("unexpected S3 migration subtree")
+					}
+
+					migratedBucket := *oldBucket
+					migratedBucket.URN = newBucketURN
+					migratedBucket.Type = newBucketType
+					migratedBucket.Inputs["versioning"] = oldVersioning.Inputs["enabled"]
+					migratedBucket.Outputs["versioning"] = oldVersioning.Outputs["enabled"]
+
+					return []apitype.ResourceV3{*component, migratedBucket}, map[resource.URN]resource.URN{
+						oldBucketURN:     newBucketURN,
+						oldVersioningURN: newBucketURN,
+					}, nil
+				}))
+			require.NoError(t, err)
+			migrations = []*pulumirpc.Callback{callback}
+		}
+
+		component, err := monitor.RegisterResource(componentType, "bucket", false, deploytest.ResourceOptions{
+			StateMigrations: migrations,
+		})
+		if err != nil {
+			return err
+		}
+		if !upgrade {
+			_, err = monitor.RegisterResource(oldBucketType, "bucket", true, deploytest.ResourceOptions{
+				Parent: component.URN,
+				Inputs: oldBucketInputs,
+			})
+			if err != nil {
+				return err
+			}
+			_, err = monitor.RegisterResource(
+				oldVersioningType, "bucket-versioning", true, deploytest.ResourceOptions{
+					Parent: component.URN,
+					Inputs: versioningInputs,
+				})
+			return err
+		}
+
+		_, err = monitor.RegisterResource(newBucketType, "bucket", true, deploytest.ResourceOptions{
+			Parent: component.URN,
+			Inputs: newBucketInputs,
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, plan, nil, nil)
+	require.NoError(t, err)
+
+	upgrade = true
+	snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+	assert.NotContains(t, snapURNs(snap), oldBucketURN)
+	assert.NotContains(t, snapURNs(snap), oldVersioningURN)
+
+	var migratedBucket *pkgresource.State
+	for _, state := range snap.Resources {
+		if state.URN == newBucketURN {
+			migratedBucket = state
+		}
+	}
+	require.NotNil(t, migratedBucket)
+	assert.Equal(t, resource.ID("bucket-name"), migratedBucket.ID)
+	for _, properties := range []resource.PropertyMap{migratedBucket.Inputs, migratedBucket.Outputs} {
+		versioning, ok := properties["versioning"]
+		require.True(t, ok)
+		assert.True(t, versioning.IsBool())
+		assert.True(t, versioning.BoolValue())
+	}
+}
+
+// TestStateMigrationConstruct exercises this migration inside a remote component:
+//
+//	remote component
+//	└─ resA (managed) -> resB (managed, retaining resA's ID)
+//
+// The callback attached to the program's remote registration must run before the component provider constructs it.
+func TestStateMigrationConstruct(t *testing.T) {
+	t.Parallel()
+
+	childName := "resA"
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				ConstructF: func(
+					_ context.Context,
+					req plugin.ConstructRequest,
+					monitor *deploytest.ResourceMonitor,
+				) (plugin.ConstructResponse, error) {
+					resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{})
+					require.NoError(t, err)
+
+					_, err = monitor.RegisterResource("pkgA:m:typA", childName, true, deploytest.ResourceOptions{
+						Parent: resp.URN,
+						Inputs: resource.PropertyMap{"foo": resource.NewProperty(1.0)},
+					})
+					require.NoError(t, err)
+
+					return plugin.ConstructResponse{URN: resp.URN}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		_, err = monitor.RegisterResource("pkgA:m:typC", "comp", false, deploytest.ResourceOptions{
+			Remote:          true,
+			StateMigrations: []*pulumirpc.Callback{renameMigration(t, callbacks, "resA", "resB")},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, p, nil, nil)
+	require.NoError(t, err)
+	require.Contains(t, snapURNs(snap), resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
+
+	childName = "resB"
+	snap, err = runUpdate(t, p, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+	urns := snapURNs(snap)
+	assert.Contains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resB"))
+	assert.NotContains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
+}
+
+// TestStateMigrationAliasedRootRename exercises this component type change:
+//
+//	Comp::comp                  CompV2::comp
+//	└─ typA::childA     ->      └─ typA::childA (URN requalified through CompV2)
+//
+// Version 2 aliases the old component type and migrates both the root and child URNs to the new qualified type.
+func TestStateMigrationAliasedRootRename(t *testing.T) {
+	t.Parallel()
+
+	newCompURN := resource.URN("urn:pulumi:test::test::my:module:CompV2::comp")
+	newChildURN := resource.URN("urn:pulumi:test::test::my:module:CompV2$pkgA:m:typA::childA")
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	compType := "my:module:Comp"
+	var migrate bool
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		options := deploytest.ResourceOptions{}
+		if migrate {
+			callback, err := callbacks.Allocate(
+				stateMigrationFunction(func(
+					urn resource.URN, resources []apitype.ResourceV3,
+				) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+					if resources[0].URN == newCompURN {
+						// Already migrated.
+						return nil, nil, nil
+					}
+					successors := make(map[resource.URN]resource.URN)
+					for i, res := range resources {
+						oldURN := res.URN
+						resources[i].URN = resource.URN(
+							strings.Replace(string(res.URN), "my:module:Comp", "my:module:CompV2", 1))
+						resources[i].Type = resources[i].URN.Type()
+						successors[oldURN] = resources[i].URN
+						if res.Parent != "" {
+							resources[i].Parent = resource.URN(
+								strings.Replace(string(res.Parent), "my:module:Comp", "my:module:CompV2", 1))
+						}
+					}
+					return resources, successors, nil
+				}))
+			require.NoError(t, err)
+			options.StateMigrations = []*pulumirpc.Callback{callback}
+			options.Aliases = []*pulumirpc.Alias{{
+				Alias: &pulumirpc.Alias_Spec_{Spec: &pulumirpc.Alias_Spec{Type: "my:module:Comp"}},
+			}}
+		}
+
+		resp, err := monitor.RegisterResource(tokens.Type(compType), "comp", false, options)
+		if err != nil {
+			return err
+		}
+		_, err = monitor.RegisterResource("pkgA:m:typA", "childA", true, deploytest.ResourceOptions{
+			Parent: resp.URN,
+			Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, p, nil, nil)
+	require.NoError(t, err)
+	require.Contains(t, snapURNs(snap), childAURN)
+
+	compType, migrate = "my:module:CompV2", true
+	snap, err = runUpdate(t, p, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+	urns := snapURNs(snap)
+	assert.Contains(t, urns, newCompURN)
+	assert.Contains(t, urns, newChildURN)
+	assert.NotContains(t, urns, compURN)
+	assert.NotContains(t, urns, childAURN)
+}
+
+// TestStateMigrationEchoNoOp exercises this no-op migration:
+//
+//	childA (managed, secret input) -> childA (unchanged)
+//
+// Returning the callback input unchanged must be treated as a no-op. For a secret property, the JSON round trip
+// changes the concrete Go value without changing the encoded data:
+//
+//	before JSON: Inputs["secret"] is *apitype.SecretV1
+//	after JSON:  Inputs["secret"] is map[string]any (with the secret signature preserved)
+//
+// No-op detection must ignore that representation-only difference.
+func TestStateMigrationEchoNoOp(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	env.childInputs = resource.PropertyMap{
+		"foo":    resource.NewProperty("bar"),
+		"secret": resource.MakeSecret(resource.NewProperty("shh")),
+	}
+	project := env.plan.GetProject()
+
+	snap, err := lt.TestOp(Update).Run(
+		project, env.plan.GetTarget(t, nil), env.plan.Options, false, env.plan.BackendClient, nil)
+	require.NoError(t, err)
+
+	// A migration that echoes its input back verbatim, on every run.
+	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+		callback, err := callbacks.Allocate(
+			stateMigrationFunction(func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				return resources, nil, nil
+			}))
+		require.NoError(t, err)
+		return []*pulumirpc.Callback{callback}
+	}
+
+	_, err = lt.TestOp(Update).Run(project, env.plan.GetTarget(t, snap), env.plan.Options, false, env.plan.BackendClient,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries, events []Event, err error) error {
+			assert.Equal(t, map[display.StepOp]int{deploy.OpSame: 3}, countSuccessfulOps(entries))
+			return err
+		})
+	require.NoError(t, err)
+}
+
+// TestStateMigrationSkippedDuringDestroy exercises this destroy path:
+//
+//	component + childA -> registered during destroy -> deleted (migration callback skipped)
+//
+// Destroy --run-program evaluates resource registrations to obtain current provider configuration and hooks, but
+// still queues the registered resources for deletion. Migrations must not run while processing those registrations.
+func TestStateMigrationSkippedDuringDestroy(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	project := env.plan.GetProject()
+
+	snap, err := lt.TestOp(Update).Run(
+		project, env.plan.GetTarget(t, nil), env.plan.Options, false, env.plan.BackendClient, nil)
+	require.NoError(t, err)
+
+	// The callback fails if invoked. Destroy must skip it even though the program registers the component and child.
+	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+		callback, err := callbacks.Allocate(
+			stateMigrationFunction(func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				return nil, nil, errors.New("migrations must not run during destroy")
+			}))
+		require.NoError(t, err)
+		return []*pulumirpc.Callback{callback}
+	}
+
+	var deleted []resource.URN
+	snap, err = lt.TestOp(DestroyV2).Run(project, env.plan.GetTarget(t, snap), env.plan.Options, false,
+		env.plan.BackendClient,
+		func(project workspace.Project, target deploy.Target, entries JournalEntries, events []Event, err error) error {
+			for _, entry := range entries {
+				if entry.Kind == TestJournalEntrySuccess && entry.Step.Op() == deploy.OpDelete {
+					deleted = append(deleted, entry.Step.URN())
+				}
+			}
+			return err
+		})
+	require.NoError(t, err)
+	assert.Contains(t, deleted, childAURN, "the child must be deleted by destroy, not skipped by a migration")
+	assert.Empty(t, snap.Resources)
+}
+
+// TestStateMigrationRewritesLaterAlias verifies alias lookup after a migration has committed earlier in the same
+// update. The program makes these registration calls in order:
+//
+//  1. Register the component. Its callback changes prior state from component$childA to component$childB.
+//  2. Register top-level childB, with component$childA as an alias.
+//
+// By the second call, component$childA no longer exists in prior state. The engine must rewrite the alias to
+// component$childB so the top-level registration adopts that state and retains its physical ID.
+func TestStateMigrationRewritesLaterAlias(t *testing.T) {
+	t.Parallel()
+
+	const topLevelChildURN = resource.URN("urn:pulumi:test::test::pkgA:m:typA::childB")
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	upgrade := false
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		if upgrade {
+			callback := renameMigration(t, callbacks, "childA", "childB")
+			_, err = monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{
+				StateMigrations: []*pulumirpc.Callback{callback},
+			})
+			if err != nil {
+				return err
+			}
+
+			// This call happens after the component registration above has run the migration. Omitting Parent makes
+			// childB top-level; the alias identifies it as the original nested childA.
+			_, err = monitor.RegisterResource("pkgA:m:typA", "childB", true, deploytest.ResourceOptions{
+				Inputs:    resource.PropertyMap{"foo": resource.NewProperty("bar")},
+				AliasURNs: []resource.URN{childAURN},
+			})
+			return err
+		}
+
+		component, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{})
+		if err != nil {
+			return err
+		}
+		_, err = monitor.RegisterResource("pkgA:m:typA", "childA", true, deploytest.ResourceOptions{
+			Parent: component.URN,
+			Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, plan, nil, nil)
+	require.NoError(t, err)
+	var childID resource.ID
+	for _, state := range snap.Resources {
+		if state.URN == childAURN {
+			childID = state.ID
+		}
+	}
+	require.NotEmpty(t, childID)
+
+	upgrade = true
+	snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+	require.NoError(t, err)
+	assert.NotContains(t, snapURNs(snap), childAURN)
+	assert.NotContains(t, snapURNs(snap), childBURN)
+	require.Contains(t, snapURNs(snap), topLevelChildURN)
+	for _, state := range snap.Resources {
+		if state.URN == topLevelChildURN {
+			assert.Equal(t, childID, state.ID)
+			assert.Empty(t, state.Parent)
+		}
+	}
+}
+
+// TestStateMigrationRejectsPredecessorURNReuse verifies that a migration's predecessor URN cannot be assigned to a
+// different resource later in the same update. It covers both operations that can introduce a primary resource URN:
+// registering a managed resource and reading an existing physical resource by ID.
+func TestStateMigrationRejectsPredecessorURNReuse(t *testing.T) {
+	t.Parallel()
+
+	for _, useReadResource := range []bool{false, true} {
+		name := "register"
+		if useReadResource {
+			name = "read"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			loaders := []*deploytest.ProviderLoader{
+				deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+					return &deploytest.Provider{}, nil
+				}),
+			}
+
+			upgrade := false
+			programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+				callbacks, err := deploytest.NewCallbacksServer()
+				require.NoError(t, err)
+				defer func() { require.NoError(t, callbacks.Close()) }()
+
+				var migrations []*pulumirpc.Callback
+				if upgrade {
+					migrations = []*pulumirpc.Callback{renameMigration(t, callbacks, "childA", "childB")}
+				}
+				component, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{
+					StateMigrations: migrations,
+				})
+				if err != nil {
+					return err
+				}
+
+				if !upgrade {
+					// The first update creates the predecessor state at component$childA.
+					_, err = monitor.RegisterResource("pkgA:m:typA", "childA", true, deploytest.ResourceOptions{
+						Parent: component.URN,
+						Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+					})
+					return err
+				}
+
+				// On the second update, registering the component above has already migrated that state to
+				// component$childB. The next operation deliberately tries to reuse component$childA.
+				if useReadResource {
+					// ReadResource asks the provider to read the existing physical resource "read-id". The childA
+					// name and component parent would assign the returned state the consumed childAURN.
+					_, _, err = monitor.ReadResource(
+						"pkgA:m:typA", "childA", "read-id", component.URN, nil, "", "", "", nil, "", "")
+					return err
+				}
+				// RegisterResource likewise attempts to assign a new managed resource the consumed childAURN.
+				_, err = monitor.RegisterResource("pkgA:m:typA", "childA", true, deploytest.ResourceOptions{
+					Parent: component.URN,
+					Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+				})
+				return err
+			})
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+			plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+			snap, err := runUpdate(t, plan, nil, nil)
+			require.NoError(t, err)
+			upgrade = true
+
+			_, err = runUpdate(t, plan, snap, nil)
+			require.ErrorContains(t, err, "resource "+string(childAURN)+" cannot be registered or read")
+			assert.ErrorContains(t, err, "replaced it with "+string(childBURN))
+		})
+	}
+}
+
+// TestStateMigrationRejectsClaimedState covers the reverse ordering of TestStateMigrationRewritesLaterAlias. The
+// upgrade first registers top-level childB with component$childA as an alias, claiming childA's prior state. When the
+// component registers afterward, its childA -> childB migration must not rewrite state already assigned to that
+// earlier registration.
+func TestStateMigrationRejectsClaimedState(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	upgrade := false
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		if upgrade {
+			// This registration runs claims the nested childA state through its alias.
+			_, err := monitor.RegisterResource("pkgA:m:typA", "childB", true, deploytest.ResourceOptions{
+				Inputs:    resource.PropertyMap{"foo": resource.NewProperty("bar")},
+				AliasURNs: []resource.URN{childAURN},
+			})
+			require.NoError(t, err)
+
+			// The later component registration attempts to migrate the same childA state that childB claimed.
+			callback := renameMigration(t, callbacks, "childA", "childB")
+			_, err = monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{
+				StateMigrations: []*pulumirpc.Callback{callback},
+			})
+			return err
+		}
+
+		resp, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{})
+		require.NoError(t, err)
+		_, err = monitor.RegisterResource("pkgA:m:typA", "childA", true, deploytest.ResourceOptions{
+			Parent: resp.URN,
+			Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+	project := p.GetProject()
+
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	require.NoError(t, err)
+
+	upgrade = true
+	_, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	require.ErrorContains(t, err, "was already claimed by")
+}
+
+// TestStateMigrationRejectsRegisteredRoot verifies that a migration cannot rewrite prior root state already claimed
+// by an earlier registration in the same update.
+func TestStateMigrationRejectsRegisteredRoot(t *testing.T) {
+	t.Parallel()
+
+	const newCompURN = resource.URN("urn:pulumi:test::test::my:module:CompV2::comp")
+
+	attemptConflictingMigration := false
+	programF := deploytest.NewLanguageRuntimeF(func(
+		_ plugin.RunInfo, monitor *deploytest.ResourceMonitor,
+	) error {
+		// Both updates register Comp. Only the second continues with a conflicting CompV2 registration.
+		_, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{})
+		if err != nil || !attemptConflictingMigration {
+			return err
+		}
+
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+		callback, err := callbacks.Allocate(
+			stateMigrationFunction(func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				require.Len(t, resources, 1)
+				resources[0].URN = newCompURN
+				resources[0].Type = newCompURN.Type()
+				return resources, map[resource.URN]resource.URN{compURN: newCompURN}, nil
+			}))
+		require.NoError(t, err)
+
+		// This second registration resolves the same prior root through its alias, then attempts to migrate it.
+		_, err = monitor.RegisterResource("my:module:CompV2", "comp", false, deploytest.ResourceOptions{
+			AliasURNs:       []resource.URN{compURN},
+			StateMigrations: []*pulumirpc.Callback{callback},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+	project := p.GetProject()
+
+	snap, err := lt.TestOp(Update).Run(
+		project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	require.NoError(t, err)
+	before := snapURNs(snap)
+
+	attemptConflictingMigration = true
+	snap, err = lt.TestOp(Update).Run(
+		project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	require.ErrorContains(t, err, "prior state of "+string(compURN)+" was already registered earlier")
+	assert.Equal(t, before, snapURNs(snap), "the rejected migration must leave prior state untouched")
+	assert.NotContains(t, snapURNs(snap), newCompURN)
+}
+
+// TestStateMigrationTargeted verifies that a state-changing migration requires a full update. No-op migrations
+// remain safe during targeted updates so callbacks can stay attached after every stack has migrated.
+func TestStateMigrationTargeted(t *testing.T) {
+	t.Parallel()
+
+	t.Run("changing migration is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		env := newStateMigrationEnv(t)
+		snap, err := runUpdate(t, env.plan, nil, nil)
+		require.NoError(t, err)
+		before := snapURNs(snap)
+
+		env.childName = "childB"
+		env.setRenameMigration("childA", "childB")
+
+		options := env.plan.Options
+		options.UpdateOptions = UpdateOptions{
+			Targets: deploy.NewUrnTargets([]string{string(childBURN)}),
+		}
+		_, err = lt.TestOp(Update).Run(
+			env.plan.GetProject(), env.plan.GetTarget(t, snap), options, false, env.plan.BackendClient, nil)
+		require.ErrorContains(t, err, "cannot change state during a targeted or excluded update")
+		assert.Equal(t, before, snapURNs(snap), "the rejected migration must leave prior state untouched")
+	})
+
+	t.Run("no-op migration proceeds", func(t *testing.T) {
+		t.Parallel()
+
+		env := newStateMigrationEnv(t)
+		snap, err := runUpdate(t, env.plan, nil, nil)
+		require.NoError(t, err)
+		env.setRenameMigration("childZ", "childA")
+
+		options := env.plan.Options
+		options.UpdateOptions = UpdateOptions{
+			Targets: deploy.NewUrnTargets([]string{string(compURN)}),
+		}
+		_, err = lt.TestOp(Update).Run(
+			env.plan.GetProject(), env.plan.GetTarget(t, snap), options, false, env.plan.BackendClient, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestStateMigrationUpdatePlan(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	project := env.plan.GetProject()
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+	before := snapURNs(snap)
+
+	options := env.plan.Options
+	options.GeneratePlan = true
+	options.Experimental = true
+
+	// A migration that would rewrite the checkpoint cannot be represented in an update plan, so reject plan
+	// generation without modifying the prior snapshot.
+	env.childName = "childB"
+	env.setRenameMigration("childA", "childB")
+	plan, err := lt.TestOp(Update).Plan(
+		project, env.plan.GetTarget(t, snap), options, env.plan.BackendClient, nil)
+	require.ErrorContains(t, err, "cannot change state while generating an update plan")
+	assert.Nil(t, plan)
+	assert.Equal(t, before, snapURNs(snap), "the rejected migration must leave prior state untouched")
+
+	// An attached no-op migration does not rewrite the checkpoint, so plan generation remains available after the
+	// stack has migrated.
+	env.childName = "childA"
+	env.setRenameMigration("childZ", "childA")
+	plan, err = lt.TestOp(Update).Plan(
+		project, env.plan.GetTarget(t, snap), options, env.plan.BackendClient, nil)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// A changing migration cannot be introduced between plan generation and application either.
+	env.childName = "childB"
+	env.setRenameMigration("childA", "childB")
+	options.Plan = plan.Clone()
+	_, err = lt.TestOp(Update).Run(
+		project, env.plan.GetTarget(t, snap), options, false, env.plan.BackendClient, nil)
+	require.ErrorContains(t, err, "cannot change state while applying an update plan")
+	assert.Equal(t, before, snapURNs(snap), "the rejected migration must leave prior state untouched")
+
+	// The same plan remains usable when the attached migration is already a no-op.
+	env.childName = "childA"
+	env.setRenameMigration("childZ", "childA")
+	options.Plan = plan.Clone()
+	_, err = lt.TestOp(Update).Run(
+		project, env.plan.GetTarget(t, snap), options, false, env.plan.BackendClient, nil)
+	require.NoError(t, err)
+}
+
+// TestStateMigrationPendingOperation verifies that any recovery state must be resolved before a migration changes
+// the checkpoint. No-op migrations still proceed so a permanently attached callback does not block recovery.
+func TestStateMigrationPendingOperation(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*stateMigrationEnv, *deploy.Snapshot) {
+		env := newStateMigrationEnv(t)
+		snap, err := runUpdate(t, env.plan, nil, nil)
+		require.NoError(t, err)
+
+		pending := &pkgresource.State{
+			URN:    "urn:pulumi:test::test::pkgA:m:consumer::pending",
+			Type:   "pkgA:m:consumer",
+			Custom: true,
+		}
+		snap.PendingOperations = append(snap.PendingOperations,
+			pkgresource.NewOperation(pending, pkgresource.OperationTypeCreating))
+		require.NoError(t, snap.VerifyIntegrity())
+		return env, snap
+	}
+
+	t.Run("changing migration is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		env, snap := setup(t)
+		before := snapURNs(snap)
+		env.childName = "childB"
+		env.setRenameMigration("childA", "childB")
+
+		_, err := runUpdate(t, env.plan, snap, nil)
+		require.ErrorContains(t, err, "snapshot has 1 pending operation")
+		assert.Equal(t, before, snapURNs(snap), "the rejected migration must leave prior state untouched")
+		require.Len(t, snap.PendingOperations, 1)
+	})
+
+	t.Run("no-op migration proceeds", func(t *testing.T) {
+		t.Parallel()
+
+		env, snap := setup(t)
+		env.setRenameMigration("childZ", "childA")
+
+		_, err := runUpdate(t, env.plan, snap, nil)
+		require.NoError(t, err)
+		require.Len(t, snap.PendingOperations, 1)
+	})
+}
+
+// TestStateMigrationPendingDelete tests migrations against prior state containing a pending-delete resource
+// under the migrated component (as left behind by an interrupted replacement): a migration that changes the
+// state fails with an explicit error and leaves the state untouched, while an update whose migrations make no
+// changes proceeds as usual and reaps the pending deletion.
+func TestStateMigrationPendingDelete(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*stateMigrationEnv, *deploy.Snapshot) {
+		env := newStateMigrationEnv(t)
+		snap, err := runUpdate(t, env.plan, nil, nil)
+		require.NoError(t, err)
+
+		// Seed a pending-delete copy of the child, as an interrupted create-before-delete replacement would
+		// leave behind.
+		var live *pkgresource.State
+		for _, res := range snap.Resources {
+			if res.URN == childAURN {
+				live = res
+			}
+		}
+		require.NotNil(t, live)
+		pending := live.Copy()
+		pending.ID = live.ID + "-old"
+		pending.Delete = true
+		snap.Resources = append(snap.Resources, pending)
+		require.NoError(t, snap.VerifyIntegrity())
+		return env, snap
+	}
+
+	t.Run("migration with changes fails explicitly", func(t *testing.T) {
+		t.Parallel()
+
+		env, snap := setup(t)
+		before := snapURNs(snap)
+
+		env.childName = "childB"
+		env.setRenameMigration("childA", "childB")
+
+		snap, err := runUpdate(t, env.plan, snap, nil)
+		require.ErrorContains(t, err, "pending deletion from a previous update")
+		// The prior state is untouched by the rejected migration.
+		assert.Equal(t, before, snapURNs(snap))
+	})
+
+	t.Run("no-op migration proceeds and reaps the pending deletion", func(t *testing.T) {
+		t.Parallel()
+
+		env, snap := setup(t)
+
+		// The rename has nothing to do ("childZ" does not exist), so the migration returns no new state.
+		env.setRenameMigration("childZ", "childA")
+
+		snap, err := runUpdate(t, env.plan, snap,
+			validateOps(t, map[display.StepOp]int{deploy.OpSame: 3, deploy.OpDeleteReplaced: 1}))
+		require.NoError(t, err)
+		for _, res := range snap.Resources {
+			assert.False(t, res.Delete, "expected the update to reap the pending deletion")
+		}
+	})
+}
+
+const (
+	nestedAURN = resource.URN("urn:pulumi:test::test::my:module:Comp$my:module:Nested::nestedA")
+	nestedBURN = resource.URN("urn:pulumi:test::test::my:module:Comp$my:module:Nested::nestedB")
+	leafAURN   = resource.URN("urn:pulumi:test::test::my:module:Comp$my:module:Nested$pkgA:m:typA::leafA")
+	leafBURN   = resource.URN("urn:pulumi:test::test::my:module:Comp$my:module:Nested$pkgA:m:typA::leafB")
+)
+
+// nestedEnv is the deeper-subtree sibling of stateMigrationEnv: a component "comp" containing a nested component
+// containing a custom leaf resource, with the nested component's and leaf's names controlled per-update.
+type nestedEnv struct {
+	plan *lt.TestPlan
+
+	nestedName       string
+	leafName         string
+	migrations       func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback
+	nestedMigrations func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback
+}
+
+func newNestedEnv(t *testing.T) *nestedEnv {
+	env := &nestedEnv{nestedName: "nestedA", leafName: "leafA"}
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		var migrations []*pulumirpc.Callback
+		if env.migrations != nil {
+			migrations = env.migrations(t, callbacks)
+		}
+		var nestedMigrations []*pulumirpc.Callback
+		if env.nestedMigrations != nil {
+			nestedMigrations = env.nestedMigrations(t, callbacks)
+		}
+
+		comp, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{
+			StateMigrations: migrations,
+		})
+		if err != nil {
+			return err
+		}
+		nested, err := monitor.RegisterResource("my:module:Nested", env.nestedName, false, deploytest.ResourceOptions{
+			Parent:          comp.URN,
+			StateMigrations: nestedMigrations,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = monitor.RegisterResource("pkgA:m:typA", env.leafName, true, deploytest.ResourceOptions{
+			Parent: nested.URN,
+			Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+	env.plan = &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+	return env
+}
+
+// TestStateMigrationNestedComponents exercises this deeper subtree migration:
+//
+//	component                   component
+//	└─ nestedA          ->      └─ nestedB
+//	   └─ leafA                    └─ leafB (managed, retaining leafA's ID)
+//
+// It covers both one callback over the complete subtree and separate callbacks on the outer and nested components.
+func TestStateMigrationNestedComponents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rename intermediate and leaf", func(t *testing.T) {
+		t.Parallel()
+
+		env := newNestedEnv(t)
+
+		snap, err := runUpdate(t, env.plan, nil, nil)
+		require.NoError(t, err)
+		urns := snapURNs(snap)
+		require.Contains(t, urns, nestedAURN)
+		require.Contains(t, urns, leafAURN)
+		var leafID resource.ID
+		for _, res := range snap.Resources {
+			if res.URN == leafAURN {
+				leafID = res.ID
+			}
+		}
+		require.NotEmpty(t, leafID)
+
+		env.nestedName = "nestedB"
+		env.leafName = "leafB"
+		env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+			callback, err := callbacks.Allocate(
+				stateMigrationFunction(func(
+					urn resource.URN, resources []apitype.ResourceV3,
+				) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+					// The whole subtree is handed over root-first, in snapshot order.
+					require.Len(t, resources, 3)
+					assert.Equal(t, compURN, resources[0].URN)
+					assert.Equal(t, nestedAURN, resources[1].URN)
+					assert.Equal(t, leafAURN, resources[2].URN)
+
+					renamed := renameByName(renameByName(resources, "nestedA", "nestedB"), "leafA", "leafB")
+					for i := range renamed {
+						if renamed[i].Parent == nestedAURN {
+							renamed[i].Parent = nestedBURN
+						}
+					}
+					return renamed, map[resource.URN]resource.URN{
+						nestedAURN: nestedBURN,
+						leafAURN:   leafBURN,
+					}, nil
+				}))
+			require.NoError(t, err)
+			return []*pulumirpc.Callback{callback}
+		}
+
+		snap, err = runUpdate(t, env.plan, snap,
+			validateOps(t, map[display.StepOp]int{deploy.OpSame: 4}))
+		require.NoError(t, err)
+
+		urns = snapURNs(snap)
+		assert.Contains(t, urns, nestedBURN)
+		assert.Contains(t, urns, leafBURN)
+		assert.NotContains(t, urns, nestedAURN)
+		assert.NotContains(t, urns, leafAURN)
+		for _, res := range snap.Resources {
+			if res.URN == leafBURN {
+				// The renamed leaf keeps its identity and is parented to the renamed intermediate.
+				assert.Equal(t, leafID, res.ID)
+				assert.Equal(t, nestedBURN, res.Parent)
+			}
+		}
+	})
+
+	t.Run("orders outer and nested migrations", func(t *testing.T) {
+		t.Parallel()
+
+		env := newNestedEnv(t)
+
+		snap, err := runUpdate(t, env.plan, nil, nil)
+		require.NoError(t, err)
+
+		// The outer migration renames only the intermediate component. The engine rewrites the leaf's parent from
+		// that successor mapping before invoking the migration registered by the nested component.
+		env.nestedName = "nestedB"
+		env.leafName = "leafB"
+		env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+			return []*pulumirpc.Callback{renameMigration(t, callbacks, "nestedA", "nestedB")}
+		}
+		env.nestedMigrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+			callback, err := callbacks.Allocate(
+				stateMigrationFunction(func(
+					urn resource.URN, resources []apitype.ResourceV3,
+				) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+					assert.Equal(t, nestedBURN, urn)
+					require.Len(t, resources, 2)
+					assert.Equal(t, nestedBURN, resources[0].URN)
+					assert.Equal(t, nestedBURN, resources[1].Parent)
+					return renameByName(resources, "leafA", "leafB"),
+						map[resource.URN]resource.URN{leafAURN: leafBURN}, nil
+				}))
+			require.NoError(t, err)
+			return []*pulumirpc.Callback{callback}
+		}
+
+		snap, err = runUpdate(t, env.plan, snap,
+			validateOps(t, map[display.StepOp]int{deploy.OpSame: 4}))
+		require.NoError(t, err)
+		urns := snapURNs(snap)
+		assert.Contains(t, urns, nestedBURN)
+		assert.Contains(t, urns, leafBURN)
+		assert.NotContains(t, urns, nestedAURN)
+		assert.NotContains(t, urns, leafAURN)
+		for _, state := range snap.Resources {
+			if state.URN == leafBURN {
+				assert.Equal(t, nestedBURN, state.Parent)
+			}
+		}
+	})
+}
+
+// TestStateMigrationAcrossTypes exercises this managed-resource type change:
+//
+//	typA::childA (managed) -> typB::childB (managed, retaining childA's ID)
+func TestStateMigrationAcrossTypes(t *testing.T) {
+	t.Parallel()
+
+	env := newStateMigrationEnv(t)
+	snap, err := runUpdate(t, env.plan, nil, nil)
+	require.NoError(t, err)
+
+	const childBTypBURN = resource.URN("urn:pulumi:test::test::my:module:Comp$pkgA:m:typB::childB")
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		callback, err := callbacks.Allocate(
+			stateMigrationFunction(func(
+				urn resource.URN, resources []apitype.ResourceV3,
+			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+				successors := make(map[resource.URN]resource.URN)
+				for i, res := range resources {
+					if res.URN == childAURN {
+						successors[res.URN] = childBTypBURN
+						resources[i].URN = childBTypBURN
+						resources[i].Type = "pkgA:m:typB"
+						// The ID is deliberately kept: the new state reuses the old resource's ID under a
+						// different type.
+					}
+				}
+				if len(successors) == 0 {
+					// Already migrated.
+					return nil, nil, nil
+				}
+				return resources, successors, nil
+			}))
+		require.NoError(t, err)
+
+		resp, err := monitor.RegisterResource("my:module:Comp", "comp", false, deploytest.ResourceOptions{
+			StateMigrations: []*pulumirpc.Callback{callback},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = monitor.RegisterResource("pkgA:m:typB", "childB", true, deploytest.ResourceOptions{
+			Parent: resp.URN,
+			Inputs: resource.PropertyMap{"foo": resource.NewProperty("bar")},
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err = runUpdate(t, p, snap, nil)
+	require.NoError(t, err)
+	urns := snapURNs(snap)
+	assert.Contains(t, urns, childBTypBURN)
+	assert.NotContains(t, urns, childAURN)
+}

--- a/pkg/engine/snapshot.go
+++ b/pkg/engine/snapshot.go
@@ -21,8 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-// SnapshotManagerCapabilities describes persistence features that may be needed before a SnapshotManager exists.
-// Backends provide these capabilities for previews, which do not construct a manager of their own.
+// SnapshotManagerCapabilities describes the features supported by the backend's persistence mode.
 type SnapshotManagerCapabilities struct {
 	// StateMigrations reports whether the selected persistence mode can store state migrations.
 	StateMigrations bool

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -1145,6 +1145,7 @@ func newUpdateSource(ctx context.Context,
 		DisableResourceReferences: opts.DisableResourceReferences,
 		DisableOutputValues:       opts.DisableOutputValues,
 		AttachDebugger:            opts.AttachDebugger,
+		SupportsStateMigrations:   opts.supportsStateMigrations,
 	}
 
 	program := deploy.NewProgramSource(plugctx, runinfo, evalOpts, panicErrs)
@@ -1290,6 +1291,17 @@ func (acts *updateActions) OnSnapshotWrite(step *deploy.Snapshot) error {
 
 func (acts *updateActions) OnRebuiltBaseState() error {
 	return acts.Context.SnapshotManager.RebuiltBaseState()
+}
+
+func (acts *updateActions) OnStateMigration(transaction *deploy.StateMigrationTransaction) error {
+	manager := acts.Context.SnapshotManager
+	if manager == nil || !manager.SupportsStateMigrations() {
+		return deploy.ErrStateMigrationsUnsupported
+	}
+	if err := manager.StateMigration(transaction); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (acts *updateActions) OnResourceStepPre(step deploy.Step) (any, error) {
@@ -1513,6 +1525,10 @@ func (acts *previewActions) OnSnapshotWrite(base *deploy.Snapshot) error {
 }
 
 func (acts *previewActions) OnRebuiltBaseState() error {
+	return nil
+}
+
+func (acts *previewActions) OnStateMigration(transaction *deploy.StateMigrationTransaction) error {
 	return nil
 }
 

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -124,6 +124,10 @@ type Options struct {
 	ShowSecrets bool
 	// Analyzers is the list of policy analyzers to run during this deployment.
 	Analyzers []plugin.Analyzer
+	// StateMigrationSerializer converts resource states to and from the checkpoint representation used by state
+	// migration callbacks. The engine injects it because the serialization logic lives in pkg/resource/stack, which
+	// already imports this package and therefore cannot be imported here.
+	StateMigrationSerializer StateMigrationResourceSerializer
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the
@@ -254,6 +258,11 @@ type StepExecutorEvents interface {
 	OnResourceOutputs(step Step) error
 }
 
+// StateMigrationEvents is implemented by event handlers that can persist state migrations.
+type StateMigrationEvents interface {
+	OnStateMigration(transaction *StateMigrationTransaction) error
+}
+
 // PolicyEvents is an interface that can be used to hook policy events.
 type PolicyEvents interface {
 	OnPolicyViolation(resource.URN, plugin.AnalyzeDiagnostic)
@@ -267,6 +276,7 @@ type PolicyEvents interface {
 type Events interface {
 	StepExecutorEvents
 	PolicyEvents
+	StateMigrationEvents
 }
 
 type resourcePlans struct {

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -236,6 +236,8 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context) (_ *Plan, err e
 
 	// Set up a step generator and executor for this deployment.
 	ex.stepExec = newStepExecutor(ctx, cancel, ex.deployment, false)
+	// Let state migrations pause resource execution while they update deployment state.
+	ex.stepGen.stepExecutionBarrier = ex.stepExec
 
 	// We iterate the source in its own goroutine because iteration is blocking and we want the main loop to be able to
 	// respond to cancellation requests promptly.

--- a/pkg/resource/deploy/deployment_executor_test.go
+++ b/pkg/resource/deploy/deployment_executor_test.go
@@ -17,12 +17,18 @@ package deploy
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/blang/semver"
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
@@ -231,6 +237,185 @@ func (iter *iterator) Next() (SourceEvent, error) {
 		return nil, errors.New("error")
 	}
 	return nil, nil
+}
+
+type eventIterator struct {
+	events     []SourceEvent
+	next       int
+	beforeNext func(int) error
+}
+
+func (iter *eventIterator) Cancel(context.Context) error { return nil }
+
+func (iter *eventIterator) Next() (SourceEvent, error) {
+	if iter.beforeNext != nil {
+		if err := iter.beforeNext(iter.next); err != nil {
+			return nil, err
+		}
+	}
+	if iter.next == len(iter.events) {
+		return nil, nil
+	}
+	event := iter.events[iter.next]
+	iter.next++
+	return event, nil
+}
+
+type testStateMigrationResourceSerializer struct{}
+
+func (testStateMigrationResourceSerializer) Serialize(
+	_ context.Context, state *pkgresource.State,
+) (apitype.ResourceV3, error) {
+	return apitype.ResourceV3{URN: state.URN, Type: state.Type}, nil
+}
+
+func (testStateMigrationResourceSerializer) Deserialize(apitype.ResourceV3) (*pkgresource.State, error) {
+	return nil, errors.New("unexpected state migration result")
+}
+
+// TestStateMigrationWaitsForAsyncPlanning verifies that a migration registration is held until an earlier parallel
+// diff has published its continuation. Otherwise the migration can wait for the executor lock while the diff waits for
+// the executor to receive its continuation, resulting in a deadlock.
+func TestStateMigrationWaitsForAsyncPlanning(t *testing.T) {
+	t.Parallel()
+
+	const timeout = time.Minute
+	wait := func(ch <-chan struct{}, description string) error {
+		select {
+		case <-ch:
+			return nil
+		case <-time.After(timeout):
+			return fmt.Errorf("timed out waiting for %s", description)
+		}
+	}
+
+	stack := tokens.MustParseStackName("test")
+	project := tokens.PackageName("project")
+	providerType := sdkproviders.MakeProviderType("pkgA")
+	providerURN := resource.NewURN(stack.Q(), project, "", providerType, "provider")
+	providerID := resource.ID("provider-id")
+
+	componentType := tokens.Type("example:m:Component")
+	componentURN := resource.NewURN(stack.Q(), project, "", componentType, "component")
+
+	oldProviderInputs := resource.PropertyMap{
+		"version": resource.NewProperty("1.0.0"),
+		"value":   resource.NewProperty("old"),
+	}
+	newProviderInputs := resource.PropertyMap{
+		"version": resource.NewProperty("1.0.0"),
+		"value":   resource.NewProperty("new"),
+	}
+	providerState := &pkgresource.State{
+		Type: providerType, URN: providerURN, Custom: true, ID: providerID,
+		Inputs: oldProviderInputs, Outputs: oldProviderInputs,
+	}
+	componentState := &pkgresource.State{
+		Type: componentType, URN: componentURN,
+	}
+
+	newRegisterResourceEvent := func(
+		typ tokens.Type, name string, custom bool, inputs resource.PropertyMap, provider string,
+		migrations ...StateMigrationFunction,
+	) *registerResourceEvent {
+		return &registerResourceEvent{
+			goal: &pkgresource.Goal{
+				Type: typ, Name: name, Custom: custom,
+				Properties: resource.FromResourcePropertyMap(inputs), Provider: provider,
+			},
+			done:            make(chan *RegisterResult, 1),
+			stateMigrations: migrations,
+		}
+	}
+
+	providerEvent := newRegisterResourceEvent(providerType, "provider", true, newProviderInputs, "")
+	var migrationCalls atomic.Int32
+	migrationEvent := newRegisterResourceEvent(componentType, "component", false, nil, "",
+		func(_ context.Context, urn resource.URN, _ []byte) ([]byte, map[resource.URN]resource.URN, error) {
+			migrationCalls.Add(1)
+			assert.Equal(t, componentURN, urn)
+			return nil, nil, nil
+		})
+
+	// diffStarted ensures that the provider's asynchronous diff is running before the source returns the migration
+	// registration.
+	diffStarted := make(chan struct{})
+	// migrationDelivered is closed after the main loop receives the migration registration. The provider diff waits
+	// for it so that its continuation is not published until the migration is pending.
+	migrationDelivered := make(chan struct{})
+	// eventIterator calls beforeNext before returning each event, including the final nil:
+	//
+	//   index 0: return the provider registration, which starts the asynchronous diff
+	//   index 1: wait for that diff to start, then return the migration registration
+	//   index 2: unblock the diff, then return nil to end the source
+	//
+	// After index 1 returns the migration, the source goroutine sends it to the main loop through incomingEvents.
+	// That channel is unbuffered, so the send must be received before the source goroutine can loop around and call
+	// Next again at index 2, so we know the migration was delivered.
+	iter := &eventIterator{
+		events: []SourceEvent{providerEvent, migrationEvent},
+		beforeNext: func(index int) error {
+			switch index {
+			case 1: // Before returning the migration registration.
+				return wait(diffStarted, "parallel diff")
+			case 2: // Before returning nil.
+				close(migrationDelivered)
+			}
+			return nil
+		},
+	}
+
+	var diffCalls atomic.Int32
+	loader := deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+		return &deploytest.Provider{
+			DiffConfigF: func(context.Context, plugin.DiffConfigRequest) (plugin.DiffResult, error) {
+				if diffCalls.Add(1) == 1 {
+					close(diffStarted)
+					if err := wait(migrationDelivered, "migration registration to reach the executor"); err != nil {
+						return plugin.DiffResult{}, err
+					}
+				}
+				return plugin.DiffResult{
+					Changes:     plugin.DiffSome,
+					ChangedKeys: []resource.PropertyKey{"value"},
+				}, nil
+			},
+		}, nil
+	})
+
+	sink := &deploytest.NoopSink{}
+	host := deploytest.NewPluginHost(sink, sink, nil, loader)
+	plugctx, err := plugin.NewContext(t.Context(), sink, sink, host, nil, "", nil, false, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, plugctx.Close()) }()
+
+	events := &mockEvents{
+		OnResourceStepPreF:  func(Step) (any, error) { return nil, nil },
+		OnResourceStepPostF: func(any, Step, resource.Status, error) error { return nil },
+		OnResourceOutputsF:  func(Step) error { return nil },
+	}
+	prev := &Snapshot{Resources: []*pkgresource.State{providerState, componentState}}
+	deployment, err := NewDeployment(
+		plugctx,
+		&Options{
+			Parallel:                 2,
+			ParallelDiff:             true,
+			StateMigrationSerializer: testStateMigrationResourceSerializer{},
+		},
+		events,
+		&Target{Name: stack, Snapshot: prev},
+		prev,
+		nil,
+		&source{iterator: iter},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = (&deploymentExecutor{deployment: deployment}).Execute(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), diffCalls.Load())
+	assert.Equal(t, int32(1), migrationCalls.Load())
 }
 
 func TestSourceIteratorClose(t *testing.T) {

--- a/pkg/resource/deploy/state_migration.go
+++ b/pkg/resource/deploy/state_migration.go
@@ -216,8 +216,6 @@ func (sg *stepGenerator) applyStateMigrations(
 func logStateMigrationResource(
 	ctx context.Context, message string, rootURN resource.URN, state *pkgresource.State,
 ) {
-	// PropertyMap's logging integration redacts secret values from plaintext logs while retaining structured values
-	// for encrypted logs and OTLP export.
 	slog.DebugContext(ctx, message,
 		"rootURN", rootURN,
 		"resourceURN", state.URN,

--- a/pkg/resource/deploy/state_migration.go
+++ b/pkg/resource/deploy/state_migration.go
@@ -1,0 +1,229 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// applyStateMigrations runs the state migrations attached to a resource registration against the prior state of
+// the resource and all prior resources transitively parented to it, and splices the transformed states back into
+// the deployment's view of the prior state before any diffing takes place for those resources.
+//
+// Every resource removed from state must name a returned successor, so a migration cannot silently leave a physical
+// resource unmanaged.
+//
+// Migrations run against the engine's in-memory view of the prior state only and issue no provider calls. A callback
+// may be evaluated while generating an update plan, but a state-changing result is rejected because plans cannot
+// describe checkpoint rewrites.
+func (sg *stepGenerator) applyStateMigrations(
+	ctx context.Context, event RegisterResourceEvent, urn resource.URN,
+) error {
+	migrations := event.StateMigrations()
+	if len(migrations) == 0 {
+		return nil
+	}
+
+	// State migrations only run during normal updates. Destroy with `--run-program` evaluates the program for current
+	// provider configuration and hooks, but still deletes resources from the recorded prior state. Refresh similarly
+	// owns reconciliation of prior state and must not have it rewritten underneath it.
+	if sg.mode != updateMode {
+		slog.DebugContext(ctx, "skipping state migrations outside update mode", "urn", urn)
+		return nil
+	}
+
+	opts := sg.deployment.opts
+
+	// Resolve the prior state of the registering resource: by URN first and then by any aliases. If there is no prior
+	// state this is a new resource and there is nothing to migrate. Do this before pausing the executor so attaching a
+	// migration callback to a newly created resource does not wait for unrelated work.
+	goal := event.Goal()
+	olds := sg.deployment.Olds()
+	root, hasOld := olds[urn]
+	if !hasOld {
+		aliases := sg.generateRewrittenAliases(goal.Name, goal.Type, goal.Parent, goal.Aliases)
+		for _, alias := range aliases {
+			if root, hasOld = olds[alias]; hasOld {
+				break
+			}
+		}
+	}
+	if !hasOld {
+		slog.DebugContext(ctx, "skipping state migrations without prior state", "urn", urn)
+		return nil
+	}
+
+	contract.Assertf(opts.StateMigrationSerializer != nil,
+		"state migration serializer must be configured for %s", urn)
+
+	// The deployment executor waits for earlier planning to finish before handling this registration, so all earlier
+	// step chains have been submitted. Pause execution until those steps finish, and keep it paused while the migration
+	// updates deployment state.
+	contract.Assertf(sg.stepExecutionBarrier != nil,
+		"step execution barrier must be configured for state migration of %s", urn)
+	sg.stepExecutionBarrier.Lock()
+	defer sg.stepExecutionBarrier.Unlock()
+
+	// Collect the prior state of the resource and all resources transitively parented to it, in snapshot order.
+	//
+	// Do not pass resources that are already pending deletion to the callback. The update still needs to finish deleting
+	// them, so we must not combine that unfinished work with a state rewrite. Keep them separately and reject the
+	// migration below only if it changes state. A no-op migration can continue so the update can finish deleting them.
+	priorSubtree := []*pkgresource.State{root}
+	var pendingDeletes []*pkgresource.State
+	for _, child := range sg.deployment.depGraph.ChildrenOf(root) {
+		if child.Delete {
+			pendingDeletes = append(pendingDeletes, child)
+			continue
+		}
+		priorSubtree = append(priorSubtree, child)
+	}
+	for _, state := range priorSubtree {
+		if state.ViewOf != "" || len(sg.deployment.oldViews[state.URN]) > 0 {
+			return fmt.Errorf("state migration for %s: resource %s is or has a view; "+
+				"state migrations do not support views", urn, state.URN)
+		}
+	}
+
+	// Reject migrating prior state that an earlier registration in this deployment already claimed.
+	if claimant, ok := sg.aliased[urn]; ok {
+		return fmt.Errorf("state migration for %s: the registration URN was already claimed as an alias by %s "+
+			"earlier in this deployment", urn, claimant)
+	}
+	for _, state := range priorSubtree {
+		if claimant, ok := sg.aliased[state.URN]; ok {
+			return fmt.Errorf("state migration for %s: the prior state of %s was already claimed by %s earlier "+
+				"in this deployment (via an alias); it cannot also be migrated as part of %s in the same "+
+				"operation", urn, state.URN, claimant, urn)
+		}
+		if state == root && state.URN == urn {
+			// generateURN recorded the current registration before applyStateMigrations was called
+			continue
+		}
+		if sg.urns[state.URN] {
+			return fmt.Errorf("state migration for %s: the prior state of %s was already registered earlier in "+
+				"this deployment; it cannot also be migrated as part of %s", urn, state.URN, urn)
+		}
+	}
+
+	// Serialize PriorSubtree to its checkpoint representation and hand it to each migration in turn.
+	serialized := make([]apitype.ResourceV3, len(priorSubtree))
+	for i, state := range priorSubtree {
+		res, err := opts.StateMigrationSerializer.Serialize(ctx, state)
+		if err != nil {
+			return fmt.Errorf("state migration for %s: serializing state of %s: %w", urn, state.URN, err)
+		}
+		serialized[i] = res
+	}
+	for _, state := range priorSubtree {
+		logStateMigrationResource(ctx, "state migration prior resource", urn, state)
+	}
+
+	callbackResult, err := runStateMigrationCallbacks(ctx, urn, migrations, serialized)
+	if err != nil {
+		return err
+	}
+	if callbackResult == nil {
+		slog.DebugContext(ctx, "state migrations made no changes", "urn", urn)
+		return nil
+	}
+	successors := callbackResult.originalToFinal
+
+	// Update plans constrain resource operations, they do not describe or authorize checkpoint rewrites. Reject
+	// state-changing migrations both when generating a plan and when applying one. No-op migrations returned above,
+	// so permanently attached migrations still work with plans.
+	if sg.deployment.plan != nil {
+		return fmt.Errorf("state migration for %s cannot change state while applying an update plan; "+
+			"run the update without the plan", urn)
+	}
+	if opts.DryRun && opts.GeneratePlan {
+		return fmt.Errorf("state migration for %s cannot change state while generating an update plan; "+
+			"run the update without a plan", urn)
+	}
+
+	if err := validateStateMigrationContext(urn, opts, sg.deployment.prev, successors); err != nil {
+		return err
+	}
+	if err := validateStateMigrationManagedIdentity(
+		urn, serialized, callbackResult.resultResources, successors); err != nil {
+		return err
+	}
+
+	// The migrations changed the state, so reject the change if the subtree contains resources that are pending
+	// deletion. Migrations that make no changes already returned above, allowing the update to reap pending deletions
+	// normally.
+	if len(pendingDeletes) > 0 {
+		pendingURNs := make([]string, len(pendingDeletes))
+		for i, pending := range pendingDeletes {
+			pendingURNs[i] = string(pending.URN)
+		}
+		return fmt.Errorf("state migration for %s: the prior state contains resources that are pending deletion "+
+			"from a previous update: %s; resolve the pending deletion (for example by completing an update in "+
+			"which this migration makes no changes) before migrating %s",
+			urn, strings.Join(pendingURNs, ", "), urn)
+	}
+
+	resultSubtree := make([]*pkgresource.State, len(callbackResult.resultResources))
+	for i, res := range callbackResult.resultResources {
+		state, err := opts.StateMigrationSerializer.Deserialize(res)
+		if err != nil {
+			return fmt.Errorf("state migration for %s: deserializing returned state of %s: %w", urn, res.URN, err)
+		}
+		resultSubtree[i] = state
+	}
+
+	rewrittenResultSubtree, err := rewriteStateMigrationReferences(
+		resultSubtree, callbackResult.allToFinal, stateMigrationSuccessorIdentities(resultSubtree))
+	if err != nil {
+		return fmt.Errorf("state migration for %s: rewriting successor references: %w", urn, err)
+	}
+	if _, err := mapResourcesToPreparedRewrites(
+		urn, resultSubtree, rewrittenResultSubtree, "returned by the migration"); err != nil {
+		return err
+	}
+	resultSubtree = rewrittenResultSubtree
+	for _, state := range resultSubtree {
+		logStateMigrationResource(ctx, "state migration result resource", urn, state)
+	}
+
+	transaction, err := sg.prepareStateMigrationTransaction(urn, root, priorSubtree, resultSubtree, successors)
+	if err != nil {
+		return err
+	}
+	return sg.commitStateMigration(ctx, transaction)
+}
+
+func logStateMigrationResource(
+	ctx context.Context, message string, rootURN resource.URN, state *pkgresource.State,
+) {
+	// PropertyMap's logging integration redacts secret values from plaintext logs while retaining structured values
+	// for encrypted logs and OTLP export.
+	slog.DebugContext(ctx, message,
+		"rootURN", rootURN,
+		"resourceURN", state.URN,
+		"resourceType", state.Type,
+		"resourceID", state.ID,
+		"parentURN", state.Parent,
+		"inputs", state.Inputs,
+		"outputs", state.Outputs)
+}

--- a/pkg/resource/deploy/state_migration_callback.go
+++ b/pkg/resource/deploy/state_migration_callback.go
@@ -1,0 +1,126 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"reflect"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// StateMigrationResourceSerializer converts resource states to and from their checkpoint representation for state
+// migration callbacks.
+type StateMigrationResourceSerializer interface {
+	Serialize(context.Context, *pkgresource.State) (apitype.ResourceV3, error)
+	Deserialize(apitype.ResourceV3) (*pkgresource.State, error)
+}
+
+type stateMigrationCallbackResult struct {
+	resultResources []apitype.ResourceV3
+	originalToFinal map[resource.URN]resource.URN
+	allToFinal      map[resource.URN]resource.URN
+}
+
+// runStateMigrationCallbacks evaluates an ordered callback chain without mutating deployment state. A nil result
+// means every callback was a no-op or the final checkpoint is semantically identical to the original.
+func runStateMigrationCallbacks(
+	ctx context.Context,
+	urn resource.URN,
+	migrations []StateMigrationFunction,
+	original []apitype.ResourceV3,
+) (*stateMigrationCallbackResult, error) {
+	currentJSON, err := json.Marshal(original)
+	if err != nil {
+		return nil, fmt.Errorf("state migration for %s: marshaling prior state: %w", urn, err)
+	}
+	originalJSON := currentJSON
+	current := original
+	allSuccessors := make(map[resource.URN]resource.URN)
+	changed := false
+
+	for i, migrate := range migrations {
+		slog.DebugContext(ctx, "running state migration",
+			"urn", urn, "migrationNumber", i+1, "migrationCount", len(migrations))
+
+		newJSON, successors, err := migrate(ctx, urn, currentJSON)
+		if err != nil {
+			return nil, fmt.Errorf("state migration %d of %d for %s: %w", i+1, len(migrations), urn, err)
+		}
+		if newJSON == nil {
+			if len(successors) > 0 {
+				return nil, fmt.Errorf("state migration %d of %d for %s: returned successors without "+
+					"returning a new state", i+1, len(migrations), urn)
+			}
+			continue
+		}
+
+		decoder := json.NewDecoder(bytes.NewReader(newJSON))
+		decoder.DisallowUnknownFields()
+		var newSet []apitype.ResourceV3
+		if err := decoder.Decode(&newSet); err != nil {
+			return nil, fmt.Errorf("state migration %d of %d for %s: unmarshaling returned state: %w",
+				i+1, len(migrations), urn, err)
+		}
+		if err := validateStateMigrationAccounting(urn, current, newSet, successors); err != nil {
+			return nil, err
+		}
+		for oldURN, successor := range successors {
+			if previous, exists := allSuccessors[oldURN]; exists && previous != successor {
+				return nil, fmt.Errorf(
+					"state migration %d of %d for %s: resource %s has conflicting successors %s and %s",
+					i+1, len(migrations), urn, oldURN, previous, successor)
+			}
+			allSuccessors[oldURN] = successor
+		}
+
+		current, currentJSON, changed = newSet, newJSON, true
+	}
+
+	if !changed {
+		return nil, nil
+	}
+
+	var normalizedOriginal []apitype.ResourceV3
+	if err := json.Unmarshal(originalJSON, &normalizedOriginal); err != nil {
+		return nil, fmt.Errorf("state migration for %s: normalizing prior state: %w", urn, err)
+	}
+	if reflect.DeepEqual(normalizedOriginal, current) {
+		// Nothing changed
+		return nil, nil
+	}
+	if err := validateStateMigrationProviderStates(urn, normalizedOriginal, current); err != nil {
+		return nil, err
+	}
+
+	// originalToFinal maps resources removed from the original subtree directly to their final successors. allToFinal
+	// also maps resources introduced and then removed by intermediate callbacks. It is used to rewrite references in
+	// the final returned state; for example, both A and B resolve to C after a chain A → B → C.
+	originalToFinal, allToFinal, err := finalStateMigrationSuccessors(original, current, allSuccessors)
+	if err != nil {
+		return nil, fmt.Errorf("state migration for %s: %w", urn, err)
+	}
+	return &stateMigrationCallbackResult{
+		resultResources: current,
+		originalToFinal: originalToFinal,
+		allToFinal:      allToFinal,
+	}, nil
+}

--- a/pkg/resource/deploy/state_migration_callback_test.go
+++ b/pkg/resource/deploy/state_migration_callback_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunStateMigrationCallbacksRejectsInvalidAccounting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rootURN  = resource.URN("urn:pulumi:test::test::pkg:m:Component::component")
+		childURN = resource.URN("urn:pulumi:test::test::pkg:m:Resource::child")
+		newURN   = resource.URN("urn:pulumi:test::test::pkg:m:Resource::renamed")
+		otherURN = resource.URN("urn:pulumi:test::test::pkg:m:Resource::other")
+	)
+	root := apitype.ResourceV3{URN: rootURN, Type: rootURN.Type()}
+	child := apitype.ResourceV3{URN: childURN, Type: childURN.Type(), Custom: true, ID: "child-id"}
+	original := []apitype.ResourceV3{root, child}
+
+	tests := []struct {
+		name       string
+		returned   []apitype.ResourceV3
+		successors map[resource.URN]resource.URN
+		noState    bool
+		want       string
+	}{
+		{
+			name:       "successor source is not prior state",
+			returned:   original,
+			successors: map[resource.URN]resource.URN{otherURN: childURN},
+			want:       "returned successor for resource " + string(otherURN),
+		},
+		{
+			name:       "successor target is not returned",
+			returned:   []apitype.ResourceV3{root},
+			successors: map[resource.URN]resource.URN{childURN: newURN},
+			want:       "is not present in the returned state",
+		},
+		{
+			name:       "successors without state",
+			noState:    true,
+			successors: map[resource.URN]resource.URN{childURN: newURN},
+			want:       "returned successors without returning a new state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			callback := func(
+				context.Context, resource.URN, []byte,
+			) ([]byte, map[resource.URN]resource.URN, error) {
+				if tt.noState {
+					return nil, tt.successors, nil
+				}
+				state, err := json.Marshal(tt.returned)
+				return state, tt.successors, err
+			}
+			_, err := runStateMigrationCallbacks(
+				t.Context(), rootURN, []StateMigrationFunction{callback}, original)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}

--- a/pkg/resource/deploy/state_migration_commit.go
+++ b/pkg/resource/deploy/state_migration_commit.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// commitStateMigration persists a prepared transaction and then commits it to Deployment.prev
+func (sg *stepGenerator) commitStateMigration(
+	ctx context.Context, transaction *StateMigrationTransaction,
+) error {
+	d := sg.deployment
+	urn := transaction.RootURN
+
+	// Persist the prepared migration before committing it to Deployment.prev.
+	if err := d.events.OnStateMigration(transaction); err != nil {
+		return fmt.Errorf("state migration for %s: %w", urn, err)
+	}
+
+	// Rewrite references in states already recorded in Deployment.news or Deployment.reads, preserving their pointers.
+	for before, after := range transaction.currentResourceRewrites {
+		before.Lock.Lock()
+		applyStateMigrationReferenceRewrite(before, after)
+		before.Lock.Unlock()
+	}
+
+	// Replace Deployment.prev.Resources while preserving retained-resource pointers.
+	committedResources := slices.Clone(transaction.PreparedPriorResources)
+	for before, after := range transaction.RetainedResourceRewrites {
+		before.Lock.Lock()
+		applyStateMigrationReferenceRewrite(before, after)
+		before.Lock.Unlock()
+		committedResources[transaction.retainedRewriteIndices[before]] = before
+	}
+	d.prev.Resources = committedResources
+
+	// Rebuild the deployment indexes derived from the now-migrated prior snapshot.
+	oldResources, hasRefreshBeforeUpdateResources, olds, allOlds, oldViews, err := buildResourceMaps(d.prev)
+	contract.AssertNoErrorf(err, "state migration for %s produced duplicate resources after verification", urn)
+	d.hasRefreshBeforeUpdateResources = hasRefreshBeforeUpdateResources
+	d.depGraph = graph.NewDependencyGraph(oldResources)
+	d.olds = olds
+	d.allOlds = allOlds
+	d.oldViews = oldViews
+
+	// Add a stateMigrationRewrite so references the program sends later in the update use successor URNs instead of
+	// predecessor URNs.
+	if len(transaction.SuccessorURNs) != 0 {
+		d.stateMigrationRewritesM.Lock()
+		d.stateMigrationRewrites = append(d.stateMigrationRewrites,
+			newStateMigrationRewrite(transaction.RootURN, transaction.SuccessorURNs, transaction.ResultSubtree))
+		d.stateMigrationRewritesM.Unlock()
+	}
+
+	priorStateURNs := make([]resource.URN, len(transaction.PriorSubtree))
+	for i, state := range transaction.PriorSubtree {
+		priorStateURNs[i] = state.URN
+	}
+	resultStateURNs := make([]resource.URN, len(transaction.ResultSubtree))
+	for i, state := range transaction.ResultSubtree {
+		resultStateURNs[i] = state.URN
+	}
+
+	slog.InfoContext(ctx, "state migration applied",
+		"rootURN", urn,
+		"preview", d.opts != nil && d.opts.DryRun,
+		"priorResourceCount", len(transaction.PriorSubtree),
+		"resultResourceCount", len(transaction.ResultSubtree),
+		"priorStateURNs", priorStateURNs,
+		"resultStateURNs", resultStateURNs,
+		"successors", transaction.SuccessorURNs)
+	return nil
+}

--- a/pkg/resource/deploy/state_migration_models.go
+++ b/pkg/resource/deploy/state_migration_models.go
@@ -83,13 +83,11 @@ type StateMigrationTransaction struct {
 
 	// retainedRewriteIndices maps each retained live pointer to the index of its prepared value in
 	// PreparedPriorResources.
-	//nolint:unused // Used by state-migration orchestration added in the engine transaction branch.
 	retainedRewriteIndices map[*pkgresource.State]int
 
 	// currentResourceRewrites maps each changed live resource already present in Deployment.news or Deployment.reads
 	// to its prepared value. The migration commit copies the rewritten fields into the live object so those maps retain
 	// the same pointer.
-	//nolint:unused // Used by state-migration orchestration added in the engine transaction branch.
 	currentResourceRewrites map[*pkgresource.State]*pkgresource.State
 }
 

--- a/pkg/resource/deploy/state_migration_test.go
+++ b/pkg/resource/deploy/state_migration_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
+)
+
+func prepareAndCommitStateMigration(
+	ctx context.Context,
+	sg *stepGenerator,
+	urn resource.URN,
+	priorSubtree, resultSubtree []*pkgresource.State,
+	successors map[resource.URN]resource.URN,
+) error {
+	registrationURN := urn
+	if successor, ok := successors[urn]; ok {
+		registrationURN = successor
+	}
+	transaction, err := sg.prepareStateMigrationTransaction(
+		registrationURN, priorSubtree[0], priorSubtree, resultSubtree, successors)
+	if err != nil {
+		return err
+	}
+	return sg.commitStateMigration(ctx, transaction)
+}
+
+func TestCommitStateMigrationPreservesLivePointers(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldURN       = resource.URN("urn:pulumi:test::test::pkgA:m:Resource::old")
+		successorURN = resource.URN("urn:pulumi:test::test::pkgB:m:Resource::successor")
+		consumerURN  = resource.URN("urn:pulumi:test::test::consumer:m:Resource::consumer")
+		currentURN   = resource.URN("urn:pulumi:test::test::consumer:m:Resource::current")
+	)
+	reference := func(urn resource.URN) resource.PropertyValue {
+		return resource.MakeSecret(resource.MakeCustomResourceReference(urn, "physical-id", "1.0.0"))
+	}
+	old := &pkgresource.State{URN: oldURN, Type: oldURN.Type(), Custom: true, ID: "physical-id"}
+	consumer := &pkgresource.State{
+		URN:          consumerURN,
+		Type:         consumerURN.Type(),
+		Custom:       true,
+		ID:           "consumer-id",
+		Dependencies: []resource.URN{oldURN},
+		Outputs:      resource.PropertyMap{"reference": reference(oldURN)},
+	}
+	current := &pkgresource.State{
+		URN:     currentURN,
+		Type:    currentURN.Type(),
+		Custom:  true,
+		ID:      "current-id",
+		Outputs: resource.PropertyMap{"reference": reference(oldURN)},
+	}
+	successor := &pkgresource.State{
+		URN: successorURN, Type: successorURN.Type(), Custom: true, ID: old.ID,
+	}
+	news := &gsync.Map[resource.URN, *pkgresource.State]{}
+	news.Store(current.URN, current)
+	d := &Deployment{
+		prev:   &Snapshot{Resources: []*pkgresource.State{old, consumer}},
+		news:   news,
+		events: &mockEvents{},
+	}
+	sg := &stepGenerator{deployment: d}
+
+	require.NoError(t, prepareAndCommitStateMigration(t.Context(), sg,
+		oldURN,
+		[]*pkgresource.State{old},
+		[]*pkgresource.State{successor},
+		map[resource.URN]resource.URN{oldURN: successorURN},
+	))
+
+	require.Len(t, d.prev.Resources, 2)
+	assert.Same(t, successor, d.prev.Resources[0])
+	assert.Same(t, consumer, d.prev.Resources[1])
+	assert.Equal(t, []resource.URN{successorURN}, consumer.Dependencies)
+	assert.Equal(t, successorURN,
+		consumer.Outputs["reference"].SecretValue().Element.ResourceReferenceValue().URN)
+	assert.Equal(t, successorURN,
+		current.Outputs["reference"].SecretValue().Element.ResourceReferenceValue().URN)
+	require.Len(t, d.stateMigrationRewrites, 1)
+	assert.Equal(t, successorURN, d.stateMigrationRewrites[0].successorURNs[oldURN])
+	assert.Equal(t, stateMigrationSuccessorIdentity{custom: true, id: "physical-id"},
+		d.stateMigrationRewrites[0].successorIdentities[successorURN])
+}

--- a/pkg/resource/deploy/state_migration_transaction.go
+++ b/pkg/resource/deploy/state_migration_transaction.go
@@ -24,8 +24,6 @@ import (
 )
 
 // prepareStateMigrationTransaction validates a migration result and prepares every rewrite that must be persisted.
-//
-//nolint:unused // Used by state-migration orchestration added in the engine transaction branch.
 func (sg *stepGenerator) prepareStateMigrationTransaction(
 	registrationURN resource.URN, priorRoot *pkgresource.State, priorSubtree, resultSubtree []*pkgresource.State,
 	successors map[resource.URN]resource.URN,
@@ -129,8 +127,6 @@ func (sg *stepGenerator) prepareStateMigrationTransaction(
 
 // mapResourcesToPreparedRewrites maps each live resource whose references changed to its prepared rewritten state.
 // Provider states must remain unchanged and are rejected if normalization produced a rewrite for one.
-//
-//nolint:unused // Used by state-migration orchestration added in the engine transaction branch.
 func mapResourcesToPreparedRewrites(
 	urn resource.URN, before, after []*pkgresource.State, origin string,
 ) (map[*pkgresource.State]*pkgresource.State, error) {

--- a/pkg/resource/deploy/step_executor_test.go
+++ b/pkg/resource/deploy/step_executor_test.go
@@ -221,6 +221,7 @@ type mockEvents struct {
 	OnResourceStepPreF   func(step Step) (any, error)
 	OnResourceStepPostF  func(ctx any, step Step, status resource.Status, err error) error
 	OnResourceOutputsF   func(step Step) error
+	OnStateMigrationF    func(transaction *StateMigrationTransaction) error
 	OnPolicyViolationF   func(resource.URN, plugin.AnalyzeDiagnostic)
 	OnPolicyRemediationF func(resource.URN, plugin.Remediation, resource.PropertyMap, resource.PropertyMap)
 }
@@ -271,6 +272,13 @@ func (e *mockEvents) OnSnapshotWrite(base *Snapshot) error {
 }
 
 func (e *mockEvents) OnRebuiltBaseState() error {
+	return nil
+}
+
+func (e *mockEvents) OnStateMigration(transaction *StateMigrationTransaction) error {
+	if e.OnStateMigrationF != nil {
+		return e.OnStateMigrationF(transaction)
+	}
 	return nil
 }
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -90,6 +90,9 @@ type stepGenerator struct {
 
 	refreshAliasLock sync.Mutex // lock to protect calls to deployment.depGraph.Alias
 
+	// stepExecutionBarrier pauses resource operations while a state migration updates deployment state.
+	stepExecutionBarrier sync.Locker
+
 	// A map of original state which will be what's seen by the snapshot system to their new refreshed state.
 	refreshStates map[*pkgresource.State]*pkgresource.State
 
@@ -786,6 +789,13 @@ func (sg *stepGenerator) generateResourceSteps(
 	ctx context.Context, event RegisterResourceEvent, urn resource.URN,
 ) ([]Step, bool, error) {
 	goal := event.Goal()
+
+	// If the registration carries state migrations, run them against the prior state of this resource and its
+	// descendants before any of that state is read for diffing.
+	if err := sg.applyStateMigrations(ctx, event, urn); err != nil {
+		return nil, false, err
+	}
+
 	if err := sg.deployment.normalizeStateMigrationGoal(goal); err != nil {
 		return nil, false, fmt.Errorf("normalizing resource goal for %s after state migration: %w", urn, err)
 	}


### PR DESCRIPTION
When an existing component is registered with migrations, the engine passes the component’s previous state and its child resources through the migration callbacks before planning any changes. The callbacks run in order.

The engine waits for any resource operations already in progress to finish, then pauses resource execution while it applies the migration.

Migrations run only during normal updates. No-op migrations are ignored, and state-changing migrations are rejected when they cannot be applied safely.

[Draft dev docs for state migrations](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html)

Ref https://github.com/pulumi/pulumi/issues/24045