### PR TITLE
Python: Propagate runtime context across thread boundaries

### DIFF
--- a/changelog/pending/sdk-python-fix-20260820-143416.yaml
+++ b/changelog/pending/sdk-python-fix-20260820-143416.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: fix
+body: Propagate runtime context across thread boundaries
+time: 2026-08-20T14:34:16.194983+02:00

--- a/sdk/python/lib/pulumi/runtime/_context.py
+++ b/sdk/python/lib/pulumi/runtime/_context.py
@@ -1,0 +1,41 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for propagating runtime context across thread boundaries."""
+
+from contextvars import copy_context
+
+from opentelemetry import context as otel_context
+
+
+def wrap_with_context(fn):
+    """Wrap a callable so it runs with the current Python and OTel contexts.
+
+    Use this when passing callables to run_in_executor, since thread pool
+    threads do not inherit context from the calling thread.
+    """
+    python_ctx = copy_context()
+    otel_ctx = otel_context.get_current()
+
+    def run(*args, **kwargs):
+        token = otel_context.attach(otel_ctx)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            otel_context.detach(token)
+
+    def wrapper(*args, **kwargs):
+        return python_ctx.run(run, *args, **kwargs)
+
+    return wrapper

--- a/sdk/python/lib/pulumi/runtime/_instrumentation.py
+++ b/sdk/python/lib/pulumi/runtime/_instrumentation.py
@@ -103,24 +103,6 @@ def _initialize_tracing() -> None:
 _initialize_tracing()
 
 
-def wrap_with_context(fn):
-    """Wrap a callable so it runs with the current OTel context.
-
-    Use this when passing callables to run_in_executor, since thread pool
-    threads do not inherit the OTel context from the calling thread.
-    """
-    ctx = otel_context.get_current()
-
-    def wrapper(*args, **kwargs):
-        token = otel_context.attach(ctx)
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            otel_context.detach(token)
-
-    return wrapper
-
-
 async def shutdown_tracing() -> None:
     """
     Shutdown the tracer provider and flush any pending spans.

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -24,7 +24,7 @@ from collections.abc import Awaitable
 
 import grpc
 
-from ._instrumentation import wrap_with_context
+from ._context import wrap_with_context
 from google.protobuf import struct_pb2
 
 from semver import VersionInfo

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -27,7 +27,7 @@ from collections.abc import Awaitable, Mapping, Sequence
 
 import grpc
 
-from ._instrumentation import wrap_with_context
+from ._context import wrap_with_context
 from google.protobuf import struct_pb2
 
 from .. import _types, log

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -18,7 +18,7 @@ Runtime settings and configuration.
 
 from __future__ import annotations
 
-from ._instrumentation import wrap_with_context
+from ._context import wrap_with_context
 
 import asyncio
 import base64

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -26,7 +26,7 @@ import grpc
 
 
 from . import settings
-from ._instrumentation import wrap_with_context
+from ._context import wrap_with_context
 from .proto import resource_pb2
 from .. import log
 from ..resource import (

--- a/sdk/python/lib/test/runtime/test_context.py
+++ b/sdk/python/lib/test/runtime/test_context.py
@@ -1,0 +1,36 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextvars import ContextVar
+import threading
+
+import pytest
+
+from pulumi.runtime._context import wrap_with_context
+
+
+@pytest.mark.asyncio
+async def test_wrap_with_context_propagates_contextvars():
+    value = ContextVar("test_context_value", default="default")
+    value.set("caller")
+    caller_thread = threading.get_ident()
+
+    worker_thread, worker_value = await asyncio.get_running_loop().run_in_executor(
+        None,
+        wrap_with_context(lambda: (threading.get_ident(), value.get())),
+    )
+
+    assert worker_thread != caller_thread
+    assert worker_value == "caller"

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -285,6 +285,33 @@ class NextSerializationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(urn, res)
 
     @pulumi_test
+    async def test_mock_resource_reference(self):
+        class ResourceReferenceMocks(MyMocks):
+            def new_resource(self, args: MockResourceArgs):
+                if args.typ == "test:index:component-with-resource":
+                    return [
+                        None,
+                        {"resource": MyCustomResource(f"{args.name}-resource")},
+                    ]
+                return super().new_resource(args)
+
+        class ComponentWithResource(ComponentResource):
+            def __init__(self, name: str):
+                super().__init__(
+                    "test:index:component-with-resource",
+                    name,
+                    {"resource": None},
+                )
+
+        rpc.register_resource_module("test", "index", MyResourceModule())
+        set_mocks(ResourceReferenceMocks())
+
+        component = ComponentWithResource("test")
+
+        resource = await component.resource.future()
+        self.assertIsInstance(resource, MyCustomResource)
+
+    @pulumi_test
     async def test_string_asset(self):
         asset = StringAsset("Python 3 is cool")
         prop = await rpc.serialize_property(asset, [], None)


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/24308 we refactored how the Python SDK checks for engine features. Before, features were looked up lazily, and after the refactor they are set eagerly via GetDeploymentInfo. The features are stored in a context var, which does not get copied over to a new thread by default. The MockMonitor happened to serialize objects in `run_in_executor`, so in a thread, and would not see the `RESOURCE_MONITOR_FEATURE_RESOURCE_REFERENCES` feature. Before the refactor, this happened to work by chance, because we would check again for the feature, but after the refactor it assumed the feature was not enabled.

To fix this, we provide the context vars to the threads.

Fixes https://github.com/pulumi/pulumi/issues/24364