### PR TITLE
Use `schema.Token` for `TokenType.Token`

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -459,7 +459,7 @@ func (pkg *pkgContext) inputType(t schema.Type) (result string) {
 		if t.UnderlyingType != nil {
 			return pkg.inputType(t.UnderlyingType)
 		}
-		return pkg.tokenToType(t.Token) + "Input"
+		return pkg.tokenToType(t.Token.String()) + "Input"
 	case *schema.UnionType:
 		// If the union is actually a relaxed enum type, use the underlying
 		// type for the input instead
@@ -625,7 +625,7 @@ func (pkg *pkgContext) argsTypeImpl(t schema.Type) (result string) {
 		if t.UnderlyingType != nil {
 			return pkg.argsTypeImpl(t.UnderlyingType)
 		}
-		return pkg.tokenToType(t.Token)
+		return pkg.tokenToType(t.Token.String())
 	case *schema.UnionType:
 		// If the union is actually a relaxed enum type, use the underlying
 		// type for the input instead
@@ -718,7 +718,7 @@ func (pkg *pkgContext) typeStringImpl(t schema.Type, argsType bool) string {
 		if t.UnderlyingType != nil {
 			return pkg.typeStringImpl(t.UnderlyingType, argsType)
 		}
-		return pkg.tokenToType(t.Token)
+		return pkg.tokenToType(t.Token.String())
 	case *schema.UnionType:
 		// If the union is actually a relaxed enum type, use the underlying
 		// type for the enum instead
@@ -927,7 +927,7 @@ func (pkg *pkgContext) outputTypeImpl(t schema.Type) string {
 		if t.UnderlyingType != nil {
 			return pkg.outputTypeImpl(t.UnderlyingType)
 		}
-		return pkg.tokenToType(t.Token) + "Output"
+		return pkg.tokenToType(t.Token.String()) + "Output"
 	case *schema.UnionType:
 		// If the union is actually a relaxed enum type, use the underlying
 		// type for the output instead
@@ -1081,7 +1081,7 @@ func (pkg *pkgContext) genericOutputTypeImpl(t schema.Type) string {
 			return pkg.genericOutputType(t.UnderlyingType)
 		}
 
-		tokenType := pkg.tokenToType(t.Token)
+		tokenType := pkg.tokenToType(t.Token.String())
 		return fmt.Sprintf("pulumix.Output[%s]", tokenType)
 	case *schema.UnionType:
 		// If the union is actually a relaxed enum type, use the underlying

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -885,7 +885,7 @@ func (g *generator) collectTypeImports(program *pcl.Program, t schema.Type) {
 		token = t.Token.String()
 		packageRef = t.PackageReference
 	case *schema.TokenType:
-		token = t.Token
+		token = t.Token.String()
 		pkg, _, name, _ := pcl.DecomposeToken(token, hcl.Range{})
 		mod := g.resolveModule(token)
 		vPath, err := g.getVersionPath(program, pkg)

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -303,7 +303,7 @@ func (mod *modContext) typeAst(t schema.Type, input bool, constValue any) tstype
 	case *schema.ResourceType:
 		return tstypes.Identifier(mod.resourceType(t))
 	case *schema.TokenType:
-		return tstypes.Identifier(tokenToName(t.Token))
+		return tstypes.Identifier(tokenToName(t.Token.String()))
 	case *schema.UnionType:
 		if !input && mod.disableUnionOutputTypes {
 			if t.DefaultType != nil {
@@ -1620,7 +1620,7 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 
 		return resourceOrTokenImport(t.Token.String())
 	case *schema.TokenType:
-		return resourceOrTokenImport(t.Token)
+		return resourceOrTokenImport(t.Token.String())
 	case *schema.UnionType:
 		needsTypes := false
 		for _, e := range t.ElementTypes {

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -466,7 +466,7 @@ func (b *binder) schemaTypeToType(src schema.Type) model.Type {
 		}
 		return objType
 	case *schema.TokenType:
-		t := model.NewOpaqueType(src.Token)
+		t := model.NewOpaqueType(src.Token.String())
 
 		if src.UnderlyingType != nil {
 			underlyingType := b.schemaTypeToType(src.UnderlyingType)

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -930,7 +930,7 @@ func hashTypeInto(h hash.Hash64, t Type) {
 		writeStr(t.Token.String())
 	case *TokenType:
 		writeTag(10)
-		writeStr(t.Token)
+		writeStr(t.Token.String())
 	case *InvalidType:
 		writeTag(11)
 	default:
@@ -1118,7 +1118,12 @@ func (t *types) bindTypeSpecRef(
 		// If the type is not a known type, bind it as an opaque token type.
 		tokenType, ok := t.tokens[ref.Token]
 		if !ok {
-			tokenType = &TokenType{Token: ref.Token}
+			tok, err := ParseToken(ref.Token)
+			if err != nil {
+				typ, diags := invalidType(errorf(path, "%v", err))
+				return typ, diags, nil
+			}
+			tokenType = &TokenType{Token: tok}
 			if spec.Type != "" {
 				ut, primDiags := t.bindPrimitiveType(path, spec.Type)
 				diags = diags.Extend(primDiags)
@@ -1856,7 +1861,7 @@ func compareTypes(a, b Type) int {
 	case *InvalidType, nil:
 		return 0 // All invalid types are the same
 	case *TokenType:
-		return strings.Compare(a.Token, b.(*TokenType).Token)
+		return a.Token.Cmp(b.(*TokenType).Token)
 	case *InputType:
 		return compareTypes(a.ElementType, b.(*InputType).ElementType)
 	default:

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -298,13 +298,13 @@ func (t *ResourceType) isType() {}
 // that can be used in place of the token.
 type TokenType struct {
 	// Token is the type's Pulumi type token.
-	Token string
+	Token Token
 	// Underlying type is the type's underlying type, if any.
 	UnderlyingType Type
 }
 
 func (t *TokenType) String() string {
-	return t.Token
+	return t.Token.String()
 }
 
 func (*TokenType) isType() {}
@@ -1623,7 +1623,7 @@ func (pkg *Package) marshalType(t Type, plain bool) TypeSpec {
 
 		return TypeSpec{
 			Type:  defaultType,
-			Ref:   pkg.marshalTypeRef(pkg.Reference(), "types", t.Token),
+			Ref:   pkg.marshalTypeRef(pkg.Reference(), "types", t.Token.String()),
 			Plain: !plain,
 		}
 	default:


### PR DESCRIPTION
`TokenType.Token` is now a parsed `schema.Token` instead of a raw string.
A dangling type reference whose token cannot be parsed now binds to an
invalid type with a diagnostic instead of an opaque token type.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
