### PR TITLE
python: allow transforms to be mocked

### DIFF
--- a/changelog/pending/sdk-python-improvement-20260820-155323.yaml
+++ b/changelog/pending/sdk-python-improvement-20260820-155323.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: improvement
+body: Allow transforms to run in tests
+time: 2026-08-20T15:53:23.245504123+02:00

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -67,6 +67,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
     _monitor: resource_pb2_grpc.ResourceMonitorStub
     _server: aio.Server
     _target: str
+    _loop: asyncio.AbstractEventLoop
 
     _transforms: dict[Union[ResourceTransform, InvokeTransform], str]
 
@@ -76,6 +77,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
         self._callbacks = {}
         self._transforms = {}
         self._monitor = monitor
+        self._loop = asyncio.get_event_loop()
         self._server = aio.server(options=_GRPC_CHANNEL_OPTIONS)
         callback_pb2_grpc.add_CallbacksServicer_to_server(self, self._server)
         port = self._server.add_insecure_port(address="127.0.0.1:0")
@@ -93,7 +95,13 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
 
     @classmethod
     async def shutdown(cls):
-        for servicer in cls._servicers:
+        # Stopping a grpc.aio server from a different event loop than it was created
+        # on raises a RuntimeError, so only stop servicers created on the current loop.
+        loop = asyncio.get_event_loop()
+        for servicer in list(cls._servicers):
+            if servicer._loop is not loop:
+                continue
+            cls._servicers.remove(servicer)
             await servicer._server.stop(grace=0)
 
     async def Invoke(

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -21,9 +21,17 @@ import logging
 from abc import ABC, abstractmethod
 from typing import NamedTuple, Optional
 
+import grpc
 from google.protobuf import empty_pb2
 
-from ..runtime.proto import engine_pb2, provider_pb2, resource_pb2
+from ..runtime.proto import (
+    callback_pb2,
+    callback_pb2_grpc,
+    engine_pb2,
+    provider_pb2,
+    resource_pb2,
+)
+from ._grpc_settings import _GRPC_CHANNEL_OPTIONS
 from ..runtime.stack import Stack, run_pulumi_func
 from . import rpc, rpc_manager
 from .settings import (
@@ -52,7 +60,8 @@ def test(fn):
 
         _sync_await(
             run_pulumi_func(
-                lambda: _sync_await(Output.from_input(fn(*args, **kwargs)).future())
+                lambda: _sync_await(Output.from_input(fn(*args, **kwargs)).future()),
+                shutdown_callbacks=False,
             )
         )
 
@@ -156,9 +165,20 @@ class MockMonitor:
     mocks: Mocks
     resources: dict[str, ResourceRegistration]
 
+    _stack_transforms: list[callback_pb2.Callback]
+    _stack_invoke_transforms: list[callback_pb2.Callback]
+    _resource_transforms: dict[str, list[callback_pb2.Callback]]
+    _parents: dict[str, str]
+    _callback_stubs: dict[str, callback_pb2_grpc.CallbacksStub]
+
     def __init__(self, mocks: Mocks):
         self.mocks = mocks
         self.resources = {}
+        self._stack_transforms = []
+        self._stack_invoke_transforms = []
+        self._resource_transforms = {}
+        self._parents = {}
+        self._callback_stubs = {}
 
     def make_urn(self, parent: str, type_: str, name: str) -> str:
         if parent != "":
@@ -175,11 +195,105 @@ class MockMonitor:
 
         return dict(self.resources)
 
+    def _callback_stub(self, target: str) -> callback_pb2_grpc.CallbacksStub:
+        stub = self._callback_stubs.get(target)
+        if stub is None:
+            stub = callback_pb2_grpc.CallbacksStub(
+                grpc.insecure_channel(target, options=_GRPC_CHANNEL_OPTIONS)
+            )
+            self._callback_stubs[target] = stub
+        return stub
+
+    def _transform_resource_options(
+        self, request
+    ) -> resource_pb2.TransformResourceOptions:
+        opts = resource_pb2.TransformResourceOptions(
+            depends_on=request.dependencies,
+            ignore_changes=request.ignoreChanges,
+            replace_on_changes=request.replaceOnChanges,
+            version=request.version,
+            aliases=request.aliases,
+            provider=request.provider,
+            providers=request.providers,
+            plugin_download_url=request.pluginDownloadURL,
+            deleted_with=request.deletedWith,
+            replace_with=request.replace_with,
+            additional_secret_outputs=request.additionalSecretOutputs,
+            plugin_checksums=request.pluginChecksums,
+            hide_diff=request.hideDiffs,
+            **{"import": request.importId},
+        )
+        if request.HasField("protect"):
+            opts.protect = request.protect
+        if request.HasField("retainOnDelete"):
+            opts.retain_on_delete = request.retainOnDelete
+        if request.deleteBeforeReplaceDefined or request.deleteBeforeReplace:
+            opts.delete_before_replace = request.deleteBeforeReplace
+        if request.HasField("customTimeouts"):
+            opts.custom_timeouts.CopyFrom(request.customTimeouts)
+        if request.HasField("hooks"):
+            opts.hooks.CopyFrom(request.hooks)
+        if request.HasField("replacement_trigger"):
+            opts.replacement_trigger.CopyFrom(request.replacement_trigger)
+        return opts
+
+    def _invoke_callback(self, callback, request) -> bytes:
+        stub = self._callback_stub(callback.target)
+        resp = stub.Invoke(
+            callback_pb2.CallbackInvokeRequest(
+                token=callback.token, request=request.SerializeToString()
+            )
+        )
+        return resp.response
+
+    def _invoke_transform(self, callback, request, props, opts):
+        transform_request = resource_pb2.TransformRequest(
+            type=request.type,
+            name=request.name,
+            custom=request.custom or False,
+            parent=request.parent,
+            properties=props,
+            options=opts,
+        )
+        response = resource_pb2.TransformResponse.FromString(
+            self._invoke_callback(callback, transform_request)
+        )
+        new_props = response.properties if response.HasField("properties") else props
+        new_opts = response.options if response.HasField("options") else opts
+        return new_props, new_opts
+
+    def _invoke_invoke_transform(self, callback, token, args, opts):
+        transform_request = resource_pb2.TransformInvokeRequest(
+            token=token, args=args, options=opts
+        )
+        response = resource_pb2.TransformInvokeResponse.FromString(
+            self._invoke_callback(callback, transform_request)
+        )
+        new_args = response.args if response.HasField("args") else args
+        new_opts = response.options if response.HasField("options") else opts
+        return new_args, new_opts
+
     def Invoke(self, request):
         # Ensure we have an event loop on this thread because it's needed when deserializing resource references.
         _ensure_event_loop()
 
-        args = rpc.deserialize_properties(request.args)
+        args_struct = request.args
+        provider = request.provider
+        invoke_transforms = list(self._stack_invoke_transforms)
+        if invoke_transforms:
+            invoke_opts = resource_pb2.TransformInvokeOptions(
+                provider=request.provider,
+                version=request.version,
+                plugin_download_url=request.pluginDownloadURL,
+                plugin_checksums=request.pluginChecksums,
+            )
+            for callback in invoke_transforms:
+                args_struct, invoke_opts = self._invoke_invoke_transform(
+                    callback, request.tok, args_struct, invoke_opts
+                )
+            provider = invoke_opts.provider
+
+        args = rpc.deserialize_properties(args_struct)
 
         if request.tok == "pulumi:pulumi:getResource":
             registered_resource = self.resources.get(args["urn"])
@@ -191,9 +305,7 @@ class MockMonitor:
             fields = {"failures": None, "return": ret_proto}
             return resource_pb2.ResourceInvokeResponse(**fields)
 
-        call_args = MockCallArgs(
-            token=request.tok, args=args, provider=request.provider
-        )
+        call_args = MockCallArgs(token=request.tok, args=args, provider=provider)
         tup = self.mocks.call(call_args)
         if isinstance(tup, dict):
             (ret, failures) = (tup, None)
@@ -243,14 +355,33 @@ class MockMonitor:
         # Ensure we have an event loop on this thread because it's needed when deserializing resource references.
         _ensure_event_loop()
 
-        inputs = rpc.deserialize_properties(request.object)
+        transforms = list(request.transforms)
+        parent = request.parent
+        while parent:
+            transforms.extend(self._resource_transforms.get(parent, []))
+            parent = self._parents.get(parent, "")
+        transforms.extend(self._stack_transforms)
+
+        props_struct = request.object
+        provider = request.provider
+        import_id = request.importId
+        if transforms:
+            opts = self._transform_resource_options(request)
+            for callback in transforms:
+                props_struct, opts = self._invoke_transform(
+                    callback, request, props_struct, opts
+                )
+            provider = opts.provider
+            import_id = getattr(opts, "import")
+
+        inputs = rpc.deserialize_properties(props_struct)
 
         resource_args = MockResourceArgs(
             typ=request.type,
             name=request.name,
             inputs=inputs,
-            provider=request.provider,
-            resource_id=request.importId,
+            provider=provider,
+            resource_id=import_id,
             custom=request.custom or False,
         )
         id_, state = self.mocks.new_resource(resource_args)
@@ -258,10 +389,28 @@ class MockMonitor:
         obj_proto = _sync_await(rpc.serialize_properties(state, {}))
 
         self.resources[urn] = MockMonitor.ResourceRegistration(urn, id_, state)
+        if request.transforms:
+            self._resource_transforms[urn] = list(request.transforms)
+        if request.parent:
+            self._parents[urn] = request.parent
 
         return resource_pb2.RegisterResourceResponse(urn=urn, id=id_, object=obj_proto)
 
     def RegisterResourceOutputs(self, request):
+        return empty_pb2.Empty()
+
+    def RegisterStackTransform(self, request):
+        self._stack_transforms.append(request)
+        return empty_pb2.Empty()
+
+    def RegisterStackInvokeTransform(self, request):
+        self._stack_invoke_transforms.append(request)
+        return empty_pb2.Empty()
+
+    def RegisterResourceHook(self, request):
+        return empty_pb2.Empty()
+
+    def RegisterErrorHook(self, request):
         return empty_pb2.Empty()
 
     def SupportsFeature(self, request):
@@ -352,6 +501,7 @@ def set_mocks(
         stack=stack if stack is not None else "stack",
         dry_run=preview,
         organization=organization,
+        callbacks=None,
     )
     configure(settings)
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -267,9 +267,7 @@ async def _get_callbacks() -> Optional[_CallbackServicer]:
         return callbacks
 
     monitor = SETTINGS.monitor
-    if monitor is None or not isinstance(
-        monitor, resource_pb2_grpc.ResourceMonitorStub
-    ):
+    if monitor is None:
         return None
 
     callbacks = _CallbackServicer(monitor)

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -53,7 +53,7 @@ from .settings import (
     is_dry_run,
     set_root_resource,
 )
-from .sync_await import _sync_await
+from .sync_await import _ensure_event_loop, _sync_await
 
 if TYPE_CHECKING:
     from ..output import Inputs
@@ -132,6 +132,7 @@ class ResourceRegistrationFailed(Exception):
 
 async def run_pulumi_func(
     func: Callable[[], Optional[Awaitable[None]]],
+    shutdown_callbacks: bool = True,
 ) -> None:
     # Run the function and grab any exception it generates
     ex: Optional[BaseException] = None
@@ -149,8 +150,9 @@ async def run_pulumi_func(
         if ex is None:
             await _wait_for_shutdown()
     finally:
-        # Finally, we must always shutdown the callbacks server when we're done.
-        await _shutdown_callbacks()
+        # Finally, shutdown the callbacks server when we're done.
+        if shutdown_callbacks:
+            await _shutdown_callbacks()
 
     # By now, all tasks have exited and we're good to go.
     log.debug("run_pulumi_func completed")
@@ -482,6 +484,13 @@ def register_stack_transformation(t: ResourceTransformation):
         root_resource._transformations = root_resource._transformations + [t]
 
 
+def _wait_for_pending_rpcs() -> None:
+    pending = asyncio.all_tasks(_ensure_event_loop())
+    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
+    if rpcs:
+        _sync_await(asyncio.gather(*rpcs))
+
+
 def register_resource_transform(t: ResourceTransform) -> None:
     """
     Add a transform to all future resources constructed in this Pulumi stack.
@@ -494,9 +503,7 @@ def register_resource_transform(t: ResourceTransform) -> None:
     # We need to make sure all the current resource registrations are finished before
     # registering the transforms.  Do so by waiting for all RPCs to complete, before
     # we go ahead and register the transform.
-    pending = asyncio.all_tasks()
-    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
-    _sync_await(asyncio.gather(*rpcs))
+    _wait_for_pending_rpcs()
 
     callbacks = _sync_await(_get_callbacks())
     if callbacks is None:
@@ -528,9 +535,7 @@ def register_invoke_transform(t: InvokeTransform) -> None:
     # We need to make sure all the current invokes are finished before
     # registering the transforms.  Do so by waiting for all RPCs to
     # complete, before we go ahead and register the transform.
-    pending = asyncio.all_tasks()
-    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
-    _sync_await(asyncio.gather(*rpcs))
+    _wait_for_pending_rpcs()
 
     callbacks = _sync_await(_get_callbacks())
     if callbacks is None:

--- a/sdk/python/lib/test/test_mock_transforms.py
+++ b/sdk/python/lib/test/test_mock_transforms.py
@@ -1,0 +1,187 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+
+import pulumi
+from pulumi.runtime import mocks
+
+
+class MyMocks(mocks.Mocks):
+    def new_resource(self, args: mocks.MockResourceArgs):
+        return f"{args.name}_id", dict(args.inputs)
+
+    def call(self, args: mocks.MockCallArgs):
+        return dict(args.args)
+
+
+class MyResource(pulumi.CustomResource):
+    def __init__(
+        self,
+        name: str,
+        props: Optional[dict] = None,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ):
+        super().__init__("test:index:MyResource", name, props or {}, opts)
+
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, opts: Optional[pulumi.ResourceOptions] = None):
+        super().__init__("test:index:MyComponent", name, None, opts)
+
+
+@pytest.fixture
+def setup_mocks():
+    mocks.set_mocks(MyMocks())
+
+
+def tags_transform(args: pulumi.ResourceTransformArgs):
+    props = dict(args.props)
+    props["tags"] = {**(props.get("tags") or {}), "foo": "bar"}
+    return pulumi.ResourceTransformResult(props, args.opts)
+
+
+def append_order(marker: str):
+    def transform(args: pulumi.ResourceTransformArgs):
+        props = dict(args.props)
+        props["order"] = [*(props.get("order") or []), marker]
+        return pulumi.ResourceTransformResult(props, args.opts)
+
+    return transform
+
+
+def test_stack_transform(setup_mocks):
+    seen = {}
+
+    def transform(args: pulumi.ResourceTransformArgs):
+        seen["type"] = args.type_
+        seen["name"] = args.name
+        seen["custom"] = args.custom
+        return tags_transform(args)
+
+    pulumi.runtime.register_resource_transform(transform)
+
+    @pulumi.runtime.test
+    async def check():
+        res = MyResource("res", {"tags": {"group": "webservers"}})
+        tags = await res.tags.future()
+        assert tags == {"group": "webservers", "foo": "bar"}
+
+    check()
+
+    assert seen == {"type": "test:index:MyResource", "name": "res", "custom": True}
+
+
+@pulumi.runtime.test
+async def test_stack_transform_registered_in_loop(setup_mocks):
+    pulumi.runtime.register_resource_transform(tags_transform)
+
+    res = MyResource("res", {"tags": {"group": "webservers"}})
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers", "foo": "bar"}
+
+
+@pulumi.runtime.test
+async def test_resource_transform(setup_mocks):
+    res = MyResource(
+        "res",
+        {"tags": {"group": "webservers"}},
+        opts=pulumi.ResourceOptions(transforms=[tags_transform]),
+    )
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers", "foo": "bar"}
+
+
+@pulumi.runtime.test
+async def test_async_resource_transform(setup_mocks):
+    async def transform(args: pulumi.ResourceTransformArgs):
+        return tags_transform(args)
+
+    res = MyResource(
+        "res",
+        {"tags": {"group": "webservers"}},
+        opts=pulumi.ResourceOptions(transforms=[transform]),
+    )
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers", "foo": "bar"}
+
+
+@pulumi.runtime.test
+async def test_transform_returning_none_leaves_resource_unchanged(setup_mocks):
+    def transform(args: pulumi.ResourceTransformArgs):
+        return None
+
+    res = MyResource(
+        "res",
+        {"tags": {"group": "webservers"}},
+        opts=pulumi.ResourceOptions(transforms=[transform]),
+    )
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers"}
+
+
+def test_transform_order(setup_mocks):
+    pulumi.runtime.register_resource_transform(append_order("stack1"))
+    pulumi.runtime.register_resource_transform(append_order("stack2"))
+
+    @pulumi.runtime.test
+    async def check():
+        parent = MyComponent(
+            "parent",
+            opts=pulumi.ResourceOptions(transforms=[append_order("parent")]),
+        )
+        child = MyResource(
+            "child",
+            {"order": []},
+            opts=pulumi.ResourceOptions(
+                parent=parent, transforms=[append_order("own")]
+            ),
+        )
+        order = await child.order.future()
+        assert order == ["own", "parent", "stack1", "stack2"]
+
+    check()
+
+
+def test_grandparent_transform(setup_mocks):
+    @pulumi.runtime.test
+    async def check():
+        grandparent = MyComponent(
+            "grandparent",
+            opts=pulumi.ResourceOptions(transforms=[tags_transform]),
+        )
+        parent = MyComponent("parent", opts=pulumi.ResourceOptions(parent=grandparent))
+        child = MyResource(
+            "child",
+            {"tags": {"group": "webservers"}},
+            opts=pulumi.ResourceOptions(parent=parent),
+        )
+        tags = await child.tags.future()
+        assert tags == {"group": "webservers", "foo": "bar"}
+
+    check()
+
+
+def test_invoke_transform(setup_mocks):
+    def transform(args: pulumi.InvokeTransformArgs):
+        new_args = dict(args.args)
+        new_args["extra"] = "added"
+        return pulumi.InvokeTransformResult(new_args, args.opts)
+
+    pulumi.runtime.register_invoke_transform(transform)
+
+    result = pulumi.runtime.invoke("test:index:MyFunction", {"orig": "value"}).value
+    assert result == {"orig": "value", "extra": "added"}


### PR DESCRIPTION
Allow transforms to be registered in python tests, by implementing a handler for them, and lets the tests run them in the same order the engine also runs them.

Only transforms that are explicitly registered are run, so transforms can be tested in isolation.

Part of #17090 (python only for now, will create PRs for the other languages if this is the direction we decide to go)