### PR TITLE
fix: ensure event loop exists in resource_output for Python 3.14

### DIFF
--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -535,14 +535,18 @@ def resource_output(
     res: "Resource",
 ) -> tuple[Callable[[Any, bool, bool, Optional[Exception]], None], "Output"]:
     # When there is no running event loop (e.g., pulumi.runtime.set_mocks()
-    # called at module scope), create one so asyncio.Future() does not
-    # raise RuntimeError. Python 3.14+ no longer creates an implicit loop
-    # when get_event_loop() is called with no running loop.
+    # called at module scope), asyncio.Future() below can raise RuntimeError
+    # on Python 3.14+, where get_event_loop() no longer creates an implicit
+    # loop. Create and set one only when neither a running loop nor a
+    # thread-local loop already exists, so an existing loop is never clobbered.
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
     data_future: asyncio.Future[_OutputData[Any]] = asyncio.Future()
 
     def resolve(value: Any, known: bool, secret: bool, exn: Optional[Exception]):

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -534,6 +534,15 @@ def create_urn(
 def resource_output(
     res: "Resource",
 ) -> tuple[Callable[[Any, bool, bool, Optional[Exception]], None], "Output"]:
+    # When there is no running event loop (e.g., pulumi.runtime.set_mocks()
+    # called at module scope), create one so asyncio.Future() does not
+    # raise RuntimeError. Python 3.14+ no longer creates an implicit loop
+    # when get_event_loop() is called with no running loop.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     data_future: asyncio.Future[_OutputData[Any]] = asyncio.Future()
 
     def resolve(value: Any, known: bool, secret: bool, exn: Optional[Exception]):

--- a/sdk/python/lib/test/test_issue_24338.py
+++ b/sdk/python/lib/test/test_issue_24338.py
@@ -1,0 +1,65 @@
+# Copyright 2016, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pulumi
+from pulumi.runtime import mocks
+
+
+class NoLoopMocks(mocks.Mocks):
+    def new_resource(self, args: mocks.MockResourceArgs):
+        return f"{args.name}_id", args.inputs
+
+    def call(self, args: mocks.MockCallArgs):
+        return {}, None
+
+
+def test_set_mocks_without_event_loop():
+    """
+    Verify that set_mocks works when called with no running event loop.
+
+    This reproduces the scenario reported in #24338: Python 3.14 no longer
+    creates an implicit event loop, so asyncio.Future() in resource_output()
+    raises RuntimeError when reached synchronously from set_mocks().
+
+    The fix ensures resource_output() creates a new event loop when none is
+    running, so set_mocks() succeeds at module scope.
+    """
+    saved = asyncio.get_event_loop()
+
+    try:
+        # Remove the event loop from the current thread to simulate the
+        # module-scope set_mocks() call on Python 3.14.
+        asyncio.set_event_loop(None)
+
+        # This must not raise RuntimeError even when no loop is running.
+        pulumi.runtime.set_mocks(NoLoopMocks())
+    finally:
+        asyncio.set_event_loop(saved)
+
+
+def test_set_mocks_with_existing_loop_not_affected():
+    """
+    Verify that the fix does not clobber or interfere with an existing
+    running event loop (the normal case).
+    """
+    saved = asyncio.get_event_loop()
+
+    try:
+        pulumi.runtime.set_mocks(NoLoopMocks())
+        # The existing loop must still be the current one.
+        assert asyncio.get_event_loop() is saved
+    finally:
+        asyncio.set_event_loop(saved)


### PR DESCRIPTION
### What happened?

On Python 3.14, `pulumi.runtime.set_mocks()` raises `RuntimeError: There is no current event loop in thread 'MainThread'` when called at module scope (outside any running event loop).

### Root cause

`set_mocks()` constructs the root `Stack()`, which registers a resource, reaching `resource_output()` in `sdk/python/lib/pulumi/runtime/resource.py`. This function creates an `asyncio.Future()` which internally calls `asyncio.get_event_loop()`. Python 3.14+ no longer creates an implicit loop, so this raises `RuntimeError`.

### Fix

Before creating `asyncio.Future()`, check if a running event loop exists. If not, create and set one. This is safe because:
- When called from within an async context (the normal case), `get_running_loop()` succeeds and no action is taken
- When called synchronously (the `set_mocks()` path), a new event loop is created for the duration of the synchronous call
- The existing `conftest.py` `ensure_event_loop` fixture already follows this pattern for tests

### Reproducer

```python
import pulumi
class M(pulumi.runtime.Mocks):
    def new_resource(self, args):
        return f"{args.name}-id", dict(args.inputs)
    def call(self, args):
        return {}
pulumi.runtime.set_mocks(M())
print("set_mocks OK")
```

Fixes #24338