### PR TITLE
Clarify three comments in the guided `pulumi new` flow

### DIFF
--- a/pkg/cmd/pulumi/cmd/terminal.go
+++ b/pkg/cmd/pulumi/cmd/terminal.go
@@ -52,7 +52,7 @@ func OptimalPageSize(opts OptimalPageSizeOpts) int {
 	} else if _, height, err := term.GetSize(0); err == nil {
 		pageSize = height
 	}
-	// Subtract the buffer from the terminal height, not from the option count.
+	// Reserve rows for the prompt and help lines so the list does not push them off screen.
 	const buffer = 5
 	if pageSize > buffer {
 		pageSize = pageSize - buffer

--- a/pkg/cmd/pulumi/project/newcmd/catalog/catalog.go
+++ b/pkg/cmd/pulumi/project/newcmd/catalog/catalog.go
@@ -118,8 +118,7 @@ func (c *Catalog[T]) Resolve(providerID, languageID string) (T, bool) {
 	return template, ok
 }
 
-// The longest known language suffix wins, which keeps "java-gradle" whole instead of reading it as
-// provider "java".
+// The longest matching suffix wins so a hyphenated language ID is not truncated to a shorter one.
 func splitTemplateName(name string) (providerID, languageID string, ok bool) {
 	if _, isLanguage := languageDisplayNames[name]; isLanguage {
 		return noneProvider, name, true

--- a/pkg/cmd/pulumi/project/newcmd/guided.go
+++ b/pkg/cmd/pulumi/project/newcmd/guided.go
@@ -183,7 +183,8 @@ func registryPublisher(t cmdTemplates.Template) (string, bool) {
 	return publisher, publisher != ""
 }
 
-// Both signals are advisory, so an organization can turn out to have nothing to show.
+// VCS template source orgs and registry publishers only tell us an organization exists, not that it
+// has templates the guided flow can offer, so a row here can still resolve to an empty list.
 func (t guidedTemplates) orgRows() []string {
 	names := slices.Clone(t.vcsOrgs)
 	for _, template := range t.database {


### PR DESCRIPTION
## What

Rewrites three comments in the guided `pulumi new` flow. No behavior change.

## Why

Review feedback on #24280 landed on code that had already merged as part of #24226, so the comments were never addressed.
