### PR TITLE
go: allow transforms to be registered in mocks

### DIFF
--- a/changelog/pending/sdk-go-improvement-20260821-122213.yaml
+++ b/changelog/pending/sdk-go-improvement-20260821-122213.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: improvement
+body: Allow transforms to be mocked
+time: 2026-08-21T12:22:13.420381646+02:00

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -595,6 +595,10 @@ func (ctx *Context) registerTransform(t ResourceTransform) (*pulumirpc.Callback,
 		return nil, fmt.Errorf("registering callback: %w", err)
 	}
 
+	if mm, ok := ctx.state.monitor.(*mockMonitor); ok {
+		mm.recordTransform(cb.Token, t)
+	}
+
 	return cb, nil
 }
 
@@ -712,6 +716,10 @@ func (ctx *Context) registerInvokeTransform(t InvokeTransform) (*pulumirpc.Callb
 	cb, err := ctx.state.callbacks.RegisterCallback(callback)
 	if err != nil {
 		return nil, fmt.Errorf("registering callback: %w", err)
+	}
+
+	if mm, ok := ctx.state.monitor.(*mockMonitor); ok {
+		mm.recordInvokeTransform(cb.Token, t)
 	}
 
 	return cb, nil

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -977,6 +977,156 @@ func TestHooksAndTransformsNoop(t *testing.T) {
 	require.NoError(t, err)
 }
 
+type transformsTestMonitor struct {
+	testMonitor
+	transforms       []ResourceTransform
+	invokeTransforms []InvokeTransform
+}
+
+func (m *transformsTestMonitor) RegisterTransform(t ResourceTransform) {
+	m.transforms = append(m.transforms, t)
+}
+
+func (m *transformsTestMonitor) RegisterInvokeTransform(t InvokeTransform) {
+	m.invokeTransforms = append(m.invokeTransforms, t)
+}
+
+func TestMockTransformsNotRun(t *testing.T) {
+	t.Parallel()
+
+	var inputs resource.PropertyMap
+	var resourceTransforms []ResourceTransform
+	mocks := &testMonitor{
+		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+			if args.Name == "res" {
+				inputs = args.Inputs
+				resourceTransforms = args.Transforms
+			}
+			return args.Name + "_id", args.Inputs, nil
+		},
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		transform := func(_ context.Context, args *ResourceTransformArgs) *ResourceTransformResult {
+			props := args.Props
+			props["foo"] = String("transformed")
+			return &ResourceTransformResult{Props: props, Opts: args.Opts}
+		}
+		err := ctx.RegisterResourceTransform(transform)
+		require.NoError(t, err)
+
+		var res testResource2
+		return ctx.RegisterResource("test:resource:type", "res", &testResource2Inputs{Foo: String("orig")}, &res,
+			Transforms([]ResourceTransform{transform}))
+	}, WithMocks("project", "stack", mocks))
+	require.NoError(t, err)
+
+	require.Equal(t, resource.NewProperty("orig"), inputs["foo"])
+
+	require.Len(t, resourceTransforms, 1)
+	result := resourceTransforms[0](t.Context(), &ResourceTransformArgs{
+		Custom: true,
+		Type:   "test:resource:type",
+		Name:   "res",
+		Props:  Map{"foo": String("orig")},
+		Opts:   ResourceOptions{},
+	})
+	require.NotNil(t, result)
+	require.Equal(t, Map{"foo": String("transformed")}, result.Props)
+}
+
+func TestMockTransformsExposed(t *testing.T) {
+	t.Parallel()
+
+	mock := &transformsTestMonitor{}
+	var gotProps Map
+	mock.NewResourceF = func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+		if args.Name != "res" {
+			return args.Name + "_id", args.Inputs, nil
+		}
+		props := Map{"foo": String(args.Inputs["foo"].StringValue())}
+		for _, transform := range append(append([]ResourceTransform{}, args.Transforms...), mock.transforms...) {
+			result := transform(t.Context(), &ResourceTransformArgs{
+				Custom: args.Custom,
+				Type:   args.TypeToken,
+				Name:   args.Name,
+				Props:  props,
+				Opts:   ResourceOptions{},
+			})
+			if result != nil {
+				props = result.Props
+			}
+		}
+		gotProps = props
+		return args.Name + "_id", args.Inputs, nil
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		err := ctx.RegisterResourceTransform(
+			func(_ context.Context, args *ResourceTransformArgs) *ResourceTransformResult {
+				props := args.Props
+				props["stack"] = String("yes")
+				return &ResourceTransformResult{Props: props, Opts: args.Opts}
+			})
+		require.NoError(t, err)
+
+		ownTransform := func(_ context.Context, args *ResourceTransformArgs) *ResourceTransformResult {
+			props := args.Props
+			props["own"] = String("yes")
+			return &ResourceTransformResult{Props: props, Opts: args.Opts}
+		}
+
+		var res testResource2
+		return ctx.RegisterResource("test:resource:type", "res", &testResource2Inputs{Foo: String("orig")}, &res,
+			Transforms([]ResourceTransform{ownTransform}))
+	}, WithMocks("project", "stack", mock))
+	require.NoError(t, err)
+
+	require.Equal(t, Map{
+		"foo":   String("orig"),
+		"own":   String("yes"),
+		"stack": String("yes"),
+	}, gotProps)
+}
+
+func TestMockInvokeTransformExposed(t *testing.T) {
+	t.Parallel()
+
+	mock := &transformsTestMonitor{}
+	var gotArgs Map
+	mock.CallF = func(args MockCallArgs) (resource.PropertyMap, error) {
+		callArgs := Map{"bang": String(args.Args["bang"].StringValue())}
+		for _, transform := range mock.invokeTransforms {
+			result := transform(t.Context(), &InvokeTransformArgs{
+				Token: args.Token,
+				Args:  callArgs,
+				Opts:  InvokeOptions{},
+			})
+			if result != nil {
+				callArgs = result.Args
+			}
+		}
+		gotArgs = callArgs
+		return resource.PropertyMap{"foo": resource.NewProperty("result")}, nil
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		err := ctx.RegisterInvokeTransform(
+			func(_ context.Context, args *InvokeTransformArgs) *InvokeTransformResult {
+				newArgs := args.Args
+				newArgs["extra"] = String("added")
+				return &InvokeTransformResult{Args: newArgs, Opts: args.Opts}
+			})
+		require.NoError(t, err)
+
+		var result invokeResult
+		return ctx.Invoke("test:index:MyFunction", invokeArgs{Bang: "3", Bar: "4"}, &result)
+	}, WithMocks("project", "stack", mock))
+	require.NoError(t, err)
+
+	require.Equal(t, Map{"bang": String("3"), "extra": String("added")}, gotArgs)
+}
+
 // packageRefMonitor is a mock monitor that tracks RegisterPackage calls and
 // returns configurable refs. It embeds mockMonitor for the full interface.
 type packageRefMonitor struct {

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -48,6 +48,16 @@ type MockResourceMonitorWithMethodCall interface {
 	MethodCall(args MockCallArgs) (resource.PropertyMap, error)
 }
 
+// MockResourceMonitorWithTransforms is an optional interface that mock resource monitors
+// can implement to be notified of stack transform registrations. The mock monitor does
+// not run transforms; implementations that want to exercise them can record them here and
+// call them from NewResource or Call.
+type MockResourceMonitorWithTransforms interface {
+	MockResourceMonitor
+	RegisterTransform(t ResourceTransform)
+	RegisterInvokeTransform(t InvokeTransform)
+}
+
 // mockResourceMonitorWithRegisterResource is a mock resource monitor that
 // also implements the RegisterResource method. A new resource monitor interface
 // is created to avoid needing to implement additional methods for existing implementations
@@ -103,6 +113,9 @@ type MockResourceArgs struct {
 	ID string
 	// Custom specifies whether or not the resource is Custom (i.e. managed by a resource provider).
 	Custom bool
+	// Transforms are the transforms declared in the resource's options. The mock monitor
+	// does not run them.
+	Transforms []ResourceTransform
 	// Full register RPC call, if available.
 	RegisterRPC *pulumirpc.RegisterResourceRequest
 	// Full read RPC call, if available
@@ -116,6 +129,40 @@ type mockMonitor struct {
 	stack     string
 	mocks     MockResourceMonitor
 	resources sync.Map // map[string]resource.PropertyMap
+
+	transformsLock           sync.Mutex
+	transformCallbacks       map[string]ResourceTransform
+	invokeTransformCallbacks map[string]InvokeTransform
+}
+
+func (m *mockMonitor) recordTransform(token string, t ResourceTransform) {
+	m.transformsLock.Lock()
+	defer m.transformsLock.Unlock()
+	if m.transformCallbacks == nil {
+		m.transformCallbacks = map[string]ResourceTransform{}
+	}
+	m.transformCallbacks[token] = t
+}
+
+func (m *mockMonitor) recordInvokeTransform(token string, t InvokeTransform) {
+	m.transformsLock.Lock()
+	defer m.transformsLock.Unlock()
+	if m.invokeTransformCallbacks == nil {
+		m.invokeTransformCallbacks = map[string]InvokeTransform{}
+	}
+	m.invokeTransformCallbacks[token] = t
+}
+
+func (m *mockMonitor) resolveTransforms(callbacks []*pulumirpc.Callback) []ResourceTransform {
+	m.transformsLock.Lock()
+	defer m.transformsLock.Unlock()
+	var transforms []ResourceTransform
+	for _, callback := range callbacks {
+		if t, has := m.transformCallbacks[callback.GetToken()]; has {
+			transforms = append(transforms, t)
+		}
+	}
+	return transforms
 }
 
 func (m *mockMonitor) newURN(parent, typ, name string) string {
@@ -327,6 +374,7 @@ func (m *mockMonitor) RegisterResource(ctx context.Context, in *pulumirpc.Regist
 		Provider:    in.GetProvider(),
 		ID:          in.GetImportId(),
 		Custom:      in.GetCustom(),
+		Transforms:  m.resolveTransforms(in.GetTransforms()),
 		RegisterRPC: in,
 	})
 	if err != nil {
@@ -386,12 +434,34 @@ func (m *mockMonitor) RegisterResourceOutputs(ctx context.Context, in *pulumirpc
 func (m *mockMonitor) RegisterStackTransform(ctx context.Context, in *pulumirpc.Callback,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
+	mocks, ok := m.mocks.(MockResourceMonitorWithTransforms)
+	if !ok {
+		return &emptypb.Empty{}, nil
+	}
+
+	m.transformsLock.Lock()
+	t, has := m.transformCallbacks[in.GetToken()]
+	m.transformsLock.Unlock()
+	if has {
+		mocks.RegisterTransform(t)
+	}
 	return &emptypb.Empty{}, nil
 }
 
 func (m *mockMonitor) RegisterStackInvokeTransform(ctx context.Context, in *pulumirpc.Callback,
 	opts ...grpc.CallOption,
 ) (*emptypb.Empty, error) {
+	mocks, ok := m.mocks.(MockResourceMonitorWithTransforms)
+	if !ok {
+		return &emptypb.Empty{}, nil
+	}
+
+	m.transformsLock.Lock()
+	t, has := m.invokeTransformCallbacks[in.GetToken()]
+	m.transformsLock.Unlock()
+	if has {
+		mocks.RegisterInvokeTransform(t)
+	}
 	return &emptypb.Empty{}, nil
 }
 


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/24406, also allow transforms to be registered in mocks in Go. The mocks are not automatically run, but the user can intercept them, and check inputs and the registration.
