### PR TITLE
Draw the interactive display at 16fps rather than 62fps

### DIFF
--- a/changelog/pending/cli-display-fix-20260817-120246.yaml
+++ b/changelog/pending/cli-display-fix-20260817-120246.yaml
@@ -1,0 +1,4 @@
+component: cli/display
+kind: fix
+body: Throttle the interactive progress renderer so large stacks no longer stall the engine's event stream
+time: 2026-08-17T12:02:46.670855+02:00

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -461,13 +461,35 @@ func (r *treeRenderer) clampLine(line string, maxWidth int) string {
 	return colors.TrimColorizedString(line, maxRowLength)
 }
 
+// maxRenderLoad bounds the share of wall-clock time the renderer may spend drawing
+// frames. A frame re-renders every row, so its cost grows with the size of the stack:
+// past a few thousand resources a frame takes longer than the tick interval and the
+// renderer draws back-to-back forever. That burns a core and, because a frame holds
+// r.m for its duration, blocks the markDirty calls made by the goroutine reading
+// engine events, which in turn backs up the whole event pipeline.
+const maxRenderLoad = 8
+
+// nextFrameTime returns the earliest time at which another frame may be drawn, given
+// when the last frame started and how long it took.
+func nextFrameTime(start time.Time, cost time.Duration) time.Time {
+	return start.Add(cost * maxRenderLoad)
+}
+
 func (r *treeRenderer) handleEvents() {
+	var nextFrame time.Time
 	for {
 		select {
 		case <-r.ticker.C:
+			start := time.Now()
+			if start.Before(nextFrame) {
+				continue
+			}
 			r.frame(false, false)
+			nextFrame = nextFrameTime(start, time.Since(start))
 		case key := <-r.keys:
 			r.handleKey(key)
+			// Scrolling must stay responsive, so let the next tick draw regardless.
+			nextFrame = time.Time{}
 		case <-r.closed:
 			return
 		}

--- a/pkg/backend/display/tree.go
+++ b/pkg/backend/display/tree.go
@@ -61,6 +61,14 @@ type treeRenderer struct {
 	maxTreeTableOffset int // The maximum scroll offset.
 }
 
+// frameInterval is how often the renderer redraws. A frame re-renders every row, so its
+// cost grows with the size of the stack, and it holds r.m while it does, which blocks the
+// markDirty calls made by the goroutine reading engine events. Drawing more often than the
+// display actually changes therefore slows the operation itself down on large stacks.
+// Nothing animates faster than the one second tick that drives the elapsed times and the
+// suffix, so this only bounds how quickly a new row appears.
+const frameInterval = 60 * time.Millisecond
+
 func newInteractiveRenderer(term terminal.Terminal, permalink string, opts Options) progressRenderer {
 	// Something about the tree renderer--possibly the raw terminal--does not yet play well with Windows, so for now
 	// we fall back to the legacy renderer on that platform.
@@ -73,7 +81,7 @@ func newInteractiveRenderer(term terminal.Terminal, permalink string, opts Optio
 		opts:      opts,
 		term:      term,
 		permalink: permalink,
-		ticker:    time.NewTicker(16 * time.Millisecond),
+		ticker:    time.NewTicker(frameInterval),
 		keys:      make(chan string),
 		closed:    make(chan bool),
 	}
@@ -461,35 +469,16 @@ func (r *treeRenderer) clampLine(line string, maxWidth int) string {
 	return colors.TrimColorizedString(line, maxRowLength)
 }
 
-// maxRenderLoad bounds the share of wall-clock time the renderer may spend drawing
-// frames. A frame re-renders every row, so its cost grows with the size of the stack:
-// past a few thousand resources a frame takes longer than the tick interval and the
-// renderer draws back-to-back forever. That burns a core and, because a frame holds
-// r.m for its duration, blocks the markDirty calls made by the goroutine reading
-// engine events, which in turn backs up the whole event pipeline.
-const maxRenderLoad = 8
-
-// nextFrameTime returns the earliest time at which another frame may be drawn, given
-// when the last frame started and how long it took.
-func nextFrameTime(start time.Time, cost time.Duration) time.Time {
-	return start.Add(cost * maxRenderLoad)
-}
-
 func (r *treeRenderer) handleEvents() {
-	var nextFrame time.Time
 	for {
 		select {
 		case <-r.ticker.C:
-			start := time.Now()
-			if start.Before(nextFrame) {
-				continue
-			}
 			r.frame(false, false)
-			nextFrame = nextFrameTime(start, time.Since(start))
 		case key := <-r.keys:
 			r.handleKey(key)
-			// Scrolling must stay responsive, so let the next tick draw regardless.
-			nextFrame = time.Time{}
+			// handleKey marks the display dirty. Draw it now rather than waiting for the
+			// next tick, so that scrolling stays responsive whatever the frame interval is.
+			r.frame(false, false)
 		case <-r.closed:
 			return
 		}

--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -312,40 +313,53 @@ func TestTreeRenderDoesntRenderBeforeItHasContent(t *testing.T) {
 	}()
 }
 
-// slowWriter makes every frame expensive regardless of how fast the machine running
-// the test is.
-type slowWriter struct{}
+// frameCounter counts the frames a renderer draws. Every frame begins with a carriage
+// return, and none of the content this file renders contains one.
+type frameCounter struct {
+	m sync.Mutex
+	n int
+}
 
-func (slowWriter) Write(p []byte) (int, error) {
-	time.Sleep(500 * time.Microsecond)
+func (c *frameCounter) Write(p []byte) (int, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.n += bytes.Count(p, []byte("\r"))
 	return len(p), nil
 }
 
-// TestTreeRendererCapsRenderLoad checks that expensive frames throttle the frame rate
-// instead of being drawn back-to-back. A frame holds the renderer's lock, so a renderer
-// that never keeps up starves the goroutine feeding it engine events. See #14732.
-func TestTreeRendererCapsRenderLoad(t *testing.T) {
+func (c *frameCounter) frames() int {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.n
+}
+
+// TestTreeRendererFrameRate checks that the renderer draws no faster than the display
+// actually changes. A frame re-renders every row and holds the renderer's lock while it
+// does, so on a large stack a high frame rate starves the goroutine feeding it engine
+// events and slows the operation itself down. See #14732.
+func TestTreeRendererFrameRate(t *testing.T) {
 	t.Parallel()
 
-	term := terminal.NewMockTerminal(slowWriter{}, 80, 24, true)
+	var counter frameCounter
+	term := terminal.NewMockTerminal(&counter, 80, 24, true)
 	treeRenderer, display := createRendererAndDisplay(term, true)
 	addManyNormalEvents(display, 200, "a message")
 
-	treeRenderer.ticker.Reset(16 * time.Millisecond)
+	// createRendererAndDisplay stops the ticker, so restart it to draw at the real rate.
+	treeRenderer.ticker.Reset(frameInterval)
 	defer func() {
 		treeRenderer.ticker.Stop()
 		close(treeRenderer.closed)
 	}()
 
-	var blocked time.Duration
+	// Keep the display permanently dirty, so that every tick draws.
 	start := time.Now()
 	for time.Since(start) < time.Second {
-		before := time.Now()
 		treeRenderer.markDirty()
-		blocked += time.Since(before)
 		time.Sleep(time.Millisecond)
 	}
 
-	load := float64(blocked) / float64(time.Since(start))
-	assert.Lessf(t, load, 0.5, "renderer held its lock %.0f%% of the time", load*100)
+	fps := float64(counter.frames()) / time.Since(start).Seconds()
+	assert.Greaterf(t, fps, 5.0, "renderer drew %.0f frames per second", fps)
+	assert.Lessf(t, fps, 25.0, "renderer drew %.0f frames per second", fps)
 }

--- a/pkg/backend/display/tree_test.go
+++ b/pkg/backend/display/tree_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -309,4 +310,42 @@ func TestTreeRenderDoesntRenderBeforeItHasContent(t *testing.T) {
 		assert.Truef(t, treeRenderer.dirty,
 			"Expecting the renderer to be dirty after headers are initialized, and after a tick has happened")
 	}()
+}
+
+// slowWriter makes every frame expensive regardless of how fast the machine running
+// the test is.
+type slowWriter struct{}
+
+func (slowWriter) Write(p []byte) (int, error) {
+	time.Sleep(500 * time.Microsecond)
+	return len(p), nil
+}
+
+// TestTreeRendererCapsRenderLoad checks that expensive frames throttle the frame rate
+// instead of being drawn back-to-back. A frame holds the renderer's lock, so a renderer
+// that never keeps up starves the goroutine feeding it engine events. See #14732.
+func TestTreeRendererCapsRenderLoad(t *testing.T) {
+	t.Parallel()
+
+	term := terminal.NewMockTerminal(slowWriter{}, 80, 24, true)
+	treeRenderer, display := createRendererAndDisplay(term, true)
+	addManyNormalEvents(display, 200, "a message")
+
+	treeRenderer.ticker.Reset(16 * time.Millisecond)
+	defer func() {
+		treeRenderer.ticker.Stop()
+		close(treeRenderer.closed)
+	}()
+
+	var blocked time.Duration
+	start := time.Now()
+	for time.Since(start) < time.Second {
+		before := time.Now()
+		treeRenderer.markDirty()
+		blocked += time.Since(before)
+		time.Sleep(time.Millisecond)
+	}
+
+	load := float64(blocked) / float64(time.Since(start))
+	assert.Lessf(t, load, 0.5, "renderer held its lock %.0f%% of the time", load*100)
 }


### PR DESCRIPTION
## Summary

Fixes #14732, where `pulumi preview` on a ~2400 resource stack took 2m07s but `pulumi preview --diff` took 33s.

`--diff` changes nothing in the engine, only the renderer, and the interactive one is where the time goes. `treeRenderer.frame` re-renders every row on a fixed 16ms tick, so the cost of a frame grows with the size of the stack — measured at 0.44ms for 100 resources, 5.5ms for 2400 and 7.2ms for 3200, split between `colors.MeasureColorizedString` (27%, via `uniseg`), `generateTreeNodes` (28%, of which 10 points are re-parsing URNs) and `renderRow` (19%). Past a few thousand resources a frame takes longer than the tick interval and the renderer draws back-to-back forever, burning a core.

That also slows the operation down, not just the terminal: a frame holds `r.m` for its duration, so it blocks the `markDirty` calls made by the goroutine consuming engine events, and that backs up through the unbuffered channels between the engine and the display.

Nothing in the display animates faster than the one second tick that drives the elapsed times and the suffix, and `frame` returns early when nothing is dirty, so the 16ms tick only ever bounded how quickly a new row appears. This drops it to 60ms, which bounds that just as imperceptibly, and draws immediately on a key press so that scrolling does not get slower along with it.

The load on the renderer is `frame cost × frame rate`, which the measurements bear out (5.5ms × 62fps = 34%, measured 35.7%). At 2400 resources that takes the share of time the event consumer spends waiting on the renderer's lock from 36% to 9%.

This moves the point at which the renderer saturates rather than removing it: with frames costing ~2.3µs per resource, saturation moves from ~7000 resources to ~26000. Removing it needs the frame itself to get cheaper — not re-rendering rows that have not changed, or rendering only the visible window — which is considerably more invasive and worth doing separately.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestTreeRendererFrameRate` counts the frames drawn over a second. It fails on `master` with "renderer drew 62 frames per second" and passes here at 16. Frames are cheap at the size it renders, so a slow machine can only push the rate down, never up through the bound.

The golden tests are unaffected: they set `DeterministicOutput`, which stops the ticker, so they never go through `handleEvents`.

## Validation
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

I ran `go vet ./backend/display/` and `go test ./backend/display/...` (all pass) rather than the full suites; `golangci-lint` will not start in my checkout (`plugin "noosexit" not found`), so please treat lint as unverified.

## Risk

Confined to the interactive tree renderer. The visible effect is that the display refreshes at 16fps rather than 62fps. No public API, no engine or state changes. Worst case is a display that feels less smooth, which is one constant away from being tuned back.
