### PR TITLE
Remove Node.js Automation API output buffer limit

### DIFF
--- a/changelog/pending/auto-nodejs-fix-20260814-162323.yaml
+++ b/changelog/pending/auto-nodejs-fix-20260814-162323.yaml
@@ -1,0 +1,4 @@
+component: auto/nodejs
+kind: fix
+body: Remove Node.js Automation API output buffer limit
+time: 2026-08-14T16:23:23.588424+02:00

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -199,7 +199,7 @@ async function exec(
     const env = additionalEnv ? { ...additionalEnv } : undefined;
 
     try {
-        const proc = execa(command, args, { env, cwd });
+        const proc = execa(command, args, { env, cwd, maxBuffer: Infinity });
 
         if (onError && proc.stderr) {
             proc.stderr!.on("data", (data: any) => {


### PR DESCRIPTION
Configure execa with an unlimited maxBuffer so Automation API commands can return more than 100 MB of stdout or stderr without closing the CLI's pipes and interrupting lifecycle operations.

We do return stdout/err as part of the call here, so we have to run with an infinite buffer.

Fixes https://github.com/pulumi/pulumi/issues/24278

