### PR TITLE
Fix config lookup for global projects

### DIFF
--- a/changelog/pending/cli-do-fix-20260814-170125.yaml
+++ b/changelog/pending/cli-do-fix-20260814-170125.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: fix
+body: Fix global project lookup
+time: 2026-08-14T17:01:25.243727+01:00

--- a/pkg/cmd/pulumi/do/do_resource_upsert.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 
 	"github.com/blang/semver"
 	"github.com/gofrs/uuid"
@@ -799,7 +800,12 @@ func DefaultRunStatefulUpdate(
 	}
 
 	ssml := cmdStack.SecretsManagerLoader{FallbackToState: true}
-	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, req.Sink, ssml, req.Stack, req.Proj, "", nil)
+	// Compute the stack config file path from req.Root rather than letting LoadProjectStack walk
+	// upward from CWD — for `pulumi do` we may be running outside any Pulumi project directory
+	// (with req.Proj/req.Root supplied by the global fallback under $PULUMI_HOME).
+	configFile := workspace.ProjectStackPath(
+		filepath.Join(req.Root, workspace.ProjectFile+".yaml"), req.Proj, req.Stack.Ref().Name().Q())
+	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, req.Sink, ssml, req.Stack, req.Proj, configFile, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get stack configuration: %w", err)
 	}

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -1203,6 +1203,70 @@ size = 3
 	_ = stderr
 }
 
+// Regression: when invoked from a directory that isn't itself a Pulumi project (the common case
+// for `pulumi do` under the global-project fallback), DefaultRunStatefulUpdate must not fail with
+// "no Pulumi.yaml project file found" from a CWD-based lookup. req.Root points at the fallback
+// project, and the stack config file path must be resolved from that, not from CWD.
+//
+//nolint:paralleltest // Uses t.Chdir and t.Setenv.
+func TestDefaultRunStatefulUpdateGlobalProjectFromUnrelatedCwd(t *testing.T) {
+	// CWD has no Pulumi.yaml.
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	// $PULUMI_HOME hosts the global fallback project.
+	home := t.TempDir()
+	t.Setenv("PULUMI_HOME", home)
+	proj, root, err := ensureGlobalProject()
+	require.NoError(t, err)
+
+	stackRef := &backend.MockStackReference{
+		StringV:             "organization/" + globalProjectName + "/default",
+		NameV:               tokens.MustParseStackName(globalStackName),
+		FullyQualifiedNameV: "organization/" + globalProjectName + "/default",
+	}
+	var previewCalled bool
+	mockBackend := &backend.MockBackend{
+		PreviewF: func(_ context.Context, _ backend.Stack, op backend.UpdateOperation,
+		) (*deploy.Plan, sdkDisplay.ResourceChanges, error) {
+			previewCalled = true
+			require.Len(t, op.Opts.Engine.TargetSnippets, 1)
+			return nil, nil, nil
+		},
+	}
+	mockStack := &backend.MockStack{
+		RefF:            func() backend.StackReference { return stackRef },
+		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{IsRemote: false} },
+		DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
+			return b64.NewBase64SecretsManager(), nil
+		},
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return &deploy.Snapshot{SecretsManager: b64.NewBase64SecretsManager()}, nil
+		},
+		BackendF: func() backend.Backend { return mockBackend },
+	}
+	var stdout, stderr bytes.Buffer
+
+	_, err = DefaultRunStatefulUpdate(
+		t.Context(), pflag.NewFlagSet("test", pflag.ContinueOnError), StatefulUpdateRequest{
+			Snippets: []resource.Snippet{{
+				UUID:       "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+				Name:       "myres",
+				Type:       "azure:index:myResource",
+				Code:       `name = "myres"`,
+				Descriptor: resource.PackageDescriptor{Name: "azure"},
+			}},
+			Stack:  mockStack,
+			DryRun: true,
+			Proj:   proj,
+			Root:   root,
+			Sink:   diag.DefaultSink(&stdout, &stderr, diag.FormatOptions{Color: colors.Never}),
+		},
+	)
+	require.NoError(t, err, "must not fail with a CWD-based project lookup when req.Root is supplied")
+	require.True(t, previewCalled)
+}
+
 //nolint:paralleltest // Uses t.Chdir
 func TestDefaultRunStatefulUpdateDryRunUsesPreview(t *testing.T) {
 	root := t.TempDir()

--- a/pkg/cmd/pulumi/do/do_resources.go
+++ b/pkg/cmd/pulumi/do/do_resources.go
@@ -16,7 +16,9 @@ package do
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -26,6 +28,7 @@ import (
 
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	backendSecrets "github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/autonames"
@@ -36,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // filterReferencesByPCLUsage returns the subset of refs whose keys appear as top-level identifier
@@ -132,10 +136,7 @@ func runShowResources(cmd *cobra.Command, ws pkgWorkspace.Context, lm cmdBackend
 	})
 	sink := &forwardingSink{base: base}
 	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
-	stack, err := cmdStack.RequireStack(
-		ctx, sink, ws, lm,
-		"", cmdStack.LoadOnly, displayOpts, "",
-	)
+	stack, err := loadStackForShowResources(ctx, sink, ws, lm, displayOpts)
 	if err != nil {
 		return fmt.Errorf("load stack: %w", err)
 	}
@@ -152,6 +153,29 @@ func runShowResources(cmd *cobra.Command, ws pkgWorkspace.Context, lm cmdBackend
 	}
 	contract.Failf("unsupported output format %q", output)
 	return nil
+}
+
+// loadStackForShowResources mirrors packageCommand.loadStackForStateful: if there's no Pulumi
+// project rooted at the CWD, fall back to the auto-materialized global project under
+// $PULUMI_HOME and its `default` stack so `pulumi do show-resources` works with the same
+// zero-setup story as the stateful `do` subcommands. Otherwise use the workspace's currently
+// selected stack via RequireStack.
+func loadStackForShowResources(
+	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
+	opts display.Options,
+) (backend.Stack, error) {
+	proj, _, err := ws.ReadProject("")
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, err
+	}
+	if proj == nil {
+		proj, root, err := ensureGlobalProject()
+		if err != nil {
+			return nil, err
+		}
+		return ensureGlobalStack(ctx, sink, ws, lm, proj, root, opts)
+	}
+	return cmdStack.RequireStack(ctx, sink, ws, lm, "", cmdStack.LoadOnly, opts, "")
 }
 
 func printShowResourcesText(cmd *cobra.Command, names map[string]string) error {

--- a/pkg/cmd/pulumi/do/do_resources_test.go
+++ b/pkg/cmd/pulumi/do/do_resources_test.go
@@ -27,9 +27,12 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -133,6 +136,77 @@ func TestDoCmdShowResourcesSubcommand(t *testing.T) {
 
 	assert.Contains(t, stdout.String(), "myBucket")
 	assert.Contains(t, stdout.String(), string(bucket))
+}
+
+// Regression: `pulumi do show-resources` must fall back to the auto-materialized global project
+// and its default stack when CWD is not itself a Pulumi project. Pre-fix, RequireStack landed in
+// ChooseStack in non-interactive mode and failed instead of provisioning the global stack.
+//
+//nolint:paralleltest // Uses t.Chdir and t.Setenv.
+func TestDoCmdShowResourcesFallsBackToGlobalProject(t *testing.T) {
+	// CWD has no Pulumi.yaml; PULUMI_HOME hosts the global fallback project.
+	t.Chdir(t.TempDir())
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	stackURN := resource.URN("urn:pulumi:default::default-global-project::aws:s3/bucket:Bucket::myBucket")
+	stackRef := &backend.MockStackReference{
+		StringV:             globalStackName,
+		NameV:               tokens.MustParseStackName(globalStackName),
+		FullyQualifiedNameV: globalStackName,
+	}
+	mockStack := &backend.MockStack{
+		RefF: func() backend.StackReference { return stackRef },
+		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+			return &deploy.Snapshot{
+				Resources: []*pkgresource.State{
+					{Type: stackURN.Type(), URN: stackURN, Custom: true},
+				},
+			}, nil
+		},
+	}
+	mockBackend := &backend.MockBackend{
+		URLF:                   func() string { return "file://~" },
+		SupportsOrganizationsF: func() bool { return false },
+		ParseStackReferenceF:   func(string) (backend.StackReference, error) { return stackRef, nil },
+		GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+			return mockStack, nil
+		},
+	}
+	// ws.New must return a workspace whose Save is a no-op (ensureGlobalStack records the stack
+	// selection via w.Save()).
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
+			return nil, "", workspace.ErrProjectNotFound
+		},
+		NewF: func(string) (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{
+				SettingsF: func() *pkgWorkspace.Settings { return &pkgWorkspace.Settings{} },
+				SaveF:     func() error { return nil },
+			}, nil
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool, bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(lm, ws, nil, testHost, panicLoadConverterPlugin, nil)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"show-resources"})
+	require.NoError(t, cmd.Execute(), "stderr: %s", stderr.String())
+	assert.Contains(t, stdout.String(), "myBucket")
 }
 
 //nolint:paralleltest // installMockUpsertBackend calls t.Setenv.

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -80,13 +80,17 @@ func DetectProjectStackPath(stackName tokens.QName) (*Project, string, error) {
 		return nil, "", err
 	}
 
+	return proj, ProjectStackPath(projPath, proj, stackName), nil
+}
+
+// ProjectStackPath returns the stack-specific Pulumi.<stack-name>.<ext> path for the given project. Use this when the
+// project location is already known (e.g. from a caller-supplied root) so the caller does not have to walk from CWD.
+func ProjectStackPath(projPath string, proj *Project, stackName tokens.QName) string {
 	fileName := fmt.Sprintf("%s.%s%s", ProjectFile, qnameFileName(stackName), filepath.Ext(projPath))
-
 	if proj.StackConfigDir != "" {
-		return proj, filepath.Join(filepath.Dir(projPath), proj.StackConfigDir, fileName), nil
+		return filepath.Join(filepath.Dir(projPath), proj.StackConfigDir, fileName)
 	}
-
-	return proj, filepath.Join(filepath.Dir(projPath), fileName), nil
+	return filepath.Join(filepath.Dir(projPath), fileName)
 }
 
 var (

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -12,19 +12,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
-[options.exclude-newer-package]
-pulumi-command = false
-pulumi-policy = false
-pulumi-aws = false
-pulumi-gcp = false
-pulumi-kubernetes = false
-pulumi-azure = false
-pulumi-cloudinit = false
-pulumi-random = false
-pulumi = false
-pulumi-azure-native = false
-pulumi-tls = false
-
 [[package]]
 name = "ast-serialize"
 version = "0.6.0"


### PR DESCRIPTION
Fix the config lookup for global projects in `pulumi do`, turns out all my tests for this happened to also have a dummy Pulumi.yaml which was making them work.