### PR TITLE
Use `schema.Token` for `Alias.Type`

### DIFF
--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -2288,8 +2288,17 @@ func (t *types) bindResourceDetails(
 	}
 
 	aliases := slice.Prealloc[*Alias](len(spec.Aliases))
-	for _, a := range spec.Aliases {
-		aliases = append(aliases, &Alias{compatibility: a.compatibility, Type: a.Type})
+	for i, a := range spec.Aliases {
+		var aliasType Token
+		if a.Type != "" {
+			var err error
+			aliasType, err = ParseToken(a.Type)
+			if err != nil {
+				diags = diags.Append(errorf(fmt.Sprintf("%s/aliases/%d/type", path, i), "%v", err))
+				continue
+			}
+		}
+		aliases = append(aliases, &Alias{compatibility: a.compatibility, Type: aliasType})
 	}
 
 	*decl = Resource{

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -382,7 +382,7 @@ type Alias struct {
 	compatibility bool
 
 	// The type alias.
-	Type string
+	Type Token
 }
 
 // Resource describes a Pulumi resource.
@@ -1400,7 +1400,7 @@ func (pkg *Package) marshalResource(r *Resource) (ResourceSpec, error) {
 	for _, a := range r.Aliases {
 		aliases = append(aliases, AliasSpec{
 			compatibility: a.compatibility,
-			Type:          a.Type,
+			Type:          a.Type.String(),
 		})
 	}
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -4098,3 +4098,30 @@ func TestMissingPropertyRefErrors(t *testing.T) {
 	assert.Contains(t, summaries,
 		"#/types/test:index:SomeType/description: property 'nonExistent' not found on type 'test:index:SomeType'")
 }
+
+func TestBindResourceAliasToken(t *testing.T) {
+	t.Parallel()
+
+	bind := func(aliasType string) (*Package, hcl.Diagnostics) {
+		pkg, diags, err := BindSpec(PackageSpec{
+			Name: "test",
+			Resources: map[string]ResourceSpec{
+				"test:index:Thing": {Aliases: []AliasSpec{{Type: aliasType}}},
+			},
+		}, NewNullLoader(), ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		return pkg, diags
+	}
+
+	pkg, diags := bind("test:index:OldThing")
+	require.False(t, diags.HasErrors(), "%v", diags)
+	require.Len(t, pkg.Resources, 1)
+	assert.Equal(t, []*Alias{{Type: NewToken("test", "index", "OldThing")}}, pkg.Resources[0].Aliases)
+
+	_, diags = bind("not a token")
+	assert.Equal(t, hcl.Diagnostics{{
+		Severity: hcl.DiagError,
+		Summary: `#/resources/test:index:Thing/aliases/0/type: invalid token "not a token": ` +
+			`expected three ':' separated parts`,
+	}}, diags)
+}


### PR DESCRIPTION
`Alias.Type` is now a parsed `schema.Token` instead of a raw string. An
alias with no type portion carries the zero `Token`. An alias whose type
cannot be parsed reports a diagnostic and is omitted from the resource.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
