### PR TITLE
Fix argumentTypeName to not depend on element order with nulls

### DIFF
--- a/changelog/pending/codegen-go-fix-20260818-000000.yaml
+++ b/changelog/pending/codegen-go-fix-20260818-000000.yaml
@@ -1,0 +1,4 @@
+component: codegen/go
+kind: fix
+body: Fix nondeterministic Go program codegen for objects that mix null and typed properties
+time: 2026-08-18T00:00:00.000000+00:00

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -224,6 +224,27 @@ func TestArgumentTypeName(t *testing.T) {
 			true, /*isInput*/
 		))
 
+	// Regression test for https://github.com/pulumi/pulumi/issues/24256:
+	// an object with a null (NoneType) property alongside typed nested data
+	// used to produce order-dependent output because Properties has random
+	// iteration order. The nested map type could "win" if visited first,
+	// yielding map[string]map[string]interface{} instead of the correct
+	// map[string]interface{}. Run many iterations to shake out map ordering.
+	// Freshly construct the map each iteration so Go's per-map iteration
+	// seed varies. In the input-side path (which does not consult
+	// anyOptional), a null (NoneType) property visited before typed
+	// entries used to leave elmType empty, letting the following typed
+	// value "win" and produce e.g. pulumi.StringMapMap instead of
+	// pulumi.Map.
+	for range 200 {
+		mixedNullObject := model.NewObjectType(map[string]model.Type{
+			"nested": model.NewObjectType(map[string]model.Type{"a": model.StringType}),
+			"null":   model.NoneType,
+		})
+		assert.Equal(t, "pulumi.Map",
+			g.argumentTypeName(mixedNullObject, true /*isInput*/))
+	}
+
 	// assert that the Output[T] + input=false is the same as T + input=true
 	// in this case where T = string
 	assert.Equal(t,

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -1552,6 +1552,15 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 				anyOptional = true
 			}
 			valType := g.argumentTypeName(v, isInput)
+			// A null property (NoneType) yields an empty type name. It can't
+			// be represented by any typed map, and treating it as compatible
+			// with the first non-empty type produces order-dependent output
+			// because Properties is a map with randomized iteration. Break
+			// uniformity so we fall back to map[string]interface{}.
+			if valType == "" {
+				allSameType = false
+				break
+			}
 			if elmType != "" && elmType != valType {
 				allSameType = false
 				break


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/24256

Special case when we see a null type when iterating and just early return 'any' rather then continuing on and trying to match the next type.