### PR TITLE
Fix Neo TUI dropping approval replies and mode updates when the outbound queue is full

### DIFF
--- a/changelog/pending/cli-fix-20260811-neo-esc-cancel.yaml
+++ b/changelog/pending/cli-fix-20260811-neo-esc-cancel.yaml
@@ -1,0 +1,7 @@
+component: cli
+kind: fix
+body: Retry `pulumi neo` cancellation requests that the service rejects and keep
+    Esc responsive instead of showing "Cancelling..." forever
+time: 2026-08-11T00:00:00Z
+custom:
+    PR: "24267"

--- a/changelog/pending/cli-neo-fix-20260818-sendout-drops.yaml
+++ b/changelog/pending/cli-neo-fix-20260818-sendout-drops.yaml
@@ -1,0 +1,7 @@
+component: cli/neo
+kind: fix
+body: Fix approval replies and mode changes being silently dropped when the
+    outbound event queue is full
+time: 2026-08-18T00:00:00Z
+custom:
+    PR: "24370"

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -3046,6 +3046,9 @@ func (pc *Client) StreamNeoTaskEvents(
 func (pc *Client) PostNeoTaskUserEvent(
 	ctx context.Context, orgName, taskID string, body any,
 ) error {
+	ctx, cancel := context.WithTimeout(ctx, NeoRequestTimeout)
+	defer cancel()
+
 	path := fmt.Sprintf("/api/preview/agents/%s/tasks/%s", orgName, taskID)
 	return pc.restCall(ctx, http.MethodPost, path, nil, struct {
 		Event any `json:"event"`

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -63,6 +63,13 @@ const nonInteractivePromptPreamble = "<details><summary>non-interactive mode</su
 var (
 	userMessageRetryInitialBackoff = 1 * time.Second
 	userMessageRetryMaxBackoff     = 30 * time.Second
+
+	// cancelRetryMaxAttempts bounds the automatic retries of a failed
+	// user_cancel post. With userMessageRetryDelay backoff this spans roughly
+	// two minutes — enough to outlast most local tool calls (during which the
+	// service 409s cancels because the task is parked) without retrying
+	// forever against a task that will never accept one.
+	cancelRetryMaxAttempts = 8
 )
 
 // neoTaskCreator is the slice of the cloud client that creates Neo tasks.
@@ -633,6 +640,10 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 						})
 					},
 					func(ctx context.Context, taskID string, body any) error {
+						// Deadline so a hung post can't wedge the serial
+						// dispatcher loop (and with it the whole TUI).
+						ctx, cancel := context.WithTimeout(ctx, client.NeoRequestTimeout)
+						defer cancel()
 						return rt.pc.PostNeoTaskUserEvent(ctx, orgName, taskID, body)
 					},
 					func(ctx context.Context, taskID string, opts client.UpdateNeoTaskOptions) error {
@@ -801,6 +812,8 @@ func runNeoResumeTUI(
 					func() string { return taskID },
 					func(string, client.NeoApprovalMode, client.NeoPermissionMode, bool) {},
 					func(ctx context.Context, taskID string, body any) error {
+						ctx, cancel := context.WithTimeout(ctx, client.NeoRequestTimeout)
+						defer cancel()
 						return pc.PostNeoTaskUserEvent(ctx, orgName, taskID, body)
 					},
 					func(ctx context.Context, taskID string, opts client.UpdateNeoTaskOptions) error {
@@ -968,6 +981,20 @@ func dispatchUserEvents(
 	var retryTimer *time.Timer
 	var retryC <-chan time.Time
 	retryNow := false
+
+	// A failed user_cancel post is retried on its own timer rather than being
+	// dropped: the service rejects cancels while the task is parked on a local
+	// tool call, and the retry is what eventually lands the cancel once the
+	// tool result posts. Single slot — repeated ESC presses while a cancel is
+	// pending are deduplicated.
+	var pendingCancel *apitype.AgentUserEventCancel
+	cancelFailures := 0
+	var cancelTimer *time.Timer
+	var cancelRetryC <-chan time.Time
+	scheduleCancelRetry := func() {
+		cancelTimer = time.NewTimer(userMessageRetryDelay(cancelFailures))
+		cancelRetryC = cancelTimer.C
+	}
 	stopRetryTimer := func() {
 		if retryTimer != nil {
 			retryTimer.Stop()
@@ -1008,6 +1035,25 @@ func dispatchUserEvents(
 			retryTimer = nil
 			retryC = nil
 			retryNow = true
+		case <-cancelRetryC:
+			cancelTimer = nil
+			cancelRetryC = nil
+			if pendingCancel == nil {
+				continue
+			}
+			if err := postEvent(ctx, getTaskID(), *pendingCancel); err != nil {
+				cancelFailures++
+				if cancelFailures >= cancelRetryMaxAttempts {
+					sendUI(uiCh, UICancelFailed{Message: err.Error()})
+					pendingCancel = nil
+					cancelFailures = 0
+					continue
+				}
+				scheduleCancelRetry()
+				continue
+			}
+			pendingCancel = nil
+			cancelFailures = 0
 		case ob, ok := <-outCh:
 			if !ok {
 				return nil
@@ -1043,6 +1089,18 @@ func dispatchUserEvents(
 				pendingMessages = append(pendingMessages, queuedUserMessage{event: msg})
 				if len(pendingMessages) == 1 {
 					retryNow = true
+				}
+				continue
+			}
+			if cancelEvt, isCancel := ob.event.(apitype.AgentUserEventCancel); isCancel {
+				if pendingCancel != nil {
+					continue
+				}
+				if err := postEvent(ctx, taskID, cancelEvt); err != nil {
+					pendingCancel = &cancelEvt
+					cancelFailures = 1
+					sendUI(uiCh, UIWarning{Message: "cancel not accepted yet, retrying: " + err.Error()})
+					scheduleCancelRetry()
 				}
 				continue
 			}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -64,12 +64,12 @@ var (
 	userMessageRetryInitialBackoff = 1 * time.Second
 	userMessageRetryMaxBackoff     = 30 * time.Second
 
-	// cancelRetryMaxAttempts bounds the automatic retries of a failed
-	// user_cancel post. With userMessageRetryDelay backoff this spans roughly
-	// two minutes — enough to outlast most local tool calls (during which the
-	// service 409s cancels because the task is parked) without retrying
-	// forever against a task that will never accept one.
-	cancelRetryMaxAttempts = 8
+	// cancelMaxPostAttempts bounds the total user_cancel posts (the initial
+	// one plus automatic retries). With userMessageRetryDelay backoff, 8
+	// posts span roughly 90 seconds — enough to outlast most local tool calls
+	// (during which the service 409s cancels because the task is parked)
+	// without retrying forever against a task that will never accept one.
+	cancelMaxPostAttempts = 8
 )
 
 // neoTaskCreator is the slice of the cloud client that creates Neo tasks.
@@ -142,6 +142,11 @@ type outboundEvent struct {
 	// posting a user event. Used by Ctrl+A / Ctrl+R after the first message has
 	// been sent, so cloud ApprovalHandler picks up the new mode immediately.
 	update *client.UpdateNeoTaskOptions
+	// abandonCancel, when true, tells the dispatcher to drop any pending
+	// user_cancel retry: the TUI sends it when a final event ends the turn the
+	// cancel targeted, so a stale retry can't fire into a later turn. event is
+	// nil on these envelopes.
+	abandonCancel bool
 }
 
 // Indirection points for the integration test in neo_integration_test.go.
@@ -640,10 +645,6 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 						})
 					},
 					func(ctx context.Context, taskID string, body any) error {
-						// Deadline so a hung post can't wedge the serial
-						// dispatcher loop (and with it the whole TUI).
-						ctx, cancel := context.WithTimeout(ctx, client.NeoRequestTimeout)
-						defer cancel()
 						return rt.pc.PostNeoTaskUserEvent(ctx, orgName, taskID, body)
 					},
 					func(ctx context.Context, taskID string, opts client.UpdateNeoTaskOptions) error {
@@ -812,8 +813,6 @@ func runNeoResumeTUI(
 					func() string { return taskID },
 					func(string, client.NeoApprovalMode, client.NeoPermissionMode, bool) {},
 					func(ctx context.Context, taskID string, body any) error {
-						ctx, cancel := context.WithTimeout(ctx, client.NeoRequestTimeout)
-						defer cancel()
 						return pc.PostNeoTaskUserEvent(ctx, orgName, taskID, body)
 					},
 					func(ctx context.Context, taskID string, opts client.UpdateNeoTaskOptions) error {
@@ -982,18 +981,10 @@ func dispatchUserEvents(
 	var retryC <-chan time.Time
 	retryNow := false
 
-	// A failed user_cancel post is retried on its own timer rather than being
-	// dropped: the service rejects cancels while the task is parked on a local
-	// tool call, and the retry is what eventually lands the cancel once the
-	// tool result posts. Single slot — repeated ESC presses while a cancel is
-	// pending are deduplicated.
-	var pendingCancel *apitype.AgentUserEventCancel
-	cancelFailures := 0
-	var cancelTimer *time.Timer
-	var cancelRetryC <-chan time.Time
-	scheduleCancelRetry := func() {
-		cancelTimer = time.NewTimer(userMessageRetryDelay(cancelFailures))
-		cancelRetryC = cancelTimer.C
+	// Single-slot retry state for the in-flight user_cancel; see cancelRetry.
+	cancel := &cancelRetry{}
+	postCancel := func() {
+		cancel.post(ctx, getTaskID(), postEvent, uiCh)
 	}
 	stopRetryTimer := func() {
 		if retryTimer != nil {
@@ -1035,28 +1026,29 @@ func dispatchUserEvents(
 			retryTimer = nil
 			retryC = nil
 			retryNow = true
-		case <-cancelRetryC:
-			cancelTimer = nil
-			cancelRetryC = nil
-			if pendingCancel == nil {
-				continue
+		case <-cancel.timerC:
+			cancel.timerC = nil
+			if cancel.pending {
+				postCancel()
 			}
-			if err := postEvent(ctx, getTaskID(), *pendingCancel); err != nil {
-				cancelFailures++
-				if cancelFailures >= cancelRetryMaxAttempts {
-					sendUI(uiCh, UICancelFailed{Message: err.Error()})
-					pendingCancel = nil
-					cancelFailures = 0
-					continue
-				}
-				scheduleCancelRetry()
-				continue
-			}
-			pendingCancel = nil
-			cancelFailures = 0
 		case ob, ok := <-outCh:
 			if !ok {
 				return nil
+			}
+			// An abandon envelope (the TUI saw the turn end) or any non-cancel
+			// user event proves a pending cancel is stale and disarms its retry
+			// so it can't fire into a later turn. The non-cancel case is the
+			// backstop for a dropped abandon (sendOut is drop-on-full): the TUI
+			// can only emit another user event after the turn ended. Mode
+			// updates (nil event) don't count — they're legal while a cancel is
+			// in flight. Checked before the taskID gate: the abandon envelope's
+			// nil event would otherwise trip the "task not ready" warning when
+			// the abandon races task creation.
+			if ob.abandonCancel || (cancel.pending && ob.event != nil && !isCancelEvent(ob.event)) {
+				cancel.disarm()
+				if ob.abandonCancel {
+					continue
+				}
 			}
 			if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
 				taskCreated = true
@@ -1092,15 +1084,10 @@ func dispatchUserEvents(
 				}
 				continue
 			}
-			if cancelEvt, isCancel := ob.event.(apitype.AgentUserEventCancel); isCancel {
-				if pendingCancel != nil {
-					continue
-				}
-				if err := postEvent(ctx, taskID, cancelEvt); err != nil {
-					pendingCancel = &cancelEvt
-					cancelFailures = 1
-					sendUI(uiCh, UIWarning{Message: "cancel not accepted yet, retrying: " + err.Error()})
-					scheduleCancelRetry()
+			if isCancelEvent(ob.event) {
+				if !cancel.pending {
+					cancel.pending = true
+					postCancel()
 				}
 				continue
 			}
@@ -1109,6 +1096,58 @@ func dispatchUserEvents(
 			}
 		}
 	}
+}
+
+// cancelRetry is the dispatcher's single-slot retry state for the in-flight
+// user_cancel. A failed post is retried on its own timer rather than being
+// dropped: the service rejects cancels while the task is parked on a local
+// tool call, and the retry is what eventually lands the cancel once the tool
+// result posts. Repeated ESC presses while a cancel is pending are
+// deduplicated against the one slot.
+type cancelRetry struct {
+	pending  bool
+	failures int
+	// timerC is the armed retry timer's channel; nil when no retry is
+	// scheduled. Disarming just nils it — no Timer.Stop needed, the orphaned
+	// timer fires into its own buffered channel and gets collected.
+	timerC <-chan time.Time
+}
+
+func (c *cancelRetry) disarm() {
+	c.pending = false
+	c.failures = 0
+	c.timerC = nil
+}
+
+// post sends the user_cancel and, on failure, arms the retry timer — giving up
+// with UICancelFailed after cancelMaxPostAttempts posts so the TUI can unlock
+// ESC for a manual retry.
+func (c *cancelRetry) post(
+	ctx context.Context,
+	taskID string,
+	postEvent func(ctx context.Context, taskID string, body any) error,
+	uiCh chan<- UIEvent,
+) {
+	err := postEvent(ctx, taskID, apitype.AgentUserEventCancel{Type: userEventUserCancel})
+	if err == nil {
+		c.disarm()
+		return
+	}
+	c.failures++
+	if c.failures == 1 {
+		sendUI(uiCh, UIWarning{Message: "cancel not accepted yet, retrying: " + err.Error()})
+	}
+	if c.failures >= cancelMaxPostAttempts {
+		sendUI(uiCh, UICancelFailed{Message: err.Error()})
+		c.disarm()
+		return
+	}
+	c.timerC = time.NewTimer(userMessageRetryDelay(c.failures)).C
+}
+
+func isCancelEvent(event any) bool {
+	_, ok := event.(apitype.AgentUserEventCancel)
+	return ok
 }
 
 type queuedUserMessage struct {

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -66,6 +66,11 @@ type neoFakeServer struct {
 	// it via endStream ends the stream cleanly.
 	streamSend chan []byte
 	endOnce    sync.Once
+
+	// userEventStatus, when set, lets a test override the response status for
+	// individual PostNeoTaskUserEvent bodies. Return 0 for the default 200.
+	// Guarded by mu; set it before starting runNeo.
+	userEventStatus func(body []byte) int
 }
 
 type recordedPost struct {
@@ -178,7 +183,19 @@ func newNeoFakeServer(t *testing.T) *neoFakeServer {
 			body, _ := io.ReadAll(r.Body)
 			s.mu.Lock()
 			s.posts = append(s.posts, recordedPost{path: r.URL.Path, body: body})
+			statusFn := s.userEventStatus
 			s.mu.Unlock()
+			if statusFn != nil {
+				if status := statusFn(body); status != 0 {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_ = json.NewEncoder(w).Encode(apitype.ErrorResponse{
+						Code:    status,
+						Message: "cannot respond while a request is still ongoing",
+					})
+					return
+				}
+			}
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -1000,4 +1017,108 @@ func TestRunNeoIntegration_DisableIntegrationsSendsEmptyList(t *testing.T) {
 		"--disable-integrations must send an explicit enabledIntegrations field")
 	assert.Equal(t, []any{}, body["enabledIntegrations"],
 		"--disable-integrations must send an empty enabledIntegrations array")
+}
+
+// TestRunNeoIntegration_EscDuringPendingTool_CancelNotLost encodes desired
+// end-to-end behavior for pulumi/pulumi-service#44059: when the service
+// rejects a user_cancel with 409 (today it does so whenever the task is
+// parked on a CLI tool call), the CLI must not wedge in "Cancelling..." —
+// the user must be able to retry the cancel. Today the 409 only surfaces as
+// a warning while the cancelling flag stays set, so every later ESC is
+// swallowed and no second user_cancel is ever posted.
+//
+//nolint:paralleltest,lll // mutates package globals (DefaultLoginManager, pkgWorkspace.Instance, newTeaProgram, isInteractive)
+func TestRunNeoIntegration_EscDuringPendingTool_CancelNotLost(t *testing.T) {
+	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
+
+	isolateWorkspace(t)
+	srv := newNeoFakeServer(t)
+
+	// The service 409s user_cancel events (the parked-task behavior); every
+	// other user event (exec_tool_call, tool_result) keeps succeeding.
+	srv.mu.Lock()
+	srv.userEventStatus = func(body []byte) int {
+		if bytes.Contains(body, []byte(userEventUserCancel)) {
+			return http.StatusConflict
+		}
+		return 0
+	}
+	srv.mu.Unlock()
+
+	installNeoTestEnv(t, srv, true /*interactive*/)
+
+	var (
+		programMu sync.Mutex
+		program   *tea.Program
+	)
+	prevProgram := newTeaProgram
+	newTeaProgram = func(m tea.Model) *tea.Program {
+		p := tea.NewProgram(
+			m,
+			tea.WithInput(nil),
+			tea.WithOutput(io.Discard),
+			tea.WithoutSignals(),
+			tea.WithoutSignalHandler(),
+			tea.WithoutRenderer(),
+		)
+		programMu.Lock()
+		program = p
+		programMu.Unlock()
+		return p
+	}
+	t.Cleanup(func() { newTeaProgram = prevProgram })
+
+	done := make(chan error, 1)
+	go func() { done <- runNeoTest(t.Context(), "do a thing", t.TempDir()) }()
+
+	// Wait for the TUI and the SSE stream, i.e. a running busy turn.
+	var p *tea.Program
+	deadline := time.Now().Add(testWaitTimeout)
+	for time.Now().Before(deadline) {
+		programMu.Lock()
+		p = program
+		programMu.Unlock()
+		if p != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NotNil(t, p, "runNeo never constructed the tea.Program")
+	require.True(t, srv.awaitStreamConnect(t, testWaitTimeout), "SSE stream never opened")
+
+	countCancelPosts := func() int {
+		n := 0
+		for _, post := range srv.recordedPosts() {
+			if strings.Contains(string(post.body), userEventUserCancel) {
+				n++
+			}
+		}
+		return n
+	}
+
+	// First ESC posts the cancel, which the server rejects with 409.
+	p.Send(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.Eventually(t, func() bool { return countCancelPosts() >= 1 },
+		testWaitTimeout, 20*time.Millisecond, "first ESC never posted a user_cancel")
+
+	// Desired: after the failed cancel, ESC must still be able to retry. Keep
+	// pressing while polling — today the cancelling guard swallows every one
+	// of these and no second post ever appears.
+	retryDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(retryDeadline) && countCancelPosts() < 2 {
+		p.Send(tea.KeyPressMsg{Code: tea.KeyEsc})
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, countCancelPosts(), 2,
+		"ESC after a 409-rejected cancel must retry the user_cancel post instead of being swallowed")
+
+	p.Quit()
+	select {
+	case err := <-done:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled, "unexpected error from runNeo: %v", err)
+		}
+	case <-time.After(testWaitTimeout):
+		t.Fatal("runNeo did not return after tea.Quit")
+	}
 }

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -1019,18 +1019,14 @@ func TestRunNeoIntegration_DisableIntegrationsSendsEmptyList(t *testing.T) {
 		"--disable-integrations must send an empty enabledIntegrations array")
 }
 
-// TestRunNeoIntegration_EscDuringPendingTool_CancelNotLost encodes desired
-// end-to-end behavior for pulumi/pulumi-service#44059: when the service
-// rejects a user_cancel with 409 (today it does so whenever the task is
-// parked on a CLI tool call), the CLI must not wedge in "Cancelling..." —
-// the user must be able to retry the cancel. Today the 409 only surfaces as
-// a warning while the cancelling flag stays set, so every later ESC is
-// swallowed and no second user_cancel is ever posted.
+// TestRunNeoIntegration_EscDuringPendingTool_CancelNotLost — end-to-end
+// pin for pulumi/pulumi-service#44059: when the service rejects a user_cancel
+// with 409 (it does so whenever the task is parked on a CLI tool call), the
+// CLI must not wedge in "Cancelling..." — the dispatcher auto-retries the
+// cancel, so a second user_cancel POST must show up.
 //
 //nolint:paralleltest,lll // mutates package globals (DefaultLoginManager, pkgWorkspace.Instance, newTeaProgram, isInteractive)
 func TestRunNeoIntegration_EscDuringPendingTool_CancelNotLost(t *testing.T) {
-	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
-
 	isolateWorkspace(t)
 	srv := newNeoFakeServer(t)
 
@@ -1101,16 +1097,12 @@ func TestRunNeoIntegration_EscDuringPendingTool_CancelNotLost(t *testing.T) {
 	require.Eventually(t, func() bool { return countCancelPosts() >= 1 },
 		testWaitTimeout, 20*time.Millisecond, "first ESC never posted a user_cancel")
 
-	// Desired: after the failed cancel, ESC must still be able to retry. Keep
-	// pressing while polling — today the cancelling guard swallows every one
-	// of these and no second post ever appears.
-	retryDeadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(retryDeadline) && countCancelPosts() < 2 {
-		p.Send(tea.KeyPressMsg{Code: tea.KeyEsc})
-		time.Sleep(100 * time.Millisecond)
-	}
-	require.GreaterOrEqual(t, countCancelPosts(), 2,
-		"ESC after a 409-rejected cancel must retry the user_cancel post instead of being swallowed")
+	// After the 409, the dispatcher must auto-retry the cancel (first retry
+	// fires after ~1s of backoff), so a second user_cancel post shows up
+	// without any further user input.
+	require.Eventually(t, func() bool { return countCancelPosts() >= 2 },
+		5*time.Second, 100*time.Millisecond,
+		"a 409-rejected cancel must be retried instead of dropped")
 
 	p.Quit()
 	select {

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -983,14 +983,14 @@ func TestDispatchUserEvents_RetriesCancelOnPostFailure(t *testing.T) {
 func TestDispatchUserEvents_CancelRetriesExhaustedEmitsUICancelFailed(t *testing.T) {
 	prevInitial := userMessageRetryInitialBackoff
 	prevMax := userMessageRetryMaxBackoff
-	prevAttempts := cancelRetryMaxAttempts
+	prevAttempts := cancelMaxPostAttempts
 	userMessageRetryInitialBackoff = time.Millisecond
 	userMessageRetryMaxBackoff = 2 * time.Millisecond
-	cancelRetryMaxAttempts = 3
+	cancelMaxPostAttempts = 3
 	t.Cleanup(func() {
 		userMessageRetryInitialBackoff = prevInitial
 		userMessageRetryMaxBackoff = prevMax
-		cancelRetryMaxAttempts = prevAttempts
+		cancelMaxPostAttempts = prevAttempts
 	})
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -1027,7 +1027,189 @@ func TestDispatchUserEvents_CancelRetriesExhaustedEmitsUICancelFailed(t *testing
 		}
 	}
 	assert.Contains(t, failed.Message, "still parked")
-	assert.Equal(t, int32(3), attempts.Load(), "give-up must happen after cancelRetryMaxAttempts posts")
+	assert.Equal(t, int32(3), attempts.Load(), "give-up must happen after cancelMaxPostAttempts posts")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
+}
+
+// TestDispatchUserEvents_AbandonCancelStopsRetries — an abandonCancel envelope
+// (sent by the TUI when the turn ends) must disarm a pending cancel retry so a
+// stale cancel can't fire into a later turn.
+//
+//nolint:paralleltest // mutates the package backoff vars
+func TestDispatchUserEvents_AbandonCancelStopsRetries(t *testing.T) {
+	prevInitial := userMessageRetryInitialBackoff
+	prevMax := userMessageRetryMaxBackoff
+	userMessageRetryInitialBackoff = 10 * time.Millisecond
+	userMessageRetryMaxBackoff = 20 * time.Millisecond
+	t.Cleanup(func() {
+		userMessageRetryInitialBackoff = prevInitial
+		userMessageRetryMaxBackoff = prevMax
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	uiCh := make(chan UIEvent, 16)
+	out := make(chan outboundEvent, 2)
+	var attempts atomic.Int32
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(ctx, out, uiCh, true,
+			func() string { return "task-1" },
+			noopSpawn,
+			func(context.Context, string, any) error {
+				attempts.Add(1)
+				return errors.New("still parked")
+			},
+			noopUpdateTask)
+	}()
+
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+	require.Eventually(t, func() bool { return attempts.Load() >= 1 },
+		3*time.Second, 5*time.Millisecond, "cancel was never posted")
+
+	out <- outboundEvent{abandonCancel: true}
+
+	// Long enough that an un-disarmed retry loop would exhaust all
+	// cancelMaxPostAttempts posts (~150ms at the shrunk backoff) and emit
+	// UICancelFailed.
+	time.Sleep(500 * time.Millisecond)
+	assert.Less(t, int(attempts.Load()), cancelMaxPostAttempts,
+		"abandonCancel must stop the retry loop before exhaustion")
+	for {
+		select {
+		case evt := <-uiCh:
+			if _, isFailed := evt.(UICancelFailed); isFailed {
+				t.Fatal("abandoned cancel must not surface UICancelFailed")
+			}
+			continue
+		default:
+		}
+		break
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
+}
+
+// TestDispatchUserEvents_AbandonCancelBeforeTaskReadyIsSilent — the abandon
+// envelope carries a nil event, so it must be handled before the empty-taskID
+// gate or it would surface a spurious "task not ready" warning (reachable when
+// a lazily-created task errors out and UIError ends the turn).
+func TestDispatchUserEvents_AbandonCancelBeforeTaskReadyIsSilent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	uiCh := make(chan UIEvent, 4)
+	out := make(chan outboundEvent, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(ctx, out, uiCh, true,
+			func() string { return "" },
+			noopSpawn,
+			func(context.Context, string, any) error { return nil },
+			noopUpdateTask)
+	}()
+
+	out <- outboundEvent{abandonCancel: true}
+
+	select {
+	case evt := <-uiCh:
+		t.Fatalf("abandonCancel with no task must be silent, got %T", evt)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
+}
+
+// TestDispatchUserEvents_UserMessageAbandonsStaleCancel — backstop for a
+// dropped abandon envelope: the TUI can only emit a non-cancel user event
+// after the turn ended, so its arrival must also disarm a pending cancel.
+//
+//nolint:paralleltest // mutates the package backoff vars
+func TestDispatchUserEvents_UserMessageAbandonsStaleCancel(t *testing.T) {
+	prevInitial := userMessageRetryInitialBackoff
+	prevMax := userMessageRetryMaxBackoff
+	userMessageRetryInitialBackoff = 10 * time.Millisecond
+	userMessageRetryMaxBackoff = 20 * time.Millisecond
+	t.Cleanup(func() {
+		userMessageRetryInitialBackoff = prevInitial
+		userMessageRetryMaxBackoff = prevMax
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	uiCh := make(chan UIEvent, 16)
+	out := make(chan outboundEvent, 2)
+	var cancelAttempts, messagePosts atomic.Int32
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(ctx, out, uiCh, true,
+			func() string { return "task-1" },
+			noopSpawn,
+			func(_ context.Context, _ string, body any) error {
+				switch body.(type) {
+				case apitype.AgentUserEventCancel:
+					cancelAttempts.Add(1)
+					return errors.New("still parked")
+				case apitype.AgentUserEventUserMessage:
+					messagePosts.Add(1)
+				}
+				return nil
+			},
+			noopUpdateTask)
+	}()
+
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+	require.Eventually(t, func() bool { return cancelAttempts.Load() >= 1 },
+		3*time.Second, 5*time.Millisecond, "cancel was never posted")
+
+	out <- outboundEvent{event: apitype.AgentUserEventUserMessage{
+		Type:    userEventUserMessage,
+		Content: "next turn",
+	}}
+	require.Eventually(t, func() bool { return messagePosts.Load() == 1 },
+		3*time.Second, 5*time.Millisecond, "user message was never posted")
+
+	// See TestDispatchUserEvents_AbandonCancelStopsRetries for the window.
+	time.Sleep(500 * time.Millisecond)
+	assert.Less(t, int(cancelAttempts.Load()), cancelMaxPostAttempts,
+		"a user message must disarm the stale cancel retry loop")
+	for {
+		select {
+		case evt := <-uiCh:
+			if _, isFailed := evt.(UICancelFailed); isFailed {
+				t.Fatal("disarmed cancel must not surface UICancelFailed")
+			}
+			continue
+		default:
+		}
+		break
+	}
 
 	cancel()
 	select {

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -900,10 +900,16 @@ func TestDispatchUserEvents_WarnsOnPostFailure(t *testing.T) {
 
 	// A backend error during PostNeoTaskUserEvent must surface as a UIWarning
 	// — losing a single user event shouldn't tear down the dispatcher loop.
+	// (Cancels are the exception: they get queued and retried, see
+	// TestDispatchUserEvents_RetriesCancelOnPostFailure.)
 	uiCh := make(chan UIEvent, 4)
 
 	out := make(chan outboundEvent, 1)
-	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+	out <- outboundEvent{event: apitype.AgentUserEventUserConfirmation{
+		Type:       userEventUserConfirmation,
+		ApprovalID: "approval-1",
+		Approved:   true,
+	}}
 	close(out)
 
 	err := dispatchUserEvents(t.Context(), out, uiCh, true,
@@ -925,6 +931,111 @@ func TestDispatchUserEvents_WarnsOnPostFailure(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Contains(t, got[0].Message, "failed to send event")
 	assert.Contains(t, got[0].Message, "network down")
+}
+
+// TestDispatchUserEvents_RetriesCancelOnPostFailure — a failed user_cancel
+// post must be retried with backoff rather than dropped: the service rejects
+// cancels while the task is parked on a local tool call, and the retry is
+// what lands the cancel once the task resumes (pulumi/pulumi-service#44059).
+func TestDispatchUserEvents_RetriesCancelOnPostFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	uiCh := make(chan UIEvent, 8)
+	out := make(chan outboundEvent, 1)
+	var attempts atomic.Int32
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(ctx, out, uiCh, true,
+			func() string { return "task-1" },
+			noopSpawn,
+			func(context.Context, string, any) error {
+				if attempts.Add(1) == 1 {
+					return errors.New("[409] Conflict: cannot respond while a request is still ongoing")
+				}
+				return nil
+			},
+			noopUpdateTask)
+	}()
+
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+
+	require.Eventually(t, func() bool { return attempts.Load() >= 2 },
+		3*time.Second, 20*time.Millisecond, "cancel must be retried after a failed post")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
+}
+
+// TestDispatchUserEvents_CancelRetriesExhaustedEmitsUICancelFailed — when
+// every retry fails, the dispatcher must give up and emit UICancelFailed so
+// the TUI can unlock ESC for a manual retry.
+//
+//nolint:paralleltest // mutates the package backoff and retry-cap vars
+func TestDispatchUserEvents_CancelRetriesExhaustedEmitsUICancelFailed(t *testing.T) {
+	prevInitial := userMessageRetryInitialBackoff
+	prevMax := userMessageRetryMaxBackoff
+	prevAttempts := cancelRetryMaxAttempts
+	userMessageRetryInitialBackoff = time.Millisecond
+	userMessageRetryMaxBackoff = 2 * time.Millisecond
+	cancelRetryMaxAttempts = 3
+	t.Cleanup(func() {
+		userMessageRetryInitialBackoff = prevInitial
+		userMessageRetryMaxBackoff = prevMax
+		cancelRetryMaxAttempts = prevAttempts
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	uiCh := make(chan UIEvent, 8)
+	out := make(chan outboundEvent, 1)
+	var attempts atomic.Int32
+
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(ctx, out, uiCh, true,
+			func() string { return "task-1" },
+			noopSpawn,
+			func(context.Context, string, any) error {
+				attempts.Add(1)
+				return errors.New("still parked")
+			},
+			noopUpdateTask)
+	}()
+
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+
+	var failed *UICancelFailed
+	deadline := time.After(3 * time.Second)
+	for failed == nil {
+		select {
+		case evt := <-uiCh:
+			if f, ok := evt.(UICancelFailed); ok {
+				failed = &f
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for UICancelFailed; attempts=%d", attempts.Load())
+		}
+	}
+	assert.Contains(t, failed.Message, "still parked")
+	assert.Equal(t, int32(3), attempts.Load(), "give-up must happen after cancelRetryMaxAttempts posts")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
 }
 
 func TestDispatchUserEvents_RetriesUserMessageOnTransientPostFailure(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -699,18 +699,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// scheduled this tick.
 		if msg.gen == m.approvalDebounceGen {
 			next := m.approvalMode
-			m.sendOut(outboundEvent{
+			if !m.sendOut(outboundEvent{
 				update: &client.UpdateNeoTaskOptions{ApprovalMode: &next},
-			})
+			}) {
+				// Outbound channel full — re-arm the debounce so the update
+				// retries rather than silently leaving the server on the old
+				// mode. The retried tick re-reads approvalMode, so latest
+				// value still wins.
+				return m, m.scheduleApprovalDebounce()
+			}
 		}
 		return m, nil
 
 	case permissionDebounceTickMsg:
 		if msg.gen == m.permissionDebounceGen {
 			next := m.permissionMode
-			m.sendOut(outboundEvent{
+			if !m.sendOut(outboundEvent{
 				update: &client.UpdateNeoTaskOptions{PermissionMode: &next},
-			})
+			}) {
+				return m, m.schedulePermissionDebounce()
+			}
 		}
 		return m, nil
 
@@ -873,7 +881,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if text == "" {
 						return m, nil
 					}
-					m.sendOut(outboundEvent{
+					// Drop-on-full send: bail before any state mutation so the
+					// prompt stays pending, the draft survives, and Enter
+					// retries — otherwise the TUI would show the answer as
+					// submitted while the agent waits forever for it.
+					if !m.sendOut(outboundEvent{
 						event: apitype.AgentUserEventUserConfirmation{
 							Type:       userEventUserConfirmation,
 							ApprovalID: m.pendingApprovalID,
@@ -881,7 +893,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							Message:    text,
 						},
 						planMode: m.planMode,
-					})
+					}) {
+						return m, m.appendWarningBlock("Answer not sent — press Enter to try again.")
+					}
 					m.clearPendingPrompt()
 					answerCmd := m.commitBlock(block{kind: blockAnswerSubmitted, raw: text})
 					return m, tea.Batch(answerCmd, m.showBusy(thinkingLabel, shimmerVerb))
@@ -892,7 +906,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					denialMsg = text
 				}
 				wasPlanApproval := m.pendingApprovalType == approvalTypePlanExit
-				m.sendOut(outboundEvent{
+				// See the question path above — a dropped confirmation must
+				// keep the approval pending rather than pretend it was sent.
+				if !m.sendOut(outboundEvent{
 					event: apitype.AgentUserEventUserConfirmation{
 						Type:       userEventUserConfirmation,
 						ApprovalID: m.pendingApprovalID,
@@ -900,7 +916,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Message:    denialMsg,
 					},
 					planMode: m.planMode,
-				})
+				}) {
+					return m, m.appendWarningBlock("Reply not sent — press Enter to try again.")
+				}
 				// Approving a plan exits plan mode server-side (the PlanModeTracker
 				// stops gating writes), so mirror that locally. Denial leaves the
 				// mode on — the agent will re-plan and gate-out again on the next

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -763,15 +763,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// users who reach for Ctrl+C don't need to learn ESC to abort.
 			// Same guards as the ESC handler below.
 			if m.busy && !m.pendingApproval && !m.cancelling {
-				if !m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}) {
-					// Outbound channel full: nothing was enqueued, so don't
-					// claim to be cancelling — the next press retries.
-					warnCmd := m.appendWarningBlock("Cancel not sent — press Esc to try again.")
-					return m, tea.Batch(warnCmd, disarmCmd)
-				}
-				m.cancelling = true
-				cancelCmd := m.showBusy("Cancelling...", shimmerVerb)
-				return m, tea.Batch(cancelCmd, disarmCmd)
+				return m, tea.Batch(m.tryStartCancel(), disarmCmd)
 			}
 			return m, disarmCmd
 		}
@@ -867,13 +859,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if m.busy && !m.pendingApproval && !m.cancelling {
-				if !m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}) {
-					// Outbound channel full: nothing was enqueued, so don't
-					// claim to be cancelling — the next press retries.
-					return m, m.appendWarningBlock("Cancel not sent — press Esc to try again.")
-				}
-				m.cancelling = true
-				return m, m.showBusy("Cancelling...", shimmerVerb)
+				return m, m.tryStartCancel()
 			}
 			return m, nil
 		}
@@ -1632,6 +1618,13 @@ func (m *Model) printlnBlock(rendered string) tea.Cmd {
 // the user's cancel request is in flight).
 func (m *Model) applyBusyForEvent(ev UIEvent) tea.Cmd {
 	if isFinalUIEvent(ev) {
+		if m.cancelling {
+			// The turn the pending cancel targeted is over — tell the
+			// dispatcher to drop its retry so it can't fire into a later turn.
+			// A dropped send is backstopped dispatcher-side: any later
+			// non-cancel user event also disarms the stale cancel.
+			m.sendOut(outboundEvent{abandonCancel: true})
+		}
 		m.cancelling = false
 		m.endBusy()
 		return nil
@@ -1765,6 +1758,19 @@ func (m *Model) schedulePermissionDebounce() tea.Cmd {
 	return tea.Tick(modeToggleDebounce, func(time.Time) tea.Msg {
 		return permissionDebounceTickMsg{gen: gen}
 	})
+}
+
+// tryStartCancel enqueues a user_cancel and enters the cancelling substate,
+// returning the "Cancelling..." spinner command. When the outbound channel is
+// full nothing was enqueued, so the model stays out of the cancelling substate
+// and warns instead — the next press retries. Shared by the ESC and Ctrl+C
+// handlers, which apply the same busy/approval/cancelling guards first.
+func (m *Model) tryStartCancel() tea.Cmd {
+	if !m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}) {
+		return m.appendWarningBlock("Cancel not sent — press Esc or Ctrl+C to try again.")
+	}
+	m.cancelling = true
+	return m.showBusy("Cancelling...", shimmerVerb)
 }
 
 // sendOut is a non-blocking send on the outbound channel. Returns true on

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -763,7 +763,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// users who reach for Ctrl+C don't need to learn ESC to abort.
 			// Same guards as the ESC handler below.
 			if m.busy && !m.pendingApproval && !m.cancelling {
-				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
+				if !m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}) {
+					// Outbound channel full: nothing was enqueued, so don't
+					// claim to be cancelling — the next press retries.
+					warnCmd := m.appendWarningBlock("Cancel not sent — press Esc to try again.")
+					return m, tea.Batch(warnCmd, disarmCmd)
+				}
 				m.cancelling = true
 				cancelCmd := m.showBusy("Cancelling...", shimmerVerb)
 				return m, tea.Batch(cancelCmd, disarmCmd)
@@ -852,15 +857,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// ESC clears a non-empty textarea; with an empty box it asks the
 		// agent to abort. The cancelling flag overrides the spinner label
 		// until the backend acknowledges via cancelled / error / a new
-		// final assistant_message. Skipped during a pending approval — the
-		// agent is already paused for us there.
+		// final assistant_message — or until UICancelFailed reports the
+		// dispatcher gave up delivering the cancel, which re-enables ESC.
+		// Skipped during a pending approval — the agent is already paused
+		// for us there.
 		if keyStr == "esc" {
 			if m.textInput.Value() != "" {
 				m.textInput.Reset()
 				return m, nil
 			}
 			if m.busy && !m.pendingApproval && !m.cancelling {
-				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
+				if !m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}) {
+					// Outbound channel full: nothing was enqueued, so don't
+					// claim to be cancelling — the next press retries.
+					return m, m.appendWarningBlock("Cancel not sent — press Esc to try again.")
+				}
 				m.cancelling = true
 				return m, m.showBusy("Cancelling...", shimmerVerb)
 			}
@@ -1056,6 +1067,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case UIWarning:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
 		cmds = append(cmds, m.appendWarningBlock(msg.Message))
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UICancelFailed:
+		// The dispatcher gave up delivering the cancel. Clear the cancelling
+		// substate so ESC works again, and restore a live spinner label — the
+		// turn is still running. Deliberately not routed through
+		// labelForUIEvent: a failure arriving after the turn already ended
+		// must not resurrect the spinner.
+		m.cancelling = false
+		if m.busy {
+			cmds = append(cmds, m.showBusy(thinkingLabel, shimmerVerb))
+		}
+		cmds = append(cmds, m.appendWarningBlock("Cancel failed: "+msg.Message+" — press Esc to retry."))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIReconnecting:

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -268,6 +268,85 @@ func TestBusy_EscIgnoredWhileApprovalPending(t *testing.T) {
 	}
 }
 
+// TestBusy_EscRetryableAfterCancelPostFailure encodes desired behavior for
+// pulumi/pulumi-service#44059: when the user_cancel POST fails (the service
+// 409s cancels while the task is parked on a CLI tool call), the user must
+// not be locked out of cancelling. Today the failure only surfaces as a
+// UIWarning while m.cancelling stays set, so every further ESC is a no-op
+// and the TUI shows "Cancelling..." forever.
+func TestBusy_EscRetryableAfterCancelPostFailure(t *testing.T) {
+	t.Parallel()
+	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
+
+	ch := make(chan UIEvent, 4)
+	outCh := make(chan outboundEvent, 4)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: true}))
+
+	// First ESC posts a cancel and enters the cancelling substate.
+	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.True(t, model.(Model).cancelling)
+	select {
+	case ev := <-outCh:
+		_, ok := ev.event.(apitype.AgentUserEventCancel)
+		require.True(t, ok, "first ESC must post an AgentUserEventCancel")
+	default:
+		t.Fatal("first ESC did not post any user event")
+	}
+
+	// The cancel POST fails; dispatchUserEvents surfaces it as a warning.
+	model, _ = model.Update(UIWarning{
+		Message: "failed to send event: [409] Conflict: cannot respond while a request is still ongoing",
+	})
+
+	// A second ESC must be able to retry the cancel instead of being swallowed
+	// by the still-set cancelling flag.
+	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m := model.(Model)
+	select {
+	case ev := <-outCh:
+		_, ok := ev.event.(apitype.AgentUserEventCancel)
+		require.True(t, ok, "retry ESC must post an AgentUserEventCancel, got %T", ev.event)
+	default:
+		t.Fatalf("ESC after a failed cancel POST must retry the cancel (cancelling=%v)", m.cancelling)
+	}
+}
+
+// TestBusy_EscWithFullOutChannelNotSilentlyDropped encodes desired behavior
+// for pulumi/pulumi-service#44059: ESC must not claim to be cancelling when
+// the cancel event was never enqueued. Today sendOut is a non-blocking send
+// whose result is ignored, so with a full outbound channel the model flips to
+// "Cancelling..." while nothing is ever posted — and the cancelling guard then
+// swallows every retry.
+func TestBusy_EscWithFullOutChannelNotSilentlyDropped(t *testing.T) {
+	t.Parallel()
+	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
+
+	ch := make(chan UIEvent, 4)
+	outCh := make(chan outboundEvent, 1)
+	outCh <- outboundEvent{event: apitype.AgentUserEventUserMessage{}} // fill the channel
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: true}))
+
+	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m := model.(Model)
+
+	// Drain the channel and look for the cancel.
+	foundCancel := false
+	for {
+		select {
+		case ev := <-outCh:
+			if _, ok := ev.event.(apitype.AgentUserEventCancel); ok {
+				foundCancel = true
+			}
+			continue
+		default:
+		}
+		break
+	}
+	if m.cancelling && !foundCancel {
+		t.Fatal("ESC entered the cancelling state without a cancel event ever being enqueued")
+	}
+}
+
 // TestBusy_UnopinionatedEventsWhenIdle — warnings, session URLs, foreign
 // user messages arriving while the TUI is idle must NOT spin up the
 // indicator. These events fall through labelForUIEvent's default branch;

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -268,15 +268,12 @@ func TestBusy_EscIgnoredWhileApprovalPending(t *testing.T) {
 	}
 }
 
-// TestBusy_EscRetryableAfterCancelPostFailure encodes desired behavior for
-// pulumi/pulumi-service#44059: when the user_cancel POST fails (the service
-// 409s cancels while the task is parked on a CLI tool call), the user must
-// not be locked out of cancelling. Today the failure only surfaces as a
-// UIWarning while m.cancelling stays set, so every further ESC is a no-op
-// and the TUI shows "Cancelling..." forever.
+// TestBusy_EscRetryableAfterCancelPostFailure — pulumi/pulumi-service#44059:
+// when the dispatcher gives up delivering a cancel and reports UICancelFailed,
+// the cancelling substate must clear so a later ESC can retry instead of
+// being swallowed and leaving the TUI in "Cancelling..." forever.
 func TestBusy_EscRetryableAfterCancelPostFailure(t *testing.T) {
 	t.Parallel()
-	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
 
 	ch := make(chan UIEvent, 4)
 	outCh := make(chan outboundEvent, 4)
@@ -293,15 +290,17 @@ func TestBusy_EscRetryableAfterCancelPostFailure(t *testing.T) {
 		t.Fatal("first ESC did not post any user event")
 	}
 
-	// The cancel POST fails; dispatchUserEvents surfaces it as a warning.
-	model, _ = model.Update(UIWarning{
-		Message: "failed to send event: [409] Conflict: cannot respond while a request is still ongoing",
+	// The dispatcher exhausted its cancel retries and reported the failure.
+	model, _ = model.Update(UICancelFailed{
+		Message: "[409] Conflict: cannot respond while a request is still ongoing",
 	})
-
-	// A second ESC must be able to retry the cancel instead of being swallowed
-	// by the still-set cancelling flag.
-	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
 	m := model.(Model)
+	require.False(t, m.cancelling, "UICancelFailed must clear the cancelling substate")
+	require.True(t, m.busy, "the turn is still live after a failed cancel")
+
+	// A second ESC must retry the cancel instead of being swallowed.
+	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = model.(Model)
 	select {
 	case ev := <-outCh:
 		_, ok := ev.event.(apitype.AgentUserEventCancel)
@@ -311,15 +310,13 @@ func TestBusy_EscRetryableAfterCancelPostFailure(t *testing.T) {
 	}
 }
 
-// TestBusy_EscWithFullOutChannelNotSilentlyDropped encodes desired behavior
-// for pulumi/pulumi-service#44059: ESC must not claim to be cancelling when
-// the cancel event was never enqueued. Today sendOut is a non-blocking send
-// whose result is ignored, so with a full outbound channel the model flips to
-// "Cancelling..." while nothing is ever posted — and the cancelling guard then
-// swallows every retry.
+// TestBusy_EscWithFullOutChannelNotSilentlyDropped — pulumi/pulumi-service#44059:
+// ESC must not claim to be cancelling when the cancel event was never
+// enqueued. sendOut is a non-blocking send, so with a full outbound channel
+// the model must stay out of the cancelling substate and let the next ESC
+// retry.
 func TestBusy_EscWithFullOutChannelNotSilentlyDropped(t *testing.T) {
 	t.Parallel()
-	t.Skip("desired behavior for https://github.com/pulumi/pulumi-service/issues/44059; un-skip when the fix lands")
 
 	ch := make(chan UIEvent, 4)
 	outCh := make(chan outboundEvent, 1)

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -94,6 +94,15 @@ type UIReconnected struct{}
 
 func (UIReconnected) uiEvent() {}
 
+// UICancelFailed signals that the user's cancel request could not be
+// delivered to the backend and the dispatcher has given up retrying. The TUI
+// clears its cancelling state so the user can press Esc to try again.
+type UICancelFailed struct {
+	Message string
+}
+
+func (UICancelFailed) uiEvent() {}
+
 // UICancelled signals the session was cancelled.
 type UICancelled struct{}
 

--- a/pkg/cmd/pulumi/neo/tui_events_test.go
+++ b/pkg/cmd/pulumi/neo/tui_events_test.go
@@ -38,6 +38,7 @@ func TestUIEventSealedInterface(t *testing.T) {
 		UIWarning{Message: "careful"},
 		UIReconnecting{},
 		UIReconnected{},
+		UICancelFailed{Message: "cancel lost"},
 		UICancelled{},
 		UITaskIdle{},
 		UISessionURL{URL: "https://example"},
@@ -57,5 +58,5 @@ func TestUIEventSealedInterface(t *testing.T) {
 	for _, e := range events {
 		e.uiEvent()
 	}
-	require.Len(t, events, 20, "bumped this when adding a new UIEvent variant")
+	require.Len(t, events, 21, "bumped this when adding a new UIEvent variant")
 }

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -489,6 +489,71 @@ func TestModel_Update_KeyCtrlC_FirstPressCancelsWhenBusy(t *testing.T) {
 	assert.Equal(t, "Cancelling...", um.blocks[idx].label)
 }
 
+func TestModel_Update_FinalEventWhileCancellingSendsAbandon(t *testing.T) {
+	t.Parallel()
+
+	// A final event ending the turn while a cancel is in flight must tell the
+	// dispatcher to abandon its pending cancel retry — otherwise a stale retry
+	// could fire into a later turn and cancel it.
+	finalEvents := map[string]UIEvent{
+		"task_idle":               UITaskIdle{},
+		"cancelled":               UICancelled{},
+		"final_assistant_message": UIAssistantMessage{Content: "done", IsFinal: true},
+		"approval_request":        UIApprovalRequest{ApprovalID: "a-1", Message: "ok?"},
+	}
+	for name, ev := range finalEvents {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			outCh := make(chan outboundEvent, 2)
+			m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
+
+			updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+			um := updated.(Model)
+			require.True(t, um.cancelling, "ESC while busy must enter the cancelling substate")
+			select {
+			case sent := <-outCh:
+				_, isCancel := sent.event.(apitype.AgentUserEventCancel)
+				require.True(t, isCancel, "ESC must post a cancel, got %T", sent.event)
+			default:
+				t.Fatal("ESC did not enqueue a cancel event")
+			}
+
+			updated, _ = um.Update(ev)
+			um = updated.(Model)
+			assert.False(t, um.cancelling, "a final event must clear the cancelling substate")
+
+			select {
+			case sent := <-outCh:
+				assert.True(t, sent.abandonCancel,
+					"turn end while cancelling must enqueue an abandonCancel envelope")
+				assert.Nil(t, sent.event, "abandon envelopes must carry no wire event")
+			default:
+				t.Fatal("turn end while cancelling did not enqueue an abandonCancel envelope")
+			}
+		})
+	}
+}
+
+func TestModel_Update_FinalEventWithoutCancelStaysSilent(t *testing.T) {
+	t.Parallel()
+
+	// An ordinary turn end (no cancel in flight) must not emit anything on the
+	// outbound channel — this also keeps history replay silent.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
+
+	updated, _ := m.Update(UITaskIdle{})
+	um := updated.(Model)
+	assert.False(t, um.busy, "a final event must end the busy state")
+
+	select {
+	case sent := <-outCh:
+		t.Fatalf("turn end without a pending cancel must be silent, got %+v", sent)
+	default:
+	}
+}
+
 func TestModel_Update_KeyCtrlC_OtherKeyDisarms(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1156,6 +1156,53 @@ func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
 	}
 }
 
+func TestModel_Update_KeyEnter_Approval_FullOutChannelKeepsPromptPending(t *testing.T) {
+	t.Parallel()
+
+	// With a full outbound channel the confirmation is never enqueued, so
+	// Enter must NOT commit the choice — otherwise the TUI shows it as
+	// submitted and goes busy while the agent waits forever for an answer
+	// that was never sent, with no recovery route (see #24267 follow-up).
+	for _, in := range []string{"yes", "no, use the staging stack"} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			outCh := make(chan outboundEvent, 1)
+			outCh <- outboundEvent{event: apitype.AgentUserEventUserMessage{}} // fill the channel
+			m := newApprovalPendingModel(t, outCh)
+			m.textInput.SetValue(in)
+
+			updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			um := updated.(Model)
+
+			assert.True(t, um.pendingApproval, "a dropped send must keep the approval pending")
+			assert.Equal(t, "appr_1", um.pendingApprovalID)
+			assert.Equal(t, in, um.textInput.Value(), "the draft must survive for the retry")
+			assert.False(t, um.busy, "must not go busy when nothing was sent")
+			assert.Equal(t, -1, um.findBlockKind(blockApprovalChoice),
+				"the choice must not be committed as sent")
+			idx := um.findBlockKind(blockWarning)
+			require.NotEqual(t, -1, idx, "a dropped reply must surface a warning")
+			assert.Contains(t, um.blocks[idx].rendered, "not sent")
+
+			// Drain the channel; the retry Enter must land the confirmation
+			// and clear the prompt.
+			<-outCh
+			updated, _ = um.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			um = updated.(Model)
+			select {
+			case got := <-outCh:
+				conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+				require.True(t, ok, "expected UserConfirmation, got %T", got.event)
+				assert.Equal(t, "appr_1", conf.ApprovalID)
+				assert.Equal(t, isAffirmative(in), conf.Approved)
+			default:
+				t.Fatal("retry Enter must post the confirmation")
+			}
+			assert.False(t, um.pendingApproval, "the retry must clear the prompt")
+		})
+	}
+}
+
 func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 	t.Parallel()
 
@@ -2017,6 +2064,55 @@ func TestModel_Update_AnswerQuestion_EmptyInputIsNoOp(t *testing.T) {
 
 	assert.True(t, m.pendingApproval, "empty Enter must leave the question pending")
 	assert.True(t, m.pendingIsQuestion, "pendingIsQuestion must remain set")
+}
+
+func TestModel_Update_AnswerQuestion_FullOutChannelKeepsQuestionPending(t *testing.T) {
+	t.Parallel()
+
+	// Same guard as the approval path: a dropped answer must keep the
+	// question pending with the draft intact instead of rendering
+	// "Answered" and going busy on a send that never happened.
+	outCh := make(chan outboundEvent, 1)
+	outCh <- outboundEvent{event: apitype.AgentUserEventUserMessage{}} // fill the channel
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: make(chan UIEvent, 4)})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_q5",
+		Message:      "Which region?",
+		ApprovalType: "general",
+		ToolName:     "ux__ask_user",
+	})
+	m = updated.(Model)
+	require.True(t, m.pendingIsQuestion)
+	m.textInput.SetValue("us-west-2")
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(Model)
+
+	assert.True(t, m.pendingApproval, "a dropped send must keep the question pending")
+	assert.True(t, m.pendingIsQuestion)
+	assert.Equal(t, "us-west-2", m.textInput.Value(), "the draft answer must survive for the retry")
+	assert.False(t, m.busy, "must not go busy when nothing was sent")
+	assert.Equal(t, -1, m.findBlockKind(blockAnswerSubmitted),
+		"the answer must not show as submitted")
+	idx := m.findBlockKind(blockWarning)
+	require.NotEqual(t, -1, idx, "a dropped answer must surface a warning")
+	assert.Contains(t, m.blocks[idx].rendered, "not sent")
+
+	// Drain the channel; the retry Enter must land the answer.
+	<-outCh
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(Model)
+	select {
+	case got := <-outCh:
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected UserConfirmation, got %T", got.event)
+		assert.Equal(t, "appr_q5", conf.ApprovalID)
+		assert.Equal(t, "us-west-2", conf.Message)
+	default:
+		t.Fatal("retry Enter must post the answer")
+	}
+	assert.False(t, m.pendingIsQuestion, "the retry must clear the prompt")
 }
 
 func TestQuestionWrapsToTerminalWidth(t *testing.T) {
@@ -3069,6 +3165,79 @@ func TestModel_Update_ApprovalDebounceTick_StaleGenDoesNotDispatch(t *testing.T)
 	case ev := <-outCh:
 		t.Fatalf("stale-gen tick must not dispatch, got %#v", ev)
 	default:
+	}
+}
+
+func TestModel_Update_ApprovalDebounceTick_FullOutChannelRearms(t *testing.T) {
+	t.Parallel()
+
+	// A tick that fires into a full outbound channel drops the update
+	// (sendOut is non-blocking). It must re-arm the debounce so the PATCH
+	// retries, instead of silently leaving the server on the previous mode.
+	outCh := make(chan outboundEvent, 1)
+	outCh <- outboundEvent{event: apitype.AgentUserEventUserMessage{}} // fill the channel
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		MessageSent:         true,
+		TaskCreated:         true,
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl})
+	m = updated.(Model)
+	gen := m.approvalDebounceGen
+
+	updated, cmd := m.Update(approvalDebounceTickMsg{gen: gen})
+	m = updated.(Model)
+	require.NotNil(t, cmd, "a dropped update must return a re-arm Tick command")
+	assert.Equal(t, gen+1, m.approvalDebounceGen, "the re-arm must advance the gen")
+
+	// Drain the channel; the re-armed tick must dispatch the update.
+	<-outCh
+	updated, _ = m.Update(approvalDebounceTickMsg{gen: m.approvalDebounceGen})
+	_ = updated
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update, "the re-armed tick must dispatch an update")
+		require.NotNil(t, got.update.ApprovalMode)
+		assert.Equal(t, client.NeoApprovalModeBalanced, *got.update.ApprovalMode)
+	default:
+		t.Fatal("the re-armed tick must dispatch once the channel drains")
+	}
+}
+
+func TestModel_Update_PermissionDebounceTick_FullOutChannelRearms(t *testing.T) {
+	t.Parallel()
+
+	// Permission-mode counterpart of the approval re-arm test above.
+	outCh := make(chan outboundEvent, 1)
+	outCh <- outboundEvent{event: apitype.AgentUserEventUserMessage{}} // fill the channel
+	m := NewModel(ModelConfig{
+		OutCh:                 outCh,
+		MessageSent:           true,
+		TaskCreated:           true,
+		InitialPermissionMode: client.NeoPermissionModeDefault,
+	})
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	m = updated.(Model)
+	gen := m.permissionDebounceGen
+
+	updated, cmd := m.Update(permissionDebounceTickMsg{gen: gen})
+	m = updated.(Model)
+	require.NotNil(t, cmd, "a dropped update must return a re-arm Tick command")
+	assert.Equal(t, gen+1, m.permissionDebounceGen, "the re-arm must advance the gen")
+
+	<-outCh
+	updated, _ = m.Update(permissionDebounceTickMsg{gen: m.permissionDebounceGen})
+	_ = updated
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update, "the re-armed tick must dispatch an update")
+		require.NotNil(t, got.update.PermissionMode)
+		assert.Equal(t, client.NeoPermissionModeReadOnly, *got.update.PermissionMode)
+	default:
+		t.Fatal("the re-armed tick must dispatch once the channel drains")
 	}
 }
 


### PR DESCRIPTION
Stacked on #24267, addressing the remaining unchecked `sendOut` call sites flagged in https://github.com/pulumi/pulumi/pull/24267#issuecomment-5326281862:

- **Approve/deny and question-answer replies**: a dropped `user_confirmation` committed the choice and left the TUI busy forever with no recovery route. The prompt now stays pending with a warning, and Enter retries.
- **Ctrl+A / Ctrl+R mode updates**: a dropped PATCH silently left the server on the previous approval/permission mode. The debounce now re-arms and retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)