### PR TITLE
Update dotnet to v3.112.1

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -53,7 +53,7 @@ download_release() {
 # live in pkg/util/plugin.go (knownLanguageRuntimes) and the CLI fetches it on demand.
 LANGUAGES=(
   # renovate: datasource=github-releases depName=pulumi/pulumi-dotnet
-  "dotnet v3.112.0"
+  "dotnet v3.112.1"
   # renovate: datasource=github-releases depName=pulumi/pulumi-java
   "java v1.36.1"
   # renovate: datasource=github-releases depName=pulumi/pulumi-yaml


### PR DESCRIPTION
## Context

This bump is part of the tracked effort to keep bundled language runtimes current in pulumi/pulumi, as described in [#18431](https://github.com/pulumi/pulumi/issues/18431), which calls for automatically updating `pulumi-dotnet`, `pulumi-java`, and `pulumi-yaml` to their latest releases.

## Overview

Bumps the .NET language provider from `v3.112.0` to `v3.112.1`.