### PR TITLE
python: allow transforms to be registered in mocks

### DIFF
--- a/changelog/pending/sdk-python-improvement-20260820-155323.yaml
+++ b/changelog/pending/sdk-python-improvement-20260820-155323.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: improvement
+body: Allow transforms to be mocked
+time: 2026-08-20T15:53:23.245504123+02:00

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -77,7 +77,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
         self._callbacks = {}
         self._transforms = {}
         self._monitor = monitor
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         self._server = aio.server(options=_GRPC_CHANNEL_OPTIONS)
         callback_pb2_grpc.add_CallbacksServicer_to_server(self, self._server)
         port = self._server.add_insecure_port(address="127.0.0.1:0")
@@ -101,7 +101,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
         #
         # Stopping a grpc.aio server from a different event loop than it was created
         # on raises a RuntimeError, so only stop servicers created on the current loop.
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         for servicer in list(cls._servicers):
             if servicer._loop is not loop:
                 continue

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -67,6 +67,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
     _monitor: resource_pb2_grpc.ResourceMonitorStub
     _server: aio.Server
     _target: str
+    _loop: asyncio.AbstractEventLoop
 
     _transforms: dict[Union[ResourceTransform, InvokeTransform], str]
 
@@ -76,6 +77,7 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
         self._callbacks = {}
         self._transforms = {}
         self._monitor = monitor
+        self._loop = asyncio.get_event_loop()
         self._server = aio.server(options=_GRPC_CHANNEL_OPTIONS)
         callback_pb2_grpc.add_CallbacksServicer_to_server(self, self._server)
         port = self._server.add_insecure_port(address="127.0.0.1:0")
@@ -93,7 +95,13 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
 
     @classmethod
     async def shutdown(cls):
-        for servicer in cls._servicers:
+        # Stopping a grpc.aio server from a different event loop than it was created
+        # on raises a RuntimeError, so only stop servicers created on the current loop.
+        loop = asyncio.get_event_loop()
+        for servicer in list(cls._servicers):
+            if servicer._loop is not loop:
+                continue
+            cls._servicers.remove(servicer)
             await servicer._server.stop(grace=0)
 
     async def Invoke(

--- a/sdk/python/lib/pulumi/runtime/_callbacks.py
+++ b/sdk/python/lib/pulumi/runtime/_callbacks.py
@@ -95,6 +95,10 @@ class _CallbackServicer(callback_pb2_grpc.CallbacksServicer):
 
     @classmethod
     async def shutdown(cls):
+        # A Pulumi program only has a single event loop, but the servicers list is
+        # shared process-wide, and a single process can run many programs on
+        # different loops, e.g. mock-based tests.
+        #
         # Stopping a grpc.aio server from a different event loop than it was created
         # on raises a RuntimeError, so only stop servicers created on the current loop.
         loop = asyncio.get_event_loop()

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -19,12 +19,17 @@ Mocks for testing.
 import functools
 import logging
 from abc import ABC, abstractmethod
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 from google.protobuf import empty_pb2
 
-from ..runtime.proto import engine_pb2, provider_pb2, resource_pb2
+from ..runtime.proto import (
+    engine_pb2,
+    provider_pb2,
+    resource_pb2,
+)
 from ..runtime.stack import Stack, run_pulumi_func
+from ._callbacks import _CallbackServicer
 from . import rpc, rpc_manager
 from .settings import (
     Settings,
@@ -35,6 +40,10 @@ from .settings import (
     SETTINGS,
 )
 from .sync_await import _ensure_event_loop, _sync_await
+
+if TYPE_CHECKING:
+    from ..invoke import InvokeTransform
+    from ..resource import ResourceTransform
 
 
 def test(fn):
@@ -70,6 +79,7 @@ class MockResourceArgs:
     provider: Optional[str] = None
     resource_id: Optional[str] = None
     custom: Optional[bool] = None
+    transforms: "list[ResourceTransform]"
 
     def __init__(
         self,
@@ -79,6 +89,7 @@ class MockResourceArgs:
         provider: Optional[str] = None,
         resource_id: Optional[str] = None,
         custom: Optional[bool] = None,
+        transforms: Optional["list[ResourceTransform]"] = None,
     ) -> None:
         """
         :param str typ: The token that indicates which resource type is being constructed. This token is of the form "package:module:type".
@@ -87,6 +98,7 @@ class MockResourceArgs:
         :param str provider: The identifier of the provider instance being used to manage this resource.
         :param str resource_id: The physical identifier of an existing resource to read or import.
         :param bool custom: Specifies whether or not the resource is Custom (i.e. managed by a resource provider).
+        :param list transforms: The transforms declared in the resource's options. The mock monitor does not run them.
         """
         self.typ = typ
         self.name = name
@@ -94,6 +106,7 @@ class MockResourceArgs:
         self.provider = provider
         self.resource_id = resource_id
         self.custom = custom
+        self.transforms = transforms or []
 
 
 class MockCallArgs:
@@ -142,6 +155,34 @@ class Mocks(ABC):
         """
         return "", {}
 
+    def register_transform(self, transform: "ResourceTransform") -> None:
+        """
+        register_transform is called when a stack transform is registered. The mock monitor
+        does not run transforms; implementations that want to exercise them can record the
+        transform here and call it from `new_resource`.
+
+        :param ResourceTransform transform.
+        """
+
+    def register_invoke_transform(self, transform: "InvokeTransform") -> None:
+        """
+        register_invoke_transform is called when a stack invoke transform is registered. The
+        mock monitor does not run transforms; implementations that want to exercise them can
+        record the transform here and call it from `call`.
+
+        :param InvokeTransform transform.
+        """
+
+
+def _resolve_callbacks(callbacks) -> list:
+    by_token = {}
+    for servicer in _CallbackServicer._servicers:
+        for fn, token in servicer._transforms.items():
+            by_token[token] = fn
+    return [
+        by_token[callback.token] for callback in callbacks if callback.token in by_token
+    ]
+
 
 class MockMonitor:
     class ResourceRegistration(NamedTuple):
@@ -156,9 +197,14 @@ class MockMonitor:
     mocks: Mocks
     resources: dict[str, ResourceRegistration]
 
+    _stack_transforms: "list[ResourceTransform]"
+    _stack_invoke_transforms: "list[InvokeTransform]"
+
     def __init__(self, mocks: Mocks):
         self.mocks = mocks
         self.resources = {}
+        self._stack_transforms = []
+        self._stack_invoke_transforms = []
 
     def make_urn(self, parent: str, type_: str, name: str) -> str:
         if parent != "":
@@ -174,6 +220,22 @@ class MockMonitor:
         """
 
         return dict(self.resources)
+
+    def get_registered_transforms(self) -> "list[ResourceTransform]":
+        """
+        get_registered_transforms returns the resource transforms registered with this monitor.
+        The mock monitor does not run them; tests that want to exercise them can call them
+        from their `Mocks.new_resource` implementation.
+        """
+        return list(self._stack_transforms)
+
+    def get_registered_invoke_transforms(self) -> "list[InvokeTransform]":
+        """
+        get_registered_invoke_transforms returns the invoke transforms registered with this
+        monitor. The mock monitor does not run them; tests that want to exercise them can
+        call them from their `Mocks.call` implementation.
+        """
+        return list(self._stack_invoke_transforms)
 
     def Invoke(self, request):
         # Ensure we have an event loop on this thread because it's needed when deserializing resource references.
@@ -252,6 +314,7 @@ class MockMonitor:
             provider=request.provider,
             resource_id=request.importId,
             custom=request.custom or False,
+            transforms=_resolve_callbacks(request.transforms),
         )
         id_, state = self.mocks.new_resource(resource_args)
 
@@ -262,6 +325,24 @@ class MockMonitor:
         return resource_pb2.RegisterResourceResponse(urn=urn, id=id_, object=obj_proto)
 
     def RegisterResourceOutputs(self, request):
+        return empty_pb2.Empty()
+
+    def RegisterStackTransform(self, request):
+        for transform in _resolve_callbacks([request]):
+            self._stack_transforms.append(transform)
+            self.mocks.register_transform(transform)
+        return empty_pb2.Empty()
+
+    def RegisterStackInvokeTransform(self, request):
+        for transform in _resolve_callbacks([request]):
+            self._stack_invoke_transforms.append(transform)
+            self.mocks.register_invoke_transform(transform)
+        return empty_pb2.Empty()
+
+    def RegisterResourceHook(self, request):
+        return empty_pb2.Empty()
+
+    def RegisterErrorHook(self, request):
         return empty_pb2.Empty()
 
     def SupportsFeature(self, request):
@@ -352,6 +433,7 @@ def set_mocks(
         stack=stack if stack is not None else "stack",
         dry_run=preview,
         organization=organization,
+        callbacks=None,
     )
     configure(settings)
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -267,9 +267,7 @@ async def _get_callbacks() -> Optional[_CallbackServicer]:
         return callbacks
 
     monitor = SETTINGS.monitor
-    if monitor is None or not isinstance(
-        monitor, resource_pb2_grpc.ResourceMonitorStub
-    ):
+    if monitor is None:
         return None
 
     callbacks = _CallbackServicer(monitor)

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -53,7 +53,7 @@ from .settings import (
     is_dry_run,
     set_root_resource,
 )
-from .sync_await import _ensure_event_loop, _sync_await
+from .sync_await import _sync_await
 
 if TYPE_CHECKING:
     from ..output import Inputs
@@ -483,7 +483,7 @@ def register_stack_transformation(t: ResourceTransformation):
 
 
 def _wait_for_pending_rpcs() -> None:
-    pending = asyncio.all_tasks(_ensure_event_loop())
+    pending = asyncio.all_tasks()
     rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
     if rpcs:
         _sync_await(asyncio.gather(*rpcs))

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -53,7 +53,7 @@ from .settings import (
     is_dry_run,
     set_root_resource,
 )
-from .sync_await import _sync_await
+from .sync_await import _ensure_event_loop, _sync_await
 
 if TYPE_CHECKING:
     from ..output import Inputs
@@ -482,6 +482,13 @@ def register_stack_transformation(t: ResourceTransformation):
         root_resource._transformations = root_resource._transformations + [t]
 
 
+def _wait_for_pending_rpcs() -> None:
+    pending = asyncio.all_tasks(_ensure_event_loop())
+    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
+    if rpcs:
+        _sync_await(asyncio.gather(*rpcs))
+
+
 def register_resource_transform(t: ResourceTransform) -> None:
     """
     Add a transform to all future resources constructed in this Pulumi stack.
@@ -494,9 +501,7 @@ def register_resource_transform(t: ResourceTransform) -> None:
     # We need to make sure all the current resource registrations are finished before
     # registering the transforms.  Do so by waiting for all RPCs to complete, before
     # we go ahead and register the transform.
-    pending = asyncio.all_tasks()
-    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
-    _sync_await(asyncio.gather(*rpcs))
+    _wait_for_pending_rpcs()
 
     callbacks = _sync_await(_get_callbacks())
     if callbacks is None:
@@ -528,9 +533,7 @@ def register_invoke_transform(t: InvokeTransform) -> None:
     # We need to make sure all the current invokes are finished before
     # registering the transforms.  Do so by waiting for all RPCs to
     # complete, before we go ahead and register the transform.
-    pending = asyncio.all_tasks()
-    rpcs = {task for task in pending if task.get_coro().__name__ == "rpc_wrapper"}  # type: ignore
-    _sync_await(asyncio.gather(*rpcs))
+    _wait_for_pending_rpcs()
 
     callbacks = _sync_await(_get_callbacks())
     if callbacks is None:

--- a/sdk/python/lib/test/test_mock_transforms.py
+++ b/sdk/python/lib/test/test_mock_transforms.py
@@ -1,0 +1,169 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+
+import pulumi
+from pulumi.runtime import mocks
+
+
+class MyMocks(mocks.Mocks):
+    def new_resource(self, args: mocks.MockResourceArgs):
+        return f"{args.name}_id", dict(args.inputs)
+
+    def call(self, args: mocks.MockCallArgs):
+        return dict(args.args)
+
+
+class TransformAwareMocks(mocks.Mocks):
+    def __init__(self):
+        self.stack_transforms = []
+        self.stack_invoke_transforms = []
+
+    def register_transform(self, transform: pulumi.ResourceTransform):
+        self.stack_transforms.append(transform)
+
+    def register_invoke_transform(self, transform: pulumi.InvokeTransform):
+        self.stack_invoke_transforms.append(transform)
+
+    def new_resource(self, args: mocks.MockResourceArgs):
+        props = dict(args.inputs)
+        for transform in [*args.transforms, *self.stack_transforms]:
+            result = transform(
+                pulumi.ResourceTransformArgs(
+                    custom=args.custom or False,
+                    type_=args.typ,
+                    name=args.name,
+                    props=props,
+                    opts=pulumi.ResourceOptions(),
+                )
+            )
+            if result is not None:
+                props = dict(result.props)
+        return f"{args.name}_id", props
+
+    def call(self, args: mocks.MockCallArgs):
+        call_args = dict(args.args)
+        for transform in self.stack_invoke_transforms:
+            result = transform(
+                pulumi.InvokeTransformArgs(
+                    token=args.token,
+                    args=call_args,
+                    opts=pulumi.InvokeOptions(),
+                )
+            )
+            if result is not None:
+                call_args = dict(result.args)
+        return call_args
+
+
+class MyResource(pulumi.CustomResource):
+    def __init__(
+        self,
+        name: str,
+        props: Optional[dict] = None,
+        opts: Optional[pulumi.ResourceOptions] = None,
+    ):
+        super().__init__("test:index:MyResource", name, props or {}, opts)
+
+
+@pytest.fixture
+def setup_mocks():
+    mocks.set_mocks(MyMocks())
+
+
+@pytest.fixture
+def setup_transform_aware_mocks():
+    monitor = mocks.MockMonitor(TransformAwareMocks())
+    mocks.set_mocks(TransformAwareMocks(), monitor=monitor)
+    yield monitor
+
+
+def tags_transform(args: pulumi.ResourceTransformArgs):
+    props = dict(args.props)
+    props["tags"] = {**(props.get("tags") or {}), "foo": "bar"}
+    return pulumi.ResourceTransformResult(props, args.opts)
+
+
+def test_transforms_are_not_run_by_the_mock_monitor(setup_mocks):
+    pulumi.runtime.register_resource_transform(tags_transform)
+
+    @pulumi.runtime.test
+    async def check():
+        res = MyResource(
+            "res",
+            {"tags": {"group": "webservers"}},
+            opts=pulumi.ResourceOptions(transforms=[tags_transform]),
+        )
+        tags = await res.tags.future()
+        assert tags == {"group": "webservers"}
+
+    check()
+
+
+@pulumi.runtime.test
+async def test_register_resource_transform_in_loop(setup_mocks):
+    pulumi.runtime.register_resource_transform(tags_transform)
+
+
+def test_registered_transforms_are_exposed(setup_transform_aware_mocks):
+    monitor = setup_transform_aware_mocks
+
+    def other_transform(args: pulumi.ResourceTransformArgs):
+        return None
+
+    pulumi.runtime.register_resource_transform(tags_transform)
+    pulumi.runtime.register_resource_transform(other_transform)
+
+    assert monitor.get_registered_transforms() == [tags_transform, other_transform]
+
+
+def test_manually_applying_stack_transforms(setup_transform_aware_mocks):
+    pulumi.runtime.register_resource_transform(tags_transform)
+
+    @pulumi.runtime.test
+    async def check():
+        res = MyResource("res", {"tags": {"group": "webservers"}})
+        tags = await res.tags.future()
+        assert tags == {"group": "webservers", "foo": "bar"}
+
+    check()
+
+
+def test_manually_applying_resource_transforms(setup_transform_aware_mocks):
+    @pulumi.runtime.test
+    async def check():
+        res = MyResource(
+            "res",
+            {"tags": {"group": "webservers"}},
+            opts=pulumi.ResourceOptions(transforms=[tags_transform]),
+        )
+        tags = await res.tags.future()
+        assert tags == {"group": "webservers", "foo": "bar"}
+
+    check()
+
+
+def test_manually_applying_invoke_transforms(setup_transform_aware_mocks):
+    def transform(args: pulumi.InvokeTransformArgs):
+        new_args = dict(args.args)
+        new_args["extra"] = "added"
+        return pulumi.InvokeTransformResult(new_args, args.opts)
+
+    pulumi.runtime.register_invoke_transform(transform)
+
+    result = pulumi.runtime.invoke("test:index:MyFunction", {"orig": "value"}).value
+    assert result == {"orig": "value", "extra": "added"}

--- a/sdk/python/lib/test/test_mock_transforms.py
+++ b/sdk/python/lib/test/test_mock_transforms.py
@@ -82,7 +82,9 @@ class MyResource(pulumi.CustomResource):
 
 @pytest.fixture
 def setup_mocks():
-    mocks.set_mocks(MyMocks())
+    monitor = mocks.MockMonitor(MyMocks())
+    mocks.set_mocks(MyMocks(), monitor=monitor)
+    yield monitor
 
 
 @pytest.fixture
@@ -98,25 +100,28 @@ def tags_transform(args: pulumi.ResourceTransformArgs):
     return pulumi.ResourceTransformResult(props, args.opts)
 
 
-def test_transforms_are_not_run_by_the_mock_monitor(setup_mocks):
-    pulumi.runtime.register_resource_transform(tags_transform)
+def extra_invoke_transform(args: pulumi.InvokeTransformArgs):
+    new_args = dict(args.args)
+    new_args["extra"] = "added"
+    return pulumi.InvokeTransformResult(new_args, args.opts)
+
+
+def test_registration_is_accepted_by_mocks_without_transform_hooks(setup_mocks):
+    monitor = setup_mocks
 
     @pulumi.runtime.test
     async def check():
-        res = MyResource(
-            "res",
-            {"tags": {"group": "webservers"}},
-            opts=pulumi.ResourceOptions(transforms=[tags_transform]),
-        )
+        pulumi.runtime.register_resource_transform(tags_transform)
+        pulumi.runtime.register_invoke_transform(extra_invoke_transform)
+
+        res = MyResource("res", {"tags": {"group": "webservers"}})
         tags = await res.tags.future()
         assert tags == {"group": "webservers"}
 
     check()
 
-
-@pulumi.runtime.test
-async def test_register_resource_transform_in_loop(setup_mocks):
-    pulumi.runtime.register_resource_transform(tags_transform)
+    assert monitor.get_registered_transforms() == [tags_transform]
+    assert monitor.get_registered_invoke_transforms() == [extra_invoke_transform]
 
 
 def test_registered_transforms_are_exposed(setup_transform_aware_mocks):
@@ -127,8 +132,10 @@ def test_registered_transforms_are_exposed(setup_transform_aware_mocks):
 
     pulumi.runtime.register_resource_transform(tags_transform)
     pulumi.runtime.register_resource_transform(other_transform)
+    pulumi.runtime.register_invoke_transform(extra_invoke_transform)
 
     assert monitor.get_registered_transforms() == [tags_transform, other_transform]
+    assert monitor.get_registered_invoke_transforms() == [extra_invoke_transform]
 
 
 def test_manually_applying_stack_transforms(setup_transform_aware_mocks):
@@ -158,12 +165,7 @@ def test_manually_applying_resource_transforms(setup_transform_aware_mocks):
 
 
 def test_manually_applying_invoke_transforms(setup_transform_aware_mocks):
-    def transform(args: pulumi.InvokeTransformArgs):
-        new_args = dict(args.args)
-        new_args["extra"] = "added"
-        return pulumi.InvokeTransformResult(new_args, args.opts)
-
-    pulumi.runtime.register_invoke_transform(transform)
+    pulumi.runtime.register_invoke_transform(extra_invoke_transform)
 
     result = pulumi.runtime.invoke("test:index:MyFunction", {"orig": "value"}).value
     assert result == {"orig": "value", "extra": "added"}

--- a/sdk/python/lib/test/test_mock_transforms.py
+++ b/sdk/python/lib/test/test_mock_transforms.py
@@ -106,25 +106,23 @@ def extra_invoke_transform(args: pulumi.InvokeTransformArgs):
     return pulumi.InvokeTransformResult(new_args, args.opts)
 
 
-def test_registration_is_accepted_by_mocks_without_transform_hooks(setup_mocks):
+@pulumi.runtime.test
+async def test_registration_is_accepted_by_mocks_without_transform_hooks(setup_mocks):
     monitor = setup_mocks
 
-    @pulumi.runtime.test
-    async def check():
-        pulumi.runtime.register_resource_transform(tags_transform)
-        pulumi.runtime.register_invoke_transform(extra_invoke_transform)
+    pulumi.runtime.register_resource_transform(tags_transform)
+    pulumi.runtime.register_invoke_transform(extra_invoke_transform)
 
-        res = MyResource("res", {"tags": {"group": "webservers"}})
-        tags = await res.tags.future()
-        assert tags == {"group": "webservers"}
-
-    check()
+    res = MyResource("res", {"tags": {"group": "webservers"}})
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers"}
 
     assert monitor.get_registered_transforms() == [tags_transform]
     assert monitor.get_registered_invoke_transforms() == [extra_invoke_transform]
 
 
-def test_registered_transforms_are_exposed(setup_transform_aware_mocks):
+@pulumi.runtime.test
+async def test_registered_transforms_are_exposed(setup_transform_aware_mocks):
     monitor = setup_transform_aware_mocks
 
     def other_transform(args: pulumi.ResourceTransformArgs):
@@ -138,33 +136,28 @@ def test_registered_transforms_are_exposed(setup_transform_aware_mocks):
     assert monitor.get_registered_invoke_transforms() == [extra_invoke_transform]
 
 
-def test_manually_applying_stack_transforms(setup_transform_aware_mocks):
+@pulumi.runtime.test
+async def test_manually_applying_stack_transforms(setup_transform_aware_mocks):
     pulumi.runtime.register_resource_transform(tags_transform)
 
-    @pulumi.runtime.test
-    async def check():
-        res = MyResource("res", {"tags": {"group": "webservers"}})
-        tags = await res.tags.future()
-        assert tags == {"group": "webservers", "foo": "bar"}
-
-    check()
+    res = MyResource("res", {"tags": {"group": "webservers"}})
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers", "foo": "bar"}
 
 
-def test_manually_applying_resource_transforms(setup_transform_aware_mocks):
-    @pulumi.runtime.test
-    async def check():
-        res = MyResource(
-            "res",
-            {"tags": {"group": "webservers"}},
-            opts=pulumi.ResourceOptions(transforms=[tags_transform]),
-        )
-        tags = await res.tags.future()
-        assert tags == {"group": "webservers", "foo": "bar"}
-
-    check()
+@pulumi.runtime.test
+async def test_manually_applying_resource_transforms(setup_transform_aware_mocks):
+    res = MyResource(
+        "res",
+        {"tags": {"group": "webservers"}},
+        opts=pulumi.ResourceOptions(transforms=[tags_transform]),
+    )
+    tags = await res.tags.future()
+    assert tags == {"group": "webservers", "foo": "bar"}
 
 
-def test_manually_applying_invoke_transforms(setup_transform_aware_mocks):
+@pulumi.runtime.test
+async def test_manually_applying_invoke_transforms(setup_transform_aware_mocks):
     pulumi.runtime.register_invoke_transform(extra_invoke_transform)
 
     result = pulumi.runtime.invoke("test:index:MyFunction", {"orig": "value"}).value


### PR DESCRIPTION
Allow transforms to be registered in the resource monitor. Note that the mock monitor does not run them, but using this mechanism, users can check that the transforms are registered properly, and check the inputs that are attached to the transform.

Note that the opts (as opposed to the props) are not provided.  Only the engine computes the options a transform receives, so tests will have to construct opts themselves.

Part of #17090 

Closes #24404