### PR TITLE
Defer untargeted same steps until their dependencies have steps

### DIFF
--- a/changelog/pending/engine-fix-20260819-121203.yaml
+++ b/changelog/pending/engine-fix-20260819-121203.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Fix an intermittent "Duplicate resource URN" failure during targeted operations when the program removes a dependency edge on an untargeted resource
+time: 2026-08-19T12:12:03.743911+02:00

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -5284,32 +5284,33 @@ func TestTargetedStepAfterDeferredUntargetedSame(t *testing.T) {
 		}),
 	}
 
-	aURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::a")
-	uURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::u")
-	vURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::v")
+	oldDependencyURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::old-dependency")
+	deferredURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::deferred")
+	targetedURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::targeted")
 
-	// When set, u no longer depends on a, so a is free to register after the resources that used
-	// to precede it. u's old state still carries the edge, so u may only be written after a.
+	// When set, the program no longer declares the dependency, so old-dependency is free to
+	// register after the resources that used to precede it. deferred's old state still carries
+	// the edge, so deferred may only be written after old-dependency.
 	var dropEdge bool
 
 	program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		uOpts := deploytest.ResourceOptions{}
+		deferredOpts := deploytest.ResourceOptions{}
 		if !dropEdge {
-			_, err := monitor.RegisterResource("pkgA:m:typA", "a", true)
+			_, err := monitor.RegisterResource("pkgA:m:typA", "old-dependency", true)
 			require.NoError(t, err)
-			uOpts.Dependencies = []resource.URN{aURN}
+			deferredOpts.Dependencies = []resource.URN{oldDependencyURN}
 		}
 
-		_, err := monitor.RegisterResource("pkgA:m:typA", "u", true, uOpts)
+		_, err := monitor.RegisterResource("pkgA:m:typA", "deferred", true, deferredOpts)
 		require.NoError(t, err)
 
-		_, err = monitor.RegisterResource("pkgA:m:typA", "v", true, deploytest.ResourceOptions{
-			Dependencies: []resource.URN{uURN},
+		_, err = monitor.RegisterResource("pkgA:m:typA", "targeted", true, deploytest.ResourceOptions{
+			Dependencies: []resource.URN{deferredURN},
 		})
 		require.NoError(t, err)
 
 		if dropEdge {
-			_, err = monitor.RegisterResource("pkgA:m:typA", "a", true)
+			_, err = monitor.RegisterResource("pkgA:m:typA", "old-dependency", true)
 			require.NoError(t, err)
 		}
 		return nil
@@ -5324,10 +5325,10 @@ func TestTargetedStepAfterDeferredUntargetedSame(t *testing.T) {
 	require.NoError(t, err)
 
 	dropEdge = true
-	targeted := opts
-	targeted.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{vURN})
+	targetedOpts := opts
+	targetedOpts.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{targetedURN})
 
-	snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), targeted, false, p.BackendClient, nil)
+	snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), targetedOpts, false, p.BackendClient, nil)
 	require.NoError(t, err)
 	require.NoError(t, snap.VerifyIntegrity())
 }

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -5128,7 +5128,6 @@ func TestTargetedPreviewNoDuplicateURN_Issue24303(t *testing.T) {
 // The bare-minimum "just short-circuit" fix would leave the old inputs in place and
 // fail this assertion.
 func TestTargetedUpdateAppliesNewInputs_Issue24303(t *testing.T) {
-	t.Skip("Currently failing")
 	t.Parallel()
 
 	loaders := []*deploytest.ProviderLoader{
@@ -5272,4 +5271,63 @@ func TestTargetedUpdateAppliesNewInputs_Issue24303(t *testing.T) {
 		}
 	}
 	require.Equal(t, rollbackCount, found, "expected all rollback resources in snapshot")
+}
+
+// A targeted resource that depends on an untargeted one whose same step has been held back must
+// still be written after it. See https://github.com/pulumi/pulumi/issues/24303.
+func TestTargetedStepAfterDeferredUntargetedSame(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	aURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::a")
+	uURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::u")
+	vURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::v")
+
+	// When set, u no longer depends on a, so a is free to register after the resources that used
+	// to precede it. u's old state still carries the edge, so u may only be written after a.
+	var dropEdge bool
+
+	program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		uOpts := deploytest.ResourceOptions{}
+		if !dropEdge {
+			_, err := monitor.RegisterResource("pkgA:m:typA", "a", true)
+			require.NoError(t, err)
+			uOpts.Dependencies = []resource.URN{aURN}
+		}
+
+		_, err := monitor.RegisterResource("pkgA:m:typA", "u", true, uOpts)
+		require.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:m:typA", "v", true, deploytest.ResourceOptions{
+			Dependencies: []resource.URN{uURN},
+		})
+		require.NoError(t, err)
+
+		if dropEdge {
+			_, err = monitor.RegisterResource("pkgA:m:typA", "a", true)
+			require.NoError(t, err)
+		}
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
+	p := &lt.TestPlan{}
+	project := p.GetProject()
+	opts := lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true}
+
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil)
+	require.NoError(t, err)
+
+	dropEdge = true
+	targeted := opts
+	targeted.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{vURN})
+
+	snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), targeted, false, p.BackendClient, nil)
+	require.NoError(t, err)
+	require.NoError(t, snap.VerifyIntegrity())
 }

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -5128,7 +5128,7 @@ func TestTargetedPreviewNoDuplicateURN_Issue24303(t *testing.T) {
 // The bare-minimum "just short-circuit" fix would leave the old inputs in place and
 // fail this assertion.
 func TestTargetedUpdateAppliesNewInputs_Issue24303(t *testing.T) {
-	t.Skip("Currently failing: requires ordering-aware deferral, see #24303")
+	t.Skip("Currently failing")
 	t.Parallel()
 
 	loaders := []*deploytest.ProviderLoader{

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -5007,7 +5007,6 @@ func TestTargetedOperationSkipsUnrelatedProviderConfiguration(t *testing.T) {
 // run the targeted preview many times to try to catch it. Registrations are performed
 // concurrently from goroutines so they can actually race.
 func TestTargetedPreviewNoDuplicateURN_Issue24303(t *testing.T) {
-	t.Skip("Currently failing")
 	t.Parallel()
 
 	loaders := []*deploytest.ProviderLoader{
@@ -5129,7 +5128,7 @@ func TestTargetedPreviewNoDuplicateURN_Issue24303(t *testing.T) {
 // The bare-minimum "just short-circuit" fix would leave the old inputs in place and
 // fail this assertion.
 func TestTargetedUpdateAppliesNewInputs_Issue24303(t *testing.T) {
-	t.Skip("Currently failing")
+	t.Skip("Currently failing: requires ordering-aware deferral, see #24303")
 	t.Parallel()
 
 	loaders := []*deploytest.ProviderLoader{

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 
@@ -5329,6 +5330,77 @@ func TestTargetedStepAfterDeferredUntargetedSame(t *testing.T) {
 	targetedOpts.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{targetedURN})
 
 	snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), targetedOpts, false, p.BackendClient, nil)
+	require.NoError(t, err)
+	require.NoError(t, snap.VerifyIntegrity())
+}
+
+// Holding a same step back must not hold the resource's registration open: the program is free to
+// register the very dependency the step is waiting on, and does so here only after the RPC for the
+// held-back resource has returned. Registering outputs also needs the held-back step to have run.
+// See https://github.com/pulumi/pulumi/issues/24303.
+func TestDeferredUntargetedSameCompletesRegistration(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	oldDependencyURN := resource.URN("urn:pulumi:test::test::pkgA:m:typComponent::old-dependency")
+	targetedURN := resource.URN("urn:pulumi:test::test::pkgA:m:typA::targeted")
+
+	var dropEdge bool
+
+	program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		deferredOpts := deploytest.ResourceOptions{}
+		if !dropEdge {
+			_, err := monitor.RegisterResource("pkgA:m:typComponent", "old-dependency", false)
+			require.NoError(t, err)
+			deferredOpts.Dependencies = []resource.URN{oldDependencyURN}
+		}
+
+		// Every call below is sequential on this goroutine, so anything the engine waits for
+		// before answering one of them can never arrive.
+		deferred, err := monitor.RegisterResource("pkgA:m:typComponent", "deferred", false, deferredOpts)
+		require.NoError(t, err)
+		require.NoError(t, monitor.RegisterResourceOutputs(deferred.URN, resource.PropertyMap{}))
+
+		_, err = monitor.RegisterResource("pkgA:m:typA", "targeted", true)
+		require.NoError(t, err)
+
+		if dropEdge {
+			_, err = monitor.RegisterResource("pkgA:m:typComponent", "old-dependency", false)
+			require.NoError(t, err)
+		}
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
+	p := &lt.TestPlan{}
+	project := p.GetProject()
+	opts := lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true}
+
+	snap, err := lt.TestOp(Update).Run(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil)
+	require.NoError(t, err)
+
+	dropEdge = true
+	targetedOpts := opts
+	targetedOpts.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{targetedURN})
+
+	// A deadlock here would otherwise surface as the whole package timing out, naming whichever
+	// test happened to be running.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		snap, err = lt.TestOp(Update).Run(project, p.GetTarget(t, snap), targetedOpts, false, p.BackendClient, nil)
+	}()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("deployment did not terminate")
+	}
+
 	require.NoError(t, err)
 	require.NoError(t, snap.VerifyIntegrity())
 }

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -326,6 +326,23 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context) (_ *Plan, err e
 			// Exit if we've seen a nil event and the step generator has no more async work to do. See the comment at
 			// the top of the loop for more details.
 			if seenNil && ex.asyncEventsExpected == 0 {
+				// The program has finished registering, so any same steps held back waiting on
+				// registrations that never came can now be emitted. Locking the step executor
+				// waits for the in-flight chains, so these land after everything registered.
+				ex.stepExec.Lock()
+				deferredSames, deferErr := ex.stepGen.FlushDeferredSames()
+				ex.stepExec.Unlock()
+				if deferErr != nil {
+					if !result.IsBail(deferErr) {
+						ex.reportError("", deferErr)
+					}
+					cancel()
+					return false, result.BailError(deferErr)
+				}
+				if len(deferredSames) > 0 {
+					ex.stepExec.ExecuteSerial(deferredSames).Wait(ctx)
+				}
+
 				// Check targets before performDeletes mutates the initial Snapshot.
 				targetErr := ex.checkTargets(ex.deployment.opts.Targets)
 

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -638,6 +638,15 @@ func (ex *deploymentExecutor) handleSingleEvent(ctx context.Context, event Sourc
 		steps, err = ex.stepGen.GenerateReadSteps(e)
 	case RegisterResourceOutputsEvent:
 		logging.V(4).Infof("deploymentExecutor.handleSingleEvent(...): received register resource outputs")
+		// Registering outputs needs the resource's own step to have executed, so release it if it
+		// is being held back.
+		released, releaseErr := ex.stepGen.ReleaseDeferredSamesFor(e.URN())
+		if releaseErr != nil {
+			return releaseErr
+		}
+		if len(released) > 0 {
+			ex.stepExec.ExecuteSerial(released).Wait(ctx)
+		}
 		return ex.stepExec.ExecuteRegisterResourceOutputs(e)
 	}
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -106,10 +106,16 @@ type stepGenerator struct {
 	pendingUntargetedSames    []Step
 	pendingUntargetedSameURNs map[resource.URN]bool
 
-	// URNs for which a speculative untargeted same step has been emitted. These are emitted for
-	// old-state dependencies of untargeted resources that have not registered yet; the program
-	// may still register them, in which case the registration must not be treated as a duplicate.
+	// URNs whose old state a speculative untargeted same step has already copied forward. Such a
+	// step is emitted on behalf of a dependency that has no step of its own; if the program turns
+	// out to register that dependency after all, the registration is neither a duplicate nor
+	// something to write to the snapshot a second time.
 	speculativeSames map[resource.URN]bool
+
+	// untargeted same steps held back because the resource's old-state dependencies have no steps
+	// yet, in registration order. See deferUntargetedSame.
+	deferredSames    []func() ([]Step, error)
+	deferredSameURNs map[resource.URN]bool
 
 	pendingDeletes map[*pkgresource.State]bool         // set of resources (not URNs!) that are pending deletion
 	providers      map[resource.URN]*pkgresource.State // URN map of providers that we have seen so far.
@@ -420,6 +426,16 @@ func (sg *stepGenerator) GenerateSteps(ctx context.Context, event RegisterResour
 // Called at the end of GenerateSteps and ContinueStepsFromDiff to validate the steps generated are valid.
 // That is they match any constraint plan or targets that are set.
 func (sg *stepGenerator) validateSteps(steps []Step) ([]Step, error) {
+	// A step that depends on a held-back same must not be written before it, so release the
+	// held-back steps into the front of this batch.
+	if len(sg.deferredSames) > 0 && sg.dependsOnDeferredSame(steps) {
+		deferred, err := sg.emitDeferredSames()
+		if err != nil {
+			return nil, err
+		}
+		steps = append(deferred, steps...)
+	}
+
 	if len(sg.pendingUntargetedSames) > 0 {
 		pending := sg.pendingUntargetedSames
 		sg.pendingUntargetedSames = nil
@@ -1555,22 +1571,18 @@ func (sg *stepGenerator) continueStepsFromImport(
 	if old != nil {
 		contract.Assertf(old != nil, "must have old resource if hasOld is true")
 
-		// If we already speculatively copied this resource's old state forward on behalf of an
-		// untargeted dependent, the snapshot already holds it in the right place. Complete the
-		// registration without writing it a second time.
+		// A flush emitted a speculative same step for this resource before the program got round
+		// to registering it. The snapshot already holds its old state, in the right place.
 		if sg.speculativeSames[urn] {
 			delete(sg.speculativeSames, urn)
 			if !isTargeted {
-				// Emitting a step here would write the resource to the snapshot a second time.
-				// Complete the registration directly instead. Note that we hand it a fresh copy
-				// of the old state rather than the state the speculative step wrote, which is
-				// owned by that step and may still be being written.
+				// Emitting a step would write it a second time, so settle the registration here.
+				// The copy is deliberate: the speculative step owns the state it wrote.
 				event.Done(&RegisterResult{State: old.Copy()})
 				return nil, false, nil
 			}
-			// The resource is targeted after all (e.g. via --target-dependents), so it may need
-			// a real step. We cannot retract the state we already wrote, so bail rather than
-			// risk a duplicate in the snapshot.
+			// Targeted, so it may need a real step -- but we cannot retract what we wrote. Bail
+			// rather than risk a duplicate in the snapshot.
 			return nil, false, sg.bailDiag(diag.GetDuplicateResourceURNError(urn), urn)
 		}
 
@@ -1759,14 +1771,19 @@ func (sg *stepGenerator) continueStepsFromImport(
 				new.ID = ""
 				rootStep := NewUntargetedSameStep(sg.deployment, event, old, new)
 				if event == nil {
-					// This step is speculative: it was emitted on behalf of a dependency that
-					// has not been registered. The program may yet register it, in which case
-					// that registration must not be treated as a duplicate, nor written to the
-					// snapshot a second time.
 					sg.speculativeSames[old.URN] = true
 				}
 				steps = append(steps, rootStep)
 				return steps, nil
+			}
+
+			// Emitting our step now would place us before dependencies that have yet to be
+			// registered, which is an invalid snapshot ordering. Hold it back instead.
+			if sg.shouldDeferUntargetedSame(old) {
+				sg.deferUntargetedSame(urn, old, event, func() ([]Step, error) {
+					return getDependencySteps(old, nil)
+				})
+				return nil, false, nil
 			}
 
 			steps, err := getDependencySteps(old, event)
@@ -2265,6 +2282,99 @@ func (sg *stepGenerator) queueUntargetedDependencySames(new *pkgresource.State) 
 	for _, dep := range allDeps {
 		queue(dep.URN)
 	}
+}
+
+// shouldDeferUntargetedSame reports whether the untargeted same step for old must be held back
+// until later in the deployment. A same step copies old's state -- including its old dependency
+// edges -- into the snapshot, so it may only be written once every one of those dependencies has
+// a step of its own. Normally the program registers dependencies first and this is free, but when
+// the program removes a dependency edge that ordering no longer holds.
+func (sg *stepGenerator) shouldDeferUntargetedSame(old *pkgresource.State) bool {
+	_, allDeps := old.GetAllDependencies()
+	for _, dep := range allDeps {
+		if sg.deferredSameURNs[dep.URN] {
+			return true
+		}
+		if sg.hasGeneratedStep(dep.URN) {
+			continue
+		}
+		// Dependencies with no old state are an error, which getDependencySteps reports. Leave
+		// them to it rather than deferring a step that can only fail.
+		if _, has := sg.deployment.Olds()[dep.URN]; has {
+			return true
+		}
+	}
+	return false
+}
+
+// deferUntargetedSame holds back a resource's untargeted same step until FlushDeferredSames runs,
+// completing its registration immediately so that the program is not blocked on a step that is,
+// by construction, waiting on registrations the program has yet to make.
+func (sg *stepGenerator) deferUntargetedSame(
+	urn resource.URN, old *pkgresource.State, event RegisterResourceEvent, emit func() ([]Step, error),
+) {
+	// Claim the URN now so that dependents neither speculatively copy this resource forward nor
+	// emit their own step ahead of ours -- shouldDeferUntargetedSame defers them behind us.
+	sg.urns[old.URN] = true
+	sg.sames[urn] = true
+	sg.sames[old.URN] = true
+	// Both URNs, so that dependents referring to this resource by its pre-alias URN are deferred
+	// behind it too.
+	sg.deferredSameURNs[urn] = true
+	sg.deferredSameURNs[old.URN] = true
+	sg.deferredSames = append(sg.deferredSames, emit)
+
+	// The registration result is fully determined for a same step, so we can settle it here. Note
+	// that this is a copy: the held-back step owns its own state and will write to it later.
+	event.Done(&RegisterResult{State: old.Copy()})
+}
+
+// emitDeferredSames emits every same step held back by deferUntargetedSame, in registration order.
+// Dependencies that registered in the meantime have steps of their own and are skipped; those that
+// never registered have their old state copied forward by a speculative step placed just before
+// their dependent.
+func (sg *stepGenerator) emitDeferredSames() ([]Step, error) {
+	var steps []Step
+	for _, emit := range sg.deferredSames {
+		emitted, err := emit()
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, emitted...)
+	}
+	sg.deferredSames = nil
+	clear(sg.deferredSameURNs)
+	return steps, nil
+}
+
+// FlushDeferredSames emits and validates the held-back same steps. It must be called once the
+// program has finished registering resources and before deletes are generated, at which point every
+// dependency that was going to register has done so.
+func (sg *stepGenerator) FlushDeferredSames() ([]Step, error) {
+	steps, err := sg.emitDeferredSames()
+	if err != nil {
+		return nil, err
+	}
+	return sg.validateSteps(steps)
+}
+
+// dependsOnDeferredSame reports whether any of the given steps is for a resource that depends on
+// one whose same step is currently held back. Such a step may not be emitted first, or it would
+// precede its own dependency in the snapshot.
+func (sg *stepGenerator) dependsOnDeferredSame(steps []Step) bool {
+	for _, s := range steps {
+		res := s.Res()
+		if res == nil {
+			continue
+		}
+		_, allDeps := res.GetAllDependencies()
+		for _, dep := range allDeps {
+			if sg.deferredSameURNs[dep.URN] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Returns true if this resource has been operated on by any steps generated so far.
@@ -3636,6 +3746,7 @@ func newStepGenerator(
 		skippedCreates:            make(map[resource.URN]bool),
 		pendingDeletes:            make(map[*pkgresource.State]bool),
 		pendingUntargetedSameURNs: make(map[resource.URN]bool),
+		deferredSameURNs:          make(map[resource.URN]bool),
 		speculativeSames:          make(map[resource.URN]bool),
 		providers:                 make(map[resource.URN]*pkgresource.State),
 		dependentReplaceKeys:      make(map[resource.URN][]resource.PropertyKey),

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -106,6 +106,11 @@ type stepGenerator struct {
 	pendingUntargetedSames    []Step
 	pendingUntargetedSameURNs map[resource.URN]bool
 
+	// URNs for which a speculative untargeted same step has been emitted. These are emitted for
+	// old-state dependencies of untargeted resources that have not registered yet; the program
+	// may still register them, in which case the registration must not be treated as a duplicate.
+	speculativeSames map[resource.URN]bool
+
 	pendingDeletes map[*pkgresource.State]bool         // set of resources (not URNs!) that are pending deletion
 	providers      map[resource.URN]*pkgresource.State // URN map of providers that we have seen so far.
 
@@ -279,7 +284,7 @@ func (sg *stepGenerator) generateURN(
 ) (resource.URN, error) {
 	// Generate a URN for this new resource, confirm we haven't seen it before in this deployment.
 	urn := sg.deployment.generateURN(parent, ty, name)
-	if sg.urns[urn] {
+	if sg.urns[urn] && !sg.speculativeSames[urn] {
 		// TODO[pulumi/pulumi-framework#19]: improve this error message!
 		return "", sg.bailDiag(diag.GetDuplicateResourceURNError(urn), urn)
 	}
@@ -1550,6 +1555,25 @@ func (sg *stepGenerator) continueStepsFromImport(
 	if old != nil {
 		contract.Assertf(old != nil, "must have old resource if hasOld is true")
 
+		// If we already speculatively copied this resource's old state forward on behalf of an
+		// untargeted dependent, the snapshot already holds it in the right place. Complete the
+		// registration without writing it a second time.
+		if sg.speculativeSames[urn] {
+			delete(sg.speculativeSames, urn)
+			if !isTargeted {
+				// Emitting a step here would write the resource to the snapshot a second time.
+				// Complete the registration directly instead. Note that we hand it a fresh copy
+				// of the old state rather than the state the speculative step wrote, which is
+				// owned by that step and may still be being written.
+				event.Done(&RegisterResult{State: old.Copy()})
+				return nil, false, nil
+			}
+			// The resource is targeted after all (e.g. via --target-dependents), so it may need
+			// a real step. We cannot retract the state we already wrote, so bail rather than
+			// risk a duplicate in the snapshot.
+			return nil, false, sg.bailDiag(diag.GetDuplicateResourceURNError(urn), urn)
+		}
+
 		// If the user requested only specific resources to update, and this resource was not in
 		// that set, then we should emit a SameStep for it.
 		if !isTargeted {
@@ -1734,6 +1758,13 @@ func (sg *stepGenerator) continueStepsFromImport(
 				new := old.Copy()
 				new.ID = ""
 				rootStep := NewUntargetedSameStep(sg.deployment, event, old, new)
+				if event == nil {
+					// This step is speculative: it was emitted on behalf of a dependency that
+					// has not been registered. The program may yet register it, in which case
+					// that registration must not be treated as a duplicate, nor written to the
+					// snapshot a second time.
+					sg.speculativeSames[old.URN] = true
+				}
 				steps = append(steps, rootStep)
 				return steps, nil
 			}
@@ -3605,6 +3636,7 @@ func newStepGenerator(
 		skippedCreates:            make(map[resource.URN]bool),
 		pendingDeletes:            make(map[*pkgresource.State]bool),
 		pendingUntargetedSameURNs: make(map[resource.URN]bool),
+		speculativeSames:          make(map[resource.URN]bool),
 		providers:                 make(map[resource.URN]*pkgresource.State),
 		dependentReplaceKeys:      make(map[resource.URN][]resource.PropertyKey),
 		aliased:                   make(map[resource.URN]resource.URN),

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -2358,6 +2358,20 @@ func (sg *stepGenerator) FlushDeferredSames() ([]Step, error) {
 	return sg.validateSteps(steps)
 }
 
+// ReleaseDeferredSamesFor emits the held-back same steps if urn is one of the resources whose step
+// is being held back. RegisterResourceOutputs needs the resource's step to have executed, so an
+// outputs event forces the release in the same way a dependent's step does.
+func (sg *stepGenerator) ReleaseDeferredSamesFor(urn resource.URN) ([]Step, error) {
+	if !sg.deferredSameURNs[urn] {
+		return nil, nil
+	}
+	steps, err := sg.emitDeferredSames()
+	if err != nil {
+		return nil, err
+	}
+	return sg.validateSteps(steps)
+}
+
 // dependsOnDeferredSame reports whether any of the given steps is for a resource that depends on
 // one whose same step is currently held back. Such a step may not be emitted first, or it would
 // precede its own dependency in the snapshot.


### PR DESCRIPTION
## Summary

Fixes #24303. #24359, already closed as a duplicate, is the Node.js form of the same defect.

Deliberately no closing keyword for #20852: this covers the shape [reduced from it in that thread](https://github.com/pulumi/pulumi/issues/20852#issuecomment-4929983102) — a targeted update plus a dependency-edge removal, producing both the duplicate URN and the ordering violation reported there — but the original BucketV2 → Bucket report that opened it was never reduced, and a maintainer suspected a different cause. Worth the reporter confirming before it is closed.

An untargeted same step copies the resource's old state — **including its old dependency edges** — into the snapshot, so it may only be written once every one of those dependencies has a step of its own. The program normally registers dependencies before their dependents, so this is free and the engine relies on it.

That ordering stops holding when the program removes a dependency *edge* rather than the dependency itself. Without the edge the SDK no longer sequences the registrations, so the dependent can register first while its old state still points at resources the program has yet to register. The engine then fails in one of two ways:

- `getDependencySteps` walks the old dependencies and emits a speculative `UntargetedSameStep` for each, claiming its URN. When the program does register it, `generateURN` reports **`Duplicate resource URN`** and the operation bails — on `up` this can leave a corrupt snapshot behind, including the case in #20852 where a delete-before-replace had already deleted the original.
- Suppress that traversal and the dependent is written **ahead of its own dependencies** instead — `resource X's dependency Y comes after it`, the second corruption reported in #20852.

Both are the same missing constraint, so this fixes it once: when an untargeted resource's old dependencies have no steps yet, hold its same step back rather than emitting it. Its registration is settled immediately (a same step's result is fully determined by the old state), so the program is never blocked on registrations it has yet to make. The held-back step is released either when a step that depends on it is generated, or once the program has finished registering.

Dependencies that never registered — the deleted-from-the-program case the traversal was written for — still get their old state copied forward by a speculative step placed just before their dependent. The difference is that this now happens only after the program is done, where it cannot collide with a registration. The one path that can still produce a speculative same during registration is an on-demand release, and a subsequent registration of such a resource completes without writing it twice.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [x] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Both regression tests checked in already-skipped by #24349 are unskipped and pass:

- `TestTargetedPreviewNoDuplicateURN_Issue24303` — 500 targeted previews after the program drops a `dependsOn` edge. Bailed on iteration 0 before.
- `TestTargetedUpdateAppliesNewInputs_Issue24303` — the semantic guard that a targeted dependency's new inputs still reach the snapshot, so the fix cannot be a bare short-circuit.

Plus two new ones:

`TestDeferredUntargetedSameCompletesRegistration` — holding a step back must never hold its registration open. The program registers the dependency the held-back step is waiting on *sequentially, after* the RPC for the held-back resource has returned, so any wait the engine inserted before answering that RPC could never be satisfied. It also covers a component registering outputs while its step is held back: `RegisterResourceOutputs` resolves the resource through the step executor's pending registrations, which are only recorded once a step has executed, so an outputs event releases the held-back steps and waits for them, exactly as a dependent's step does.

`TestTargetedStepAfterDeferredUntargetedSame`: a *targeted* resource depending on a held-back one must still be written after it. This is what motivated releasing held-back steps on demand rather than only at the end of the program; without that it fails snapshot integrity.

## Validation
- [x] `make lint` — clean
- [ ] `make test_fast` — not run in full; instead ran `./engine/...`, `./resource/deploy/...` and `./backend/...` (all pass, 1182 tests in `lifecycletest`), plus `./engine/lifecycletest/` and `./resource/deploy/` under `-race`
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes) — no SDK changes
- [ ] `make check_proto` — no proto changes

## Risk

Confined to the target-constrained path: `shouldDeferUntargetedSame` only returns true when an untargeted resource's old dependency has no step and does exist in the old state, which cannot happen in an unconstrained deployment where every resource is stepped in program order. Nothing defers in the common case and behaviour is unchanged.

Two things a reviewer should weigh:

1. A held-back resource's registration is settled with a copy of the old state rather than the state its step later writes, so a subsequent `RegisterResourceOutputs` on it would not reach the snapshot. Only reachable for a component in this path, and the resource is untargeted, so its outputs should not be changing. Sharing the pointer instead is a real data race against the display and `resourcePlan.Outputs` — caught with `-race` while iterating on this.
2. Held-back steps surface later in the display than they used to. The golden display tests are unaffected, since nothing defers unless the program has actually removed a dependency edge.

## Changelog
- [x] Changelog entry added.

