### PR TITLE
Preserve DIY checkpoints when compression transition writes fail

### DIFF
--- a/changelog/pending/20260819--backend-diy--checkpoint-compression-transition-durability.yaml
+++ b/changelog/pending/20260819--backend-diy--checkpoint-compression-transition-durability.yaml
@@ -1,0 +1,4 @@
+component: backend/diy
+kind: fix
+body: Keep DIY backend stacks readable when checkpoint compression transitions fail
+time: 2026-08-19T13:14:02+02:00

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -310,7 +310,7 @@ func (b *diyBackend) saveCheckpoint(
 		case encoding.CompressionZstd:
 			oldFile = filePlain + encoding.ZSTDExt
 		}
-		if backupTarget(ctx, b.bucket, oldFile, true) == "" {
+		if backupFile = backupTarget(ctx, b.bucket, oldFile, true); backupFile == "" {
 			oldFile = ""
 		}
 	}

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -296,19 +296,22 @@ func (b *diyBackend) saveCheckpoint(
 	// .json file to know the stack currently exists (see https://github.com/pulumi/pulumi/issues/9033 for
 	// context).
 	//
-	// We only back up the file we're about to write and, if the compression format changed, clean up the
-	// old format.
+	// We only back up the file we're about to write and, if the compression format changed, back up the
+	// old format. Keep the old format active until the replacement has been written successfully.
 	backupFile = backupTarget(ctx, b.bucket, file, true)
+	oldFile := ""
 	if existingCompression != b.compression {
-		// The compression format changed — clean up the old file.
 		filePlain := stripCompressionExt(file)
 		switch existingCompression {
 		case encoding.CompressionNone:
-			backupTarget(ctx, b.bucket, filePlain, false)
+			oldFile = filePlain
 		case encoding.CompressionGzip:
-			backupTarget(ctx, b.bucket, filePlain+encoding.GZIPExt, false)
+			oldFile = filePlain + encoding.GZIPExt
 		case encoding.CompressionZstd:
-			backupTarget(ctx, b.bucket, filePlain+encoding.ZSTDExt, false)
+			oldFile = filePlain + encoding.ZSTDExt
+		}
+		if backupTarget(ctx, b.bucket, oldFile, true) == "" {
+			oldFile = ""
 		}
 	}
 
@@ -323,7 +326,7 @@ func (b *diyBackend) saveCheckpoint(
 		backoff := 1.2
 
 		// Retry the write 10 times in case of upstream bucket errors
-		_, _, err = retry.Until(ctx, retry.Acceptor{
+		accepted, _, err := retry.Until(ctx, retry.Acceptor{
 			Delay:    &delay,
 			MaxDelay: &maxDelay,
 			Backoff:  &backoff,
@@ -342,6 +345,15 @@ func (b *diyBackend) saveCheckpoint(
 		})
 		if err != nil {
 			return backupFile, "", err
+		}
+		if !accepted {
+			return backupFile, "", ctx.Err()
+		}
+	}
+
+	if oldFile != "" {
+		if err := b.bucket.Delete(ctx, oldFile); err != nil {
+			logging.V(5).Infof("error deleting source object after rename: %v (%v) skipping", oldFile, err)
 		}
 	}
 

--- a/pkg/backend/diy/state_test.go
+++ b/pkg/backend/diy/state_test.go
@@ -347,11 +347,11 @@ func TestSaveCheckpointPreservesActiveCheckpointOnCompressionTransitionFailure(t
 
 	stackAfter, err := b.GetStack(ctx, ref)
 	require.NoError(t, err)
-	assert.NotNil(t, stackAfter)
+	require.NotNil(t, stackAfter)
 
 	namesAfter, _, err := b.ListStackNames(ctx, backend.ListStackNamesFilter{}, nil)
 	require.NoError(t, err)
-	assert.Len(t, namesAfter, 1)
+	require.Len(t, namesAfter, 1)
 
 	checkpointAfter, _, _, err := b.getCheckpoint(ctx, diyRef)
 	require.NoError(t, err)

--- a/pkg/backend/diy/state_test.go
+++ b/pkg/backend/diy/state_test.go
@@ -333,8 +333,9 @@ func TestSaveCheckpointPreservesActiveCheckpointOnCompressionTransitionFailure(t
 	}
 	b.bucket = failingBucket
 
-	_, _, saveErr := b.saveCheckpoint(writeCtx, diyRef, versionedCheckpoint)
+	backupFile, _, saveErr := b.saveCheckpoint(writeCtx, diyRef, versionedCheckpoint)
 	assert.ErrorIs(t, saveErr, context.Canceled)
+	assert.Equal(t, oldPath+".bak", backupFile)
 	assert.True(t, failingBucket.attemptedWrite())
 
 	oldBytesAfter, err := innerBucket.ReadAll(ctx, oldPath)

--- a/pkg/backend/diy/state_test.go
+++ b/pkg/backend/diy/state_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/blob"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -40,6 +41,37 @@ type spyBucket struct {
 	copyCalls   int
 	deleteCalls int
 	writeCalls  int
+}
+
+// cancelingWriteBucket cancels the write context instead of writing the selected key.
+type cancelingWriteBucket struct {
+	Bucket
+
+	targetKey string
+	cancel    context.CancelFunc
+
+	mu        sync.Mutex
+	attempted bool
+}
+
+func (b *cancelingWriteBucket) WriteAll(
+	ctx context.Context, key string, p []byte, opts *blob.WriterOptions,
+) error {
+	if key != b.targetKey {
+		return b.Bucket.WriteAll(ctx, key, p, opts)
+	}
+
+	b.mu.Lock()
+	b.attempted = true
+	b.mu.Unlock()
+	b.cancel()
+	return ctx.Err()
+}
+
+func (b *cancelingWriteBucket) attemptedWrite() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.attempted
 }
 
 func (s *spyBucket) Exists(ctx context.Context, key string) (bool, error) {
@@ -233,6 +265,95 @@ func TestSaveCheckpointBucketOps(t *testing.T) {
 				tt.wantExistsCalls, spy.existsCalls)
 		})
 	}
+}
+
+// TestSaveCheckpointPreservesActiveCheckpointOnCompressionTransitionFailure verifies that a failed
+// write to a new compression variant does not make the existing stack unavailable.
+func TestSaveCheckpointPreservesActiveCheckpointOnCompressionTransitionFailure(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	ctx := t.Context()
+	project := &workspace.Project{Name: "testproj"}
+
+	// Create the existing checkpoint without compression.
+	b, err := newDIYBackend(
+		ctx, diagtest.LogSink(t),
+		"file://"+filepath.ToSlash(stateDir),
+		project,
+		&diyBackendOptions{Env: env.NewEnv(env.MapStore{})},
+	)
+	require.NoError(t, err)
+
+	ref, err := b.ParseStackReference("transition-failure")
+	require.NoError(t, err)
+	_, err = b.CreateStack(ctx, ref, "", nil, nil)
+	require.NoError(t, err)
+
+	// Reopen the backend with gzip enabled so the next save changes the active key.
+	b, err = newDIYBackend(
+		ctx, diagtest.LogSink(t),
+		"file://"+filepath.ToSlash(stateDir),
+		project,
+		&diyBackendOptions{Env: env.NewEnv(env.MapStore{
+			env.DIYBackendGzip.Var().Name(): "true",
+		})},
+	)
+	require.NoError(t, err)
+
+	ref, err = b.ParseStackReference("transition-failure")
+	require.NoError(t, err)
+	diyRef := ref.(*diyBackendReference)
+
+	stackBefore, err := b.GetStack(ctx, ref)
+	require.NoError(t, err)
+	require.NotNil(t, stackBefore)
+	namesBefore, _, err := b.ListStackNames(ctx, backend.ListStackNamesFilter{}, nil)
+	require.NoError(t, err)
+	require.Len(t, namesBefore, 1)
+
+	checkpointBefore, version, features, err := b.getCheckpoint(ctx, diyRef)
+	require.NoError(t, err)
+	versionedCheckpoint, err := marshalVersionedCheckpoint(version, features, checkpointBefore)
+	require.NoError(t, err)
+
+	innerBucket := b.bucket
+	oldPath := b.stackPath(ctx, diyRef)
+	oldBytes, err := innerBucket.ReadAll(ctx, oldPath)
+	require.NoError(t, err)
+	targetPath := oldPath + encoding.GZIPExt
+
+	// Cancel on the target write so retry termination is immediate and deterministic.
+	writeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	failingBucket := &cancelingWriteBucket{
+		Bucket:    innerBucket,
+		targetKey: targetPath,
+		cancel:    cancel,
+	}
+	b.bucket = failingBucket
+
+	_, _, saveErr := b.saveCheckpoint(writeCtx, diyRef, versionedCheckpoint)
+
+	// Collect every externally observable result before asserting so a failure cannot hide stack disappearance.
+	oldBytesAfter, oldReadErr := innerBucket.ReadAll(ctx, oldPath)
+	targetExists, targetExistsErr := innerBucket.Exists(ctx, targetPath)
+	stackAfter, getStackErr := b.GetStack(ctx, ref)
+	namesAfter, _, listErr := b.ListStackNames(ctx, backend.ListStackNamesFilter{}, nil)
+	checkpointAfter, _, _, checkpointErr := b.getCheckpoint(ctx, diyRef)
+
+	assert.ErrorIs(t, saveErr, context.Canceled)
+	assert.True(t, failingBucket.attemptedWrite())
+	assert.NoError(t, oldReadErr)
+	assert.Equal(t, oldBytes, oldBytesAfter)
+	assert.NoError(t, targetExistsErr)
+	assert.False(t, targetExists)
+	assert.NoError(t, getStackErr)
+	assert.NotNil(t, stackAfter)
+	assert.NoError(t, listErr)
+	assert.Len(t, namesAfter, 1)
+	assert.NoError(t, checkpointErr)
+	assert.Equal(t, checkpointBefore, checkpointAfter)
 }
 
 // TestSaveCheckpointTransitionCleansUpOldFile verifies that when switching

--- a/pkg/backend/diy/state_test.go
+++ b/pkg/backend/diy/state_test.go
@@ -334,25 +334,27 @@ func TestSaveCheckpointPreservesActiveCheckpointOnCompressionTransitionFailure(t
 	b.bucket = failingBucket
 
 	_, _, saveErr := b.saveCheckpoint(writeCtx, diyRef, versionedCheckpoint)
-
-	// Collect every externally observable result before asserting so a failure cannot hide stack disappearance.
-	oldBytesAfter, oldReadErr := innerBucket.ReadAll(ctx, oldPath)
-	targetExists, targetExistsErr := innerBucket.Exists(ctx, targetPath)
-	stackAfter, getStackErr := b.GetStack(ctx, ref)
-	namesAfter, _, listErr := b.ListStackNames(ctx, backend.ListStackNamesFilter{}, nil)
-	checkpointAfter, _, _, checkpointErr := b.getCheckpoint(ctx, diyRef)
-
 	assert.ErrorIs(t, saveErr, context.Canceled)
 	assert.True(t, failingBucket.attemptedWrite())
-	assert.NoError(t, oldReadErr)
+
+	oldBytesAfter, err := innerBucket.ReadAll(ctx, oldPath)
+	require.NoError(t, err)
 	assert.Equal(t, oldBytes, oldBytesAfter)
-	assert.NoError(t, targetExistsErr)
+
+	targetExists, err := innerBucket.Exists(ctx, targetPath)
+	require.NoError(t, err)
 	assert.False(t, targetExists)
-	assert.NoError(t, getStackErr)
+
+	stackAfter, err := b.GetStack(ctx, ref)
+	require.NoError(t, err)
 	assert.NotNil(t, stackAfter)
-	assert.NoError(t, listErr)
+
+	namesAfter, _, err := b.ListStackNames(ctx, backend.ListStackNamesFilter{}, nil)
+	require.NoError(t, err)
 	assert.Len(t, namesAfter, 1)
-	assert.NoError(t, checkpointErr)
+
+	checkpointAfter, _, _, err := b.getCheckpoint(ctx, diyRef)
+	require.NoError(t, err)
 	assert.Equal(t, checkpointBefore, checkpointAfter)
 }
 


### PR DESCRIPTION
## Summary

When a DIY checkpoint changes compression format, `saveCheckpoint` removes the active variant before writing its replacement. If the retry context ends without accepting a write, `saveCheckpoint` can return success even though no active checkpoint remains.

Keep the previous variant until the replacement write succeeds, return the context error when the retry is not accepted, and retain the existing best-effort cleanup behavior after a successful write.

## Test plan

- [x] Added a regression test verifying that a canceled replacement write leaves the original checkpoint unchanged, readable, and listed

## Validation

- [x] `go test ./backend/diy -count=1`
- [x] `go test -tags all ./backend/diy -count=1`
- [x] `go vet ./backend/diy`
- [x] `gofmt`

## Changelog

- [x] Changelog entry added

## Risk

A crash after the replacement write but before cleanup can leave both compression variants present. The same state was already possible when the existing best-effort cleanup failed.

This does not change any public API or checkpoint format.