### PR TITLE
Don't replace resources due to secret changes

### DIFF
--- a/changelog/pending/engine-fix-20260819-094300.yaml
+++ b/changelog/pending/engine-fix-20260819-094300.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Avoid replacing imported resources when an input changes from plain to a secret or output-wrapped value with the same inner value
+time: 2026-08-19T08:43:00Z

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func TestImportOption(t *testing.T) {
@@ -676,6 +677,159 @@ func diffImportResource(
 		Changes:      plugin.DiffSome,
 		DetailedDiff: detailedDiff,
 	}, nil
+}
+
+func TestImportThenSecretValueDoesNotReplace(t *testing.T) {
+	t.Parallel()
+
+	valueDiff := func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
+		old := resource.FromResourcePropertyMap(req.OldOutputs)
+		new := resource.FromResourcePropertyMap(req.NewInputs)
+		sameSecretValue := old.Get("foo").Equals(new.Get("foo").WithSecret(false).WithDependencies(nil))
+		sameOutputValue := old.Get("fromOutput").Equals(new.Get("fromOutput").WithSecret(false).WithDependencies(nil))
+		if sameSecretValue && sameOutputValue {
+			return plugin.DiffResult{Changes: plugin.DiffNone}, nil
+		}
+		return plugin.DiffResult{
+			Changes:     plugin.DiffSome,
+			ReplaceKeys: []resource.PropertyKey{"foo", "fromOutput"},
+		}, nil
+	}
+
+	diffUnknown := func(context.Context, plugin.DiffRequest) (plugin.DiffResult, error) {
+		return plugin.DiffResult{Changes: plugin.DiffUnknown}, nil
+	}
+
+	for _, tt := range []struct {
+		name  string
+		diffF func(context.Context, plugin.DiffRequest) (plugin.DiffResult, error)
+	}{
+		{
+			name:  "provider diffs by value",
+			diffF: valueDiff,
+		},
+		{
+			name:  "engine diffs DiffUnknown",
+			diffF: diffUnknown,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			readInputs := resource.PropertyMap{
+				"foo":        resource.NewProperty("bar"),
+				"fromOutput": resource.NewProperty("output-value"),
+			}
+			readOutputs := resource.PropertyMap{
+				"foo":        resource.NewProperty("bar"),
+				"fromOutput": resource.NewProperty("output-value"),
+			}
+
+			loaders := []*deploytest.ProviderLoader{
+				deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+					return &deploytest.Provider{
+						DiffF: tt.diffF,
+						CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+							return plugin.CreateResponse{
+								ID:         "created-id",
+								Properties: req.Properties,
+								Status:     resource.StatusOK,
+							}, nil
+						},
+						UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+							return plugin.UpdateResponse{
+								Properties: req.NewInputs,
+								Status:     resource.StatusOK,
+							}, nil
+						},
+						ReadF: func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error) {
+							return plugin.ReadResponse{
+								ReadResult: plugin.ReadResult{
+									ID:      "imported-id",
+									Inputs:  readInputs,
+									Outputs: readOutputs,
+								},
+								Status: resource.StatusOK,
+							}, nil
+						},
+					}, nil
+				}),
+			}
+
+			inputs := resource.PropertyMap{
+				"foo": resource.MakeSecret(resource.NewProperty("bar")),
+				"fromOutput": resource.NewProperty(resource.Output{
+					Element: resource.NewProperty("output-value"),
+					Known:   true,
+				}),
+			}
+			programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+				_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+					Inputs:           inputs,
+					ReplaceOnChanges: []string{"foo", "fromOutput"},
+				})
+				require.NoError(t, err)
+				return nil
+			})
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+			p := &lt.TestPlan{
+				Options: lt.TestUpdateOptions{
+					T:                t,
+					HostF:            hostF,
+					SkipDisplayTests: true,
+				},
+			}
+
+			project := p.GetProject()
+			snap, err := lt.ImportOp([]deploy.Import{{
+				Type: "pkgA:m:typA",
+				Name: "resA",
+				ID:   "imported-id",
+			}}).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+			require.NoError(t, err)
+			require.NotNil(t, snap)
+
+			resURN := p.NewURN("pkgA:m:typA", "resA", "")
+			imported := findImportTestResourceByURN(snap, resURN)
+			require.NotNil(t, imported)
+			assert.False(t, imported.Inputs["foo"].IsSecret())
+			assert.False(t, imported.Inputs["fromOutput"].IsOutput())
+
+			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
+				func(_ workspace.Project, _ deploy.Target, entries JournalEntries, _ []Event, err error) error {
+					ops := []display.StepOp{}
+					for _, entry := range entries {
+						if entry.Kind == TestJournalEntrySuccess && entry.Step.URN() == resURN {
+							ops = append(ops, entry.Step.Op())
+						}
+					}
+					assert.NotContains(t, ops, deploy.OpReplace)
+					assert.NotContains(t, ops, deploy.OpCreateReplacement)
+					assert.NotContains(t, ops, deploy.OpDeleteReplaced)
+					assert.NotEmpty(t, ops)
+					return err
+				}, "1")
+			require.NoError(t, err)
+			require.NotNil(t, snap)
+			updated := findImportTestResourceByURN(snap, resURN)
+			require.NotNil(t, updated)
+			assert.True(t, updated.Inputs["foo"].IsSecret())
+			fromOutput := resource.FromResourcePropertyValue(updated.Inputs["fromOutput"]).
+				WithSecret(false).
+				WithDependencies(nil)
+			assert.True(t, property.New("output-value").Equals(fromOutput))
+		})
+	}
+}
+
+func findImportTestResourceByURN(snap *deploy.Snapshot, urn resource.URN) *pkgresource.State {
+	for _, res := range snap.Resources {
+		if res.URN == urn {
+			return res
+		}
+	}
+	return nil
 }
 
 func TestImportPlan(t *testing.T) {

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1548,7 +1548,7 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 			resource.NewProperty("foo"),
 			resource.NewProperty("bar"),
 		})),
-	}, nil, []display.StepOp{deploy.OpUpdate}, "ignore-secret")
+	}, nil, []display.StepOp{deploy.OpSame}, "ignore-secret")
 
 	// Now check that changing a value (but not secretness) can be ignored
 	_ = updateProgramWithProps(snap, resource.PropertyMap{

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -2983,14 +2983,11 @@ func diffResource(d diag.Sink, urn resource.URN, id resource.ID, oldInputs, oldO
 	}
 	if diff.Changes == plugin.DiffUnknown {
 		new := processIgnoreChanges(d, urn, newInputs, oldInputs, ignoreChanges)
-		tmp := oldInputs.Diff(new)
+		tmp := unwrapResourceSecretsAndOutputs(oldInputs).Diff(unwrapResourceSecretsAndOutputs(new))
 		if tmp.AnyChanges() {
 			diff.Changes = plugin.DiffSome
-			unwrapped := unwrapResourceSecretsAndOutputs(oldInputs).Diff(unwrapResourceSecretsAndOutputs(new))
-			if unwrapped.AnyChanges() {
-				diff.ChangedKeys = unwrapped.ChangedKeys()
-				diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(unwrapped, true /* inputDiff */)
-			}
+			diff.ChangedKeys = tmp.ChangedKeys()
+			diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(tmp, true /* inputDiff */)
 		} else {
 			diff.Changes = plugin.DiffNone
 		}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -2986,13 +2986,52 @@ func diffResource(d diag.Sink, urn resource.URN, id resource.ID, oldInputs, oldO
 		tmp := oldInputs.Diff(new)
 		if tmp.AnyChanges() {
 			diff.Changes = plugin.DiffSome
-			diff.ChangedKeys = tmp.ChangedKeys()
-			diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(tmp, true /* inputDiff */)
+			unwrapped := unwrapResourceSecretsAndOutputs(oldInputs).Diff(unwrapResourceSecretsAndOutputs(new))
+			if unwrapped.AnyChanges() {
+				diff.ChangedKeys = unwrapped.ChangedKeys()
+				diff.DetailedDiff = plugin.NewDetailedDiffFromObjectDiff(unwrapped, true /* inputDiff */)
+			}
 		} else {
 			diff.Changes = plugin.DiffNone
 		}
 	}
 	return diff, nil
+}
+
+func unwrapResourceSecretsAndOutputs(properties resource.PropertyMap) resource.PropertyMap {
+	unwrapped := make(resource.PropertyMap, len(properties))
+	for k, v := range properties {
+		unwrapped[k] = unwrapResourcePropertySecretsAndOutputs(v)
+	}
+	return unwrapped
+}
+
+func unwrapResourcePropertySecretsAndOutputs(value resource.PropertyValue) resource.PropertyValue {
+	switch {
+	case value.IsSecret():
+		return unwrapResourcePropertySecretsAndOutputs(value.SecretValue().Element)
+	case value.IsOutput():
+		return unwrapResourcePropertySecretsAndOutputs(value.OutputValue().Element)
+	case value.IsComputed():
+		return resource.NewProperty(resource.Computed{
+			Element: unwrapResourcePropertySecretsAndOutputs(value.Input().Element),
+		})
+	case value.IsArray():
+		elements := value.ArrayValue()
+		unwrapped := make([]resource.PropertyValue, len(elements))
+		for i, element := range elements {
+			unwrapped[i] = unwrapResourcePropertySecretsAndOutputs(element)
+		}
+		return resource.NewProperty(unwrapped)
+	case value.IsObject():
+		return resource.NewProperty(unwrapResourceSecretsAndOutputs(value.ObjectValue()))
+	case value.IsResourceReference():
+		ref := value.ResourceReferenceValue()
+		ref.ID = unwrapResourcePropertySecretsAndOutputs(ref.ID)
+		return resource.NewProperty(ref)
+	default:
+		return value
+	}
 }
 
 // issueCheckErrors prints any check errors to the diagnostics error sink.


### PR DESCRIPTION
This adds a test and a fix to step_gen so that we don't trigger a replace on a resource with `ReplaceOnChanges` for a field that has just changed secret-ness.