### PR TITLE
Update language runtimes

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -53,11 +53,11 @@ download_release() {
 # live in pkg/util/plugin.go (knownLanguageRuntimes) and the CLI fetches it on demand.
 LANGUAGES=(
   # renovate: datasource=github-releases depName=pulumi/pulumi-dotnet
-  "dotnet v3.111.1"
+  "dotnet v3.112.0"
   # renovate: datasource=github-releases depName=pulumi/pulumi-java
-  "java v1.36.0"
+  "java v1.36.1"
   # renovate: datasource=github-releases depName=pulumi/pulumi-yaml
-  "yaml v1.38.2"
+  "yaml v1.38.3"
 )
 
 for i in "${LANGUAGES[@]}"; do


### PR DESCRIPTION
## Overview

Bumps language runtime versions: dotnet `v3.111.1` → `v3.112.0`, java `v1.36.0` → `v1.36.1`, yaml `v1.38.2` → `v1.38.3`.