### PR TITLE
Report the configured backend URL, not the normalized one, when a state backend cannot be opened

### DIFF
--- a/changelog/pending/20260814--backend-diy--bucket-open-error-url.yaml
+++ b/changelog/pending/20260814--backend-diy--bucket-open-error-url.yaml
@@ -1,0 +1,5 @@
+component: backend/diy
+kind: improvement
+body: Report the state backend URL as configured when a bucket cannot be opened, adding
+    the resolved form only when normalization changed it
+time: 2026-08-14T12:00:00Z

--- a/changelog/pending/20260814--backend-diy--bucket-open-error-url.yaml
+++ b/changelog/pending/20260814--backend-diy--bucket-open-error-url.yaml
@@ -1,5 +1,6 @@
 component: backend/diy
 kind: improvement
-body: Report the state backend URL as configured when a bucket cannot be opened, adding
-    the resolved form only when normalization changed it
+body: Report the state backend URL as configured when it cannot be opened, adding the
+    resolved form when normalization changed it, and name a local path a state directory
+    rather than a bucket
 time: 2026-08-14T12:00:00Z

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -582,10 +582,7 @@ func describeBackendURL(originalURL, normalized string, cause error) string {
 	return fmt.Sprintf("%q (resolved to %q)", originalURL, resolved)
 }
 
-// withoutInjectedNoTmpDir strips the no_tmp_dir parameter that massageBlobPath adds, unless
-// the user set it themselves, in which case it is theirs to see. Only file:// URLs are
-// considered, since that is the only scheme massageBlobPath injects it for — another backend
-// may use a parameter of that name for its own purposes.
+// withoutInjectedNoTmpDir strips the no_tmp_dir parameter that massageBlobPath adds
 func withoutInjectedNoTmpDir(originalURL, normalized string) string {
 	if !strings.HasPrefix(originalURL, FilePathPrefix) || strings.Contains(originalURL, "no_tmp_dir") {
 		return normalized

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -583,9 +583,11 @@ func describeBackendURL(originalURL, normalized string, cause error) string {
 }
 
 // withoutInjectedNoTmpDir strips the no_tmp_dir parameter that massageBlobPath adds, unless
-// the user set it themselves, in which case it is theirs to see.
+// the user set it themselves, in which case it is theirs to see. Only file:// URLs are
+// considered, since that is the only scheme massageBlobPath injects it for — another backend
+// may use a parameter of that name for its own purposes.
 func withoutInjectedNoTmpDir(originalURL, normalized string) string {
-	if strings.Contains(originalURL, "no_tmp_dir") {
+	if !strings.HasPrefix(originalURL, FilePathPrefix) || strings.Contains(originalURL, "no_tmp_dir") {
 		return normalized
 	}
 	u, err := url.Parse(normalized)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -267,7 +267,8 @@ func newDIYBackend(
 
 	bucket, err := blobmux.OpenBucket(ctx, u)
 	if err != nil {
-		return nil, fmt.Errorf("unable to open bucket %s: %w", describeBucketURL(originalURL, u, err), err)
+		return nil, fmt.Errorf("unable to open %s %s: %w",
+			stateStoreNoun(originalURL), describeBackendURL(originalURL, u, err), err)
 	}
 
 	if !strings.HasPrefix(u, FilePathPrefix) {
@@ -556,15 +557,24 @@ func (b *diyBackend) upgradeStack(
 	return nil
 }
 
-// describeBucketURL names the bucket we tried to open, for use in an error message. It
-// reports the URL as the user configured it, and adds the normalized form we actually
-// handed to go-cloud when normalization changed something the user did not write: a `~`
-// or relative path that resolved elsewhere, or legacy S3 parameters that were translated.
-// The `no_tmp_dir` parameter is excluded from that comparison, since massageBlobPath adds
-// it to every file:// URL and it says nothing about why the open failed. Some go-cloud
-// errors (the S3 ones) already quote the normalized URL, so cause is checked to avoid
-// printing it twice; if that ever stops being true we simply report it ourselves.
-func describeBucketURL(originalURL, normalized string, cause error) string {
+// stateStoreNoun names what a backend URL points at, so that errors do not call a local
+// directory or a database a "bucket" — go-cloud's vocabulary rather than the user's.
+func stateStoreNoun(originalURL string) string {
+	switch {
+	case strings.HasPrefix(originalURL, FilePathPrefix):
+		return "state directory"
+	case strings.HasPrefix(originalURL, "postgres://"):
+		return "state database"
+	default:
+		return "bucket"
+	}
+}
+
+// describeBackendURL names the backend for an error message: the URL as configured, plus
+// the normalized form when normalization changed something the user did not write. The
+// injected no_tmp_dir parameter is ignored, and a cause that already quotes the normalized
+// URL (go-cloud's S3 errors do) suppresses it rather than printing it twice.
+func describeBackendURL(originalURL, normalized string, cause error) string {
 	resolved := withoutInjectedNoTmpDir(originalURL, normalized)
 	if resolved == originalURL || strings.Contains(cause.Error(), resolved) {
 		return fmt.Sprintf("%q", originalURL)

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -267,7 +267,7 @@ func newDIYBackend(
 
 	bucket, err := blobmux.OpenBucket(ctx, u)
 	if err != nil {
-		return nil, fmt.Errorf("unable to open bucket %s: %w", u, err)
+		return nil, fmt.Errorf("unable to open bucket %s: %w", describeBucketURL(originalURL, u, err), err)
 	}
 
 	if !strings.HasPrefix(u, FilePathPrefix) {
@@ -554,6 +554,41 @@ func (b *diyBackend) upgradeStack(
 	}
 
 	return nil
+}
+
+// describeBucketURL names the bucket we tried to open, for use in an error message. It
+// reports the URL as the user configured it, and adds the normalized form we actually
+// handed to go-cloud when normalization changed something the user did not write: a `~`
+// or relative path that resolved elsewhere, or legacy S3 parameters that were translated.
+// The `no_tmp_dir` parameter is excluded from that comparison, since massageBlobPath adds
+// it to every file:// URL and it says nothing about why the open failed. Some go-cloud
+// errors (the S3 ones) already quote the normalized URL, so cause is checked to avoid
+// printing it twice; if that ever stops being true we simply report it ourselves.
+func describeBucketURL(originalURL, normalized string, cause error) string {
+	resolved := withoutInjectedNoTmpDir(originalURL, normalized)
+	if resolved == originalURL || strings.Contains(cause.Error(), resolved) {
+		return fmt.Sprintf("%q", originalURL)
+	}
+	return fmt.Sprintf("%q (resolved to %q)", originalURL, resolved)
+}
+
+// withoutInjectedNoTmpDir strips the no_tmp_dir parameter that massageBlobPath adds, unless
+// the user set it themselves, in which case it is theirs to see.
+func withoutInjectedNoTmpDir(originalURL, normalized string) string {
+	if strings.Contains(originalURL, "no_tmp_dir") {
+		return normalized
+	}
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return normalized
+	}
+	query := u.Query()
+	if query.Get("no_tmp_dir") == "" {
+		return normalized
+	}
+	query.Del("no_tmp_dir")
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 // massageBlobPath takes the path the user provided and converts it to an appropriate form go-cloud

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -571,9 +571,7 @@ func stateStoreNoun(originalURL string) string {
 }
 
 // describeBackendURL names the backend for an error message: the URL as configured, plus
-// the normalized form when normalization changed something the user did not write. The
-// injected no_tmp_dir parameter is ignored, and a cause that already quotes the normalized
-// URL (go-cloud's S3 errors do) suppresses it rather than printing it twice.
+// the normalized form when normalization changed something the user did not write.
 func describeBackendURL(originalURL, normalized string, cause error) string {
 	resolved := withoutInjectedNoTmpDir(originalURL, normalized)
 	if resolved == originalURL || strings.Contains(cause.Error(), resolved) {

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -2142,3 +2142,69 @@ func TestJSONCheckpointIsCompact(t *testing.T) {
 	require.NoError(t, json.Compact(&compact, data))
 	assert.Equal(t, compact.String(), string(data))
 }
+
+// TestDescribeBucketURL checks that a failed bucket open names the URL the user configured,
+// and adds the normalized form only when normalization changed something they did not write.
+func TestDescribeBucketURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		original   string
+		normalized string
+		cause      error
+		expected   string
+	}{
+		{
+			name:       "injected no_tmp_dir is not worth reporting",
+			original:   "file:///tmp/state",
+			normalized: "file:///tmp/state?no_tmp_dir=true",
+			expected:   `"file:///tmp/state"`,
+		},
+		{
+			name:       "a resolved tilde path is new information",
+			original:   "file://~/state",
+			normalized: "file:///home/someone/state?no_tmp_dir=true",
+			expected:   `"file://~/state" (resolved to "file:///home/someone/state")`,
+		},
+		{
+			name:       "no_tmp_dir set by the user is theirs to see",
+			original:   "file:///tmp/state?no_tmp_dir=yes",
+			normalized: "file:///tmp/state?no_tmp_dir=yes",
+			expected:   `"file:///tmp/state?no_tmp_dir=yes"`,
+		},
+		{
+			name:       "translated S3 parameters are new information",
+			original:   "s3://bucket?endpoint=127.0.0.1:9000&disableSSL=true",
+			normalized: "s3://bucket?disable_https=true&endpoint=http%3A%2F%2F127.0.0.1%3A9000",
+			expected: `"s3://bucket?endpoint=127.0.0.1:9000&disableSSL=true"` +
+				` (resolved to "s3://bucket?disable_https=true&endpoint=http%3A%2F%2F127.0.0.1%3A9000")`,
+		},
+		{
+			name:       "a cause that already names the resolved URL is not repeated",
+			original:   "s3://bucket?endpoint=127.0.0.1:9000&disableSSL=true",
+			normalized: "s3://bucket?disable_https=true&endpoint=http%3A%2F%2F127.0.0.1%3A9000",
+			cause: errors.New(
+				"open bucket s3://bucket?disable_https=true&endpoint=http%3A%2F%2F127.0.0.1%3A9000: no credentials"),
+			expected: `"s3://bucket?endpoint=127.0.0.1:9000&disableSSL=true"`,
+		},
+		{
+			name:       "an untouched cloud URL is reported once",
+			original:   "azblob://container",
+			normalized: "azblob://container",
+			expected:   `"azblob://container"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cause := tt.cause
+			if cause == nil {
+				cause = errors.New("some failure")
+			}
+			assert.Equal(t, tt.expected, describeBucketURL(tt.original, tt.normalized, cause))
+		})
+	}
+}

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -2174,6 +2174,13 @@ func TestDescribeBackendURL(t *testing.T) {
 			expected:   `"file:///tmp/state?no_tmp_dir=yes"`,
 		},
 		{
+			name:       "no_tmp_dir on another scheme is not ours to strip",
+			original:   "s3://bucket?endpoint=127.0.0.1:9000",
+			normalized: "s3://bucket?endpoint=http%3A%2F%2F127.0.0.1%3A9000&no_tmp_dir=true",
+			expected: `"s3://bucket?endpoint=127.0.0.1:9000"` +
+				` (resolved to "s3://bucket?endpoint=http%3A%2F%2F127.0.0.1%3A9000&no_tmp_dir=true")`,
+		},
+		{
 			name:       "translated S3 parameters are new information",
 			original:   "s3://bucket?endpoint=127.0.0.1:9000&disableSSL=true",
 			normalized: "s3://bucket?disable_https=true&endpoint=http%3A%2F%2F127.0.0.1%3A9000",

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -2143,9 +2143,9 @@ func TestJSONCheckpointIsCompact(t *testing.T) {
 	assert.Equal(t, compact.String(), string(data))
 }
 
-// TestDescribeBucketURL checks that a failed bucket open names the URL the user configured,
+// TestDescribeBackendURL checks that a failed bucket open names the URL the user configured,
 // and adds the normalized form only when normalization changed something they did not write.
-func TestDescribeBucketURL(t *testing.T) {
+func TestDescribeBackendURL(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -2204,7 +2204,33 @@ func TestDescribeBucketURL(t *testing.T) {
 			if cause == nil {
 				cause = errors.New("some failure")
 			}
-			assert.Equal(t, tt.expected, describeBucketURL(tt.original, tt.normalized, cause))
+			assert.Equal(t, tt.expected, describeBackendURL(tt.original, tt.normalized, cause))
+		})
+	}
+}
+
+// TestStateStoreNoun checks that errors do not call a local directory or a database a
+// "bucket", which is go-cloud's vocabulary rather than the user's.
+func TestStateStoreNoun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"file:///tmp/state", "state directory"},
+		{"file://~", "state directory"},
+		{"postgres://user:pw@localhost:5432/pulumi", "state database"},
+		{"s3://my-state", "bucket"},
+		{"gs://my-state", "bucket"},
+		{"azblob://my-state", "bucket"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, stateStoreNoun(tt.url))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #24330. Split out of #24322, where @tgummerer asked to keep one change per PR.

When a DIY backend cannot be opened, the error reported the *normalized* URL — carrying query parameters the user never wrote — and called every backend a "bucket":

```
error: unable to open bucket file:///private/tmp/pulumi-state?no_tmp_dir=true: stat /private/tmp/pulumi-state: no such file or directory
```

Two changes, both to that one message.

### 1. Report the URL as configured, and the resolved form when it differs

`massageBlobPath` injects `no_tmp_dir=true` into every `file://` backend (see #15352 — it stops fileblob's temp-file rename from crossing a mount boundary), so for file paths that parameter is a constant that says nothing about the failure.

But the rest of the massaging *is* diagnostic, as @tgummerer noted on #24322: tilde and relative paths resolve elsewhere, and legacy S3 parameters get translated. So rather than choosing between the two forms, show both — and only when they actually differ:

```
unable to open state directory "file:///private/tmp/pulumi-state": stat /private/tmp/pulumi-state: no such file or directory

unable to open state directory "file://~/pulumi-state" (resolved to "file:///Users/me/pulumi-state"): stat /Users/me/pulumi-state: no such file or directory

unable to open state directory "file://./state" (resolved to "file:///Users/me/src/demo/state"): stat /Users/me/src/demo/state: no such file or directory
```

This stays quiet in the common case: `translateLegacyS3Params` returns its input untouched when nothing needs translating, and azblob/gs are never rewritten, so the extra clause appears only when normalization changed something.

Two details worth flagging for review:

- **`OpenBucket` is lazy about the network but eager about AWS config resolution**, so translated S3 parameters do reach this message — an unresolvable `AWS_PROFILE` is enough. They are preserved, not stripped.
- **go-cloud's own S3 errors already quote the normalized URL**, so the cause is checked to avoid printing it twice. If that ever stops being true we report it ourselves, so the failure mode is redundancy rather than a loss.

### 2. Do not call a local directory a "bucket"

go-cloud models every DIY backend as a blob bucket, but that vocabulary only fits the object stores. `file://` is a directory on disk and `postgres://` is a database:

| Scheme | Noun |
|---|---|
| `file://` | state directory |
| `postgres://` | state database |
| `s3://`, `gs://`, `azblob://` | bucket |

## Ordering note

#24322 adjusts `unwrapBucketOpenError` to match on `"unable to open "` rather than the full `"unable to open bucket "` prefix. That is what keeps this PR's noun change from double-printing the URL through `pulumi login` once both land. The relaxed matcher also handles the old wording, so **the two PRs are safe to merge in either order** — but #24322 should not be reverted to the strict prefix afterwards.

`pulumi login` output is unaffected by this PR: it strips the wrapper and supplies its own noun ("state backend").

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestDescribeBackendURL` covers the injected parameter, a resolved tilde path, a user-supplied `no_tmp_dir` (which stays visible, since then it is theirs), translated S3 parameters, an untouched cloud URL, and the no-double-print case. `TestStateStoreNoun` pins the noun per scheme.

Also exercised end to end against real `diy.New` failures for each URL shape, including the S3 config-resolution failure.

## Validation

- [x] `make lint` — clean
- [x] `make format` — clean
- [x] `pkg/backend/diy` tests pass

Note: `TestS3LegacyURLCopy` fails on a clean checkout of `master` when `AWS_PROFILE` is set to a profile the sandbox cannot resolve, and passes with it unset. Unrelated to this change.

## Changelog

- [x] Changelog entry added.

## Risk

User-facing error text only — no behavior, state, or API changes. This message surfaces from every command that opens a DIY backend, so the reach is wide, but nothing asserts on the string outside this package and the `pulumi login` matcher discussed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
