### PR TITLE
Use `schema.Token` for `Function.Token`

### DIFF
--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -58,7 +58,7 @@ func functionSchemaHelp(fn *schema.Function) string {
 }
 
 func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command {
-	_, _, name, diags := pcl.DecomposeToken(fn.Token, hcl.Range{})
+	_, _, name, diags := pcl.DecomposeToken(fn.Token.String(), hcl.Range{})
 	contract.Assertf(!diags.HasErrors(), "token should decompose")
 
 	shorthelp := fmt.Sprintf("Invoke the %s function", name)
@@ -100,7 +100,7 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 			}
 
 			response, err := pc.provider.Invoke(ctx, plugin.InvokeRequest{
-				Tok:     tokens.ModuleMember(fn.Token),
+				Tok:     tokens.ModuleMember(fn.Token.String()),
 				Args:    resource.FromResourcePropertyMap(inputs),
 				Preview: pc.dryrun,
 			})

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -431,7 +431,8 @@ func evaluateFunctionFile(
 		return attrs, inputType, properties, diags
 	}
 	return evaluateFile(
-		ctx, path, fileType, inputFormat, fn.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+		ctx, path, fileType, inputFormat, fn.Token.String(), bind, loadConverter, loaderTarget, packageDescriptor,
+		evalContext,
 		inputFlags,
 	)
 }

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -288,7 +288,7 @@ func TestInterpretPulumiRefs(t *testing.T) {
 					return obj.Token, true
 				}
 			case schema.DocRefKindFunction:
-				return ref.Function.Token, true
+				return ref.Function.Token.String(), true
 			}
 			return "", false
 		})

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -136,11 +136,11 @@ func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
 }
 
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
-	funcName := tokenToName(f.Token)
+	funcName := tokenToName(f.Token.String())
 	if d.topLevelPkg == nil {
 		return funcName
 	}
-	pkg, ok := d.packages[tokenToPackage(d.topLevelPkg, d.goPkgInfo.ModuleToPackage, f.Token)]
+	pkg, ok := d.packages[tokenToPackage(d.topLevelPkg, d.goPkgInfo.ModuleToPackage, f.Token.String())]
 	if !ok {
 		return funcName
 	}

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -159,7 +159,7 @@ func TestGetFunctionName(t *testing.T) {
 
 	names := map[string]string{}
 	for _, f := range pkg.Functions {
-		names[f.Token] = d.GetFunctionName(f)
+		names[f.Token.String()] = d.GetFunctionName(f)
 	}
 
 	assert.Equal(t, map[string]string{
@@ -236,7 +236,7 @@ func buildSelfRefFixture(t *testing.T) (*schema.Package, *schema.Resource, *sche
 	require.NotNil(t, settings)
 	var getWidget *schema.Function
 	for _, f := range pkg.Functions {
-		if f.Token == "demo:mod:getWidget" {
+		if f.Token.String() == "demo:mod:getWidget" {
 			getWidget = f
 		}
 	}

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -3275,8 +3275,8 @@ func (pkg *pkgContext) docRefFunctionName(f *schema.Function) string {
 		return ""
 	}
 
-	name := tokenToName(f.Token)
-	mod := pkg.tokenToPackage(f.Token)
+	name := tokenToName(f.Token.String())
+	mod := pkg.tokenToPackage(f.Token.String())
 	if modPkg, ok := pkg.packages[mod]; ok {
 		if override, ok := modPkg.functionNames[f]; ok {
 			name = override
@@ -4935,10 +4935,10 @@ func generatePackageContextMap(tool string, pkg schema.PackageReference, goInfo 
 			continue
 		}
 
-		pkg := getPkgFromToken(f.Token)
+		pkg := getPkgFromToken(f.Token.String())
 		pkg.functions = append(pkg.functions, f)
 
-		name := tokenToName(f.Token)
+		name := tokenToName(f.Token.String())
 
 		if pkg.names.Contains(name) ||
 			pkg.names.Contains(name+"Args") ||
@@ -5294,7 +5294,7 @@ func GeneratePackage(tool string,
 				continue
 			}
 
-			fileName := path.Join(mod, cgstrings.Camel(tokenToName(f.Token))+".go")
+			fileName := path.Join(mod, cgstrings.Camel(tokenToName(f.Token.String()))+".go")
 			code, err := pkg.genFunctionCodeFile(f)
 			if err != nil {
 				return nil, err

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -109,7 +109,7 @@ func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
 }
 
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
-	return tokenToFunctionName(f.Token)
+	return tokenToFunctionName(f.Token.String())
 }
 
 // GetResourceFunctionResultName returns the name of the result type when a function is used to lookup

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -385,11 +385,11 @@ func (mod *modContext) docRefResolver(selfRef schema.DocRef) func(schema.DocRef)
 		case schema.DocRefKindResourceInputProperty:
 			base = tokenToName(ref.ResourceToken()) + "Args"
 		case schema.DocRefKindFunction:
-			base = tokenToFunctionName(ref.Function.Token)
+			base = tokenToFunctionName(ref.Function.Token.String())
 		case schema.DocRefKindFunctionInputProperty:
-			base = tokenToName(ref.Function.Token) + "Args"
+			base = tokenToName(ref.Function.Token.String()) + "Args"
 		case schema.DocRefKindFunctionOutputProperty:
-			base = tokenToName(ref.Function.Token) + "Result"
+			base = tokenToName(ref.Function.Token.String()) + "Result"
 		case schema.DocRefKindType, schema.DocRefKindTypeProperty:
 			base = tokenToName(ref.Type.String())
 		case schema.DocRefKindUnknown:
@@ -1211,7 +1211,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 }
 
 func (mod *modContext) functionReturnType(fun *schema.Function) string {
-	name := tokenToFunctionName(fun.Token)
+	name := tokenToFunctionName(fun.Token.String())
 	if fun.ReturnType == nil {
 		return "void"
 	}
@@ -1254,7 +1254,7 @@ func runtimeInvokeFunction(fun *schema.Function, plain bool) string {
 }
 
 func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, plain bool) (functionFileInfo, error) {
-	name := tokenToFunctionName(fun.Token)
+	name := tokenToFunctionName(fun.Token.String())
 	info := functionFileInfo{}
 
 	// Write the TypeDoc/JSDoc for the data source function.
@@ -2176,9 +2176,9 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 			return err
 		}
 
-		fileName := cgstrings.Camel(tokenToName(f.Token)) + ".ts"
+		fileName := cgstrings.Camel(tokenToName(f.Token.String())) + ".ts"
 		if mod.isReservedSourceFileName(fileName) {
-			fileName = cgstrings.Camel(tokenToName(f.Token)) + "_.ts"
+			fileName = cgstrings.Camel(tokenToName(f.Token.String())) + "_.ts"
 		}
 		addFunctionFile(funInfo, fileName, buffer.String())
 	}
@@ -2881,7 +2881,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, extraFiles map[s
 	// Clear the input and outputs sets: we want the visitors below to touch the transitive closure of types reachable
 	// from function inputs and outputs, including types that have already been visited.
 	for _, f := range pkg.Functions {
-		mod := getModFromToken(f.Token)
+		mod := getModFromToken(f.Token.String())
 		if !f.IsMethod {
 			mod.functions = append(mod.functions, f)
 		}

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -114,13 +114,13 @@ func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
 }
 
 func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
-	return PyName(tokenToName(f.Token))
+	return PyName(tokenToName(f.Token.String()))
 }
 
 // GetResourceFunctionResultName returns the name of the result type when a function is used to lookup
 // an existing resource.
 func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *schema.Function) string {
-	return cgstrings.UppercaseFirst(tokenToName(f.Token)) + "Result"
+	return cgstrings.UppercaseFirst(tokenToName(f.Token.String())) + "Result"
 }
 
 // ResolveDocRef renders a single doc ref as a Python name. It honours per-package

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -730,7 +730,7 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 		if err != nil {
 			return err
 		}
-		fnName := PyName(tokenToName(f.Token))
+		fnName := PyName(tokenToName(f.Token.String()))
 		if mod.conflictsWithChildModule(fnName) {
 			fnName = fnName + "_"
 		}
@@ -2005,7 +2005,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	if returnTypeObj != nil {
 		baseName, awaitableName = awaitableTypeNames(returnTypeObj.Token)
 	}
-	name := PyName(tokenToName(fun.Token))
+	name := PyName(tokenToName(fun.Token.String()))
 
 	// Export only the symbols we want exported.
 	fmt.Fprintf(w, "__all__ = [\n")
@@ -2205,7 +2205,7 @@ func (mod *modContext) genFunDeprecationMessage(w io.Writer, fun *schema.Functio
 	if fun.DeprecationMessage == "" {
 		return
 	}
-	name := PyName(tokenToName(fun.Token))
+	name := PyName(tokenToName(fun.Token.String()))
 	fmt.Fprintf(w, "    pulumi.log.warn(\"\"\"%s is deprecated: %s\"\"\")\n", name, fun.DeprecationMessage)
 }
 
@@ -2601,11 +2601,11 @@ func (mod *modContext) docRefResolver(selfRef schema.DocRef) func(schema.DocRef)
 		case schema.DocRefKindResourceInputProperty:
 			base = mod.resourceArgsClassName(ref.Type.(*schema.ResourceType))
 		case schema.DocRefKindFunction:
-			base = PyName(tokenToName(ref.Function.Token))
+			base = PyName(tokenToName(ref.Function.Token.String()))
 		case schema.DocRefKindFunctionInputProperty:
-			base = cgstrings.UppercaseFirst(PyName(tokenToName(ref.Function.Token))) + "Args"
+			base = cgstrings.UppercaseFirst(PyName(tokenToName(ref.Function.Token.String()))) + "Args"
 		case schema.DocRefKindFunctionOutputProperty:
-			base = cgstrings.UppercaseFirst(PyName(tokenToName(ref.Function.Token))) + "Result"
+			base = cgstrings.UppercaseFirst(PyName(tokenToName(ref.Function.Token.String()))) + "Result"
 		case schema.DocRefKindType, schema.DocRefKindTypeProperty:
 			switch t := ref.Type.(type) {
 			case *schema.ObjectType:
@@ -3369,7 +3369,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 
 	// Find input and output types referenced by functions.
 	for _, f := range pkg.Functions {
-		mod := getModFromToken(f.Token, f.PackageReference)
+		mod := getModFromToken(f.Token.String(), f.PackageReference)
 		if !f.IsMethod {
 			mod.functions = append(mod.functions, f)
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -2047,8 +2047,9 @@ func bindMethods(
 			diags = diags.Append(errorf(methodPath, "function %s is already a method", token))
 			continue
 		}
-		idx := strings.LastIndex(function.Token, "/")
-		if idx == -1 || function.Token[:idx] != resourceToken {
+		functionToken := function.Token.String()
+		idx := strings.LastIndex(functionToken, "/")
+		if idx == -1 || functionToken[:idx] != resourceToken {
 			d := errorf(methodPath, "invalid function token format %s", token)
 			d.Detail = fmt.Sprintf(`expected a token of the shape: "%s/<method name>"`, resourceToken)
 			diags = diags.Append(d)
@@ -2412,13 +2413,13 @@ func (t *types) bindFunctionDef(token string, options ValidationOptions) (*Funct
 	if diag := validatePrintableName(path, "function name", token); diag != nil {
 		diags = diags.Append(diag)
 	}
-	parts := strings.Split(token, ":")
-	if len(parts) == 3 {
-		name := parts[2]
-		if isReservedKeyword(name) {
-			diags = diags.Append(errorf(path, "%s", name+" is a reserved name, cannot name function"))
-			return nil, diags, errors.New(name + " is a reserved name, cannot name function")
-		}
+	tok, err := ParseToken(token)
+	if err != nil {
+		return nil, diags.Append(errorf(path, "%v", err)), nil
+	}
+	if name := tok.Name(); isReservedKeyword(name) {
+		diags = diags.Append(errorf(path, "%s", name+" is a reserved name, cannot name function"))
+		return nil, diags, errors.New(name + " is a reserved name, cannot name function")
 	}
 
 	// Check that spec.MultiArgumentInputs => spec.Inputs
@@ -2551,7 +2552,7 @@ func (t *types) bindFunctionDef(token string, options ValidationOptions) (*Funct
 
 	fn := &Function{
 		PackageReference:          t.externalPackage(),
-		Token:                     token,
+		Token:                     tok,
 		Comment:                   spec.Description,
 		Inputs:                    inputs,
 		MultiArgumentInputs:       len(spec.MultiArgumentInputs) > 0,
@@ -2580,11 +2581,11 @@ func (t *types) finishFunctions(tokens []string, options ValidationOptions) ([]*
 		if err != nil {
 			return nil, diags, fmt.Errorf("error binding function %v: %w", token, err)
 		}
-		functions = append(functions, f)
+		if f != nil {
+			functions = append(functions, f)
+		}
 	}
-	sort.Slice(functions, func(i, j int) bool {
-		return functions[i].Token < functions[j].Token
-	})
+	slices.SortFunc(functions, func(a, b *Function) int { return a.Token.Cmp(b.Token) })
 
 	return functions, diags, nil
 }

--- a/pkg/codegen/schema/docs.go
+++ b/pkg/codegen/schema/docs.go
@@ -180,7 +180,7 @@ func interpretPulumiRefs(
 			} else if ref.Type != nil {
 				name = ref.Type.String()
 			} else if ref.Function != nil {
-				name = ref.Function.Token
+				name = ref.Function.Token.String()
 			} else {
 				name = ref.Ref
 			}
@@ -390,7 +390,7 @@ func DocRefForResource(r *Resource) DocRef {
 
 // DocRefForFunction returns a DocRef for the given function.
 func DocRefForFunction(f *Function) DocRef {
-	return DocRef{Kind: DocRefKindFunction, Function: f, Ref: "#/functions/" + url.PathEscape(f.Token)}
+	return DocRef{Kind: DocRefKindFunction, Function: f, Ref: "#/functions/" + url.PathEscape(f.Token.String())}
 }
 
 type internalDocRef struct {

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -80,7 +80,7 @@ func getDocsForObjectType(path string, t *ObjectType) []doc {
 }
 
 func getDocsForFunction(f *Function) []doc {
-	entity := "#/functions/" + url.PathEscape(f.Token)
+	entity := "#/functions/" + url.PathEscape(f.Token.String())
 	docs := []doc{
 		{entity: entity + "/description", content: f.Comment},
 		{entity: entity + "/deprecationMessage", content: f.DeprecationMessage},

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -20,7 +20,6 @@ import (
 	"maps"
 	"reflect"
 	"slices"
-	"sort"
 	"sync"
 
 	"github.com/blang/semver"
@@ -369,7 +368,7 @@ type packageDefFunctionsIter struct {
 }
 
 func (i *packageDefFunctionsIter) Token() string {
-	return i.f.Token
+	return i.f.Token.String()
 }
 
 func (i *packageDefFunctionsIter) Function() (*Function, error) {
@@ -841,9 +840,7 @@ func (p *PartialPackage) Snapshot() (*Package, error) {
 	for token, fn := range p.types.functionDefs {
 		functions, functionDefs[token] = append(functions, fn), fn
 	}
-	sort.Slice(functions, func(i, j int) bool {
-		return functions[i].Token < functions[j].Token
-	})
+	slices.SortFunc(functions, func(a, b *Function) int { return a.Token.Cmp(b.Token) })
 
 	typeList, diags, err := p.types.finishTypes(nil, ValidationOptions{
 		AllowDanglingReferences: true,

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -544,7 +544,7 @@ type Function struct {
 	// PackageReference is the PackageReference that defines the function.
 	PackageReference PackageReference
 	// Token is the function's Pulumi type token.
-	Token string
+	Token Token
 	// Comment is the description of the function, if any.
 	Comment string
 	// Inputs is the bag of input values for the function, if any.
@@ -1284,7 +1284,7 @@ func (pkg *Package) MarshalSpec() (spec *PackageSpec, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("marshaling function '%v': %w", fn.Token, err)
 		}
-		spec.Functions[fn.Token] = f
+		spec.Functions[fn.Token.String()] = f
 	}
 
 	return spec, nil
@@ -1408,7 +1408,7 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 	if len(r.Methods) != 0 {
 		methods = map[string]string{}
 		for _, m := range r.Methods {
-			methods[m.Name] = m.Function.Token
+			methods[m.Name] = m.Function.Token.String()
 		}
 	}
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1689,7 +1689,7 @@ func TestIsOverlay(t *testing.T) {
 			}
 		}
 		for _, v := range pkg.Functions {
-			if strings.Contains(v.Token, "Overlay") {
+			if strings.Contains(v.Token.String(), "Overlay") {
 				assert.Truef(t, v.IsOverlay, "function %q", v.Token)
 			} else {
 				assert.Falsef(t, v.IsOverlay, "function %q", v.Token)
@@ -1738,12 +1738,12 @@ func TestOverlaySupportedLanguages(t *testing.T) {
 			}
 		}
 		for _, v := range pkg.Functions {
-			if strings.Contains(v.Token, "Overlay") {
+			if strings.Contains(v.Token.String(), "Overlay") {
 				assert.Truef(t, v.IsOverlay, "function %q", v.Token)
 			} else {
 				assert.Falsef(t, v.IsOverlay, "function %q", v.Token)
 			}
-			if strings.Contains(v.Token, "ConstrainedLanguages") {
+			if strings.Contains(v.Token.String(), "ConstrainedLanguages") {
 				assert.Equalf(t, []string{"go", "nodejs", "python"}, v.OverlaySupportedLanguages, "resource %q", v.Token)
 			} else {
 				assert.Nilf(t, v.OverlaySupportedLanguages, "resource %q", v.Token)
@@ -2551,7 +2551,7 @@ func TestFunctionToFunctionSpecTurnaround(t *testing.T) {
 			name: "return-type-plain",
 			fn: &Function{
 				PackageReference: nil,
-				Token:            "token",
+				Token:            NewToken("pkg", "index", "fn"),
 				ReturnType:       IntType,
 				ReturnTypePlain:  true,
 				Plain:            true,
@@ -2581,13 +2581,13 @@ func TestFunctionToFunctionSpecTurnaround(t *testing.T) {
 				spec: packageSpecSource{
 					&PackageSpec{
 						Functions: map[string]FunctionSpec{
-							"token": tc.fspec,
+							"pkg:index:fn": tc.fspec,
 						},
 					},
 				},
 				functionDefs: map[string]*Function{},
 			}
-			fn, diags, err := ts.bindFunctionDef("token", ValidationOptions{
+			fn, diags, err := ts.bindFunctionDef("pkg:index:fn", ValidationOptions{
 				AllowDanglingReferences: true,
 			})
 			require.NoError(t, err)
@@ -2997,6 +2997,12 @@ func TestFunctionToken(t *testing.T) {
 					Summary:  "#/functions/123:index:getFunction: invalid token '123:index:getFunction' (must have package name 'test')",
 					Detail:   "",
 				},
+				{
+					Severity: hcl.DiagError,
+					Summary: "#/functions/123:index:getFunction: invalid token \"123:index:getFunction\": " +
+						"invalid package \"123\": must match ^[a-zA-Z][-a-zA-Z0-9_]*$",
+					Detail: "",
+				},
 			},
 		},
 		{
@@ -3012,6 +3018,12 @@ func TestFunctionToken(t *testing.T) {
 					Severity: hcl.DiagError,
 					Summary:  "#/functions/test:123:getFunction: does not match pattern '^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/-]*)?:[^0-9][a-zA-Z0-9._/-]*$'",
 					Detail:   "",
+				},
+				{
+					Severity: hcl.DiagError,
+					Summary: "#/functions/test:123:getFunction: invalid token \"test:123:getFunction\": " +
+						"invalid module \"123\": must match ^([^0-9:][a-zA-Z0-9._/-]*)?$",
+					Detail: "",
 				},
 			},
 		},
@@ -3037,6 +3049,10 @@ func TestFunctionToken(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, diags)
+			if tt.expected.HasErrors() {
+				assert.Empty(t, pkg.Functions, "functions with malformed tokens are not bound")
+				return
+			}
 
 			// Test marshaling
 			newSpec, err := pkg.MarshalSpec()
@@ -3441,7 +3457,7 @@ func TestGetWithModuleFormat(t *testing.T) {
 
 		f, ok := pkg.GetFunction("test:mod:getThing")
 		require.True(t, ok)
-		assert.Equal(t, "test:mod_v2:getThing", f.Token)
+		assert.Equal(t, NewToken("test", "mod_v2", "getThing"), f.Token)
 
 		typ, ok := pkg.GetType("test:mod:ThingBlock")
 		require.True(t, ok)
@@ -3471,7 +3487,7 @@ func TestGetWithModuleFormat(t *testing.T) {
 		f, ok, err := pkg.Functions().Get("test:mod:getThing")
 		require.NoError(t, err)
 		require.True(t, ok)
-		assert.Equal(t, "test:mod_v2:getThing", f.Token)
+		assert.Equal(t, NewToken("test", "mod_v2", "getThing"), f.Token)
 
 		typ, ok, err := pkg.Types().Get("test:mod:ThingBlock")
 		require.NoError(t, err)

--- a/pkg/codegen/testing/test/type_driver.go
+++ b/pkg/codegen/testing/test/type_driver.go
@@ -145,11 +145,11 @@ func TestTypeNameCodegen(
 		}
 		for _, f := range pkg.Functions {
 			if f.Inputs != nil {
-				runTests("/functions/"+f.Token+"/inputs/properties", f.Inputs.Properties, false)
+				runTests("/functions/"+f.Token.String()+"/inputs/properties", f.Inputs.Properties, false)
 			}
 			if f.ReturnType != nil {
 				if objectType, ok := f.ReturnType.(*schema.ObjectType); ok && objectType != nil {
-					runTests("/functions/"+f.Token+"/outputs/properties", objectType.Properties, false)
+					runTests("/functions/"+f.Token.String()+"/outputs/properties", objectType.Properties, false)
 				}
 			}
 		}

--- a/pkg/pcl/runtime/builtinFunctions.go
+++ b/pkg/pcl/runtime/builtinFunctions.go
@@ -345,7 +345,7 @@ func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 			}
 			// Use the canonical schema token (the alias lookup in Get may have resolved a
 			// normalized form like "pkg:index:name" to the source-form "pkg:index_name:name").
-			token = fun.Token
+			token = fun.Token.String()
 
 			argsPV, err := ctyToPropertyValue(args[1])
 			if err != nil {
@@ -577,7 +577,7 @@ func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 			}
 
 			request := &pulumirpc.ResourceCallRequest{
-				Tok:               fun.Token,
+				Tok:               fun.Token.String(),
 				Args:              obj,
 				AcceptsByteString: true,
 			}


### PR DESCRIPTION
`Function.Token` is now a parsed `schema.Token` instead of a raw string.
`bindFunctionDef` parses the token and reports a diagnostic if it is
malformed; a function whose token cannot be parsed is omitted from the
bound package rather than bound with an empty token. The reserved-name
check now uses the parsed name component directly.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
