### PR TITLE
Use `schema.Token` for `ResourceType.Token`

### DIFF
--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -171,7 +171,7 @@ func TestInterpretPulumiRefs(t *testing.T) {
 		result, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
 			if ref.Kind == schema.DocRefKindResource {
 				rt := ref.Type.(*schema.ResourceType)
-				tok := tokens.Type(rt.Token)
+				tok := tokens.Type(rt.Token.String())
 				return tok.Module().Name().String() + "." + tok.Name().String(), true
 			}
 			return "", false
@@ -282,7 +282,7 @@ func TestInterpretPulumiRefs(t *testing.T) {
 		result, err := pkg.InterpretPulumiRefs(pkg.Description, func(ref schema.DocRef) (string, bool) {
 			switch ref.Kind { //nolint:exhaustive // test doesn't care about other cases
 			case schema.DocRefKindResource:
-				return ref.Type.(*schema.ResourceType).Token, true
+				return ref.Type.(*schema.ResourceType).Token.String(), true
 			case schema.DocRefKindType:
 				if obj, ok := ref.Type.(*schema.ObjectType); ok {
 					return obj.Token, true

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -782,7 +782,7 @@ func (pkg *pkgContext) isExternalReferenceWithPackage(t schema.Type) (
 		isExternal = typ.Resource != nil && pkg.pkg != nil && !codegen.PkgEquals(typ.Resource.PackageReference, pkg.pkg)
 		if isExternal {
 			extPkg = typ.Resource.PackageReference
-			token = typ.Token
+			token = typ.Token.String()
 		}
 		return isExternal, extPkg, token
 	case *schema.EnumType:
@@ -802,10 +802,10 @@ func (pkg *pkgContext) isExternalReferenceWithPackage(t schema.Type) (
 // optional and convert the type to a pointer if necessary.
 func (pkg *pkgContext) resolveResourceType(t *schema.ResourceType) string {
 	if !pkg.isExternalReference(t) {
-		return pkg.tokenToResource(t.Token)
+		return pkg.tokenToResource(t.Token.String())
 	}
 	extPkgCtx, _ := pkg.contextForExternalReference(t)
-	resType := extPkgCtx.tokenToResource(t.Token)
+	resType := extPkgCtx.tokenToResource(t.Token.String())
 	if !strings.Contains(resType, ".") {
 		resType = fmt.Sprintf("%s.%s", extPkgCtx.pkg.Name(), resType)
 	}
@@ -4134,10 +4134,10 @@ func (pkg *pkgContext) getTypeImports(t schema.Type, recurse bool, importsAndAli
 			}
 		}
 	case *schema.ResourceType:
-		if importExternal(t.Token) {
+		if importExternal(t.Token.String()) {
 			break
 		}
-		mod := pkg.tokenToPackage(t.Token)
+		mod := pkg.tokenToPackage(t.Token.String())
 		if mod != pkg.mod {
 			p := path.Join(pkg.importBasePath, mod)
 			importsAndAliases[path.Join(pkg.importBasePath, mod)] = pkg.pkgImportAliases[p]

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -894,7 +894,7 @@ func (g *generator) collectTypeImports(program *pcl.Program, t schema.Type) {
 		}
 		g.addPulumiImport(pkg, vPath, mod, name)
 	case *schema.ResourceType:
-		token = t.Token
+		token = t.Token.String()
 		if t.Resource != nil {
 			packageRef = t.Resource.PackageReference
 		}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -216,8 +216,8 @@ func (mod *modContext) objectType(pkg schema.PackageReference, details *typeDeta
 }
 
 func (mod *modContext) resourceType(r *schema.ResourceType) string {
-	if after, ok := strings.CutPrefix(r.Token, "pulumi:providers:"); ok {
-		pkgName := after
+	if r.Token.Pkg() == "pulumi" && r.Token.Module() == "providers" {
+		pkgName := r.Token.Name()
 		if pkgName == mod.pkg.Name() {
 			// Inside the package's own code, refer to the Provider type unqualified so it resolves
 			// against the local declaration rather than a (non-existent) namespace.
@@ -232,12 +232,12 @@ func (mod *modContext) resourceType(r *schema.ResourceType) string {
 	}
 	namingCtx, pkgName, external := mod.namingContext(pkg)
 	if !external {
-		name := tokenToName(r.Token)
+		name := tokenToName(r.Token.String())
 		return cgstrings.UppercaseFirst(name)
 	}
 
 	pkgName = externalModuleName(pkgName)
-	modName, name := namingCtx.tokenToModName(r.Token), tokenToName(r.Token)
+	modName, name := namingCtx.tokenToModName(r.Token.String()), tokenToName(r.Token.String())
 
 	return pkgName + modName + cgstrings.UppercaseFirst(name)
 }
@@ -1618,7 +1618,7 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 			return false
 		}
 
-		return resourceOrTokenImport(t.Token)
+		return resourceOrTokenImport(t.Token.String())
 	case *schema.TokenType:
 		return resourceOrTokenImport(t.Token)
 	case *schema.UnionType:

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -194,7 +194,7 @@ func (mod *modContext) modNameAndName(pkg schema.PackageReference, t schema.Type
 		}
 		token, name = t.Token, namingCtx.unqualifiedObjectTypeName(t, input)
 	case *schema.ResourceType:
-		token, name = t.Token, tokenToName(t.Token)
+		token, name = t.Token.String(), tokenToName(t.Token.String())
 	}
 
 	modName = tokenToModule(token, pkg, info.ModuleNameOverrides)
@@ -302,13 +302,12 @@ func (mod *modContext) enumType(enum *schema.EnumType) string {
 
 func (mod *modContext) resourceType(r *schema.ResourceType) string {
 	if r.Resource == nil || codegen.PkgEquals(r.Resource.PackageReference, mod.pkg) {
-		return mod.tokenToResource(r.Token)
+		return mod.tokenToResource(r.Token.String())
 	}
 
 	// Is it a provider resource?
-	if after, ok := strings.CutPrefix(r.Token, "pulumi:providers:"); ok {
-		pkgName := after
-		return fmt.Sprintf("pulumi_%s.Provider", pkgName)
+	if r.Token.Pkg() == "pulumi" && r.Token.Module() == "providers" {
+		return fmt.Sprintf("pulumi_%s.Provider", r.Token.Name())
 	}
 
 	pkg := r.Resource.PackageReference
@@ -351,8 +350,8 @@ func (mod *modContext) tokenToResource(tok string) string {
 // `StorageClass`) genResource falls back to `<Resource>InitArgs`. Mirror that decision so
 // references in doc comments resolve to the same class name.
 func (mod *modContext) resourceArgsClassName(rt *schema.ResourceType) string {
-	base := mod.tokenToResource(rt.Token)
-	if _, exists, _ := mod.pkg.Types().Get(rt.Token); exists {
+	base := mod.tokenToResource(rt.Token.String())
+	if _, exists, _ := mod.pkg.Types().Get(rt.Token.String()); exists {
 		return base + "InitArgs"
 	}
 	return base + "Args"
@@ -1004,16 +1003,14 @@ func (mod *modContext) importResourceType(r *schema.ResourceType) string {
 		return "import " + PyPack(r.Resource.PackageReference.Namespace(), r.Resource.PackageReference.Name())
 	}
 
-	tok := r.Token
-	parts := strings.Split(tok, ":")
-	contract.Assertf(len(parts) == 3, "type token %q is not in the form '<pkg>:<mod>:<type>'", tok)
+	tok := r.Token.String()
 
 	// If it's a provider resource, import the top-level package unless we're currently generating
 	// code inside that same package, in which case we fall through to the relative-import path to
 	// avoid a circular `import pulumi_<pkg>` inside `pulumi_<pkg>`.
-	if parts[0] == "pulumi" && parts[1] == "providers" {
-		if mod.pkg == nil || parts[2] != mod.pkg.Name() {
-			return "import pulumi_" + parts[2]
+	if r.Token.Pkg() == "pulumi" && r.Token.Module() == "providers" {
+		if mod.pkg == nil || r.Token.Name() != mod.pkg.Name() {
+			return "import pulumi_" + r.Token.Name()
 		}
 	}
 
@@ -1022,11 +1019,11 @@ func (mod *modContext) importResourceType(r *schema.ResourceType) string {
 		// We want a relative import if we're in the same module: from .some_member import SomeMember
 		importPath := mod.getRelImportFromRoot(modName)
 
-		name := PyName(tokenToName(r.Token))
+		name := PyName(tokenToName(tok))
 		if mod.compatibility == kubernetes20 {
 			// To maintain backward compatibility for kubernetes, the file names
 			// need to be CamelCase instead of the standard snake_case.
-			name = tokenToName(r.Token)
+			name = tokenToName(tok)
 		}
 		if r.Resource != nil && r.Resource.IsProvider {
 			name = "provider"
@@ -3356,7 +3353,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 				case *schema.ObjectType:
 					getModFromToken(T.Token, T.PackageReference).details(T).inputType = true
 				case *schema.ResourceType:
-					getModFromToken(T.Token, T.Resource.PackageReference)
+					getModFromToken(T.Token.String(), T.Resource.PackageReference)
 				}
 			})
 		}
@@ -3383,7 +3380,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 					getModFromToken(T.Token, T.PackageReference).details(T).inputType = true
 					getModFromToken(T.Token, T.PackageReference).details(T).plainType = true
 				case *schema.ResourceType:
-					getModFromToken(T.Token, T.Resource.PackageReference)
+					getModFromToken(T.Token.String(), T.Resource.PackageReference)
 				}
 			})
 		}
@@ -3402,7 +3399,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 					getModFromToken(T.Token, T.PackageReference).details(T).outputType = true
 					getModFromToken(T.Token, T.PackageReference).details(T).plainType = true
 				case *schema.ResourceType:
-					getModFromToken(T.Token, T.Resource.PackageReference)
+					getModFromToken(T.Token.String(), T.Resource.PackageReference)
 				}
 			})
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -924,7 +924,7 @@ func hashTypeInto(h hash.Hash64, t Type) {
 		}
 	case *ResourceType:
 		writeTag(8)
-		writeStr(t.Token)
+		writeStr(t.Token.String())
 	case *EnumType:
 		writeTag(9)
 		writeStr(t.Token)
@@ -1006,7 +1006,11 @@ func (t *types) bindResourceTypeDef(token string, options ValidationOptions) (*R
 	if res == nil {
 		return nil, diags, nil
 	}
-	typ := &ResourceType{Token: token, Resource: res}
+	tok, err := ParseToken(token)
+	if err != nil {
+		return nil, diags.Append(errorf(memberPath("resources", token), "%v", err)), nil
+	}
+	typ := &ResourceType{Token: tok, Resource: res}
 	t.resources[token] = typ
 	return typ, diags, nil
 }
@@ -1844,7 +1848,7 @@ func compareTypes(a, b Type) int {
 
 		return cmp.Compare(bToI(a.IsInputShape()), bToI(b.IsInputShape()))
 	case *ResourceType:
-		return strings.Compare(a.Token, b.(*ResourceType).Token)
+		return strings.Compare(a.Token.String(), b.(*ResourceType).Token.String())
 	case *EnumType:
 		return strings.Compare(a.Token, b.(*EnumType).Token)
 	case *InvalidType, nil:
@@ -2369,6 +2373,9 @@ func (t *types) finishResources(
 		diags = diags.Extend(resDiags)
 		if err != nil {
 			return nil, nil, diags, fmt.Errorf("error binding resource %v: %w", token, err)
+		}
+		if res == nil {
+			continue
 		}
 		resources = append(resources, res.Resource)
 	}

--- a/pkg/codegen/schema/docs.go
+++ b/pkg/codegen/schema/docs.go
@@ -328,7 +328,7 @@ type DocRef struct {
 func (r DocRef) ResourceToken() string {
 	rt, ok := r.Type.(*ResourceType)
 	contract.Assertf(ok, "ResourceToken called on non-resource ref (kind=%v)", r.Kind)
-	return rt.Token
+	return rt.Token.String()
 }
 
 // tokenString extracts the token string from the Ref field.
@@ -373,7 +373,7 @@ func (r DocRef) IsWithin(other DocRef) bool {
 func DocRefForType(t Type) DocRef {
 	switch v := t.(type) {
 	case *ResourceType:
-		return DocRef{Kind: DocRefKindResource, Type: v, Ref: "#/resources/" + url.PathEscape(v.Token)}
+		return DocRef{Kind: DocRefKindResource, Type: v, Ref: "#/resources/" + url.PathEscape(v.Token.String())}
 	case *ObjectType:
 		return DocRef{Kind: DocRefKindType, Type: v, Ref: "#/types/" + url.PathEscape(v.Token)}
 	case *EnumType:

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -283,13 +283,13 @@ func (*ObjectType) isType() {}
 
 type ResourceType struct {
 	// Token is the type's Pulumi type token.
-	Token string
+	Token Token
 	// Resource is the type's underlying resource.
 	Resource *Resource
 }
 
 func (t *ResourceType) String() string {
-	return t.Token
+	return t.Token.String()
 }
 
 func (t *ResourceType) isType() {}
@@ -1612,7 +1612,7 @@ func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 		}
 	case *ResourceType:
 		return TypeSpec{
-			Ref:   pkg.marshalTypeRef(t.Resource.PackageReference, "resources", t.Token),
+			Ref:   pkg.marshalTypeRef(t.Resource.PackageReference, "resources", t.Token.String()),
 			Plain: !plain,
 		}
 	case *TokenType:

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1547,7 +1547,7 @@ func TestMethods(t *testing.T) {
 				inputs := pkg.Resources[0].Methods[0].Function.Inputs.Properties
 				assert.Equal(t, "__self__", inputs[0].Name)
 				assert.Equal(t, &ResourceType{
-					Token:    pkg.Resources[0].Token,
+					Token:    NewToken("xyz", "index", "Foo"),
 					Resource: pkg.Resources[0],
 				}, inputs[0].Type)
 
@@ -3449,7 +3449,7 @@ func TestGetWithModuleFormat(t *testing.T) {
 
 		rt, ok := pkg.GetResourceType("test:mod:Thing")
 		require.True(t, ok)
-		assert.Equal(t, "test:mod_v2:Thing", rt.Token)
+		assert.Equal(t, NewToken("test", "mod_v2", "Thing"), rt.Token)
 	})
 
 	t.Run("PartialPackage", func(t *testing.T) {
@@ -3481,7 +3481,7 @@ func TestGetWithModuleFormat(t *testing.T) {
 		rt, ok, err := pkg.Resources().GetType("test:mod:Thing")
 		require.NoError(t, err)
 		require.True(t, ok)
-		assert.Equal(t, "test:mod_v2:Thing", rt.Token)
+		assert.Equal(t, NewToken("test", "mod_v2", "Thing"), rt.Token)
 	})
 }
 

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1369,7 +1369,7 @@ func TestStructuralTypeChecks(t *testing.T) {
 			URN: "urn:pulumi:s::p::pkg:index:R::r",
 			ID:  property.New("id"),
 		})
-		resType := &schema.ResourceType{Token: "pkg:index:R"}
+		resType := &schema.ResourceType{Token: schema.NewToken("pkg", "index", "R")}
 
 		assert.True(t, valueStructurallyTypedAs(value, resType))
 		assert.True(t, valueStructurallyTypedAs(value, schema.AnyResourceType))


### PR DESCRIPTION
`ResourceType.Token` is now a parsed `schema.Token` instead of a raw
string. Binding parses the token and reports a diagnostic if it is
malformed. Consumers in the language generators use the structured
accessors where they previously split the string, and `String()` where
they hand the token to string-based helpers.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
