### PR TITLE
make `policy group ls` respect the default org

### DIFF
--- a/changelog/pending/cli-policy-fix-20260819-152512.yaml
+++ b/changelog/pending/cli-policy-fix-20260819-152512.yaml
@@ -1,0 +1,4 @@
+component: cli/policy
+kind: fix
+body: Make `policy group ls` respect the default org
+time: 2026-08-19T15:25:12.518766964+02:00

--- a/pkg/cmd/pulumi/policy/policy_group_list.go
+++ b/pkg/cmd/pulumi/policy/policy_group_list.go
@@ -86,9 +86,15 @@ func newPolicyGroupListCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				orgName = cliArgs[0]
 			} else {
-				orgName, _, _, err = b.CurrentUser()
+				orgName, err = b.GetDefaultOrg(ctx)
 				if err != nil {
 					return err
+				}
+				if orgName == "" {
+					orgName, _, _, err = b.CurrentUser()
+					if err != nil {
+						return err
+					}
 				}
 			}
 


### PR DESCRIPTION
This command currently doesn't respect the default org, while its sibling commands do.  Presumably this is an oversight, so fix it.

Noticed (by Claude) while working on https://github.com/pulumi/pulumi/pull/24384.
