### PR TITLE
Fix RegisterPackageRefs returning extension refs for non-extension requests

### DIFF
--- a/changelog/pending/engine-fix-20260817-120018.yaml
+++ b/changelog/pending/engine-fix-20260817-120018.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Fix the engine returning extension package refs for non-parameterised packages against the same base
+time: 2026-08-17T12:00:18.757953413+01:00

--- a/pkg/engine/lifecycletest/extension_test.go
+++ b/pkg/engine/lifecycletest/extension_test.go
@@ -137,6 +137,8 @@ func TestExtensionParameterizedProvider(t *testing.T) {
 			Name: "ext-a", Version: "1.0.0", Value: []byte("blob-a"),
 		})
 		require.NoError(t, err)
+
+		assert.Equal(t, refA, refADup, "a byte-identical extension must yield the same ref")
 		return nil
 	})
 

--- a/pkg/engine/lifecycletest/package_ref_test.go
+++ b/pkg/engine/lifecycletest/package_ref_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// TestPackageRefSharedBase is a regression test for https://github.com/pulumi/pulumi/issues/24336. Check that
+// we don't return a parmameterized reference for a non-parameterized package of the same base provider.
+func TestPackageRefSharedBase(t *testing.T) {
+	t.Parallel()
+
+	for _, asExtension := range []bool{false, true} {
+		title := "replacement"
+		if asExtension {
+			title = "extension"
+		}
+		t.Run(title, func(t *testing.T) {
+			t.Parallel()
+
+			loaders := []*deploytest.ProviderLoader{
+				deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+					return &deploytest.Provider{}, nil
+				}),
+			}
+
+			programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+				parameterization := &pulumirpc.Parameterization{
+					Name:    "extPkg",
+					Version: "2.0.0",
+					Value:   []byte{0, 1, 2, 3},
+				}
+
+				var replacement, extension *pulumirpc.Parameterization
+				if asExtension {
+					extension = parameterization
+				} else {
+					replacement = parameterization
+				}
+
+				pkg1Ref, err := monitor.RegisterPackage("pkgA", "1.0.0", "", nil, replacement, extension)
+				require.NoError(t, err)
+
+				pkg2Ref, err := monitor.RegisterPackage("pkgA", "1.0.0", "", nil, nil, nil)
+				require.NoError(t, err)
+
+				// These two packages should have resolved to different references, since one is parameterized and the other is not.
+				assert.NotEqual(t, pkg1Ref, pkg2Ref)
+				return nil
+			})
+
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+			p := &lt.TestPlan{
+				Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+			}
+
+			snap, err := lt.TestOp(Update).
+				RunStep(p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+			require.NoError(t, err)
+			require.NotNil(t, snap)
+		})
+	}
+}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -421,6 +421,13 @@ func NewCallbacksClient(conn *grpc.ClientConn) *CallbacksClient {
 // DialOptions returns dial options to be used for the gRPC client.
 type DialOptions func(metadata any) []grpc.DialOption
 
+// The tuple of ProviderRequest and Extension that we save for an extension package in
+// `resmon.extensionRefMap`.
+type extensionRef struct {
+	provider  providers.ProviderRequest
+	extension apitype.Extension
+}
+
 // resmon implements the pulumirpc.ResourceMonitor interface and acts as the gateway between a language runtime's
 // evaluation of a program and the internal resource planning and deployment logic.
 type resmon struct {
@@ -476,7 +483,7 @@ type resmon struct {
 
 	extensionRefLock sync.RWMutex
 	// A map of UUIDs to the provider extension they respond to
-	extensionRefMap map[string]apitype.Extension
+	extensionRefMap map[string]extensionRef
 
 	// parameterizedExtensions tracks (providerRef, packageRef) pairs already
 	// passed to Parameterize so remote-component Construct calls don't repeat
@@ -552,7 +559,7 @@ func newResourceMonitor(
 		resourceHooks:           src.resourceHooks,
 		resourceTransforms:      map[resource.URN][]TransformFunction{},
 		packageRefMap:           map[string]providers.ProviderRequest{},
-		extensionRefMap:         map[string]apitype.Extension{},
+		extensionRefMap:         map[string]extensionRef{},
 		parameterizedExtensions: map[string]bool{},
 		grpcDialOptions:         src.plugctx.DialOptions,
 		observer:                src.observer,
@@ -811,10 +818,9 @@ func (rm *resmon) RegisterPackage(ctx context.Context,
 		}
 
 		rm.extensionRefLock.Lock()
-		rm.extensionRefMap[ref] = extension
+		rm.extensionRefMap[ref] = extensionRef{pi, extension}
 		rm.extensionRefLock.Unlock()
 
-		rm.packageRefMap[ref] = pi
 		logging.V(5).Infof("ResourceMonitor.RegisterPackage(%v) created %s", req, ref)
 		return &pulumirpc.RegisterPackageResponse{Ref: ref}, nil
 	}
@@ -847,9 +853,17 @@ func hashExtension(ext apitype.Extension) string {
 // lookupPackageRef returns the provider request for the given package ref,
 // holding the read lock for thread safety.
 func (rm *resmon) lookupPackageRef(ref string) (providers.ProviderRequest, bool) {
+	// First check the package refs
 	rm.packageRefLock.RLock()
-	defer rm.packageRefLock.RUnlock()
 	req, has := rm.packageRefMap[ref]
+	rm.packageRefLock.RUnlock()
+	if !has {
+		// Try the extension refs
+		rm.extensionRefLock.RLock()
+		extRef, has := rm.extensionRefMap[ref]
+		rm.extensionRefLock.RUnlock()
+		return extRef.provider, has
+	}
 	return req, has
 }
 
@@ -865,11 +879,12 @@ func (rm *resmon) ensureExtensionParameterizedForConstruct(
 		return nil
 	}
 	rm.extensionRefLock.RLock()
-	ext, isExtension := rm.extensionRefMap[packageRef]
+	extRef, isExtension := rm.extensionRefMap[packageRef]
 	rm.extensionRefLock.RUnlock()
 	if !isExtension {
 		return nil
 	}
+	ext := extRef.extension
 
 	key := providerRef.String() + "|" + packageRef
 	rm.parameterizedExtensionsLock.Lock()
@@ -2905,7 +2920,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		if packageRef := req.GetPackageRef(); packageRef != "" {
 			rm.extensionRefLock.RLock()
 			if e, has := rm.extensionRefMap[packageRef]; has {
-				ext = &e
+				ext = &e.extension
 				// Only carry the ref onto the event when there's an actual
 				// extension blob — replacement-param packageRefs don't belong
 				// in ResourceV3.ExtensionRef.

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -812,7 +812,7 @@ func (rm *resmon) RegisterPackage(ctx context.Context,
 		}
 		ref := hashExtension(extension)
 
-		if _, already := rm.packageRefMap[ref]; already {
+		if _, already := rm.extensionRefMap[ref]; already {
 			logging.V(5).Infof("ResourceMonitor.RegisterPackage(%v) matched %s", req, ref)
 			return &pulumirpc.RegisterPackageResponse{Ref: ref}, nil
 		}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -818,6 +818,8 @@ func (rm *resmon) RegisterPackage(ctx context.Context,
 		}
 
 		rm.extensionRefLock.Lock()
+		_, has := rm.extensionRefMap[ref]
+		contract.Assertf(!has, "extension ref already added to map")
 		rm.extensionRefMap[ref] = extensionRef{pi, extension}
 		rm.extensionRefLock.Unlock()
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -813,12 +813,12 @@ func (rm *resmon) RegisterPackage(ctx context.Context,
 		ref := hashExtension(extension)
 
 		rm.extensionRefLock.Lock()
+		defer rm.extensionRefLock.Unlock()
 		if _, already := rm.extensionRefMap[ref]; already {
 			logging.V(5).Infof("ResourceMonitor.RegisterPackage(%v) matched %s", req, ref)
 			return &pulumirpc.RegisterPackageResponse{Ref: ref}, nil
 		}
 		rm.extensionRefMap[ref] = extensionRef{pi, extension}
-		rm.extensionRefLock.Unlock()
 
 		logging.V(5).Infof("ResourceMonitor.RegisterPackage(%v) created %s", req, ref)
 		return &pulumirpc.RegisterPackageResponse{Ref: ref}, nil

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -812,14 +812,11 @@ func (rm *resmon) RegisterPackage(ctx context.Context,
 		}
 		ref := hashExtension(extension)
 
+		rm.extensionRefLock.Lock()
 		if _, already := rm.extensionRefMap[ref]; already {
 			logging.V(5).Infof("ResourceMonitor.RegisterPackage(%v) matched %s", req, ref)
 			return &pulumirpc.RegisterPackageResponse{Ref: ref}, nil
 		}
-
-		rm.extensionRefLock.Lock()
-		_, has := rm.extensionRefMap[ref]
-		contract.Assertf(!has, "extension ref already added to map")
 		rm.extensionRefMap[ref] = extensionRef{pi, extension}
 		rm.extensionRefLock.Unlock()
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -40,6 +40,7 @@ import (
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
@@ -2742,6 +2743,52 @@ func TestResmonCancel(t *testing.T) {
 
 	// Cancel always returns nil or a joinErrors.
 	assert.Equal(t, errors.Join(err), rm.Cancel(t.Context()))
+}
+
+func TestRegisterPackageSameExtensionThreeTimesDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	rm := &resmon{
+		packageRefMap:   map[string]providers.ProviderRequest{},
+		extensionRefMap: map[string]extensionRef{},
+	}
+	req := &pulumirpc.RegisterPackageRequest{
+		Name:    "pkgA",
+		Version: "1.0.0",
+		Extension: &pulumirpc.Parameterization{
+			Name:    "pkgA-ext",
+			Version: "1.0.0",
+			Value:   []byte("extension-value"),
+		},
+	}
+
+	type result struct {
+		refs []string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		refs := make([]string, 0, 3)
+		for range 3 {
+			resp, err := rm.RegisterPackage(t.Context(), req)
+			if err != nil {
+				done <- result{err: err}
+				return
+			}
+			refs = append(refs, resp.Ref)
+		}
+		done <- result{refs: refs}
+	}()
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		require.Len(t, res.refs, 3)
+		assert.Equal(t, res.refs[0], res.refs[1])
+		assert.Equal(t, res.refs[0], res.refs[2])
+	case <-time.After(2 * time.Second):
+		t.Fatal("RegisterPackage deadlocked when registering the same extension package three times")
+	}
 }
 
 func TestGetDeploymentInfo(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/24336

We now only store extension packages in `extensionRefMap` as both the provider request and extension information. `packageRefMap` is just non-extension packages. When doing a package lookup we now need to check both maps for find the provider information, but means we don't incorrectly de-dupe plain packages against extension packages with the same provider.