### PR TITLE
Move DetectProject to pkg

### DIFF
--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -403,7 +403,7 @@ func ParseConfigKey(ws pkgWorkspace.Context, key string, path bool) (config.Key,
 }
 
 func PrettyKey(k config.Key) string {
-	proj, err := workspace.DetectProject()
+	proj, err := pkgWorkspace.DetectProject()
 	if err != nil {
 		return fmt.Sprintf("%s:%s", k.Namespace(), k.Name())
 	}

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -146,11 +146,11 @@ func readStackConfiguration(ctx context.Context, sink diag.Sink, ws pkgWorkspace
 		if configFile != "" {
 			return workspace.LoadProjectStack(sink, project, configFile)
 		}
-		return workspace.DetectProjectStack(sink, stackRef.Name().Q())
+		return pkgWorkspace.DetectProjectStack(sink, stackRef.Name().Q())
 	}
 	ps, err := LoadProjectStack(ctx, sink, project, s, configFile)
 	if configFile == "" && (err != nil || ps == nil) {
-		return workspace.DetectProjectStack(sink, stackRef.Name().Q())
+		return pkgWorkspace.DetectProjectStack(sink, stackRef.Name().Q())
 	}
 
 	return ps, err

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -15,9 +15,27 @@
 package workspace
 
 import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	sdkWorkspace "github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+// DetectProject loads the closest project from the current working directory, or an error if not found.
+func DetectProject() (*sdkWorkspace.Project, error) {
+	path, err := sdkWorkspace.DetectProjectPath()
+	if err != nil {
+		return nil, err
+	}
+	return sdkWorkspace.LoadProject(path)
+}
+
+func DetectProjectStack(diags diag.Sink, stackName tokens.QName) (*sdkWorkspace.ProjectStack, error) {
+	project, path, err := sdkWorkspace.DetectProjectStackPath(stackName)
+	if err != nil {
+		return nil, err
+	}
+	return sdkWorkspace.LoadProjectStack(diags, project, path)
+}
 
 const (
 	// BackupDir is the name of the folder where backup stack information is stored.

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
@@ -194,21 +193,6 @@ func DetectPolicyPackPathAt(path string) (string, error) {
 		return packPath, nil
 	}
 	return "", nil
-}
-
-// DetectProject loads the closest project from the current working directory, or an error if not found.
-func DetectProject() (*Project, error) {
-	proj, _, err := detectProjectAndPath()
-	return proj, err
-}
-
-func DetectProjectStack(diags diag.Sink, stackName tokens.QName) (*ProjectStack, error) {
-	project, path, err := DetectProjectStackPath(stackName)
-	if err != nil {
-		return nil, err
-	}
-
-	return LoadProjectStack(diags, project, path)
 }
 
 // detectProjectAndPath loads the closest package from the current working directory, or an error if not found.  It


### PR DESCRIPTION
Continuing to chip away at moving things to pkg from sdk/go/common.