### PR TITLE
Fix cloning templates and repositories into paths containing symlinks with absolute targets

### DIFF
--- a/changelog/pending/cli-new-fix-20260814-100000.yaml
+++ b/changelog/pending/cli-new-fix-20260814-100000.yaml
@@ -1,0 +1,4 @@
+component: cli/new
+kind: fix
+body: Fix cloning templates and repositories into paths containing symlinks with absolute targets
+time: 2026-08-14T14:20:10.429573+02:00

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -519,7 +519,7 @@ func expandHomeDir(path string) (string, error) {
 // resolveSymlinks resolves symbolic links in path. go-git v6 uses os.Root for local paths, which rejects symlinks with
 // absolute targets, so cloning into such a path (e.g. a home directory symlinked to an NFS mount) would fail. Resolving
 // the clone destination is safe: os.Root's checks against malicious symlinks inside cloned repos still apply. If path
-// does not exist yet, its closest existing ancestor is resolved instead and the remaining componts are re-appended. On
+// does not exist yet, its closest existing ancestor is resolved instead and the remaining components are re-appended. On
 // any other error the path is returned unchanged.
 func resolveSymlinks(path string) string {
 	resolved, err := filepath.EvalSymlinks(path)

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -519,8 +519,8 @@ func expandHomeDir(path string) (string, error) {
 // resolveSymlinks resolves symbolic links in path. go-git v6 uses os.Root for local paths, which rejects symlinks with
 // absolute targets, so cloning into such a path (e.g. a home directory symlinked to an NFS mount) would fail. Resolving
 // the clone destination is safe: os.Root's checks against malicious symlinks inside cloned repos still apply. If path
-// does not exist yet, its closest existing ancestor is resolved instead and the remaining components are re-appended. On
-// any other error the path is returned unchanged.
+// does not exist yet, its closest existing ancestor is resolved instead and the remaining components are re-appended.
+// On any other error the path is returned unchanged.
 func resolveSymlinks(path string) string {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err == nil {

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -516,6 +516,24 @@ func expandHomeDir(path string) (string, error) {
 	return filepath.Join(home, path[1:]), nil
 }
 
+// resolveSymlinks resolves symbolic links in path. go-git v6 uses os.Root for local paths, which rejects symlinks with
+// absolute targets, so cloning into such a path (e.g. a home directory symlinked to an NFS mount) would fail. Resolving
+// the clone destination is safe: os.Root's checks against malicious symlinks inside cloned repos still apply. If path
+// does not exist yet, its closest existing ancestor is resolved instead and the remaining componts are re-appended. On
+// any other error the path is returned unchanged.
+func resolveSymlinks(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		if dir := filepath.Dir(path); dir != path {
+			return filepath.Join(resolveSymlinks(dir), filepath.Base(path))
+		}
+	}
+	return path
+}
+
 // GitCloneAndCheckoutCommit clones the Git repository and checkouts the specified commit.
 func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.Hash, path string) error {
 	logging.V(10).Infof("Attempting to clone from %s at commit %v and path %s", url, commit, path)
@@ -524,7 +542,7 @@ func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.
 	if err != nil {
 		return err
 	}
-	repo, err := git.PlainCloneContext(ctx, path, &git.CloneOptions{
+	repo, err := git.PlainCloneContext(ctx, resolveSymlinks(path), &git.CloneOptions{
 		URL:           u,
 		ClientOptions: gitClientOptions(auth),
 	})
@@ -551,7 +569,7 @@ func GitCloneAndCheckoutRevision(ctx context.Context, url string, revision plumb
 	if err != nil {
 		return err
 	}
-	repo, err := git.PlainCloneContext(ctx, path, &git.CloneOptions{
+	repo, err := git.PlainCloneContext(ctx, resolveSymlinks(path), &git.CloneOptions{
 		URL:           u,
 		ClientOptions: gitClientOptions(auth),
 	})
@@ -598,6 +616,8 @@ func GitCloneOrPull(
 func gitCloneOrPull(
 	ctx context.Context, url string, referenceName plumbing.ReferenceName, path string, shallow bool,
 ) error {
+	path = resolveSymlinks(path)
+
 	// For shallow clones, use a depth of 1.
 	depth := 0
 	if shallow {

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -757,6 +757,32 @@ func TestGitCloneAndCheckoutRevision(t *testing.T) {
 	}
 }
 
+// TestGitCloneOrPullThroughAbsoluteSymlink is a regression test for
+// https://github.com/pulumi/pulumi/issues/24286: cloning into a path that
+// traverses a symlink with an absolute target (e.g. a home directory
+// symlinked to an NFS mount) must work. go-git v6 accesses local paths
+// through os.Root, which rejects absolute symlink targets.
+func TestGitCloneOrPullThroughAbsoluteSymlink(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	require.NoError(t, os.Mkdir(real, 0o755))
+	link := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(real, link))
+	dest := filepath.Join(link, "templates")
+
+	ref := plumbing.NewBranchReferenceName("main")
+
+	// Clone, then run again to exercise the pull path.
+	require.NoError(t, GitCloneOrPull(t.Context(), "testdata/revision-test.git", ref, dest, false))
+	require.NoError(t, GitCloneOrPull(t.Context(), "testdata/revision-test.git", ref, dest, false))
+
+	content, err := os.ReadFile(filepath.Join(dest, "test"))
+	require.NoError(t, err)
+	assert.Equal(t, "HEAD\n", string(content))
+}
+
 func TestGetLatestTagOrHash(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
go-git v6 accesses local paths through Go's `os.Root`, which rejects any symlink with an absolute target, including in the clone destination path, before cloning even starts. Resolve the path before handing it to go-git.

Fixes https://github.com/pulumi/pulumi/issues/24286
