### PR TITLE
[esc] Always emit the value and environment JSON keys

### DIFF
--- a/changelog/pending/20260817--sdk-go--esc-always-emit-value-and-environment.yaml
+++ b/changelog/pending/20260817--sdk-go--esc-always-emit-value-and-environment.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: fix
+body: Always emit the `value` and `environment` keys when serializing `esc.Value` and `esc.Range`, matching the fields the ESC OpenAPI contract marks required
+time: 2026-08-17T00:00:00+00:00

--- a/pkg/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
+++ b/pkg/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
@@ -36,6 +36,7 @@ environments:
 ---
 > esc env get default/test --value detailed null
 {
+  "value": null,
   "trace": {
     "def": {
       "environment": "\u003cyaml\u003e",
@@ -517,6 +518,7 @@ environments:
 }
 > esc env get default/test --value detailed open
 {
+  "value": null,
   "unknown": true,
   "trace": {
     "def": {

--- a/pkg/cmd/esc/cli/testdata/open-detailed-files.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-detailed-files.yaml
@@ -125,6 +125,7 @@ environments:
   },
   "trace": {
     "def": {
+      "environment": "",
       "begin": {
         "line": 0,
         "column": 0,

--- a/pkg/cmd/esc/cli/testdata/open-detailed.yaml
+++ b/pkg/cmd/esc/cli/testdata/open-detailed.yaml
@@ -71,6 +71,7 @@ environments:
   },
   "trace": {
     "def": {
+      "environment": "",
       "begin": {
         "line": 0,
         "column": 0,

--- a/sdk/go/common/esc/expr.go
+++ b/sdk/go/common/esc/expr.go
@@ -108,7 +108,7 @@ type BuiltinExpr struct {
 // A Range defines a range within an environment definition.
 type Range struct {
 	// The name of the environment.
-	Environment string `json:"environment,omitempty"`
+	Environment string `json:"environment"`
 
 	// The beginning of the range.
 	Begin Pos `json:"begin"`

--- a/sdk/go/common/esc/value.go
+++ b/sdk/go/common/esc/value.go
@@ -35,7 +35,7 @@ type ValueType interface {
 type Value struct {
 	// Value holds the concrete representation of the value. May be nil, bool, json.Number, string, []Value, or
 	// map[string]Value.
-	Value any `json:"value,omitempty"`
+	Value any `json:"value"`
 
 	// Secret is true if this value is secret.
 	Secret bool `json:"secret,omitempty"`


### PR DESCRIPTION
`esc.Value.Value` and `esc.Range.Environment` were serialized with `omitempty`, so an unknown value (nil interface) omitted `value` and a zero `Range` omitted `environment`. Both fields are marked required in the ESC OpenAPI contract, and clients generated from it reject payloads with a missing required key (`no value given for required property ...`).

Dropping `omitempty` makes the producer match the contract: `value` now serializes as `null` and `environment` as `""` at their zero values. `esc.Accessor.Key` keeps `omitempty`: integer-index accessors have no key, and the contract marks it optional.

Fixes https://github.com/pulumi/pulumi/issues/24022

## Test plan

1. Automated tests
   - The `pkg/cmd/esc/cli` golden files pin the new serialization: `value: null` and `environment: ""` now appear in the detailed outputs
   - `go test ./go/common/esc/...` in `sdk`
   - `go test ./backend/httpstate/... ./cmd/pulumi/config/... ./workspace/...` in `pkg`