### PR TITLE
Use resolved names for ESC environment imports

### DIFF
--- a/changelog/pending/sdk-go-fix-20260818-141805.yaml
+++ b/changelog/pending/sdk-go-fix-20260818-141805.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: fix
+body: Use resolved environment names when evaluating ESC imports
+time: 2026-08-18T14:18:05.778019-05:00

--- a/pkg/cmd/esc/analysis/common_test.go
+++ b/pkg/cmd/esc/analysis/common_test.go
@@ -82,11 +82,11 @@ func (testProviders) LoadRotator(ctx context.Context, name string) (esc.Rotator,
 
 type testEnvironments struct{}
 
-func (testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, eval.Decrypter, error) {
+func (testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, string, eval.Decrypter, error) {
 	if name != "a" {
-		return nil, nil, errors.New("not found")
+		return nil, "", nil, errors.New("not found")
 	}
-	return []byte(`{"values": {}}`), nil, nil
+	return []byte(`{"values": {}}`), name, nil, nil
 }
 
 func (testEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {

--- a/pkg/cmd/esc/cli/cli_test.go
+++ b/pkg/cmd/esc/cli/cli_test.go
@@ -201,7 +201,7 @@ type testEnvironments struct {
 	environments map[string]*testEnvironment
 }
 
-func (e *testEnvironments) LoadEnvironment(ctx context.Context, ref string) ([]byte, eval.Decrypter, error) {
+func (e *testEnvironments) LoadEnvironment(ctx context.Context, ref string) ([]byte, string, eval.Decrypter, error) {
 	var name string
 
 	// This "emulates" the backend behavior of resolving refs
@@ -214,9 +214,9 @@ func (e *testEnvironments) LoadEnvironment(ctx context.Context, ref string) ([]b
 
 	env, ok := e.environments[name]
 	if !ok {
-		return nil, nil, errors.New("not found")
+		return nil, "", nil, errors.New("not found")
 	}
-	return env.latest().yaml, rot128{}, nil
+	return env.latest().yaml, ref, rot128{}, nil
 }
 
 func (e *testEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -197,12 +197,12 @@ func mapEvalDiags(diags syntax.Diagnostics) apitype.EnvironmentDiagnostics {
 type envDefMap map[string]string
 
 // LoadEnvironment loads the definition for the environment with the given name.
-func (m envDefMap) LoadEnvironment(ctx context.Context, name string) ([]byte, eval.Decrypter, error) {
+func (m envDefMap) LoadEnvironment(ctx context.Context, name string) ([]byte, string, eval.Decrypter, error) {
 	def, ok := m[name]
 	if !ok {
-		return nil, nil, errors.New("not found")
+		return nil, "", nil, errors.New("not found")
 	}
-	return []byte(def), nil, nil
+	return []byte(def), name, nil, nil
 }
 
 func (m envDefMap) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {

--- a/sdk/go/common/esc/eval/eval.go
+++ b/sdk/go/common/esc/eval/eval.go
@@ -49,7 +49,7 @@ type ProviderLoader interface {
 // An EnvironmentLoader provides the environment evaluator the capability to load imported environment definitions.
 type EnvironmentLoader interface {
 	// LoadEnvironment loads the definition for the environment with the given name.
-	LoadEnvironment(ctx context.Context, name string) ([]byte, Decrypter, error)
+	LoadEnvironment(ctx context.Context, name string) (yaml []byte, resolvedName string, decrypter Decrypter, err error)
 
 	// AuthorizeImport reports whether the environment named by importer may import the environment named by imported.
 	AuthorizeImport(ctx context.Context, importer string, imported string, importerIsRoot bool) error
@@ -247,6 +247,7 @@ type evalContext struct {
 	rotating     bool                 // true if we are invoking rotators
 	showSecrets  bool                 // true if secrets should be decrypted during validation
 	name         string               // the name of the environment
+	declaredName string               // the declared name used to cache the environment
 	env          *ast.EnvironmentDecl // the root of the environment AST
 	isRootEnv    bool                 // true if this environment is the root of evaluation (not an import)
 	decrypter    Decrypter            // the decrypter to use for the environment
@@ -291,6 +292,7 @@ func newEvalContext(
 		rotating:       rotating,
 		showSecrets:    showSecrets,
 		name:           name,
+		declaredName:   name,
 		env:            env,
 		isRootEnv:      isRootEnv,
 		decrypter:      decrypter,
@@ -506,7 +508,7 @@ func (e *evalContext) isReserveTopLevelKey(k string) bool {
 func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	mine := &imported{evaluating: true}
 	defer func() { mine.evaluating = false }()
-	e.imports[e.name] = mine
+	e.imports[e.declaredName] = mine
 
 	// Evaluate context. We prepare the context values to later evaluate interpolations.
 	e.evaluateContext()
@@ -620,13 +622,13 @@ func (e *evalContext) evaluateImport(expr ast.Expr, name string) (*value, bool) 
 		}
 		val = imported.value
 	} else {
-		bytes, dec, err := e.environments.LoadEnvironment(e.ctx, name)
+		bytes, resolvedName, dec, err := e.environments.LoadEnvironment(e.ctx, name)
 		if err != nil {
 			e.errorf(expr, "%s", err.Error())
 			return nil, false
 		}
 
-		env, diags, err := LoadYAMLBytes(name, bytes)
+		env, diags, err := LoadYAMLBytes(resolvedName, bytes)
 		e.diags.Extend(diags...)
 		if err != nil {
 			e.errorf(expr, "%s", err.Error())
@@ -637,7 +639,8 @@ func (e *evalContext) evaluateImport(expr ast.Expr, name string) (*value, bool) 
 		}
 
 		// we only want to rotate the root environment, so set rotating flag to false when evaluating imports
-		imp := newEvalContext(e.ctx, e.validating, false, name, env, false, dec, e.providers, e.environments, e.imports, e.execContext, e.showSecrets, nil) //nolint:lll
+		imp := newEvalContext(e.ctx, e.validating, false, resolvedName, env, false, dec, e.providers, e.environments, e.imports, e.execContext, e.showSecrets, nil) //nolint:lll
+		imp.declaredName = name
 		imp.traceMode = e.traceMode
 		v, diags := imp.evaluate()
 		e.diags.Extend(diags...)

--- a/sdk/go/common/esc/eval/eval_options_test.go
+++ b/sdk/go/common/esc/eval/eval_options_test.go
@@ -37,12 +37,12 @@ func chainDepth(v *esc.Value) int {
 // topologies without testdata files.
 type inlineEnvironments map[string][]byte
 
-func (e inlineEnvironments) LoadEnvironment(_ context.Context, name string) ([]byte, Decrypter, error) {
+func (e inlineEnvironments) LoadEnvironment(_ context.Context, name string) ([]byte, string, Decrypter, error) {
 	src, ok := e[name]
 	if !ok {
-		return nil, nil, os.ErrNotExist
+		return nil, "", nil, os.ErrNotExist
 	}
-	return src, rot128{}, nil
+	return src, name, rot128{}, nil
 }
 
 func (e inlineEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {

--- a/sdk/go/common/esc/eval/eval_test.go
+++ b/sdk/go/common/esc/eval/eval_test.go
@@ -287,9 +287,9 @@ type testEnvironments struct {
 	root string
 }
 
-func (e *testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, Decrypter, error) {
+func (e *testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, string, Decrypter, error) {
 	if e.root == "" {
-		return nil, nil, os.ErrNotExist
+		return nil, "", nil, os.ErrNotExist
 	}
 
 	bytes, err := os.ReadFile(filepath.Join(e.root, name+".yaml"))
@@ -297,11 +297,11 @@ func (e *testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]
 		// Normalize to an OS-independent error: os.ReadFile's message and path
 		// separators differ across platforms, which breaks golden comparisons on Windows.
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("environment %q not found", name)
+			return nil, "", nil, fmt.Errorf("environment %q not found", name)
 		}
-		return nil, nil, err
+		return nil, "", nil, err
 	}
-	return bytes, rot128{}, nil
+	return bytes, name, rot128{}, nil
 }
 
 func (e *testEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
@@ -340,14 +340,14 @@ func newBenchEnvironments(root string, delay time.Duration) (*benchEnvironments,
 	return &benchEnvironments{defs, delay}, nil
 }
 
-func (e *benchEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, Decrypter, error) {
+func (e *benchEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, string, Decrypter, error) {
 	time.Sleep(e.delay)
 
 	bytes, ok := e.defs[name]
 	if !ok {
-		return nil, nil, os.ErrNotExist
+		return nil, "", nil, os.ErrNotExist
 	}
-	return bytes, rot128{}, nil
+	return bytes, name, rot128{}, nil
 }
 
 func (e *benchEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
@@ -385,6 +385,63 @@ func normalize[T any](t *testing.T, v T) T {
 	err = dec.Decode(&decoded)
 	require.NoError(t, err)
 	return decoded
+}
+
+type importAuthorization struct {
+	importer string
+	imported string
+}
+
+type overrideEnvironments struct {
+	defs           map[string]string
+	overrides      map[string]string
+	authorizations []importAuthorization
+}
+
+func (e *overrideEnvironments) LoadEnvironment(_ context.Context, name string) ([]byte, string, Decrypter, error) {
+	resolved, ok := e.overrides[name]
+	if !ok {
+		resolved = name
+	}
+	def, ok := e.defs[resolved]
+	if !ok {
+		return nil, "", nil, os.ErrNotExist
+	}
+	return []byte(def), resolved, rot128{}, nil
+}
+
+func (e *overrideEnvironments) AuthorizeImport(_ context.Context, importer, imported string, _ bool) error {
+	e.authorizations = append(e.authorizations, importAuthorization{importer: importer, imported: imported})
+	return nil
+}
+
+func TestEvalEnvironmentUsesResolvedImportName(t *testing.T) {
+	t.Parallel()
+
+	env, diags, err := LoadYAMLBytes("root", []byte(`imports:
+  - dev
+values:
+  importedEnvironmentName: ${imports.dev.environmentName}
+`))
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), "%v", diags)
+
+	execContext, err := esc.NewExecContext(nil)
+	require.NoError(t, err)
+	environments := &overrideEnvironments{
+		defs: map[string]string{
+			"prod":  "imports:\n  - child\nvalues:\n  environmentName: ${context.currentEnvironment.name}\n",
+			"child": "values: {}\n",
+		},
+		overrides: map[string]string{"dev": "prod"},
+	}
+	result, diags := EvalEnvironment(
+		t.Context(), "root", env, rot128{}, testProviders{}, environments, execContext, EvalOptions{},
+	)
+	require.False(t, diags.HasErrors(), "%v", diags)
+	require.NotNil(t, result)
+	assert.Equal(t, "prod", result.Properties["importedEnvironmentName"].Value)
+	assert.Contains(t, environments.authorizations, importAuthorization{importer: "prod", imported: "child"})
 }
 
 func TestEval(t *testing.T) {


### PR DESCRIPTION
Track resolved env name of imports (which can be different if using environment overrides)