### PR TITLE
introduce PULUMI_DEFAULT_ORGANIZATION env var

### DIFF
--- a/changelog/pending/cli-feat-20260819-142815.yaml
+++ b/changelog/pending/cli-feat-20260819-142815.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Introduce `PULUMI_DEFAULT_ORGANIZATION` to be able to set the default org
+time: 2026-08-19T14:28:15.720763832+02:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -241,14 +241,16 @@ func New(ctx context.Context, d diag.Sink,
 	})
 	escClient := esc_client.New(client.UserAgent(), cloudURL, apiToken, insecure)
 
-	config, err := workspace.GetPulumiConfig()
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("get Pulumi config: %w", err)
-	}
-	var org string
-	if beConfig, ok := config.BackendConfig[cloudURL]; ok {
-		if beConfig.DefaultOrg != "" {
-			org = beConfig.DefaultOrg
+	org := env.DefaultOrg.Value()
+	if org == "" {
+		config, err := workspace.GetPulumiConfig()
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("get Pulumi config: %w", err)
+		}
+		if beConfig, ok := config.BackendConfig[cloudURL]; ok {
+			if beConfig.DefaultOrg != "" {
+				org = beConfig.DefaultOrg
+			}
 		}
 	}
 

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -1556,11 +1556,20 @@ func TestNewDefaultOrgResolution(t *testing.T) {
 
 	tests := []struct {
 		name                 string
+		envOrg               string
 		configuredOrg        string
 		serviceOrg           string
 		expectedOrg          string
 		expectedDefaultCalls int
 	}{
+		{
+			name:                 "prefers env var default org",
+			envOrg:               "env-org",
+			configuredOrg:        "configured-org",
+			serviceOrg:           "service-org",
+			expectedOrg:          "env-org",
+			expectedDefaultCalls: 0,
+		},
 		{
 			name:                 "prefers configured default org",
 			configuredOrg:        "configured-org",
@@ -1579,6 +1588,7 @@ func TestNewDefaultOrgResolution(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("PULUMI_HOME", t.TempDir())
+			t.Setenv("PULUMI_DEFAULT_ORGANIZATION", tt.envOrg)
 
 			defaultOrgCalls := 0
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -1629,6 +1639,53 @@ func TestNewDefaultOrgResolution(t *testing.T) {
 			assert.Equal(t, tt.expectedDefaultCalls, defaultOrgCalls)
 		})
 	}
+}
+
+//nolint:paralleltest // mutates PULUMI_HOME-backed credentials/config
+func TestParseStackReferenceExplicitOrgBeatsEnvVar(t *testing.T) {
+	ctx := t.Context()
+
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	t.Setenv("PULUMI_DEFAULT_ORGANIZATION", "env-org")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/capabilities":
+			err := json.NewEncoder(rw).Encode(apitype.CapabilitiesResponse{})
+			require.NoError(t, err)
+		case "/api/user":
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"githubLogin":   "test-user",
+				"organizations": []map[string]string{},
+			})
+			require.NoError(t, err)
+		default:
+			panic(fmt.Sprintf("Path not supported: %v", req.URL.Path))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken: testJWT,
+	}, true)
+	require.NoError(t, err)
+
+	b, err := New(ctx, diagtest.LogSink(t), server.URL, &workspace.Project{Name: "proj"}, false)
+	require.NoError(t, err)
+
+	// New spawns goroutines that may log to the test's diag sink;
+	// wait for them before the test finishes.
+	cb := b.(*cloudBackend)
+	_, _ = cb.capabilities.Result(ctx)
+	_, _ = cb.userInfo.Result(ctx)
+
+	ref, err := b.ParseStackReference("explicit-org/proj/stack")
+	require.NoError(t, err)
+	assert.Equal(t, "explicit-org", ref.(cloudBackendReference).owner)
+
+	ref, err = b.ParseStackReference("stack")
+	require.NoError(t, err)
+	assert.Equal(t, "env-org", ref.(cloudBackendReference).owner)
 }
 
 //nolint:paralleltest // mutates global state

--- a/pkg/backend/organizations.go
+++ b/pkg/backend/organizations.go
@@ -23,6 +23,10 @@ import (
 )
 
 func getBackendConfigDefaultOrg(project *workspace.Project) (string, error) {
+	if defaultOrg := env.DefaultOrg.Value(); defaultOrg != "" {
+		return defaultOrg, nil
+	}
+
 	config, err := workspace.GetPulumiConfig()
 	if err != nil && !os.IsNotExist(err) {
 		return "", err

--- a/pkg/backend/organizations_test.go
+++ b/pkg/backend/organizations_test.go
@@ -22,6 +22,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:paralleltest // mutates environment variables
+func TestGetBackendConfigDefaultOrg(t *testing.T) {
+	t.Run("prefers PULUMI_DEFAULT_ORGANIZATION over configured default org", func(t *testing.T) {
+		t.Setenv("PULUMI_HOME", t.TempDir())
+		t.Setenv("PULUMI_BACKEND_URL", "https://api.example.com")
+		t.Setenv("PULUMI_DEFAULT_ORGANIZATION", "env-org")
+		require.NoError(t, workspace.SetBackendConfigDefaultOrg("https://api.example.com", "configured-org"))
+
+		org, err := getBackendConfigDefaultOrg(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "env-org", org)
+	})
+
+	t.Run("falls back to configured default org", func(t *testing.T) {
+		t.Setenv("PULUMI_HOME", t.TempDir())
+		t.Setenv("PULUMI_BACKEND_URL", "https://api.example.com")
+		t.Setenv("PULUMI_DEFAULT_ORGANIZATION", "")
+		require.NoError(t, workspace.SetBackendConfigDefaultOrg("https://api.example.com", "configured-org"))
+
+		org, err := getBackendConfigDefaultOrg(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "configured-org", org)
+	})
+}
+
 func TestGetLegacyDefaultOrgFallback(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/esc/cli/esc.go
+++ b/pkg/cmd/esc/cli/esc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/esc/cli/client"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -175,10 +176,15 @@ func valueOrDefault[T comparable](v, def T) T {
 }
 
 // Looks up the default org.
-// Prefers default org that the user has configured locally in their ~/.pulumi/config.json
+// Prefers the PULUMI_DEFAULT_ORGANIZATION environment variable, then the default org that the user
+// has configured locally in their ~/.pulumi/config.json.
 // If unset, then it will attempt to make an API call to the backend to determine the service's opinion
 // of which user organization should be the default; defaults to individual org otherwise if unset.
 func (esc *escCommand) lookupDefaultOrg(ctx context.Context, backendURL, username string) (string, error) {
+	if defaultOrg := env.DefaultOrg.Value(); defaultOrg != "" {
+		return defaultOrg, nil
+	}
+
 	// Read the locally-configured default org from Pulumi's shared config, exactly as the rest of
 	// the Pulumi CLI does (see pkg/backend/organizations.go).
 	cfg, err := workspace.GetPulumiConfig()

--- a/pkg/cmd/esc/cli/login_test.go
+++ b/pkg/cmd/esc/cli/login_test.go
@@ -336,10 +336,34 @@ func TestDefaultOrgConfiguration(t *testing.T) { //nolint:paralleltest,lll // no
 		},
 	}
 
+	t.Run("prefers environment variable", func(t *testing.T) { //nolint:paralleltest,lll // non-thread-safe shared state
+		// The user has set PULUMI_DEFAULT_ORGANIZATION and configured a default org (in an isolated PULUMI_HOME):
+		envDefaultOrg := "env-default-org"
+		t.Setenv("PULUMI_DEFAULT_ORGANIZATION", envDefaultOrg)
+		t.Setenv("PULUMI_HOME", t.TempDir())
+		require.NoError(t, pulumi_workspace.SetBackendConfigDefaultOrg(backend, "my-default-org"))
+
+		testClient := testPulumiClient{}
+		esc := &escCommand{
+			command: "esc",
+			login:   &testLoginManager{creds: creds},
+			ws:      mockWorkspace(creds),
+			newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
+				return &testClient
+			},
+		}
+
+		err := esc.getCachedClient(t.Context())
+
+		require.NoError(t, err)
+		assert.Equal(t, envDefaultOrg, esc.account.DefaultOrg)
+	})
+
 	t.Run("prefers user configuration", func(t *testing.T) { //nolint:paralleltest,lll // non-thread-safe shared state
 		// GIVEN
 		// The user has configured a default org (in an isolated PULUMI_HOME):
 		userConfiguredDefaultOrg := "my-default-org"
+		t.Setenv("PULUMI_DEFAULT_ORGANIZATION", "")
 		t.Setenv("PULUMI_HOME", t.TempDir())
 		require.NoError(t, pulumi_workspace.SetBackendConfigDefaultOrg(backend, userConfiguredDefaultOrg))
 
@@ -364,6 +388,7 @@ func TestDefaultOrgConfiguration(t *testing.T) { //nolint:paralleltest,lll // no
 	t.Run("falls back to backend client configuration", func(t *testing.T) { //nolint:paralleltest,lll // non-thread-safe shared state
 		// GIVEN
 		// The user has not configured a default org (isolated, empty PULUMI_HOME):
+		t.Setenv("PULUMI_DEFAULT_ORGANIZATION", "")
 		t.Setenv("PULUMI_HOME", t.TempDir())
 
 		// But the backend has an opinion on the default org:
@@ -392,6 +417,7 @@ func TestDefaultOrgConfiguration(t *testing.T) { //nolint:paralleltest,lll // no
 	t.Run("falls back to individual org as last resort", func(t *testing.T) { //nolint:paralleltest,lll // non-thread-safe shared state
 		// GIVEN
 		// The user has not configured a default org (isolated, empty PULUMI_HOME):
+		t.Setenv("PULUMI_DEFAULT_ORGANIZATION", "")
 		t.Setenv("PULUMI_HOME", t.TempDir())
 
 		// And the service has no opinion:

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -100,6 +100,10 @@ var ContinueOnError = env.Bool("CONTINUE_ON_ERROR",
 var BackendURL = env.String("BACKEND_URL",
 	"Set the backend that will be used instead of the currently logged in backend or the current project's backend.")
 
+var DefaultOrg = env.String("DEFAULT_ORGANIZATION",
+	"Set the default organization to use when the organization is not otherwise specified. Takes precedence over "+
+		"any default organization set with `pulumi org set-default`.")
+
 // Neo environment variables
 
 var SuppressNeoLink = env.Bool("SUPPRESS_NEO_LINK",


### PR DESCRIPTION
Allow the default or being set through the environment.  This overrides any settings set through `pulumi org set-default`, but the `--org` flag takes precedence over the setting and the env variable, per er usual precedence rules.

Fixes https://github.com/pulumi/pulumi/issues/16379