### PR TITLE
Add regression test for import file name collisions

### DIFF
--- a/pkg/cmd/pulumi/operations/preview_test.go
+++ b/pkg/cmd/pulumi/operations/preview_test.go
@@ -767,6 +767,60 @@ func TestBuildImportFile_regress_15068(t *testing.T) {
 	assert.ErrorContains(t, err, "could not parse provider reference")
 }
 
+// Regression test for https://github.com/pulumi/pulumi/issues/15454
+// Tests that when an existing explicit provider and an existing component resource share the same
+// logical name, the generated import file gives them distinct name table entries.
+func TestBuildImportFile_regress_15454(t *testing.T) {
+	t.Parallel()
+
+	const name = "same-name-for-provider-and-component-resource"
+
+	events := make(chan engine.Event)
+	importFilePromise := buildImportFile(t.Context(), events, sdkconfig.NopEncrypter)
+
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeRootStackMetadata(deploy.OpSame),
+	})
+
+	providerState := makeStateMetadata(t, name, "pulumi:providers:aws", true, stateOptions{
+		Inputs: resource.NewPropertyMapFromMap(map[string]any{
+			"version": "6.22.0",
+		}),
+	})
+	uuid, err := uuid.NewV4()
+	require.NoError(t, err)
+	providerState.ID = resource.ID(uuid.String())
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, providerState),
+	})
+
+	component := makeStateMetadata(t, name, "company:product:CRClass", false, stateOptions{})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpSame, component),
+	})
+
+	providerRef, err := providers.NewReference(providerState.URN, providerState.ID)
+	require.NoError(t, err)
+	child := makeStateMetadata(t, "ssm-parameter", "aws:ssm/parameter:Parameter", true, stateOptions{
+		Parent:   component.URN,
+		Provider: &providerRef,
+	})
+	events <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: makeMetadata(deploy.OpCreate, child),
+	})
+
+	close(events)
+
+	importFile, err := importFilePromise.Result(t.Context())
+	require.NoError(t, err)
+	require.Len(t, importFile.Resources, 1)
+
+	spec := importFile.Resources[0]
+	assert.NotEqual(t, spec.Parent, spec.Provider)
+	assert.Equal(t, component.URN, importFile.NameTable[spec.Parent])
+	assert.Equal(t, providerState.URN, importFile.NameTable[spec.Provider])
+}
+
 // Regression test for https://github.com/pulumi/pulumi/issues/24056
 // Tests that when multiple existing component resources share the same name,
 // generated import resources still reference the correct distinct parents.


### PR DESCRIPTION
## Summary

Closes https://github.com/pulumi/pulumi/issues/15454.

When generating an import file with `pulumi preview --import-file`, an explicit provider and a component resource sharing a logical name used to collapse into a single `nameTable` entry, so the imported child was reparented onto the provider. The import succeeded silently and the next preview proposed a delete-and-recreate.

This was already fixed by the name collision rewrite in #24069 (which tracks collisions by old logical name + type and suffixes the type). The provider/component shape from #15454 was not covered by a test, so this adds one rather than changing any behaviour.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestBuildImportFile_regress_15454` reproduces the issue's exact scenario: an existing `pulumi:providers:aws` and an existing `company:product:CRClass` component with the same name, plus a created `aws:ssm/parameter:Parameter` parented on the component and using the provider.

Verified in both directions:
- Against `master`: passes.
- Against `pkg/cmd/pulumi/operations/preview.go` from `676cc1c536^` (before #24069): fails with the parent alias resolving to the provider's URN — exactly the symptom reported.

## Validation
- [x] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Ran `make lint_golang` (clean) and `go test ./cmd/pulumi/operations/...` in `pkg` (all pass) rather than the full `make test_fast`.

## Changelog
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

Test-only change, no user-visible behaviour change — needs `impact/no-changelog-required`.

## Risk

None. No production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)