### PR TITLE
Migrate InvokeRequest and Response to property.Map

### DIFF
--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -101,22 +101,23 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 
 			response, err := pc.provider.Invoke(ctx, plugin.InvokeRequest{
 				Tok:     tokens.ModuleMember(fn.Token),
-				Args:    inputs,
+				Args:    resource.FromResourcePropertyMap(inputs),
 				Preview: pc.dryrun,
 			})
 			if err != nil {
 				return err
 			}
 
+			outputProperties := resource.ToResourcePropertyMap(response.Properties)
 			var result resource.PropertyValue
 			if fn.Outputs != nil {
-				result = resource.NewProperty(filterOutputs(response.Properties, fn.Outputs.Properties))
+				result = resource.NewProperty(filterOutputs(outputProperties, fn.Outputs.Properties))
 			} else if fn.ReturnType != nil {
-				if len(response.Properties) != 1 {
-					return fmt.Errorf("expected exactly one return value from function but got %d", len(response.Properties))
+				if len(outputProperties) != 1 {
+					return fmt.Errorf("expected exactly one return value from function but got %d", len(outputProperties))
 				}
 
-				for _, value := range response.Properties {
+				for _, value := range outputProperties {
 					result = filterOutput(value, fn.ReturnType)
 					break
 				}

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -32,11 +32,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -196,15 +196,15 @@ func TestDoCmdFunctionInvoke(t *testing.T) {
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.False(t, req.Preview, "expected Preview to be false")
 					assert.Equal(t, "azure:index:myFunction", string(req.Tok))
-					assert.Equal(t, "hello", req.Args["param1"].StringValue())
-					assert.Equal(t, 42.0, req.Args["param2"].NumberValue())
-					assert.Equal(t, true, req.Args["param3"].BoolValue())
+					assert.Equal(t, "hello", req.Args.Get("param1").AsString())
+					assert.Equal(t, 42.0, req.Args.Get("param2").AsNumber())
+					assert.Equal(t, true, req.Args.Get("param3").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"output1": resource.NewProperty("world"),
-							"output2": resource.NewProperty(43.0),
-							"output3": resource.NewProperty(false),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"output1": property.New("world"),
+							"output2": property.New(43.0),
+							"output3": property.New(false),
+						}),
 					}, nil
 				},
 			},
@@ -259,11 +259,11 @@ func TestDoCmdFunctionInvokeFiltersOutputsToSchema(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"result":     resource.NewProperty("visible"),
-							"__defaults": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("internal")}),
-							"extra":      resource.NewProperty("hidden"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"result":     property.New("visible"),
+							"__defaults": property.New([]property.Value{property.New("internal")}),
+							"extra":      property.New("hidden"),
+						}),
 					}, nil
 				},
 			},
@@ -332,31 +332,31 @@ func TestDoCmdFunctionInvokeFiltersNestedObjectsInCollections(t *testing.T) {
 				},
 			},
 		}
-		extras := resource.PropertyMap{
-			"__defaults": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("internal")}),
-			"extra":      resource.NewProperty("hidden"),
+		extras := map[string]property.Value{
+			"__defaults": property.New([]property.Value{property.New("internal")}),
+			"extra":      property.New("hidden"),
 		}
-		listItem := resource.PropertyMap{
-			"name":       resource.NewProperty("list-item"),
+		listItem := property.NewMap(map[string]property.Value{
+			"name":       property.New("list-item"),
 			"__defaults": extras["__defaults"],
 			"extra":      extras["extra"],
-		}
-		mapItem := resource.PropertyMap{
-			"name":       resource.NewProperty("map-item"),
+		})
+		mapItem := property.NewMap(map[string]property.Value{
+			"name":       property.New("map-item"),
 			"__defaults": extras["__defaults"],
 			"extra":      extras["extra"],
-		}
+		})
 		return &testProvider{
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"items": resource.NewProperty([]resource.PropertyValue{resource.NewProperty(listItem)}),
-							"itemsByKey": resource.NewProperty(resource.PropertyMap{
-								"a": resource.NewProperty(mapItem),
+						Properties: property.NewMap(map[string]property.Value{
+							"items": property.New([]property.Value{property.New(listItem)}),
+							"itemsByKey": property.New(map[string]property.Value{
+								"a": property.New(mapItem),
 							}),
-						},
+						}),
 					}, nil
 				},
 			},
@@ -412,9 +412,9 @@ func TestDoCmdFunctionInvokeReturnType(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"result": resource.NewProperty("visible"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("visible"),
+						}),
 					}, nil
 				},
 			},
@@ -482,18 +482,18 @@ func TestDoCmdFunctionInvokeReturnTypeFiltersSchema(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"payload": resource.NewProperty(resource.PropertyMap{
-								"name": resource.NewProperty("visible"),
-								"details": resource.NewProperty(resource.PropertyMap{
-									"enabled":    resource.NewProperty(true),
-									"__defaults": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("internal")}),
-									"extra":      resource.NewProperty("hidden"),
+						Properties: property.NewMap(map[string]property.Value{
+							"payload": property.New(map[string]property.Value{
+								"name": property.New("visible"),
+								"details": property.New(map[string]property.Value{
+									"enabled":    property.New(true),
+									"__defaults": property.New([]property.Value{property.New("internal")}),
+									"extra":      property.New("hidden"),
 								}),
-								"__defaults": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("internal")}),
-								"extra":      resource.NewProperty("hidden"),
+								"__defaults": property.New([]property.Value{property.New("internal")}),
+								"extra":      property.New("hidden"),
 							}),
-						},
+						}),
 					}, nil
 				},
 			},
@@ -566,18 +566,18 @@ func TestDoCmdFunctionInvokeReturnTypeFiltersSchemaSecrets(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"payload": resource.NewProperty(resource.PropertyMap{
-								"name": resource.NewProperty("visible"),
-								"details": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
-									"enabled":    resource.NewProperty(true),
-									"__defaults": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("internal")}),
-									"extra":      resource.NewProperty("hidden"),
-								})),
-								"__defaults": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("internal")}),
-								"extra":      resource.NewProperty("hidden"),
+						Properties: property.NewMap(map[string]property.Value{
+							"payload": property.New(map[string]property.Value{
+								"name": property.New("visible"),
+								"details": property.New(map[string]property.Value{
+									"enabled":    property.New(true),
+									"__defaults": property.New([]property.Value{property.New("internal")}),
+									"extra":      property.New("hidden"),
+								}).WithSecret(true),
+								"__defaults": property.New([]property.Value{property.New("internal")}),
+								"extra":      property.New("hidden"),
 							}),
-						},
+						}),
 					}, nil
 				},
 			},
@@ -646,11 +646,11 @@ func TestDoCmdFunctionInvokeNestedModule(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "pkg:mod1/mod2:fun", string(req.Tok))
-					assert.Equal(t, "hello", req.Args["param"].StringValue())
+					assert.Equal(t, "hello", req.Args.Get("param").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"result": resource.NewProperty("world"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("world"),
+						}),
 					}, nil
 				},
 			},
@@ -1048,13 +1048,13 @@ func TestDoCmdFunctionInvokeInputFileSchemaConversions(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "44", req.Args["param1"].StringValue())
-					assert.True(t, req.Args["param2"].BoolValue())
-					assert.Equal(t, 45.0, req.Args["param3"].NumberValue())
+					assert.Equal(t, "44", req.Args.Get("param1").AsString())
+					assert.True(t, req.Args.Get("param2").AsBool())
+					assert.Equal(t, 45.0, req.Args.Get("param3").AsNumber())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"output1": resource.NewProperty("world"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"output1": property.New("world"),
+						}),
 					}, nil
 				},
 			},
@@ -1129,15 +1129,15 @@ func TestDoCmdFunctionInvokeDryRun(t *testing.T) {
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Truef(t, req.Preview, "expected Preview to be true")
 					assert.Equal(t, "azure:index:myFunction", string(req.Tok))
-					assert.Equal(t, "hello", req.Args["param1"].StringValue())
-					assert.Equal(t, 42.0, req.Args["param2"].NumberValue())
-					assert.Equal(t, true, req.Args["param3"].BoolValue())
+					assert.Equal(t, "hello", req.Args.Get("param1").AsString())
+					assert.Equal(t, 42.0, req.Args.Get("param2").AsNumber())
+					assert.Equal(t, true, req.Args.Get("param3").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"output1": resource.NewProperty("world"),
-							"output2": resource.NewProperty(43.0),
-							"output3": resource.MakeComputed(resource.NewProperty("")),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"output1": property.New("world"),
+							"output2": property.New(43.0),
+							"output3": property.New(property.Computed),
+						}),
 					}, nil
 				},
 			},
@@ -1205,12 +1205,12 @@ func TestDoCmdFunctionInvokeWithBuiltinFunctions(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, `{"value":true}`, req.Args["param1"].StringValue())
-					assert.Equal(t, 6.0, req.Args["param2"].NumberValue())
+					assert.Equal(t, `{"value":true}`, req.Args.Get("param1").AsString())
+					assert.Equal(t, 6.0, req.Args.Get("param2").AsNumber())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"ok": resource.NewProperty(true),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"ok": property.New(true),
+						}),
 					}, nil
 				},
 			},
@@ -1281,13 +1281,13 @@ func TestDoCmdFunctionInvokeWithProjectContext(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, mainDir, req.Args["pwd"].StringValue())
-					assert.Equal(t, root, req.Args["root"].StringValue())
-					assert.Equal(t, "my-project", req.Args["project"].StringValue())
+					assert.Equal(t, mainDir, req.Args.Get("pwd").AsString())
+					assert.Equal(t, root, req.Args.Get("root").AsString())
+					assert.Equal(t, "my-project", req.Args.Get("project").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"ok": resource.NewProperty(true),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"ok": property.New(true),
+						}),
 					}, nil
 				},
 			},
@@ -1371,15 +1371,15 @@ func TestDoCmdFunctionInvokeWithConfiguration(t *testing.T) {
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.False(t, req.Preview, "expected Preview to be false")
 					assert.Equal(t, "azure:index:myFunction", string(req.Tok))
-					assert.Equal(t, "hello", req.Args["param1"].StringValue())
-					assert.Equal(t, 42.0, req.Args["param2"].NumberValue())
-					assert.Equal(t, true, req.Args["param3"].BoolValue())
+					assert.Equal(t, "hello", req.Args.Get("param1").AsString())
+					assert.Equal(t, 42.0, req.Args.Get("param2").AsNumber())
+					assert.Equal(t, true, req.Args.Get("param3").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"output1": resource.NewProperty("world"),
-							"output2": resource.NewProperty(43.0),
-							"output3": resource.NewProperty(false),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"output1": property.New("world"),
+							"output2": property.New(43.0),
+							"output3": property.New(false),
+						}),
 					}, nil
 				},
 			},
@@ -1460,16 +1460,16 @@ func TestDoCmdFunctionInvokeNestedResults(t *testing.T) {
 					assert.Equal(t, "azure:index:myFunction", string(req.Tok))
 					assert.Empty(t, req.Args, "expected Args to be empty")
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"secret": resource.MakeSecret(resource.NewProperty("hello")),
-							"list": resource.NewProperty([]resource.PropertyValue{
-								resource.NewProperty("a"),
-								resource.NewProperty("b"),
+						Properties: property.NewMap(map[string]property.Value{
+							"secret": property.New("hello").WithSecret(true),
+							"list": property.New([]property.Value{
+								property.New("a"),
+								property.New("b"),
 							}),
-							"object": resource.NewProperty(resource.PropertyMap{
-								"nested": resource.NewProperty("value"),
+							"object": property.New(map[string]property.Value{
+								"nested": property.New("value"),
 							}),
-						},
+						}),
 					}, nil
 				},
 			},
@@ -1531,12 +1531,12 @@ func TestDoCmdFunctionInvokeShowSecrets(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"secret": resource.MakeSecret(resource.NewProperty("hello")),
-							"object": resource.NewProperty(resource.PropertyMap{
-								"nested": resource.MakeSecret(resource.NewProperty("value")),
+						Properties: property.NewMap(map[string]property.Value{
+							"secret": property.New("hello").WithSecret(true),
+							"object": property.New(map[string]property.Value{
+								"nested": property.New("value").WithSecret(true),
 							}),
-						},
+						}),
 					}, nil
 				},
 			},
@@ -1602,10 +1602,10 @@ func TestDoCmdFunctionInvokeAssetArchiveResults(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"asset":   resource.NewProperty(textAsset),
-							"archive": resource.NewProperty(literalArchive),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"asset":   property.New(textAsset),
+							"archive": property.New(literalArchive),
+						}),
 					}, nil
 				},
 			},
@@ -1717,11 +1717,11 @@ func TestDoCmdFunctionInvokeWithParameterizedPackage(t *testing.T) {
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "myparam:index:myFunction", string(req.Tok))
-					assert.Equal(t, "hello", req.Args["x"].StringValue())
+					assert.Equal(t, "hello", req.Args.Get("x").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"y": resource.NewProperty("world"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"y": property.New("world"),
+						}),
 					}, nil
 				},
 			},
@@ -1840,15 +1840,15 @@ param3 = true
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "azure:index:myFunction", string(req.Tok))
-					assert.Equal(t, "hello", req.Args["param1"].StringValue())
-					assert.Equal(t, 42.0, req.Args["param2"].NumberValue())
-					assert.Equal(t, true, req.Args["param3"].BoolValue())
+					assert.Equal(t, "hello", req.Args.Get("param1").AsString())
+					assert.Equal(t, 42.0, req.Args.Get("param2").AsNumber())
+					assert.Equal(t, true, req.Args.Get("param3").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"output1": resource.NewProperty("world"),
-							"output2": resource.NewProperty(43.0),
-							"output3": resource.NewProperty(false),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"output1": property.New("world"),
+							"output2": property.New(43.0),
+							"output3": property.New(false),
+						}),
 					}, nil
 				},
 			},
@@ -1935,9 +1935,9 @@ func TestDoCmdFunctionInvokeYAMLInputByDefault(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "hello", req.Args["x"].StringValue())
+					assert.Equal(t, "hello", req.Args.Get("x").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"y": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"y": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2039,9 +2039,9 @@ func TestDoCmdFunctionInvokeWithYAMLInputFileParameterized(t *testing.T) {
 					return plugin.ParameterizeResponse{Name: "myparam", Version: subVersion}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "hello", req.Args["x"].StringValue())
+					assert.Equal(t, "hello", req.Args.Get("x").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"y": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"y": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2176,7 +2176,7 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFile(t *testing.T) {
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2492,11 +2492,11 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "p1", req.Args["in1"].StringValue())
-					assert.Equal(t, "p2", req.Args["inTwo"].StringValue())
-					assert.Equal(t, true, req.Args["dryRun"].BoolValue())
+					assert.Equal(t, "p1", req.Args.Get("in1").AsString())
+					assert.Equal(t, "p2", req.Args.Get("inTwo").AsString())
+					assert.Equal(t, true, req.Args.Get("dryRun").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2620,11 +2620,11 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "p1", req.Args["in1"].StringValue())
-					assert.Equal(t, "p2", req.Args["inTwo"].StringValue())
-					assert.Equal(t, true, req.Args["dryRun"].BoolValue())
+					assert.Equal(t, "p1", req.Args.Get("in1").AsString())
+					assert.Equal(t, "p2", req.Args.Get("inTwo").AsString())
+					assert.Equal(t, true, req.Args.Get("dryRun").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2719,9 +2719,9 @@ func TestDoCmdFunctionInvokeWithYAMLInputFlagsNoInputFile(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "outstring", req.Args["message"].StringValue())
+					assert.Equal(t, "outstring", req.Args.Get("message").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2774,9 +2774,9 @@ func TestDoCmdFunctionInvokeWithPlainFlagsSkipsConverter(t *testing.T) {
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t,
 						"convert: allow empty files):\nwith ${not.interpolated} and %{no.directive}",
-						req.Args["message"].StringValue())
+						req.Args.Get("message").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
 					}, nil
 				},
 			},
@@ -2872,11 +2872,11 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, 37.0, req.Args["number"].NumberValue())
-					assert.Equal(t, 45.0, req.Args["expr"].SecretValue().Element.NumberValue())
-					assert.Equal(t, false, req.Args["flag"].BoolValue())
+					assert.Equal(t, 37.0, req.Args.Get("number").AsNumber())
+					assert.Equal(t, 45.0, req.Args.Get("expr").AsNumber())
+					assert.Equal(t, false, req.Args.Get("flag").AsBool())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
 					}, nil
 				},
 			},

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -964,13 +965,13 @@ func TestDoCmdFunctionInvokeWithStackContext(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					assert.Equal(t, "acme", req.Args["organization"].StringValue())
-					assert.Equal(t, "my-project", req.Args["project"].StringValue())
-					assert.Equal(t, "dev", req.Args["stack"].StringValue())
+					assert.Equal(t, "acme", req.Args.Get("organization").AsString())
+					assert.Equal(t, "my-project", req.Args.Get("project").AsString())
+					assert.Equal(t, "dev", req.Args.Get("stack").AsString())
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"ok": resource.NewProperty(true),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"ok": property.New(true),
+						}),
 					}, nil
 				},
 			},
@@ -1042,9 +1043,9 @@ func TestDoCmdFunctionInvokeWithoutStackContext(t *testing.T) {
 				spec: makeSpec(),
 				MockProvider: plugin.MockProvider{
 					InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-						assert.Equal(t, "my-project", req.Args["project"].StringValue())
+						assert.Equal(t, "my-project", req.Args.Get("project").AsString())
 						return plugin.InvokeResponse{
-							Properties: resource.PropertyMap{"ok": resource.NewProperty(true)},
+							Properties: property.NewMap(map[string]property.Value{"ok": property.New(true)}),
 						}, nil
 					},
 				},

--- a/pkg/codegen/convert/mapper_server_test.go
+++ b/pkg/codegen/convert/mapper_server_test.go
@@ -29,10 +29,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // TestMapperServerFromHost_RealProvider verifies the full mapper handshake loop against a real provider binary:
@@ -82,11 +82,11 @@ func TestMapperServerFromHost_RealProvider(t *testing.T) {
 
 	res, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 		Tok:  "mapptest:index:getMapping",
-		Args: resource.PropertyMap{},
+		Args: property.Map{},
 	})
 	require.NoError(t, err)
 	require.Empty(t, res.Failures)
-	assert.Equal(t, resource.PropertyMap{
-		"mapping": resource.NewProperty(`{"hello":"world"}`),
-	}, res.Properties)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"mapping": property.New(`{"hello":"world"}`),
+	}), res.Properties)
 }

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -442,7 +442,7 @@ func TestProviderInheritanceGolangLifecycle(t *testing.T) {
 				},
 			}
 			v.InvokeF = func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-				assert.True(t, v.Config.DeepEquals(req.Args))
+				assert.True(t, v.Config.DeepEquals(resource.ToResourcePropertyMap(req.Args)))
 				return plugin.InvokeResponse{}, nil
 			}
 			return v, nil
@@ -467,7 +467,7 @@ func TestProviderInheritanceGolangLifecycle(t *testing.T) {
 				},
 			}
 			v.InvokeF = func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-				assert.True(t, v.Config.DeepEquals(req.Args))
+				assert.True(t, v.Config.DeepEquals(resource.ToResourcePropertyMap(req.Args)))
 				return plugin.InvokeResponse{}, nil
 			}
 			return v, nil

--- a/pkg/engine/lifecycletest/invoke_test.go
+++ b/pkg/engine/lifecycletest/invoke_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func TestPreviewInvoke(t *testing.T) {
@@ -47,9 +48,9 @@ func TestPreviewInvoke(t *testing.T) {
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, expectPreview, req.Preview)
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"result": resource.NewProperty("invoked"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("invoked"),
+						}),
 					}, nil
 				},
 			}, nil
@@ -93,9 +94,9 @@ func TestInvokeParentResolvesComponentProviders(t *testing.T) {
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"instance": resource.NewProperty(instance),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"instance": property.New(instance),
+						}),
 					}, nil
 				},
 			}, nil
@@ -185,9 +186,11 @@ func TestInvokeDependsOnRemoteComponent(t *testing.T) {
 				},
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					invoked = true
-					return plugin.InvokeResponse{Properties: resource.PropertyMap{
-						"result": resource.NewProperty("read"),
-					}}, nil
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("read"),
+						}),
+					}, nil
 				},
 			}, nil
 		}),
@@ -267,9 +270,11 @@ func TestInvokeDependsOnNestedRemoteComponent(t *testing.T) {
 				},
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					invoked = true
-					return plugin.InvokeResponse{Properties: resource.PropertyMap{
-						"result": resource.NewProperty("read"),
-					}}, nil
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("read"),
+						}),
+					}, nil
 				},
 			}, nil
 		}),
@@ -328,9 +333,11 @@ func TestInvokeDependsOnPendingCustomResource(t *testing.T) {
 			return &deploytest.Provider{
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					invoked = true
-					return plugin.InvokeResponse{Properties: resource.PropertyMap{
-						"result": resource.NewProperty("read"),
-					}}, nil
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("read"),
+						}),
+					}, nil
 				},
 			}, nil
 		}),
@@ -378,9 +385,11 @@ func TestInvokeDependsOnStopsAtCustomResources(t *testing.T) {
 			return &deploytest.Provider{
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					invoked = true
-					return plugin.InvokeResponse{Properties: resource.PropertyMap{
-						"result": resource.NewProperty("read"),
-					}}, nil
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("read"),
+						}),
+					}, nil
 				},
 			}, nil
 		}),
@@ -433,9 +442,11 @@ func TestInvokeDependsOnTargetedUp(t *testing.T) {
 			return &deploytest.Provider{
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					invoked = true
-					return plugin.InvokeResponse{Properties: resource.PropertyMap{
-						"result": resource.NewProperty("read"),
-					}}, nil
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("read"),
+						}),
+					}, nil
 				},
 			}, nil
 		}),
@@ -486,9 +497,11 @@ func TestInvokeDependsOnDestroyRunProgram(t *testing.T) {
 				},
 				InvokeF: func(_ context.Context, _ plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					invoked++
-					return plugin.InvokeResponse{Properties: resource.PropertyMap{
-						"result": resource.NewProperty("read"),
-					}}, nil
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("read"),
+						}),
+					}, nil
 				},
 			}, nil
 		}),
@@ -567,9 +580,9 @@ func TestSecretsInvoke(t *testing.T) {
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, expectPreview, req.Preview)
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"result": resource.NewProperty("invoked"),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("invoked"),
+						}),
 					}, nil
 				},
 			}, nil

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -162,12 +162,12 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 				},
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "pkgExt:index:func", req.Tok.String())
-					assert.Equal(t, resource.NewProperty("in"), req.Args["input"])
+					assert.Equal(t, resource.NewProperty("in"), resource.ToResourcePropertyValue(req.Args.Get("input")))
 
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"output": resource.NewProperty("in " + param),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"output": property.New("in " + param),
+						}),
 					}, nil
 				},
 				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // pclSnippetTestProvider returns a loader for a single-resource "pkgA" provider whose schema is
@@ -679,12 +680,12 @@ func TestPclSnippetInvoke(t *testing.T) {
 					return plugin.CreateResponse{ID: resource.ID(id), Properties: cr.Properties}, nil
 				},
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					input := req.Args["input"].StringValue()
+					input := req.Args.Get("input").AsString()
 					invoked = append(invoked, input)
 					return plugin.InvokeResponse{
-						Properties: resource.PropertyMap{
-							"result": resource.NewProperty("echoed: " + input),
-						},
+						Properties: property.NewMap(map[string]property.Value{
+							"result": property.New("echoed: " + input),
+						}),
 					}, nil
 				},
 			}, nil

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -2308,15 +2308,15 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-					name := req.Args["name"]
+					name := req.Args.Get("name")
 					ret := "unexpected"
 					if name.IsString() {
-						ret = "Hello, " + name.StringValue() + "!"
+						ret = "Hello, " + name.AsString() + "!"
 					}
 
 					return plugin.InvokeResponse{
-						Properties: resource.NewPropertyMapFromMap(map[string]any{
-							"message": ret,
+						Properties: property.NewMap(map[string]property.Value{
+							"message": property.New(ret),
 						}),
 					}, nil
 				},

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
 )
 
@@ -201,7 +202,7 @@ func (p *builtinProvider) Create(ctx context.Context, req plugin.CreateRequest) 
 	switch typ { //nolint:exhaustive
 	case stackReferenceType:
 
-		state, err := p.readStackReference(ctx, req.Properties)
+		state, err := p.readStackReference(ctx, resource.FromResourcePropertyMap(req.Properties))
 		if err != nil {
 			return plugin.CreateResponse{Status: resource.StatusUnknown}, err
 		}
@@ -218,7 +219,7 @@ func (p *builtinProvider) Create(ctx context.Context, req plugin.CreateRequest) 
 
 		return plugin.CreateResponse{
 			ID:         id,
-			Properties: state,
+			Properties: resource.ToResourcePropertyMap(state),
 			Status:     resource.StatusOK,
 		}, nil
 	case stashType:
@@ -292,7 +293,7 @@ func (p *builtinProvider) Read(ctx context.Context, req plugin.ReadRequest) (plu
 			return plugin.ReadResponse{Status: resource.StatusUnknown}, errors.New("stack reference can not be imported")
 		}
 
-		outputs, err := p.readStackReference(ctx, req.State)
+		outputs, err := p.readStackReference(ctx, resource.FromResourcePropertyMap(req.State))
 		if err != nil {
 			return plugin.ReadResponse{Status: resource.StatusUnknown}, err
 		}
@@ -301,7 +302,7 @@ func (p *builtinProvider) Read(ctx context.Context, req plugin.ReadRequest) (plu
 			ReadResult: plugin.ReadResult{
 				ID:      req.ID,
 				Inputs:  req.Inputs,
-				Outputs: outputs,
+				Outputs: resource.ToResourcePropertyMap(outputs),
 			},
 			Status: resource.StatusOK,
 		}, nil
@@ -335,7 +336,7 @@ const (
 )
 
 func (p *builtinProvider) Invoke(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-	var outs resource.PropertyMap
+	var outs property.Map
 	var err error
 	switch req.Tok {
 	case readStackOutputs:
@@ -368,18 +369,18 @@ func (p *builtinProvider) SignalCancellation(context.Context) error {
 }
 
 func (p *builtinProvider) readStackReference(
-	ctx context.Context, inputs resource.PropertyMap,
-) (resource.PropertyMap, error) {
+	ctx context.Context, inputs property.Map,
+) (property.Map, error) {
 	tracer := otel.Tracer("pulumi-cli")
 	ctx, span := cmdutil.StartSpan(ctx, tracer, "builtinProvider.readStackReference")
 	defer span.End()
 
-	name, ok := inputs["name"]
+	name, ok := inputs.GetOk("name")
 	contract.Assertf(ok, "missing required property 'name'")
 	contract.Assertf(name.IsString(), "expected 'name' to be a string")
 
 	if p.backendClient == nil {
-		return nil, errors.New("no backend client is available")
+		return property.Map{}, errors.New("no backend client is available")
 	}
 
 	// If we fail to decrypt secrets when fetching the stack's outputs, we'll catch the error and log diagnostics rather
@@ -387,70 +388,70 @@ func (p *builtinProvider) readStackReference(
 	var decryptionErr error
 	outputs, err := p.backendClient.GetStackOutputs(
 		ctx,
-		name.StringValue(),
+		name.AsString(),
 		func(e error) error { decryptionErr = e; return nil },
 	)
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 
 	if decryptionErr != nil {
-		p.diag.Infof(diag.Message("", "eliding undecryptable secrets for stack reference '%s'"), name.StringValue())
-		p.diag.Debugf(diag.Message("", "stack reference '%s' decryption error: %v"), name.StringValue(), decryptionErr)
+		p.diag.Infof(diag.Message("", "eliding undecryptable secrets for stack reference '%s'"), name.AsString())
+		p.diag.Debugf(diag.Message("", "stack reference '%s' decryption error: %v"), name.AsString(), decryptionErr)
 	}
 
-	secretOutputs := make([]resource.PropertyValue, 0)
+	secretOutputs := make([]property.Value, 0)
 	for k, v := range outputs.All {
 		if v.HasSecrets() {
-			secretOutputs = append(secretOutputs, resource.NewProperty(k))
+			secretOutputs = append(secretOutputs, property.New(k))
 		}
 	}
 
 	// Sort the secret outputs so the order is deterministic, to avoid spurious diffs during updates.
 	sort.Slice(secretOutputs, func(i, j int) bool {
-		return secretOutputs[i].String() < secretOutputs[j].String()
+		return secretOutputs[i].AsString() < secretOutputs[j].AsString()
 	})
 
-	return resource.PropertyMap{
+	return property.NewMap(map[string]property.Value{
 		"name":              name,
-		"outputs":           resource.NewProperty(resource.ToResourcePropertyMap(outputs)),
-		"secretOutputNames": resource.NewProperty(secretOutputs),
-	}, nil
+		"outputs":           property.New(outputs),
+		"secretOutputNames": property.New(secretOutputs),
+	}), nil
 }
 
-func (p *builtinProvider) readStackResourceOutputs(inputs resource.PropertyMap) (resource.PropertyMap, error) {
-	name, ok := inputs["stackName"]
+func (p *builtinProvider) readStackResourceOutputs(inputs property.Map) (property.Map, error) {
+	name, ok := inputs.GetOk("stackName")
 	contract.Assertf(ok, "missing required property 'stackName'")
 	contract.Assertf(name.IsString(), "expected 'stackName' to be a string")
 
 	if p.backendClient == nil {
-		return nil, errors.New("no backend client is available")
+		return property.Map{}, errors.New("no backend client is available")
 	}
 
-	outputs, err := p.backendClient.GetStackResourceOutputs(p.context, name.StringValue())
+	outputs, err := p.backendClient.GetStackResourceOutputs(p.context, name.AsString())
 	if err != nil {
-		return nil, err
+		return property.Map{}, err
 	}
 
-	return resource.PropertyMap{
+	return property.NewMap(map[string]property.Value{
 		"name":    name,
-		"outputs": resource.NewProperty(resource.ToResourcePropertyMap(outputs)),
-	}, nil
+		"outputs": property.New(outputs),
+	}), nil
 }
 
-func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.PropertyMap, error) {
-	urnInput, ok := inputs["urn"]
+func (p *builtinProvider) getResource(inputs property.Map) (property.Map, error) {
+	urnInput, ok := inputs.GetOk("urn")
 	contract.Assertf(ok, "missing required property 'urn'")
 	contract.Assertf(urnInput.IsString(), "expected 'urn' to be a string")
 
 	// When looking up a resource to hydrate it, we'll first check for new states produced by resource registrations. If
 	// we fail to find a match there, we'll look for states that have been read.
-	urn := resource.URN(urnInput.StringValue())
+	urn := resource.URN(urnInput.AsString())
 	state, ok := p.news.Load(urn)
 	if !ok {
 		state, ok = p.reads.Load(urn)
 		if !ok {
-			return nil, fmt.Errorf("unknown resource %v", urnInput.StringValue())
+			return property.Map{}, fmt.Errorf("unknown resource %v", urnInput.AsString())
 		}
 	}
 
@@ -458,10 +459,10 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 	state.Lock.Lock()
 	defer state.Lock.Unlock()
 
-	return resource.PropertyMap{
+	return property.NewMap(map[string]property.Value{
 		"urn":      urnInput,
-		"id":       resource.NewProperty(string(state.ID)),
-		"provider": resource.NewProperty(state.Provider),
-		"state":    resource.NewProperty(state.Outputs),
-	}, nil
+		"id":       property.New(string(state.ID)),
+		"provider": property.New(state.Provider),
+		"state":    property.New(resource.FromResourcePropertyMap(state.Outputs)),
+	}), nil
 }

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -159,9 +159,9 @@ func TestBuiltinProvider(t *testing.T) {
 				p := &builtinProvider{}
 				_, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: readStackOutputs,
-					Args: resource.PropertyMap{
-						"name": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"name": property.New("res-name"),
+					}),
 				})
 				assert.ErrorContains(t, err, "no backend client is available")
 			})
@@ -181,18 +181,18 @@ func TestBuiltinProvider(t *testing.T) {
 				}
 				resp, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: readStackOutputs,
-					Args: resource.PropertyMap{
-						"name": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"name": property.New("res-name"),
+					}),
 				})
 				require.NoError(t, err)
 				assert.True(t, called)
 				assert.Nil(t, resp.Failures)
 
-				assert.Equal(t, "res-name", resp.Properties["name"].V)
+				assert.Equal(t, "res-name", resp.Properties.Get("name").AsString())
 
-				assert.Equal(t, "foo", resp.Properties["outputs"].ObjectValue()["normal"].StringValue())
-				require.Len(t, resp.Properties["secretOutputNames"].V, 1)
+				assert.Equal(t, "foo", resp.Properties.Get("outputs").AsMap().Get("normal").AsString())
+				require.Equal(t, 1, resp.Properties.Get("secretOutputNames").AsArray().Len())
 			})
 		})
 		t.Run(readStackResourceOutputs, func(t *testing.T) {
@@ -202,9 +202,9 @@ func TestBuiltinProvider(t *testing.T) {
 				p := &builtinProvider{}
 				_, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: readStackResourceOutputs,
-					Args: resource.PropertyMap{
-						"stackName": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"stackName": property.New("res-name"),
+					}),
 				})
 				assert.ErrorContains(t, err, "no backend client is available")
 			})
@@ -221,9 +221,9 @@ func TestBuiltinProvider(t *testing.T) {
 				}
 				_, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: readStackResourceOutputs,
-					Args: resource.PropertyMap{
-						"stackName": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"stackName": property.New("res-name"),
+					}),
 				})
 				require.NoError(t, err)
 				assert.True(t, called)
@@ -250,13 +250,13 @@ func TestBuiltinProvider(t *testing.T) {
 
 				actual, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: getResource,
-					Args: resource.PropertyMap{
-						"urn": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"urn": property.New("res-name"),
+					}),
 				})
 
 				require.NoError(t, err)
-				assert.Equal(t, expected.Outputs, actual.Properties["state"].ObjectValue())
+				assert.Equal(t, resource.FromResourcePropertyMap(expected.Outputs), actual.Properties.Get("state").AsMap())
 			})
 
 			t.Run("ok read", func(t *testing.T) {
@@ -277,13 +277,13 @@ func TestBuiltinProvider(t *testing.T) {
 
 				actual, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: getResource,
-					Args: resource.PropertyMap{
-						"urn": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"urn": property.New("res-name"),
+					}),
 				})
 
 				require.NoError(t, err)
-				assert.Equal(t, expected.Outputs, actual.Properties["state"].ObjectValue())
+				assert.Equal(t, resource.FromResourcePropertyMap(expected.Outputs), actual.Properties.Get("state").AsMap())
 			})
 
 			t.Run("err", func(t *testing.T) {
@@ -294,9 +294,9 @@ func TestBuiltinProvider(t *testing.T) {
 				}
 				_, err := p.Invoke(t.Context(), plugin.InvokeRequest{
 					Tok: getResource,
-					Args: resource.PropertyMap{
-						"urn": resource.NewProperty("res-name"),
-					},
+					Args: property.NewMap(map[string]property.Value{
+						"urn": property.New("res-name"),
+					}),
 				})
 				assert.ErrorContains(t, err, "unknown resource")
 			})

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type Provider struct {
@@ -231,7 +232,7 @@ func (prov *Provider) Construct(ctx context.Context, req plugin.ConstructRequest
 func (prov *Provider) Invoke(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 	if prov.InvokeF == nil {
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{},
+			Properties: property.Map{},
 		}, nil
 	}
 	return prov.InvokeF(ctx, req)

--- a/pkg/resource/deploy/deploytest/provider_test.go
+++ b/pkg/resource/deploy/deploytest/provider_test.go
@@ -256,9 +256,9 @@ func TestProvider(t *testing.T) {
 		t.Parallel()
 		t.Run("has InvokeF", func(t *testing.T) {
 			t.Parallel()
-			expectedPropertyMap := resource.PropertyMap{
-				"key": resource.NewProperty("expected-value"),
-			}
+			expectedPropertyMap := property.NewMap(map[string]property.Value{
+				"key": property.New("expected-value"),
+			})
 			var called bool
 			prov := &Provider{
 				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
@@ -280,7 +280,7 @@ func TestProvider(t *testing.T) {
 			resp, err := prov.Invoke(t.Context(), plugin.InvokeRequest{})
 			require.NoError(t, err)
 			assert.Empty(t, resp.Failures)
-			assert.Equal(t, resource.PropertyMap{}, resp.Properties)
+			assert.Equal(t, property.Map{}, resp.Properties)
 		})
 	})
 	t.Run("Call", func(t *testing.T) {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1124,7 +1124,7 @@ func (rm *resmon) Invoke(
 	logging.V(5).Infof("ResourceMonitor.Invoke received: tok=%v #args=%v", tok, len(args))
 	resp, err := prov.Invoke(ctx, plugin.InvokeRequest{
 		Tok:     tok,
-		Args:    args,
+		Args:    resource.FromResourcePropertyMap(args),
 		Preview: rm.opts.DryRun,
 	})
 	if err != nil {
@@ -1139,7 +1139,7 @@ func (rm *resmon) Invoke(
 		keepResources = true
 	}
 
-	mret, err := plugin.MarshalProperties(resp.Properties, plugin.MarshalOptions{
+	mret, err := plugin.MarshalProperties(resource.ToResourcePropertyMap(resp.Properties), plugin.MarshalOptions{
 		Label:            label,
 		KeepUnknowns:     true,
 		KeepSecrets:      true,

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -463,12 +463,12 @@ type ConstructResponse = ConstructResult
 
 type InvokeRequest struct {
 	Tok     tokens.ModuleMember
-	Args    resource.PropertyMap
+	Args    property.Map
 	Preview bool
 }
 
 type InvokeResponse struct {
-	Properties resource.PropertyMap
+	Properties property.Map
 	Failures   []CheckFailure
 }
 

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -55,6 +55,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -2224,7 +2225,7 @@ func (p *provider) Invoke(ctx context.Context, req InvokeRequest) (InvokeRespons
 	contract.Assertf(req.Tok != "", "Invoke requires a token")
 
 	label := fmt.Sprintf("%s.Invoke(%s)", p.label(), req.Tok)
-	logging.V(7).Infof("%s executing (#args=%d)", label, len(req.Args))
+	logging.V(7).Infof("%s executing (#args=%d)", label, req.Args.Len())
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
@@ -2235,10 +2236,11 @@ func (p *provider) Invoke(ctx context.Context, req InvokeRequest) (InvokeRespons
 
 	// If the provider is not fully configured, return an empty property map.
 	if !pcfg.known {
-		return InvokeResponse{Properties: resource.PropertyMap{}}, nil
+		return InvokeResponse{Properties: property.Map{}}, nil
 	}
 
-	margs, err := MarshalProperties(req.Args, MarshalOptions{
+	args := resource.ToResourcePropertyMap(req.Args)
+	margs, err := MarshalProperties(args, MarshalOptions{
 		Label:          label + ".args",
 		KeepSecrets:    protocol.acceptSecrets,
 		KeepResources:  protocol.acceptResources,
@@ -2278,7 +2280,7 @@ func (p *provider) Invoke(ctx context.Context, req InvokeRequest) (InvokeRespons
 		failures = append(failures, CheckFailure{resource.PropertyKey(failure.Property), failure.Reason})
 	}
 
-	if req.Args.ContainsSecrets() && !protocol.acceptSecrets {
+	if args.ContainsSecrets() && !protocol.acceptSecrets {
 		for k, v := range ret {
 			if v.IsSecret() || (v.IsOutput() && v.OutputValue().Secret) {
 				continue
@@ -2289,7 +2291,7 @@ func (p *provider) Invoke(ctx context.Context, req InvokeRequest) (InvokeRespons
 
 	logging.V(7).Infof("%s success (#ret=%d,#failures=%d) success", label, len(ret), len(failures))
 	return InvokeResponse{
-		Properties: ret,
+		Properties: resource.FromResourcePropertyMap(ret),
 		Failures:   failures,
 	}, nil
 }

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -998,14 +998,14 @@ func (p *providerServer) Invoke(ctx context.Context, req *pulumirpc.InvokeReques
 
 	resp, err := p.provider.Invoke(ctx, InvokeRequest{
 		Tok:     tokens.ModuleMember(req.GetTok()),
-		Args:    args,
+		Args:    resource.FromResourcePropertyMap(args),
 		Preview: req.GetPreview(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	rpcResult, err := MarshalProperties(resp.Properties, p.marshalOptions("result"))
+	rpcResult, err := MarshalProperties(resource.ToResourcePropertyMap(resp.Properties), p.marshalOptions("result"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testing/pulumi-test-language/providers/any_type_function_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/any_type_function_provider.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type AnyTypeFunctionProvider struct {
@@ -171,7 +171,7 @@ func (p *AnyTypeFunctionProvider) Invoke(
 	ctx context.Context, req plugin.InvokeRequest,
 ) (plugin.InvokeResponse, error) {
 	if req.Tok == "any-type-function:index:dynListToDyn" {
-		value, ok := req.Args["inputs"]
+		value, ok := req.Args.GetOk("inputs")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("inputs", "missing inputs"),
@@ -185,11 +185,11 @@ func (p *AnyTypeFunctionProvider) Invoke(
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(resource.PropertyMap{
-					"resultProperty": resource.NewProperty("resultValue"),
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(map[string]property.Value{
+					"resultProperty": property.New("resultValue"),
 				}),
-			},
+			}),
 		}, nil
 	}
 

--- a/pkg/testing/pulumi-test-language/providers/component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_provider.go
@@ -254,14 +254,14 @@ func (p *ComponentProvider) Invoke(
 	if req.Tok != "component:index:identity" {
 		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
 	}
-	input, ok := req.Args["input"]
+	input, ok := req.Args.GetOk("input")
 	if !ok || !input.IsString() {
 		return plugin.InvokeResponse{}, errors.New("missing string argument 'input'")
 	}
 	return plugin.InvokeResponse{
-		Properties: resource.PropertyMap{
+		Properties: property.NewMap(map[string]property.Value{
 			"result": input,
-		},
+		}),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/config_grpc_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_grpc_provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -295,11 +296,11 @@ func (p *ConfigGrpcProvider) Invoke(
 ) (plugin.InvokeResponse, error) {
 	switch {
 	case string(req.Tok) == fmt.Sprintf("%s:index:toSecret", p.pkg()):
-		secreted := req.Args.Copy()
+		secreted := req.Args.AsMap()
 		for k, v := range secreted {
-			secreted[k] = resource.MakeSecret(v)
+			secreted[k] = v.WithSecret(true)
 		}
-		return plugin.InvokeResponse{Properties: secreted}, nil
+		return plugin.InvokeResponse{Properties: property.NewMap(secreted)}, nil
 	default:
 		return plugin.InvokeResponse{}, errors.New("Unknown function")
 	}

--- a/pkg/testing/pulumi-test-language/providers/config_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // Config provider is a small provider to test things related to provider configuration and explicit provider resources.
@@ -197,7 +198,7 @@ func (p *ConfigProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
 	}
 
-	text, ok := req.Args["text"]
+	text, ok := req.Args.GetOk("text")
 	if !ok {
 		return plugin.InvokeResponse{
 			Failures: makeCheckFailure("text", "missing text"),
@@ -210,9 +211,9 @@ func (p *ConfigProvider) Invoke(
 	}
 
 	return plugin.InvokeResponse{
-		Properties: resource.PropertyMap{
-			"text": resource.NewProperty(p.name + ": " + text.StringValue()),
-		},
+		Properties: property.NewMap(map[string]property.Value{
+			"text": property.New(p.name + ": " + text.AsString()),
+		}),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/docs_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/docs_provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // A small provider that uses documentation references for various properties. The correctness of documentation can't
@@ -297,18 +298,18 @@ func (p *DocsProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("invalid function token: %s", req.Tok)
 	}
 
-	in := req.Args["in"]
+	in := req.Args.Get("in")
 	if !in.IsBool() {
 		return plugin.InvokeResponse{
 			Failures: makeCheckFailure("in", fmt.Sprintf("invalid argument 'in': %v", in)),
 		}, nil
 	}
 
-	out := !in.BoolValue()
+	out := !in.AsBool()
 
 	return plugin.InvokeResponse{
-		Properties: resource.NewPropertyMapFromMap(map[string]any{
-			"out": out,
+		Properties: property.NewMap(map[string]property.Value{
+			"out": property.New(out),
 		}),
 	}, nil
 }

--- a/pkg/testing/pulumi-test-language/providers/extension_parameterized_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/extension_parameterized_provider.go
@@ -238,8 +238,8 @@ func (p *ExtensionParameterizedProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("invalid invoke token %s, expected %s", req.Tok, expected)
 	}
 	return plugin.InvokeResponse{
-		Properties: resource.NewPropertyMapFromMap(map[string]any{
-			"greeting": string(value) + ", " + req.Args["name"].StringValue(),
+		Properties: property.NewMap(map[string]property.Value{
+			"greeting": property.New(string(value) + ", " + req.Args.Get("name").AsString()),
 		}),
 	}, nil
 }

--- a/pkg/testing/pulumi-test-language/providers/index_mod_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/index_mod_provider.go
@@ -259,7 +259,7 @@ func (p *IndexModProvider) Invoke(
 ) (plugin.InvokeResponse, error) {
 	switch req.Tok {
 	case "index-mod:indexMine:concatWorld", "index-mod:indexMine/nested:concatWorld":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -279,9 +279,9 @@ func (p *IndexModProvider) Invoke(
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(value.StringValue() + " world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(value.AsString() + " world"),
+			}),
 		}, nil
 	}
 	return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)

--- a/pkg/testing/pulumi-test-language/providers/module_format_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/module_format_provider.go
@@ -337,7 +337,7 @@ func (p *ModuleFormatProvider) Invoke(
 ) (plugin.InvokeResponse, error) {
 	switch req.Tok {
 	case "module-format:index_concatWorld:concatWorld", "module-format:mod_concatWorld:concatWorld", "module-format:mod/nested_concatWorld:concatWorld": //nolint:lll
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -360,9 +360,9 @@ func (p *ModuleFormatProvider) Invoke(
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(value.StringValue() + " world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(value.AsString() + " world"),
+			}),
 		}, nil
 	}
 	return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)

--- a/pkg/testing/pulumi-test-language/providers/multi_argument_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/multi_argument_invoke_provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // MultiArgumentInvokeProvider exposes a function that uses multiArgumentInputs, so its inputs are
@@ -157,7 +158,7 @@ func (p *MultiArgumentInvokeProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
 	}
 
-	first, ok := req.Args["first"]
+	first, ok := req.Args.GetOk("first")
 	if !ok {
 		return plugin.InvokeResponse{
 			Failures: makeCheckFailure("first", "missing first"),
@@ -169,21 +170,21 @@ func (p *MultiArgumentInvokeProvider) Invoke(
 		}, nil
 	}
 
-	result := first.StringValue()
+	result := first.AsString()
 	// "second" is optional; when provided it is appended to the result.
-	if second, ok := req.Args["second"]; ok && !second.IsNull() {
+	if second, ok := req.Args.GetOk("second"); ok && !second.IsNull() {
 		if !second.IsString() {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("second", "second is not a string"),
 			}, nil
 		}
-		result += " " + second.StringValue()
+		result += " " + second.AsString()
 	}
 
 	return plugin.InvokeResponse{
-		Properties: resource.PropertyMap{
-			"result": resource.NewProperty(result),
-		},
+		Properties: property.NewMap(map[string]property.Value{
+			"result": property.New(result),
+		}),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type NestedObjectProvider struct {
@@ -213,7 +214,7 @@ func (p *NestedObjectProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
 	}
 
-	names, ok := req.Args["names"]
+	names, ok := req.Args.GetOk("names")
 	if !ok || !names.IsArray() {
 		return plugin.InvokeResponse{
 			Failures: makeCheckFailure("names", "missing names list"),
@@ -221,9 +222,9 @@ func (p *NestedObjectProvider) Invoke(
 	}
 
 	return plugin.InvokeResponse{
-		Properties: resource.PropertyMap{
+		Properties: property.NewMap(map[string]property.Value{
 			"results": names,
-		},
+		}),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type OutputOnlyInvokeProvider struct {
@@ -203,7 +204,7 @@ func (p *OutputOnlyInvokeProvider) Invoke(
 ) (plugin.InvokeResponse, error) {
 	switch req.Tok {
 	case "output-only-invoke:index:myInvoke":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -226,12 +227,12 @@ func (p *OutputOnlyInvokeProvider) Invoke(
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(value.StringValue() + " world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(value.AsString() + " world"),
+			}),
 		}, nil
 	case "output-only-invoke:index:myInvokeScalar":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -256,24 +257,24 @@ func (p *OutputOnlyInvokeProvider) Invoke(
 		// Single value returns work because SDKs automatically extract single value returns in their
 		// invoke implementations.
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(true),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(true),
+			}),
 		}, nil
 	case "output-only-invoke:index:unit":
-		if len(req.Args) > 0 {
+		if req.Args.Len() > 0 {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.Args)),
 			}, nil
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty("Hello world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New("Hello world"),
+			}),
 		}, nil
 	case "output-only-invoke:index:secretInvoke":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -293,7 +294,7 @@ func (p *OutputOnlyInvokeProvider) Invoke(
 			}, nil
 		}
 
-		secretResponse, ok := req.Args["secretResponse"]
+		secretResponse, ok := req.Args.GetOk("secretResponse")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("secretResponse", "missing secretResponse"),
@@ -306,15 +307,15 @@ func (p *OutputOnlyInvokeProvider) Invoke(
 		}
 
 		// if the secretResponse is true, wrap the response as a secret
-		response := resource.NewProperty(value.StringValue() + " world")
-		if secretResponse.BoolValue() {
-			response = resource.MakeSecret(response)
+		response := property.New(value.AsString() + " world")
+		if secretResponse.AsBool() {
+			response = response.WithSecret(true)
 		}
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
+			Properties: property.NewMap(map[string]property.Value{
 				"response": response,
 				"secret":   secretResponse,
-			},
+			}),
 		}, nil
 	}
 	return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)

--- a/pkg/testing/pulumi-test-language/providers/parameterized_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/parameterized_provider.go
@@ -302,20 +302,18 @@ func (p *ParameterizedProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("invalid function token: %s. Expected %s", req.Tok, functionToken)
 	}
 
-	input, ok := req.Args["input"]
+	input, ok := req.Args.GetOk("input")
 	if !ok {
 		return plugin.InvokeResponse{}, errors.New("missing required argument 'input'")
 	}
 	if !input.IsString() {
-		return plugin.InvokeResponse{}, fmt.Errorf("expected input to be a string, got %s", input.TypeString())
-	}
-
-	outputs := resource.PropertyMap{
-		"output": resource.NewProperty(input.StringValue() + string(p.parameterValue)),
+		return plugin.InvokeResponse{}, fmt.Errorf("expected input to be a string, got %v", input)
 	}
 
 	return plugin.InvokeResponse{
-		Properties: outputs,
+		Properties: property.NewMap(map[string]property.Value{
+			"output": property.New(input.AsString() + string(p.parameterValue)),
+		}),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/primitive_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/primitive_provider.go
@@ -319,13 +319,13 @@ func (p *PrimitiveProvider) Invoke(
 		assertField := func(key resource.PropertyKey, typ string,
 			assertType func(resource.PropertyValue) bool,
 		) *plugin.InvokeResponse {
-			v, ok := req.Args[key]
+			v, ok := req.Args.GetOk(string(key))
 			if !ok {
 				return &plugin.InvokeResponse{
 					Failures: makeCheckFailure(key, "missing value"),
 				}
 			}
-			if !assertType(unsecret(v)) {
+			if !assertType(unsecret(resource.ToResourcePropertyValue(v))) {
 				return &plugin.InvokeResponse{
 					Failures: makeCheckFailure(key, "value is not a "+typ),
 				}
@@ -354,7 +354,7 @@ func (p *PrimitiveProvider) Invoke(
 		if check != nil {
 			return *check, nil
 		}
-		for _, v := range unsecret(req.Args["numberArray"]).ArrayValue() {
+		for _, v := range unsecret(resource.ToResourcePropertyValue(req.Args.Get("numberArray"))).ArrayValue() {
 			if !unsecret(v).IsNumber() {
 				return plugin.InvokeResponse{
 					Failures: makeCheckFailure("numberArray", "array element is not a number"),
@@ -365,7 +365,7 @@ func (p *PrimitiveProvider) Invoke(
 		if check != nil {
 			return *check, nil
 		}
-		for _, v := range unsecret(req.Args["booleanMap"]).ObjectValue() {
+		for _, v := range unsecret(resource.ToResourcePropertyValue(req.Args.Get("booleanMap"))).ObjectValue() {
 			if !unsecret(v).IsBool() {
 				return plugin.InvokeResponse{
 					Failures: makeCheckFailure("booleanMap", "map value is not a boolean"),
@@ -373,7 +373,7 @@ func (p *PrimitiveProvider) Invoke(
 			}
 		}
 
-		if len(req.Args) != 6 {
+		if req.Args.Len() != 6 {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.Args)),
 			}, nil

--- a/pkg/testing/pulumi-test-language/providers/scalar_returns_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/scalar_returns_provider.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type ScalarReturnsProvider struct {
@@ -157,7 +157,7 @@ func (p *ScalarReturnsProvider) Invoke(
 	_ context.Context, req plugin.InvokeRequest,
 ) (plugin.InvokeResponse, error) {
 	if req.Tok == "scalar-returns:index:invokeSecret" {
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -182,13 +182,13 @@ func (p *ScalarReturnsProvider) Invoke(
 		// Single value returns work because SDKs automatically extract single value returns in their
 		// invoke implementations.
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"return": resource.MakeSecret(resource.NewProperty(float64(len(value.StringValue())))),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"return": property.New(float64(len(value.AsString()))).WithSecret(true),
+			}),
 		}, nil
 	}
 	if req.Tok == "scalar-returns:index:invokeArray" {
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -210,26 +210,26 @@ func (p *ScalarReturnsProvider) Invoke(
 			}, nil
 		}
 
-		result := []resource.PropertyValue{}
-		for i := 0; i < len(value.StringValue()); i++ {
-			c := value.StringValue()[i]
+		result := []property.Value{}
+		for i := 0; i < len(value.AsString()); i++ {
+			c := value.AsString()[i]
 			if c == 'i' || c == 'o' || c == 'u' || c == 'e' || c == 'a' {
-				result = append(result, resource.NewProperty(true))
+				result = append(result, property.New(true))
 			} else {
-				result = append(result, resource.NewProperty(false))
+				result = append(result, property.New(false))
 			}
 		}
 
 		// Single value returns work because SDKs automatically extract single value returns in their
 		// invoke implementations.
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"thisCanBeAnything": resource.NewProperty(result),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"thisCanBeAnything": property.New(result),
+			}),
 		}, nil
 	}
 	if req.Tok == "scalar-returns:index:invokeMap" {
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -251,18 +251,18 @@ func (p *ScalarReturnsProvider) Invoke(
 			}, nil
 		}
 
-		result := resource.NewProperty(resource.PropertyMap{
-			"value": resource.NewProperty(value.StringValue() + " world"),
+		result := property.New(map[string]property.Value{
+			"value": property.New(value.AsString() + " world"),
 		})
 
-		if value.StringValue() == "secret" {
-			result = resource.MakeSecret(result)
+		if value.AsString() == "secret" {
+			result = result.WithSecret(true)
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
+			Properties: property.NewMap(map[string]property.Value{
 				"result": result,
-			},
+			}),
 		}, nil
 	}
 

--- a/pkg/testing/pulumi-test-language/providers/simple_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_invoke_provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type SimpleInvokeProvider struct {
@@ -235,7 +236,7 @@ func (p *SimpleInvokeProvider) Invoke(
 ) (plugin.InvokeResponse, error) {
 	switch req.Tok {
 	case "simple-invoke:index:myInvoke":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -258,12 +259,12 @@ func (p *SimpleInvokeProvider) Invoke(
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(value.StringValue() + " world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(value.AsString() + " world"),
+			}),
 		}, nil
 	case "simple-invoke:index:myInvokeScalar":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -288,24 +289,24 @@ func (p *SimpleInvokeProvider) Invoke(
 		// Single value returns work because SDKs automatically extract single value returns in their
 		// invoke implementations.
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(true),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(true),
+			}),
 		}, nil
 	case "simple-invoke:index:unit":
-		if len(req.Args) > 0 {
+		if req.Args.Len() > 0 {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.Args)),
 			}, nil
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty("Hello world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New("Hello world"),
+			}),
 		}, nil
 	case "simple-invoke:index:secretInvoke":
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -318,10 +319,7 @@ func (p *SimpleInvokeProvider) Invoke(
 			}, nil
 		}
 
-		valueIsSecret := value.IsSecret()
-		if valueIsSecret {
-			value = value.SecretValue().Element
-		}
+		valueIsSecret := value.Secret()
 
 		if !value.IsString() {
 			reason := fmt.Sprintf("value is not a string: %#v", value)
@@ -330,7 +328,7 @@ func (p *SimpleInvokeProvider) Invoke(
 			}, nil
 		}
 
-		secretResponse, ok := req.Args["secretResponse"]
+		secretResponse, ok := req.Args.GetOk("secretResponse")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("secretResponse", "missing secretResponse"),
@@ -343,18 +341,18 @@ func (p *SimpleInvokeProvider) Invoke(
 		}
 
 		// if the secretResponse is true, wrap the response as a secret
-		response := resource.NewProperty(value.StringValue() + " world")
-		if secretResponse.BoolValue() || valueIsSecret {
-			response = resource.MakeSecret(response)
+		response := property.New(value.AsString() + " world")
+		if secretResponse.AsBool() || valueIsSecret {
+			response = response.WithSecret(true)
 		}
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
+			Properties: property.NewMap(map[string]property.Value{
 				"response": response,
 				"secret":   secretResponse,
-			},
+			}),
 		}, nil
 	case "simple-invoke:index:getText":
-		text, ok := req.Args["text"]
+		text, ok := req.Args.GetOk("text")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("text", "missing text"),
@@ -377,7 +375,7 @@ func (p *SimpleInvokeProvider) Invoke(
 		}
 
 		p.mu.Lock()
-		created := slices.Contains(p.created, text.StringValue())
+		created := slices.Contains(p.created, text.AsString())
 		p.mu.Unlock()
 		if !created {
 			// SDKs must not call this invoke before the StringResource
@@ -386,14 +384,14 @@ func (p *SimpleInvokeProvider) Invoke(
 			// exist yet.
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("text",
-					fmt.Sprintf("no StringResource with text %q has been created", text.StringValue())),
+					fmt.Sprintf("no StringResource with text %q has been created", text.AsString())),
 			}, nil
 		}
 
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(text.StringValue() + " world"),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(text.AsString() + " world"),
+			}),
 		}, nil
 	}
 	return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)

--- a/pkg/testing/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type SimpleInvokeWithScalarReturnProvider struct {
@@ -136,7 +137,7 @@ func (p *SimpleInvokeWithScalarReturnProvider) Invoke(
 	_ context.Context, req plugin.InvokeRequest,
 ) (plugin.InvokeResponse, error) {
 	if req.Tok == "simple-invoke-with-scalar-return:index:myInvokeScalar" {
-		value, ok := req.Args["value"]
+		value, ok := req.Args.GetOk("value")
 		if !ok {
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -161,9 +162,9 @@ func (p *SimpleInvokeWithScalarReturnProvider) Invoke(
 		// Single value returns work because SDKs automatically extract single value returns in their
 		// invoke implementations.
 		return plugin.InvokeResponse{
-			Properties: resource.PropertyMap{
-				"result": resource.NewProperty(true),
-			},
+			Properties: property.NewMap(map[string]property.Value{
+				"result": property.New(true),
+			}),
 		}, nil
 	}
 

--- a/pkg/testing/pulumi-test-language/providers/snake_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/snake_names_provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // SnakeNamesProvider is used to test snake_case naming features in the Pulumi SDK, and that they are used
@@ -309,26 +310,26 @@ func (p *SnakeNamesProvider) Invoke(
 		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
 	}
 
-	nestedArr, ok := req.Args["nested"]
+	nestedArr, ok := req.Args.GetOk("nested")
 	if !ok {
 		return plugin.InvokeResponse{
 			Failures: makeCheckFailure("nested", "missing nested"),
 		}, nil
 	}
 
-	firstEntry := nestedArr.ArrayValue()[0].ObjectValue()
-	firstValue := firstEntry["value"].StringValue()
+	firstEntry := nestedArr.AsArray().AsSlice()[0].AsMap()
+	firstValue := firstEntry.Get("value").AsString()
 
 	return plugin.InvokeResponse{
-		Properties: resource.PropertyMap{
-			"nested_output": resource.NewProperty([]resource.PropertyValue{
-				resource.NewProperty(resource.PropertyMap{
-					"key": resource.NewProperty(resource.PropertyMap{
-						"value": resource.NewProperty(firstValue),
+		Properties: property.NewMap(map[string]property.Value{
+			"nested_output": property.New([]property.Value{
+				property.New(map[string]property.Value{
+					"key": property.New(map[string]property.Value{
+						"value": property.New(firstValue),
 					}),
 				}),
 			}),
-		},
+		}),
 	}, nil
 }
 


### PR DESCRIPTION
Next part of `property.Map` migration. This covers invoke requests and responses.