### PR TITLE
nodejs: allow transforms to be registered in mocks

### DIFF
--- a/changelog/pending/sdk-nodejs-improvement-20260821-121942.yaml
+++ b/changelog/pending/sdk-nodejs-improvement-20260821-121942.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: improvement
+body: Allow transforms to be mocked
+time: 2026-08-21T12:19:42.571722631+02:00

--- a/sdk/nodejs/runtime/callbacks.ts
+++ b/sdk/nodejs/runtime/callbacks.ts
@@ -442,6 +442,10 @@ export class CallbackServer implements ICallbackServer {
         };
         const uuid = randomUUID();
         this._callbacks.set(uuid, tryCb);
+        const monitor = this._monitor as any;
+        if (typeof monitor.recordTransformCallback === "function") {
+            monitor.recordTransformCallback(uuid, transform);
+        }
         const req = new Callback();
         req.setToken(uuid);
         req.setTarget(await this._target);
@@ -539,6 +543,10 @@ export class CallbackServer implements ICallbackServer {
         };
         const uuid = randomUUID();
         this._callbacks.set(uuid, tryCb);
+        const monitor = this._monitor as any;
+        if (typeof monitor.recordTransformCallback === "function") {
+            monitor.recordTransformCallback(uuid, transform);
+        }
         const req = new Callback();
         req.setToken(uuid);
         req.setTarget(await this._target);

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { InvokeTransform } from "../invoke";
+import { ResourceTransform } from "../resource";
 import { deserializeProperties, serializeProperties } from "./rpc";
 import { getProject, getStack, setMockOptions } from "./settings";
 import { getStore } from "./state";
@@ -57,6 +59,12 @@ export interface MockResourceArgs {
      * import.
      */
     id?: string;
+
+    /**
+     * The transforms declared in the resource's options. The mock monitor does
+     * not run them.
+     */
+    transforms?: ResourceTransform[];
 }
 
 /**
@@ -118,12 +126,36 @@ export interface Mocks {
      * @param args MockResourceArgs
      */
     newResource(args: MockResourceArgs): MockResourceResult | Promise<MockResourceResult>;
+
+    /**
+     * Called when a stack transform is registered. The mock monitor does not
+     * run transforms; implementations that want to exercise them can record the
+     * transform here and call it from {@link newResource}.
+     *
+     * @param transform ResourceTransform
+     */
+    registerTransform?(transform: ResourceTransform): void;
+
+    /**
+     * Called when a stack invoke transform is registered. The mock monitor does
+     * not run transforms; implementations that want to exercise them can record
+     * the transform here and call it from {@link call}.
+     *
+     * @param transform InvokeTransform
+     */
+    registerInvokeTransform?(transform: InvokeTransform): void;
 }
 
 export class MockMonitor {
     readonly resources = new Map<string, { urn: string; id: string | null; state: any }>();
 
+    private readonly transformCallbacks = new Map<string, ResourceTransform | InvokeTransform>();
+
     constructor(readonly mocks: Mocks) {}
+
+    public recordTransformCallback(token: string, transform: ResourceTransform | InvokeTransform) {
+        this.transformCallbacks.set(token, transform);
+    }
 
     private newUrn(parent: string, type: string, name: string): string {
         if (parent) {
@@ -190,6 +222,11 @@ export class MockMonitor {
 
     public async registerResource(req: any, callback: (err: any, innerResponse: any) => void) {
         try {
+            const transforms = req
+                .getTransformsList()
+                .map((cb: any) => this.transformCallbacks.get(cb.getToken()))
+                .filter((transform: any) => transform !== undefined) as ResourceTransform[];
+
             const result: MockResourceResult = await this.mocks.newResource({
                 type: req.getType(),
                 name: req.getName(),
@@ -197,6 +234,7 @@ export class MockMonitor {
                 provider: req.getProvider(),
                 custom: req.getCustom(),
                 id: req.getImportid(),
+                transforms: transforms,
             });
 
             const urn = this.newUrn(req.getParent(), req.getType(), req.getName());
@@ -230,6 +268,22 @@ export class MockMonitor {
         } catch (err) {
             callback(err, undefined);
         }
+    }
+
+    public registerStackTransform(req: any, callback: (err: any, innerResponse: any) => void) {
+        const transform = this.transformCallbacks.get(req.getToken());
+        if (transform !== undefined) {
+            this.mocks.registerTransform?.(transform as ResourceTransform);
+        }
+        callback(null, {});
+    }
+
+    public registerStackInvokeTransform(req: any, callback: (err: any, innerResponse: any) => void) {
+        const transform = this.transformCallbacks.get(req.getToken());
+        if (transform !== undefined) {
+            this.mocks.registerInvokeTransform?.(transform as InvokeTransform);
+        }
+        callback(null, {});
     }
 
     public supportsFeature(req: any, callback: (err: any, innerResponse: any) => void) {
@@ -303,7 +357,8 @@ export async function setMocks(
     store.supportsDeletedWith = true;
     store.supportsReplaceWith = true;
     store.supportsAliasSpecs = true;
-    store.supportsTransforms = false;
+    store.supportsTransforms = true;
+    store.supportsInvokeTransforms = true;
     store.supportsParameterization = true;
     store.supportsResourceHooks = true;
     store.supportsErrorHooks = true;

--- a/sdk/nodejs/tests_with_mocks/transforms.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/transforms.spec.ts
@@ -1,0 +1,127 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as pulumi from "../index";
+import { MockCallArgs, MockCallResult, MockResourceArgs, MockResourceResult } from "../runtime";
+
+class MyResource extends pulumi.CustomResource {
+    tags!: pulumi.Output<Record<string, string>>;
+    constructor(name: string, props?: Record<string, any>, opts?: pulumi.CustomResourceOptions) {
+        super("test:index:MyResource", name, props ?? {}, opts);
+    }
+}
+
+const tagsTransform: pulumi.ResourceTransform = (args) => ({
+    props: { ...args.props, tags: { ...(args.props.tags ?? {}), foo: "bar" } },
+    opts: args.opts,
+});
+
+describe("mocks: transforms", function () {
+    describe("mocks without transform hooks", function () {
+        const resourceTransforms: pulumi.ResourceTransform[] = [];
+
+        before(async () => {
+            await pulumi.runtime.setMocks({
+                call: (args: MockCallArgs): MockCallResult => ({ ...args.inputs }),
+                newResource: (args: MockResourceArgs): MockResourceResult => {
+                    resourceTransforms.push(...(args.transforms ?? []));
+                    return {
+                        id: `${args.name}_id`,
+                        state: { ...args.inputs },
+                    };
+                },
+            });
+            pulumi.runtime.registerResourceTransform(tagsTransform);
+            pulumi.runtime.registerInvokeTransform((args) => ({
+                args: { ...args.args, extra: "added" },
+                opts: args.opts,
+            }));
+        });
+
+        it("accepts and delivers transform registrations without running them", async () => {
+            const res = new MyResource("res", { tags: { group: "webservers" } }, { transforms: [tagsTransform] });
+            assert.deepStrictEqual(await res.tags.promise(), { group: "webservers" });
+            assert.deepStrictEqual(resourceTransforms, [tagsTransform]);
+
+            const result = await pulumi.runtime.invoke("test:index:MyFunction", { orig: "value" });
+            assert.strictEqual(result.orig, "value");
+            assert.strictEqual(result.extra, undefined);
+        });
+    });
+
+    describe("transform-aware mocks", function () {
+        const stackTransforms: pulumi.ResourceTransform[] = [];
+        const stackInvokeTransforms: pulumi.InvokeTransform[] = [];
+
+        before(async () => {
+            await pulumi.runtime.setMocks({
+                call: async (args: MockCallArgs): Promise<MockCallResult> => {
+                    let callArgs = { ...args.inputs };
+                    for (const transform of stackInvokeTransforms) {
+                        const result = await transform({ token: args.token, args: callArgs, opts: {} });
+                        if (result !== undefined) {
+                            callArgs = { ...result.args };
+                        }
+                    }
+                    return callArgs;
+                },
+                newResource: async (args: MockResourceArgs): Promise<MockResourceResult> => {
+                    let props = { ...args.inputs };
+                    for (const transform of [...(args.transforms ?? []), ...stackTransforms]) {
+                        const result = await transform({
+                            custom: args.custom ?? false,
+                            type: args.type,
+                            name: args.name,
+                            props: props,
+                            opts: {},
+                        });
+                        if (result !== undefined) {
+                            props = { ...result.props };
+                        }
+                    }
+                    return { id: `${args.name}_id`, state: props };
+                },
+                registerTransform: (transform) => {
+                    stackTransforms.push(transform);
+                },
+                registerInvokeTransform: (transform) => {
+                    stackInvokeTransforms.push(transform);
+                },
+            });
+        });
+
+        it("exposes a resource's own transforms to newResource", async () => {
+            const res = new MyResource("res", { tags: { group: "webservers" } }, { transforms: [tagsTransform] });
+            assert.deepStrictEqual(await res.tags.promise(), { group: "webservers", foo: "bar" });
+        });
+
+        it("notifies the mocks of stack transform registrations", async () => {
+            pulumi.runtime.registerResourceTransform(tagsTransform);
+            const res = new MyResource("res2", { tags: { group: "webservers" } });
+            assert.deepStrictEqual(await res.tags.promise(), { group: "webservers", foo: "bar" });
+            assert.deepStrictEqual(stackTransforms, [tagsTransform]);
+        });
+
+        it("notifies the mocks of invoke transform registrations", async () => {
+            pulumi.runtime.registerInvokeTransform((args) => ({
+                args: { ...args.args, extra: "added" },
+                opts: args.opts,
+            }));
+            const result = await pulumi.runtime.invoke("test:index:MyFunction", { orig: "value" });
+            assert.strictEqual(result.orig, "value");
+            assert.strictEqual(result.extra, "added");
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -131,6 +131,7 @@
         "tests/provider/experimental/analyzer.spec.ts",
         "tests/provider/experimental/schema.spec.ts",
         "tests_with_mocks/mocks.spec.ts",
+        "tests_with_mocks/transforms.spec.ts",
         "tests_with_mocks/pendingRegistrations.spec.ts",
         "npm/testdata/nested/project/index.ts",
         "types/arborist.d.ts",


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/24406, also allow transforms to be registered in mocks in nodejs. The mocks are not automatically run, but the user can intercept them, and check inputs and the registration.

Part of #17090 