### PR TITLE
Use new() instead of ptr helpers

### DIFF
--- a/.golangci/rules.go
+++ b/.golangci/rules.go
@@ -14,16 +14,15 @@ func deferIgnoreClose(m dsl.Matcher) {
 		Suggest("defer contract.IgnoreClose($x)")
 }
 
-// ptrHelperName forbids private pointer-wrapper helpers whose body is just
-// `return &v` from being named anything other than `ptr`. It catches both the
-// monomorphic form (e.g. `intPtr`, `strPtr`, `continuationPtr`) and the generic
-// form (e.g. `func ref[T any](v T) *T { return &v }`). This avoids unnecessary
-// duplication.
-func ptrHelperName(m dsl.Matcher) {
+// ptrHelper forbids private pointer-wrapper helpers whose body is just
+// `return &v`. Use Go 1.26's `new(expr)` instead of adding a helper like
+// `func ptr[T any](v T) *T { return &v }`.
+func ptrHelper(m dsl.Matcher) {
 	m.Match(
 		`func $name($v $T) *$T { return &$v }`,
-		`func $name[$T $_]($v $T) *$T { return &$v }`,
+		`func $name[$T any]($v $T) *$T { return &$v }`,
+		`$name := func($v $T) *$T { return &$v }`,
 	).
-		Where(m["name"].Text != "ptr" && m["name"].Text.Matches(`^[a-z]`)).
-		Report(`pointer-wrapping helper "$name" must be named "ptr"; prefer a single generic func ptr[T any](v T) *T { return &v }`)
+		Where(m["name"].Text.Matches(`^[a-z]`)).
+		Report(`pointer-wrapping helper "$name" is unnecessary; use new(expr) instead`)
 }

--- a/docs/utils/go.mod
+++ b/docs/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/docs
 
-go 1.25.11
+go 1.26.6
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
@@ -250,7 +250,7 @@ func TestListPackages(t *testing.T) {
 	}))
 
 	results := []apitype.PackageMetadata{}
-	for pkg, err := range client.ListPackages(ctx, ptr("castai")) {
+	for pkg, err := range client.ListPackages(ctx, new("castai")) {
 		require.NoError(t, err)
 		results = append(results, pkg)
 	}
@@ -308,12 +308,10 @@ func TestListPackagesNoMatches(t *testing.T) {
 	}))
 
 	results := []apitype.PackageMetadata{}
-	for pkg, err := range client.ListPackages(ctx, ptr("404-not-found")) {
+	for pkg, err := range client.ListPackages(ctx, new("404-not-found")) {
 		require.NoError(t, err)
 		results = append(results, pkg)
 	}
 
 	assert.Equal(t, []apitype.PackageMetadata{}, results)
 }
-
-func ptr[T any](v T) *T { return &v }

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -300,10 +300,6 @@ func (t updateToken) Get(ctx context.Context) (string, error) {
 	return t.source.GetToken(ctx)
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 // retryPolicy defines the policy for retrying requests by httpClient.Do.
 type retryPolicy int
 
@@ -431,11 +427,11 @@ func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Res
 	// maximum delay is reached. Stop after maxRetryCount requests have
 	// been made.
 	opts := httputil.RetryOpts{
-		Delay:    ptr(time.Second),
-		Backoff:  ptr(2.0),
-		MaxDelay: ptr(30 * time.Second),
+		Delay:    new(time.Second),
+		Backoff:  new(2.0),
+		MaxDelay: new(30 * time.Second),
 
-		MaxRetryCount:         ptr(4),
+		MaxRetryCount:         new(4),
 		HandshakeTimeoutsOnly: !policy.shouldRetry(req),
 	}
 	return httputil.DoWithRetryOpts(req, &tracingClient, opts)
@@ -579,8 +575,7 @@ func pulumiAPICall(ctx context.Context,
 
 		if resp.StatusCode == 401 {
 			loginErr := backenderr.LoginRequiredError{}
-			var errResp *apitype.ErrorResponse
-			if errors.As(err, &errResp) {
+			if errResp, ok := errors.AsType[*apitype.ErrorResponse](err); ok {
 				for _, e := range errResp.Errors {
 					if (e.ErrorType == "saml_reauth_required" || e.ErrorType == "saml_login_required") && e.Attribute != nil {
 						if u := CloudConsoleURL(cloudAPI, "signin", "sso", *e.Attribute, "reauth"); u != "" {

--- a/pkg/backend/httpstate/client/client_org_usage_test.go
+++ b/pkg/backend/httpstate/client/client_org_usage_test.go
@@ -36,15 +36,15 @@ func TestGetOrgUsageSummary(t *testing.T) {
 			Summary: []apitype.OrgResourceCountSummary{
 				{
 					Year:          2026,
-					Month:         ptr(5),
-					Day:           ptr(1),
+					Month:         new(5),
+					Day:           new(1),
 					Resources:     1200,
 					ResourceHours: 28800,
 				},
 				{
 					Year:          2026,
-					Month:         ptr(5),
-					Day:           ptr(2),
+					Month:         new(5),
+					Day:           new(2),
 					Resources:     1300,
 					ResourceHours: 31200,
 				},

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -756,7 +756,7 @@ func TestListTemplates(t *testing.T) {
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{
 					Templates:         firstPageTemplates,
-					ContinuationToken: ptr("next-page-token-1"),
+					ContinuationToken: new("next-page-token-1"),
 				})
 				require.NoError(t, err)
 			case 1:
@@ -766,7 +766,7 @@ func TestListTemplates(t *testing.T) {
 
 				responseData, err = json.Marshal(apitype.ListTemplatesResponse{
 					Templates:         secondPageTemplates,
-					ContinuationToken: ptr("next-page-token-2"),
+					ContinuationToken: new("next-page-token-2"),
 				})
 				require.NoError(t, err)
 			case 2:

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1089,7 +1089,7 @@ func TestListPackages(t *testing.T) {
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{
 					Packages:          firstPagePackages,
-					ContinuationToken: ptr("next-page-token-1"),
+					ContinuationToken: new("next-page-token-1"),
 				})
 				require.NoError(t, err)
 			case 1:
@@ -1099,7 +1099,7 @@ func TestListPackages(t *testing.T) {
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{
 					Packages:          secondPagePackages,
-					ContinuationToken: ptr("next-page-token-2"),
+					ContinuationToken: new("next-page-token-2"),
 				})
 				require.NoError(t, err)
 			case 2:

--- a/pkg/backend/httpstate/token_source.go
+++ b/pkg/backend/httpstate/token_source.go
@@ -116,8 +116,7 @@ func (ts *tokenSource) handleRequests(
 		newToken, newTokenExpires, err := refreshToken(ctx, duration, state.token)
 		// Renewing might fail because of network issues, or because the token is no longer valid.
 		// We only care about the latter, if it's just a network issue we should retry again.
-		var expired expiredTokenError
-		if errors.As(err, &expired) {
+		if _, ok := errors.AsType[expiredTokenError](err); ok {
 			logging.V(3).Infof("error renewing lease: %v", err)
 			state.error = fmt.Errorf("renewing lease: %w", err)
 			renewTicker.Stop()

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -888,8 +888,7 @@ func (sm *SnapshotManager) saveSnapshot() error {
 	}
 	if !DisableIntegrityChecking && integrityError != nil {
 		if autoRepairErr != nil {
-			var sie *snapshot.SnapshotIntegrityError
-			if errors.As(integrityError, &sie) {
+			if sie, ok := errors.AsType[*snapshot.SnapshotIntegrityError](integrityError); ok {
 				sie.AutoRepairErr = autoRepairErr
 			}
 		}

--- a/pkg/cmd/esc/cli/client/retry.go
+++ b/pkg/cmd/esc/cli/client/retry.go
@@ -71,16 +71,12 @@ func doWithRetry(client *http.Client, req *http.Request, policy retryPolicy) (*h
 	// maximum delay is reached. Stop after maxRetryCount requests have
 	// been made.
 	opts := httputil.RetryOpts{
-		Delay:    ptr(time.Second),
-		Backoff:  ptr(float64(2.0)),
-		MaxDelay: ptr(30 * time.Second),
+		Delay:    new(time.Second),
+		Backoff:  new(float64(2.0)),
+		MaxDelay: new(30 * time.Second),
 
-		MaxRetryCount:         ptr(int(4)),
+		MaxRetryCount:         new(int(4)),
 		HandshakeTimeoutsOnly: !policy.shouldRetry(req),
 	}
 	return httputil.DoWithRetryOpts(req, client, opts)
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/pkg/cmd/esc/cli/env_settings_set.go
+++ b/pkg/cmd/esc/cli/env_settings_set.go
@@ -73,8 +73,7 @@ func newEnvSettingsSetCmd(env *envCommand, registry *EnvSettingsRegistry) *cobra
 
 			err = env.esc.client.PatchEnvironmentSettings(ctx, ref.orgName, ref.projectName, ref.envName, req)
 			if err != nil {
-				var errResp *apitype.ErrorResponse
-				if errors.As(err, &errResp) {
+				if errResp, ok := errors.AsType[*apitype.ErrorResponse](err); ok {
 					if errResp.Code == http.StatusForbidden {
 						return errors.New("permission denied: insufficient permissions to update settings")
 					}

--- a/pkg/cmd/esc/cli/style/dark_style.go
+++ b/pkg/cmd/esc/cli/style/dark_style.go
@@ -24,14 +24,14 @@ var Dark = ansi.StyleConfig{
 		StylePrimitive: ansi.StylePrimitive{
 			BlockPrefix: "\n",
 			BlockSuffix: "\n",
-			Color:       ptr("252"),
+			Color:       new("252"),
 		},
-		Margin: ptr(uint(2)),
+		Margin: new(uint(2)),
 	},
 	BlockQuote: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{},
-		Indent:         ptr(uint(1)),
-		IndentToken:    ptr("│ "),
+		Indent:         new(uint(1)),
+		IndentToken:    new("│ "),
 	},
 	List: ansi.StyleList{
 		LevelIndent: 2,
@@ -39,17 +39,17 @@ var Dark = ansi.StyleConfig{
 	Heading: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			BlockSuffix: "\n",
-			Color:       ptr("39"),
-			Bold:        ptr(true),
+			Color:       new("39"),
+			Bold:        new(true),
 		},
 	},
 	H1: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			Prefix:          " ",
 			Suffix:          " ",
-			Color:           ptr("228"),
-			BackgroundColor: ptr("63"),
-			Bold:            ptr(true),
+			Color:           new("228"),
+			BackgroundColor: new("63"),
+			Bold:            new(true),
 		},
 	},
 	H2: ansi.StyleBlock{
@@ -75,21 +75,21 @@ var Dark = ansi.StyleConfig{
 	H6: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			Prefix: "###### ",
-			Color:  ptr("35"),
-			Bold:   ptr(false),
+			Color:  new("35"),
+			Bold:   new(false),
 		},
 	},
 	Strikethrough: ansi.StylePrimitive{
-		CrossedOut: ptr(true),
+		CrossedOut: new(true),
 	},
 	Emph: ansi.StylePrimitive{
-		Italic: ptr(true),
+		Italic: new(true),
 	},
 	Strong: ansi.StylePrimitive{
-		Bold: ptr(true),
+		Bold: new(true),
 	},
 	HorizontalRule: ansi.StylePrimitive{
-		Color:  ptr("240"),
+		Color:  new("240"),
 		Format: "\n--------\n",
 	},
 	Item: ansi.StylePrimitive{
@@ -104,117 +104,117 @@ var Dark = ansi.StyleConfig{
 		Unticked:       "[ ] ",
 	},
 	Link: ansi.StylePrimitive{
-		Color:     ptr("30"),
-		Underline: ptr(true),
+		Color:     new("30"),
+		Underline: new(true),
 	},
 	LinkText: ansi.StylePrimitive{
-		Color: ptr("35"),
-		Bold:  ptr(true),
+		Color: new("35"),
+		Bold:  new(true),
 	},
 	Image: ansi.StylePrimitive{
-		Color:     ptr("212"),
-		Underline: ptr(true),
+		Color:     new("212"),
+		Underline: new(true),
 	},
 	ImageText: ansi.StylePrimitive{
-		Color:  ptr("243"),
+		Color:  new("243"),
 		Format: "Image: {{.text}} →",
 	},
 	Code: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			Prefix:          " ",
 			Suffix:          " ",
-			Color:           ptr("203"),
-			BackgroundColor: ptr("236"),
+			Color:           new("203"),
+			BackgroundColor: new("236"),
 		},
 	},
 	CodeBlock: ansi.StyleCodeBlock{
 		StyleBlock: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Color: ptr("244"),
+				Color: new("244"),
 			},
-			Margin: ptr(uint(2)),
+			Margin: new(uint(2)),
 		},
 		Chroma: &ansi.Chroma{
 			Text: ansi.StylePrimitive{
-				Color: ptr("#C4C4C4"),
+				Color: new("#C4C4C4"),
 			},
 			Error: ansi.StylePrimitive{
-				Color:           ptr("#F1F1F1"),
-				BackgroundColor: ptr("#F05B5B"),
+				Color:           new("#F1F1F1"),
+				BackgroundColor: new("#F05B5B"),
 			},
 			Comment: ansi.StylePrimitive{
-				Color: ptr("#676767"),
+				Color: new("#676767"),
 			},
 			CommentPreproc: ansi.StylePrimitive{
-				Color: ptr("#FF875F"),
+				Color: new("#FF875F"),
 			},
 			Keyword: ansi.StylePrimitive{
-				Color: ptr("#00AAFF"),
+				Color: new("#00AAFF"),
 			},
 			KeywordReserved: ansi.StylePrimitive{
-				Color: ptr("#FF5FD2"),
+				Color: new("#FF5FD2"),
 			},
 			KeywordNamespace: ansi.StylePrimitive{
-				Color: ptr("#FF5F87"),
+				Color: new("#FF5F87"),
 			},
 			KeywordType: ansi.StylePrimitive{
-				Color: ptr("#6E6ED8"),
+				Color: new("#6E6ED8"),
 			},
 			Operator: ansi.StylePrimitive{
-				Color: ptr("#EF8080"),
+				Color: new("#EF8080"),
 			},
 			Punctuation: ansi.StylePrimitive{
-				Color: ptr("#E8E8A8"),
+				Color: new("#E8E8A8"),
 			},
 			Name: ansi.StylePrimitive{
-				Color: ptr("#C4C4C4"),
+				Color: new("#C4C4C4"),
 			},
 			NameBuiltin: ansi.StylePrimitive{
-				Color: ptr("#FF8EC7"),
+				Color: new("#FF8EC7"),
 			},
 			NameTag: ansi.StylePrimitive{
-				Color: ptr("#B083EA"),
+				Color: new("#B083EA"),
 			},
 			NameAttribute: ansi.StylePrimitive{
-				Color: ptr("#7A7AE6"),
+				Color: new("#7A7AE6"),
 			},
 			NameClass: ansi.StylePrimitive{
-				Color:     ptr("#F1F1F1"),
-				Underline: ptr(true),
-				Bold:      ptr(true),
+				Color:     new("#F1F1F1"),
+				Underline: new(true),
+				Bold:      new(true),
 			},
 			NameDecorator: ansi.StylePrimitive{
-				Color: ptr("#FFFF87"),
+				Color: new("#FFFF87"),
 			},
 			NameFunction: ansi.StylePrimitive{
-				Color: ptr("#00D787"),
+				Color: new("#00D787"),
 			},
 			LiteralNumber: ansi.StylePrimitive{
-				Color: ptr("#6EEFC0"),
+				Color: new("#6EEFC0"),
 			},
 			LiteralString: ansi.StylePrimitive{
-				Color: ptr("#C69669"),
+				Color: new("#C69669"),
 			},
 			LiteralStringEscape: ansi.StylePrimitive{
-				Color: ptr("#AFFFD7"),
+				Color: new("#AFFFD7"),
 			},
 			GenericDeleted: ansi.StylePrimitive{
-				Color: ptr("#FD5B5B"),
+				Color: new("#FD5B5B"),
 			},
 			GenericEmph: ansi.StylePrimitive{
-				Italic: ptr(true),
+				Italic: new(true),
 			},
 			GenericInserted: ansi.StylePrimitive{
-				Color: ptr("#00D787"),
+				Color: new("#00D787"),
 			},
 			GenericStrong: ansi.StylePrimitive{
-				Bold: ptr(true),
+				Bold: new(true),
 			},
 			GenericSubheading: ansi.StylePrimitive{
-				Color: ptr("#777777"),
+				Color: new("#777777"),
 			},
 			Background: ansi.StylePrimitive{
-				BackgroundColor: ptr("#373737"),
+				BackgroundColor: new("#373737"),
 			},
 		},
 	},
@@ -222,9 +222,9 @@ var Dark = ansi.StyleConfig{
 		StyleBlock: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{},
 		},
-		CenterSeparator: ptr("┼"),
-		ColumnSeparator: ptr("│"),
-		RowSeparator:    ptr("─"),
+		CenterSeparator: new("┼"),
+		ColumnSeparator: new("│"),
+		RowSeparator:    new("─"),
 	},
 	DefinitionDescription: ansi.StylePrimitive{
 		BlockPrefix: "\n🠶 ",

--- a/pkg/cmd/esc/cli/style/light_style.go
+++ b/pkg/cmd/esc/cli/style/light_style.go
@@ -24,14 +24,14 @@ var Light = ansi.StyleConfig{
 		StylePrimitive: ansi.StylePrimitive{
 			BlockPrefix: "\n",
 			BlockSuffix: "\n",
-			Color:       ptr("234"),
+			Color:       new("234"),
 		},
-		Margin: ptr(uint(2)),
+		Margin: new(uint(2)),
 	},
 	BlockQuote: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{},
-		Indent:         ptr(uint(1)),
-		IndentToken:    ptr("│ "),
+		Indent:         new(uint(1)),
+		IndentToken:    new("│ "),
 	},
 	List: ansi.StyleList{
 		LevelIndent: 2,
@@ -39,17 +39,17 @@ var Light = ansi.StyleConfig{
 	Heading: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			BlockSuffix: "\n",
-			Color:       ptr("27"),
-			Bold:        ptr(true),
+			Color:       new("27"),
+			Bold:        new(true),
 		},
 	},
 	H1: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			Prefix:          " ",
 			Suffix:          " ",
-			Color:           ptr("228"),
-			BackgroundColor: ptr("63"),
-			Bold:            ptr(true),
+			Color:           new("228"),
+			BackgroundColor: new("63"),
+			Bold:            new(true),
 		},
 	},
 	H2: ansi.StyleBlock{
@@ -75,20 +75,20 @@ var Light = ansi.StyleConfig{
 	H6: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			Prefix: "###### ",
-			Bold:   ptr(false),
+			Bold:   new(false),
 		},
 	},
 	Strikethrough: ansi.StylePrimitive{
-		CrossedOut: ptr(true),
+		CrossedOut: new(true),
 	},
 	Emph: ansi.StylePrimitive{
-		Italic: ptr(true),
+		Italic: new(true),
 	},
 	Strong: ansi.StylePrimitive{
-		Bold: ptr(true),
+		Bold: new(true),
 	},
 	HorizontalRule: ansi.StylePrimitive{
-		Color:  ptr("249"),
+		Color:  new("249"),
 		Format: "\n--------\n",
 	},
 	Item: ansi.StylePrimitive{
@@ -103,117 +103,117 @@ var Light = ansi.StyleConfig{
 		Unticked:       "[ ] ",
 	},
 	Link: ansi.StylePrimitive{
-		Color:     ptr("36"),
-		Underline: ptr(true),
+		Color:     new("36"),
+		Underline: new(true),
 	},
 	LinkText: ansi.StylePrimitive{
-		Color: ptr("29"),
-		Bold:  ptr(true),
+		Color: new("29"),
+		Bold:  new(true),
 	},
 	Image: ansi.StylePrimitive{
-		Color:     ptr("205"),
-		Underline: ptr(true),
+		Color:     new("205"),
+		Underline: new(true),
 	},
 	ImageText: ansi.StylePrimitive{
-		Color:  ptr("243"),
+		Color:  new("243"),
 		Format: "Image: {{.text}} →",
 	},
 	Code: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
 			Prefix:          " ",
 			Suffix:          " ",
-			Color:           ptr("203"),
-			BackgroundColor: ptr("254"),
+			Color:           new("203"),
+			BackgroundColor: new("254"),
 		},
 	},
 	CodeBlock: ansi.StyleCodeBlock{
 		StyleBlock: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Color: ptr("242"),
+				Color: new("242"),
 			},
-			Margin: ptr(uint(2)),
+			Margin: new(uint(2)),
 		},
 		Chroma: &ansi.Chroma{
 			Text: ansi.StylePrimitive{
-				Color: ptr("#2A2A2A"),
+				Color: new("#2A2A2A"),
 			},
 			Error: ansi.StylePrimitive{
-				Color:           ptr("#F1F1F1"),
-				BackgroundColor: ptr("#FF5555"),
+				Color:           new("#F1F1F1"),
+				BackgroundColor: new("#FF5555"),
 			},
 			Comment: ansi.StylePrimitive{
-				Color: ptr("#8D8D8D"),
+				Color: new("#8D8D8D"),
 			},
 			CommentPreproc: ansi.StylePrimitive{
-				Color: ptr("#FF875F"),
+				Color: new("#FF875F"),
 			},
 			Keyword: ansi.StylePrimitive{
-				Color: ptr("#279EFC"),
+				Color: new("#279EFC"),
 			},
 			KeywordReserved: ansi.StylePrimitive{
-				Color: ptr("#FF5FD2"),
+				Color: new("#FF5FD2"),
 			},
 			KeywordNamespace: ansi.StylePrimitive{
-				Color: ptr("#FB406F"),
+				Color: new("#FB406F"),
 			},
 			KeywordType: ansi.StylePrimitive{
-				Color: ptr("#7049C2"),
+				Color: new("#7049C2"),
 			},
 			Operator: ansi.StylePrimitive{
-				Color: ptr("#FF2626"),
+				Color: new("#FF2626"),
 			},
 			Punctuation: ansi.StylePrimitive{
-				Color: ptr("#FA7878"),
+				Color: new("#FA7878"),
 			},
 			NameBuiltin: ansi.StylePrimitive{
-				Color: ptr("#0A1BB1"),
+				Color: new("#0A1BB1"),
 			},
 			NameTag: ansi.StylePrimitive{
-				Color: ptr("#581290"),
+				Color: new("#581290"),
 			},
 			NameAttribute: ansi.StylePrimitive{
-				Color: ptr("#8362CB"),
+				Color: new("#8362CB"),
 			},
 			NameClass: ansi.StylePrimitive{
-				Color:     ptr("#212121"),
-				Underline: ptr(true),
-				Bold:      ptr(true),
+				Color:     new("#212121"),
+				Underline: new(true),
+				Bold:      new(true),
 			},
 			NameConstant: ansi.StylePrimitive{
-				Color: ptr("#581290"),
+				Color: new("#581290"),
 			},
 			NameDecorator: ansi.StylePrimitive{
-				Color: ptr("#A3A322"),
+				Color: new("#A3A322"),
 			},
 			NameFunction: ansi.StylePrimitive{
-				Color: ptr("#019F57"),
+				Color: new("#019F57"),
 			},
 			LiteralNumber: ansi.StylePrimitive{
-				Color: ptr("#22CCAE"),
+				Color: new("#22CCAE"),
 			},
 			LiteralString: ansi.StylePrimitive{
-				Color: ptr("#7E5B38"),
+				Color: new("#7E5B38"),
 			},
 			LiteralStringEscape: ansi.StylePrimitive{
-				Color: ptr("#00AEAE"),
+				Color: new("#00AEAE"),
 			},
 			GenericDeleted: ansi.StylePrimitive{
-				Color: ptr("#FD5B5B"),
+				Color: new("#FD5B5B"),
 			},
 			GenericEmph: ansi.StylePrimitive{
-				Italic: ptr(true),
+				Italic: new(true),
 			},
 			GenericInserted: ansi.StylePrimitive{
-				Color: ptr("#00D787"),
+				Color: new("#00D787"),
 			},
 			GenericStrong: ansi.StylePrimitive{
-				Bold: ptr(true),
+				Bold: new(true),
 			},
 			GenericSubheading: ansi.StylePrimitive{
-				Color: ptr("#777777"),
+				Color: new("#777777"),
 			},
 			Background: ansi.StylePrimitive{
-				BackgroundColor: ptr("#373737"),
+				BackgroundColor: new("#373737"),
 			},
 		},
 	},
@@ -221,9 +221,9 @@ var Light = ansi.StyleConfig{
 		StyleBlock: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{},
 		},
-		CenterSeparator: ptr("┼"),
-		ColumnSeparator: ptr("│"),
-		RowSeparator:    ptr("─"),
+		CenterSeparator: new("┼"),
+		ColumnSeparator: new("│"),
+		RowSeparator:    new("─"),
 	},
 	DefinitionDescription: ansi.StylePrimitive{
 		BlockPrefix: "\n🠶 ",

--- a/pkg/cmd/esc/cli/style/style.go
+++ b/pkg/cmd/esc/cli/style/style.go
@@ -22,10 +22,6 @@ import (
 	"github.com/muesli/termenv"
 )
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func Glamour(w io.Writer, options ...glamour.TermRendererOption) (*glamour.TermRenderer, error) {
 	opts := make([]glamour.TermRendererOption, 0, 2+len(options))
 	opts = append(opts, glamour.WithStyles(Default()), glamour.WithColorProfile(Profile(w)))

--- a/pkg/cmd/pulumi/cmd/exit_codes.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes.go
@@ -74,8 +74,7 @@ func ExitCodeFor(err error) int {
 	// / etc.) reaches the shell instead of collapsing to the generic bail
 	// default. Checked before the bail branch because processCmdErrors
 	// wraps these in a BailError to suppress double-printing the message.
-	var apiErr *cloud.APIError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*cloud.APIError](err); ok {
 		return apiErr.ExitCode
 	}
 

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -418,8 +418,7 @@ func prepareNeoRuntime(ctx context.Context, stderr io.Writer, cwdFlag string) (*
 		return nil, err
 	}
 	cloudBe, err := resolveNeoCloudBackend(ctx, be)
-	var upgradeErr neoUpgradeRequiredError
-	if errors.As(err, &upgradeErr) {
+	if upgradeErr, ok := errors.AsType[neoUpgradeRequiredError](err); ok {
 		// Print the upgrade message bare (no "error:" prefix) and bail.
 		return nil, result.FprintBailf(stderr, "%s", upgradeErr.msg)
 	}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -192,12 +192,10 @@ func isTransientStreamError(err error) bool {
 	if errors.As(err, &ne) && ne.Timeout() {
 		return true
 	}
-	var ue *url.Error
-	if errors.As(err, &ue) {
+	if ue, ok := errors.AsType[*url.Error](err); ok {
 		return !errors.Is(ue.Err, context.Canceled)
 	}
-	var streamErr http2.StreamError
-	if errors.As(err, &streamErr) {
+	if streamErr, ok := errors.AsType[http2.StreamError](err); ok {
 		if streamErr.Code == http2.ErrCodeInternal ||
 			streamErr.Code == http2.ErrCodeCancel ||
 			streamErr.Code == http2.ErrCodeRefusedStream {

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -226,8 +226,7 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 		Truncated: stdout.truncated || stderr.truncated,
 	}
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			res.ExitCode = exitErr.ExitCode()
 		} else {
 			res.Err = err.Error()

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -681,10 +681,6 @@ func TestParseImportFileUnknownValues(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func TestMakeImportFileFromResourceListInputsOutputs(t *testing.T) {
 	t.Parallel()
 
@@ -693,10 +689,11 @@ func TestMakeImportFileFromResourceListInputsOutputs(t *testing.T) {
 			Type: "aws:s3/bucket:Bucket",
 			Name: "thing",
 			ID:   "thing-id",
-			Inputs: ptr(property.NewMap(map[string]property.Value{
+			Inputs: new(property.NewMap(map[string]property.Value{
 				"password": property.New("shh").WithSecret(true),
 			})),
-			Outputs: ptr(property.NewMap(map[string]property.Value{
+
+			Outputs: new(property.NewMap(map[string]property.Value{
 				"arn": property.New("some:arn"),
 			})),
 		},

--- a/pkg/cmd/pulumi/org/org_member_edit_test.go
+++ b/pkg/cmd/pulumi/org/org_member_edit_test.go
@@ -113,7 +113,7 @@ func TestOrgMemberEdit_DefaultOutput_RoleOnly(t *testing.T) {
 		{
 			org:       "acme",
 			userLogin: "alice",
-			req:       apitype.UpdateOrganizationMemberRequest{Role: ptr("admin")},
+			req:       apitype.UpdateOrganizationMemberRequest{Role: new("admin")},
 		},
 	}, c.updateCalls)
 
@@ -154,8 +154,8 @@ func TestOrgMemberEdit_JSONOutput_BothFlags(t *testing.T) {
 			org:       "acme",
 			userLogin: "alice",
 			req: apitype.UpdateOrganizationMemberRequest{
-				Role:      ptr("admin"),
-				FgaRoleId: ptr("role-abc"),
+				Role:      new("admin"),
+				FgaRoleId: new("role-abc"),
 			},
 		},
 	}, c.updateCalls)

--- a/pkg/cmd/pulumi/org/org_usage_test.go
+++ b/pkg/cmd/pulumi/org/org_usage_test.go
@@ -59,22 +59,20 @@ func stubUsageFactory(c orgUsageGetClient, resolvedOrg string) orgUsageGetClient
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func sampleDailyUsage() apitype.OrgUsageSummaryResponse {
 	return apitype.OrgUsageSummaryResponse{
 		Summary: []apitype.OrgResourceCountSummary{
 			{
 				Year:          2026,
-				Month:         ptr(5),
-				Day:           ptr(1),
+				Month:         new(5),
+				Day:           new(1),
 				Resources:     1200,
 				ResourceHours: 28800,
 			},
 			{
 				Year:          2026,
-				Month:         ptr(5),
-				Day:           ptr(2),
+				Month:         new(5),
+				Day:           new(2),
 				Resources:     1300,
 				ResourceHours: 31200,
 			},
@@ -166,9 +164,9 @@ func TestOrgUsageGet_HourlyColumns(t *testing.T) {
 	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{
 		Summary: []apitype.OrgResourceCountSummary{{
 			Year:          2026,
-			Month:         ptr(5),
-			Day:           ptr(14),
-			Hour:          ptr(13),
+			Month:         new(5),
+			Day:           new(14),
+			Hour:          new(13),
 			Resources:     50,
 			ResourceHours: 50,
 		}},

--- a/pkg/cmd/pulumi/org/org_webhook_list_test.go
+++ b/pkg/cmd/pulumi/org/org_webhook_list_test.go
@@ -46,7 +46,7 @@ func sampleOrgWebhooks() []apitype.Webhook {
 			DisplayName:      "Deploy Hook",
 			PayloadURL:       "https://example.com/webhook",
 			Active:           true,
-			Format:           ptr("raw"),
+			Format:           new("raw"),
 			Groups:           []string{"stacks", "deployments"},
 			Filters:          []string{"stack_created"},
 		},
@@ -56,7 +56,7 @@ func sampleOrgWebhooks() []apitype.Webhook {
 			DisplayName:      "Slack Alerts",
 			PayloadURL:       "https://hooks.slack.com/T00",
 			Active:           false,
-			Format:           ptr("slack"),
+			Format:           new("slack"),
 		},
 	}
 }

--- a/pkg/cmd/pulumi/packagecmd/package_add_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add_test.go
@@ -36,8 +36,6 @@ import (
 func TestLoadEnclosingTarget(t *testing.T) {
 	t.Parallel()
 
-	ptr := func(s string) *string { return &s }
-
 	tests := []struct {
 		name  string
 		files map[string]string
@@ -54,7 +52,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			wd: ".",
 			expected: addTarget{
 				installRoot:     ".",
-				projectFilePath: ptr("PulumiPlugin.yaml"),
+				projectFilePath: new("PulumiPlugin.yaml"),
 				proj: &workspace.PluginProject{
 					Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
 				},
@@ -68,7 +66,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			wd: "subdir/nested",
 			expected: addTarget{
 				installRoot:     ".",
-				projectFilePath: ptr("PulumiPlugin.yaml"),
+				projectFilePath: new("PulumiPlugin.yaml"),
 				proj: &workspace.PluginProject{
 					Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
 				},
@@ -82,7 +80,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			wd: ".",
 			expected: addTarget{
 				installRoot:     ".",
-				projectFilePath: ptr("Pulumi.yaml"),
+				projectFilePath: new("Pulumi.yaml"),
 				proj: &workspace.Project{
 					Name:    "test-project",
 					Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
@@ -97,7 +95,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			wd: "nested/deep/subdir",
 			expected: addTarget{
 				installRoot:     ".",
-				projectFilePath: ptr("Pulumi.yaml"),
+				projectFilePath: new("Pulumi.yaml"),
 				proj: &workspace.Project{
 					Name:    "test-project",
 					Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
@@ -113,7 +111,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			wd: "plugin/subdir",
 			expected: addTarget{
 				installRoot:     "plugin",
-				projectFilePath: ptr("plugin/PulumiPlugin.yaml"),
+				projectFilePath: new("plugin/PulumiPlugin.yaml"),
 				proj: &workspace.PluginProject{
 					Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
 				},
@@ -128,7 +126,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			wd: "project/subdir",
 			expected: addTarget{
 				installRoot:     "project",
-				projectFilePath: ptr("project/Pulumi.yaml"),
+				projectFilePath: new("project/Pulumi.yaml"),
 				proj: &workspace.Project{
 					Name:    "test-project",
 					Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
@@ -175,7 +173,7 @@ func TestLoadEnclosingTarget(t *testing.T) {
 			actual.reg = nil
 			tt.expected.installRoot = filepath.Join(root, tt.expected.installRoot)
 			require.NotNil(t, tt.expected.projectFilePath)
-			tt.expected.projectFilePath = ptr(filepath.Join(root, *tt.expected.projectFilePath))
+			tt.expected.projectFilePath = new(filepath.Join(root, *tt.expected.projectFilePath))
 			if p, ok := actual.proj.(*workspace.Project); ok {
 				// Create a copy of actual.proj up to private keys. This
 				// way, we get a clean comparison.

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -84,8 +84,7 @@ func InstallPackage(stdout io.Writer, ws pkgWorkspace.Context, proj workspace.Ba
 	pkgSpec, specOverride, err := SchemaFromSchemaSource(ws, pctx, schemaSource, parameters, registry, e, concurrency,
 		asExtension, pluginDownloadURL)
 	if err != nil {
-		var diagErr hcl.Diagnostics
-		if errors.As(err, &diagErr) {
+		if diagErr, ok := errors.AsType[hcl.Diagnostics](err); ok {
 			return nil, nil, nil, fmt.Errorf("failed to get schema. Diagnostics: %w", errors.Join(diagErr.Errs()...))
 		}
 		return nil, nil, nil, fmt.Errorf("failed to get schema: %w", err)

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -404,8 +404,7 @@ func (cmd *pluginInstallCmd) resolvePluginSpec(
 			AllowNonInvertableLocalWorkspaceResolution: cmd.reinstall,
 		})
 	if err != nil {
-		var packageNotFoundErr *packageresolution.PackageNotFoundError
-		if errors.As(err, &packageNotFoundErr) {
+		if packageNotFoundErr, ok := errors.AsType[*packageresolution.PackageNotFoundError](err); ok {
 			for _, suggested := range packageNotFoundErr.Suggestions() {
 				cmd.diag.Infof(diag.Message("", "%s/%s/%s@%s is a similar package"),
 					suggested.Source, suggested.Publisher, suggested.Name,

--- a/pkg/cmd/pulumi/plugin/plugin_list.go
+++ b/pkg/cmd/pulumi/plugin/plugin_list.go
@@ -104,10 +104,6 @@ type pluginInfoJSON struct {
 }
 
 func formatPluginsJSON(w io.Writer, plugins []workspace.PluginInfo) error {
-	makeStringRef := func(s string) *string {
-		return &s
-	}
-
 	jsonPluginInfo := make([]pluginInfoJSON, len(plugins))
 	for idx, plugin := range plugins {
 		var version string
@@ -127,11 +123,11 @@ func formatPluginsJSON(w io.Writer, plugins []workspace.PluginInfo) error {
 		}
 
 		if !installTime.IsZero() {
-			jsonPluginInfo[idx].InstallTime = makeStringRef(cmd.FormatTime(installTime.UTC()))
+			jsonPluginInfo[idx].InstallTime = new(cmd.FormatTime(installTime.UTC()))
 		}
 
 		if !lastUsedTime.IsZero() {
-			jsonPluginInfo[idx].LastUsedTime = makeStringRef(cmd.FormatTime(lastUsedTime.UTC()))
+			jsonPluginInfo[idx].LastUsedTime = new(cmd.FormatTime(lastUsedTime.UTC()))
 		}
 	}
 

--- a/pkg/cmd/pulumi/policy/policy_group_edit_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit_test.go
@@ -77,8 +77,6 @@ func failingPolicyGroupEditFactory(err error) policyGroupEditClientFactory {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func TestPolicyGroupEdit_RenameOnly_DefaultOutput(t *testing.T) {
 	t.Parallel()
 
@@ -102,7 +100,7 @@ func TestPolicyGroupEdit_RenameOnly_DefaultOutput(t *testing.T) {
 	// Rename-only does not touch any list, so the pre-edit GET is skipped.
 	assert.Equal(t, 1, c.getCalls)
 	assert.Equal(t, []apitype.UpdatePolicyGroupRequest{
-		{NewName: ptr("production")},
+		{NewName: new("production")},
 	}, c.updates)
 	assert.Equal(t, []string{"prod-policies"}, c.updateGroups)
 	assert.Equal(t, "acme", c.gotGetOrg)
@@ -162,7 +160,7 @@ func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 	// A single batched PATCH with the rename and the full replacement lists.
 	require.Len(t, c.updates, 1)
 	got := c.updates[0]
-	assert.Equal(t, ptr("production"), got.NewName)
+	assert.Equal(t, new("production"), got.NewName)
 
 	require.NotNil(t, got.Stacks)
 	assert.Equal(t, []apitype.PulumiStackReference{

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1098,8 +1098,6 @@ Available Templates:
 	assert.Equal(t, "", stderr.String())
 }
 
-func ptr[T any](v T) *T { return &v }
-
 // singlePage answers a template listing with one page holding the given templates.
 func singlePage(templates ...apitype.TemplateMetadata) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
@@ -1116,9 +1114,9 @@ func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 				ctx context.Context, opts registry.ListTemplatesOptions,
 			) iter.Seq2[apitype.ListTemplatesResponse, error] {
 				return singlePage(apitype.TemplateMetadata{
-					Name: "template-1", Description: ptr("Describe 1"), Publisher: "Some org",
+					Name: "template-1", Description: new("Describe 1"), Publisher: "Some org",
 				}, apitype.TemplateMetadata{
-					Name: "template-2", Description: ptr("Describe 2"), RepoSlug: ptr("some-org/repo"), Source: "github",
+					Name: "template-2", Description: new("Describe 2"), RepoSlug: new("some-org/repo"), Source: "github",
 				})
 			},
 		},

--- a/pkg/cmd/pulumi/schemainfo/description.go
+++ b/pkg/cmd/pulumi/schemainfo/description.go
@@ -26,8 +26,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 // helpWrapWidth is the column at which description text is wrapped.
 const helpWrapWidth = 80
 
@@ -46,7 +44,7 @@ var markerReplacer = strings.NewReplacer(linkStartMarker, "", linkEndMarker, "")
 func helpMarkdownStyle(styled bool) ansi.StyleConfig {
 	style := ansi.StyleConfig{
 		Document:   ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{BlockSuffix: "\n"}},
-		BlockQuote: ansi.StyleBlock{Indent: ptr(uint(1)), IndentToken: ptr("│ ")},
+		BlockQuote: ansi.StyleBlock{Indent: new(uint(1)), IndentToken: new("│ ")},
 		Paragraph:  ansi.StyleBlock{},
 		List:       ansi.StyleList{LevelIndent: 2},
 		// glamour only applies the URL's block prefix and suffix when the link has separate text,
@@ -60,12 +58,12 @@ func helpMarkdownStyle(styled bool) ansi.StyleConfig {
 		style.Code = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{BlockPrefix: "`", BlockSuffix: "`"}}
 		return style
 	}
-	style.Heading = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Bold: ptr(true)}}
-	style.Strong = ansi.StylePrimitive{Bold: ptr(true)}
-	style.Emph = ansi.StylePrimitive{Italic: ptr(true)}
-	style.Link.Underline = ptr(true)
-	style.LinkText.Bold = ptr(true)
-	style.Code = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Bold: ptr(true), Italic: ptr(true)}}
+	style.Heading = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Bold: new(true)}}
+	style.Strong = ansi.StylePrimitive{Bold: new(true)}
+	style.Emph = ansi.StylePrimitive{Italic: new(true)}
+	style.Link.Underline = new(true)
+	style.LinkText.Bold = new(true)
+	style.Code = ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{Bold: new(true), Italic: new(true)}}
 	return style
 }
 

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -167,10 +167,6 @@ type configValueJSON struct {
 }
 
 func buildUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter) ([]updateInfoJSON, error) {
-	makeStringRef := func(s string) *string {
-		return &s
-	}
-
 	updatesJSON := make([]updateInfoJSON, len(updates))
 	for idx, update := range updates {
 		info := updateInfoJSON{
@@ -191,9 +187,9 @@ func buildUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter) 
 				if err != nil {
 					// We don't actually want to error here
 					// we are just going to mark as "UNKNOWN" and then let the command continue
-					configValue.Value = makeStringRef(errorDecryptingValue)
+					configValue.Value = new(errorDecryptingValue)
 				} else {
-					configValue.Value = makeStringRef(value)
+					configValue.Value = new(value)
 
 					if value != "" && v.Object() {
 						var obj any
@@ -208,7 +204,7 @@ func buildUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter) 
 		}
 		info.Result = string(update.Result)
 		if update.Result != backend.InProgressResult {
-			info.EndTime = makeStringRef(cmd.FormatTime(time.Unix(update.EndTime, 0).UTC()))
+			info.EndTime = new(cmd.FormatTime(time.Unix(update.EndTime, 0).UTC()))
 			resourceChanges := make(map[string]int)
 			for k, v := range update.ResourceChanges {
 				resourceChanges[string(k)] = v

--- a/pkg/cmd/pulumi/stack/stack_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_list_test.go
@@ -37,10 +37,6 @@ import (
 func TestParseTagFilter(t *testing.T) {
 	t.Parallel()
 
-	p := func(s string) *string {
-		return &s
-	}
-
 	tests := []struct {
 		Filter    string
 		WantName  string
@@ -53,14 +49,14 @@ func TestParseTagFilter(t *testing.T) {
 		{Filter: "tag-name123", WantName: "tag-name123"},
 
 		// Tag name and value
-		{Filter: "tag-name123=tag value", WantName: "tag-name123", WantValue: p("tag value")},
-		{Filter: "tag-name123=tag value:with-colon", WantName: "tag-name123", WantValue: p("tag value:with-colon")},
-		{Filter: "tag-name123=tag value=with-equal", WantName: "tag-name123", WantValue: p("tag value=with-equal")},
+		{Filter: "tag-name123=tag value", WantName: "tag-name123", WantValue: new("tag value")},
+		{Filter: "tag-name123=tag value:with-colon", WantName: "tag-name123", WantValue: new("tag value:with-colon")},
+		{Filter: "tag-name123=tag value=with-equal", WantName: "tag-name123", WantValue: new("tag value=with-equal")},
 
 		// Degenerate cases
-		{Filter: "=", WantName: "", WantValue: p("")},
-		{Filter: "no tag value=", WantName: "no tag value", WantValue: p("")},
-		{Filter: "=no tag name", WantName: "", WantValue: p("no tag name")},
+		{Filter: "=", WantName: "", WantValue: new("")},
+		{Filter: "no tag value=", WantName: "no tag value", WantValue: new("")},
+		{Filter: "=no tag name", WantName: "", WantValue: new("no tag name")},
 	}
 
 	for _, test := range tests {
@@ -76,10 +72,6 @@ func TestParseTagFilter(t *testing.T) {
 			}
 		}
 	}
-}
-
-func newContToken(s string) backend.ContinuationToken {
-	return &s
 }
 
 // mockStackSummary implements the backend.StackSummary interface.
@@ -129,13 +121,13 @@ func TestListStacksPagination(t *testing.T) {
 			summaries: []backend.StackSummary{
 				&mockStackSummary{name: "stack-in-page-1"},
 			},
-			outContToken: newContToken("first-cont-token-response"),
+			outContToken: new("first-cont-token-response"),
 		},
 
 		// Pages 2 and 3. We don't expect a backend to return a nil result of StackSummary objects,
 		// but we do expect the situation to be handled gracefully by the CLI.
-		{nil, newContToken("second-cont-token-response")},
-		{[]backend.StackSummary{}, newContToken("third-cont-token-response")},
+		{nil, new("second-cont-token-response")},
+		{[]backend.StackSummary{}, new("third-cont-token-response")},
 
 		// Page 4.
 		{

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -85,8 +85,7 @@ func newStackSelectCmd() *cobra.Command {
 
 				s, stackErr := b.GetStack(ctx, stackRef)
 				if stackErr != nil {
-					var notFound backenderr.NotFoundError
-					if errors.As(stackErr, &notFound) {
+					if _, ok := errors.AsType[backenderr.NotFoundError](stackErr); ok {
 						return backenderr.StackNotFoundError{StackName: stackRef.String()}
 					}
 					return stackErr

--- a/pkg/cmd/pulumi/stack/stack_webhook_edit_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_edit_test.go
@@ -58,13 +58,13 @@ func stubEditFactory(c stackWebhookEditClient) stackWebhookEditClientFactory {
 func existingWebhook() apitype.Webhook {
 	return apitype.Webhook{
 		OrganizationName: "my-org",
-		ProjectName:      ptr("my-project"),
-		StackName:        ptr("dev"),
+		ProjectName:      new("my-project"),
+		StackName:        new("dev"),
 		Name:             "my-hook",
 		DisplayName:      "My Hook",
 		PayloadURL:       "https://example.com/webhook",
 		Active:           true,
-		Format:           ptr("raw"),
+		Format:           new("raw"),
 		Groups:           []string{"stacks"},
 		Filters:          []string{"deployment_queued"},
 		HasSecret:        true,

--- a/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
@@ -43,13 +43,13 @@ func (m *mockWebhookGetClient) GetStackWebhook(
 func sampleWebhook() apitype.Webhook {
 	return apitype.Webhook{
 		OrganizationName: "my-org",
-		ProjectName:      ptr("my-project"),
-		StackName:        ptr("dev"),
+		ProjectName:      new("my-project"),
+		StackName:        new("dev"),
 		Name:             "deploy-hook",
 		DisplayName:      "Deploy Hook",
 		PayloadURL:       "https://example.com/webhook",
 		Active:           true,
-		Format:           ptr("raw"),
+		Format:           new("raw"),
 		Groups:           []string{"stacks"},
 		Filters:          []string{"stack_update"},
 		HasSecret:        true,

--- a/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
@@ -55,8 +55,6 @@ func failingFactory(err error) stackWebhookListClientFactory {
 	}
 }
 
-func ptr(s string) *string { return &s }
-
 func sampleWebhooks() []apitype.Webhook {
 	return []apitype.Webhook{
 		{
@@ -65,7 +63,7 @@ func sampleWebhooks() []apitype.Webhook {
 			DisplayName:      "Deploy Hook",
 			PayloadURL:       "https://example.com/webhook",
 			Active:           true,
-			Format:           ptr("raw"),
+			Format:           new("raw"),
 			Groups:           []string{"stacks"},
 			Filters:          []string{"stack_update"},
 		},
@@ -75,7 +73,7 @@ func sampleWebhooks() []apitype.Webhook {
 			DisplayName:      "Slack Notifications",
 			PayloadURL:       "https://hooks.slack.com/services/T00/B00/xxx",
 			Active:           false,
-			Format:           ptr("slack"),
+			Format:           new("slack"),
 			Groups:           []string{"stacks", "deployments"},
 			Filters:          []string{"stack_update", "drift_detected"},
 		},

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -56,13 +56,13 @@ func failingNewFactory(err error) stackWebhookNewClientFactory {
 func createdWebhook() apitype.Webhook {
 	return apitype.Webhook{
 		OrganizationName: "my-org",
-		ProjectName:      ptr("my-project"),
-		StackName:        ptr("dev"),
+		ProjectName:      new("my-project"),
+		StackName:        new("dev"),
 		Name:             "my-hook",
 		DisplayName:      "My Hook",
 		PayloadURL:       "https://example.com/webhook",
 		Active:           true,
-		Format:           ptr("raw"),
+		Format:           new("raw"),
 		HasSecret:        true,
 	}
 }

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -60,8 +60,7 @@ func parseTemplateURL(templateName string) (*registry.URLInfo, error) {
 	if registry.IsRegistryURL(templateName) {
 		urlInfo, err := registry.ParseRegistryURL(templateName)
 		if err != nil {
-			var invalidRegistryURL *registry.InvalidRegistryURLError
-			if errors.As(err, &invalidRegistryURL) {
+			if invalidRegistryURL, ok := errors.AsType[*registry.InvalidRegistryURLError](err); ok {
 				// Wrap this particular error reason because formats other than the
 				// full registry:// URL format are supported by `pulumi new`.
 				if strings.Contains(invalidRegistryURL.Reason, "expected format") {
@@ -80,8 +79,7 @@ func parseTemplateURL(templateName string) (*registry.URLInfo, error) {
 	// 2. Try parsing as a partial registry URL
 	urlInfo, err := registry.ParsePartialRegistryURL(templateName, "templates")
 	if err != nil {
-		var missingVersion *registry.MissingVersionAfterAtSignError
-		if errors.As(err, &missingVersion) {
+		if _, ok := errors.AsType[*registry.MissingVersionAfterAtSignError](err); ok {
 			return nil, err
 		}
 

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -661,12 +661,12 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 						Name:      "gh-org/repo/name",
 						Source:    "github",
 						Publisher: "pulumi-org",
-						RepoSlug:  ptr("gh-org/repo"),
+						RepoSlug:  new("gh-org/repo"),
 					}, {
 						Name:      "gl-org/repo/name",
 						Source:    "gitlab",
 						Publisher: "pulumi-org",
-						RepoSlug:  ptr("gl-org/repo"),
+						RepoSlug:  new("gl-org/repo"),
 					}},
 				}
 				require.Len(t, opts.Backing, 1)
@@ -763,7 +763,7 @@ func TestBothFetchesListingEverythingIsNotDuplicated(t *testing.T) {
 	) iter.Seq2[apitype.ListTemplatesResponse, error] {
 		return singlePage(
 			apitype.TemplateMetadata{Name: "vpc", Source: "private", Publisher: "acme"},
-			apitype.TemplateMetadata{Name: "org/repo/eks", Source: "github", Publisher: "acme", RepoSlug: ptr("org/repo")},
+			apitype.TemplateMetadata{Name: "org/repo/eks", Source: "github", Publisher: "acme", RepoSlug: new("org/repo")},
 		)
 	})
 
@@ -786,18 +786,18 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 				return singlePage(apitype.TemplateMetadata{
 					Name:        "gh-org/repo/target",
 					Source:      "github",
-					Description: ptr("This is from GH"),
+					Description: new("This is from GH"),
 					Publisher:   "pulumi-org",
-					RepoSlug:    ptr("gh-org/repo"),
+					RepoSlug:    new("gh-org/repo"),
 				}, apitype.TemplateMetadata{
 					Name:      "gl-org/repo/name",
 					Source:    "gitlab",
 					Publisher: "pulumi-org",
-					RepoSlug:  ptr("gl-org/repo"),
+					RepoSlug:  new("gl-org/repo"),
 				}, apitype.TemplateMetadata{
 					Name:        "target",
 					Source:      "private",
-					Description: ptr("This is from the registry"),
+					Description: new("This is from the registry"),
 					Publisher:   "pulumi-org",
 				})
 			},
@@ -853,8 +853,6 @@ func testContext(t *testing.T) context.Context {
 	return ctx
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func singlePage(templates ...apitype.TemplateMetadata) iter.Seq2[apitype.ListTemplatesResponse, error] {
 	return func(yield func(apitype.ListTemplatesResponse, error) bool) {
 		yield(apitype.ListTemplatesResponse{Templates: templates}, nil)
@@ -874,7 +872,7 @@ func TestRegistryTemplateResolution(t *testing.T) {
 					Name:        "csharp-documented",
 					Source:      "private",
 					Publisher:   "pulumi_local",
-					Description: ptr("A C# template"),
+					Description: new("A C# template"),
 				}, apitype.TemplateMetadata{
 					Name:      "csharp-documented",
 					Source:    "github",
@@ -883,13 +881,13 @@ func TestRegistryTemplateResolution(t *testing.T) {
 					Name:        "gh-org/repo/target",
 					Source:      "github",
 					Publisher:   "pulumi-org",
-					RepoSlug:    ptr("gh-org/repo"),
-					Description: ptr("A template from VCS"),
+					RepoSlug:    new("gh-org/repo"),
+					Description: new("A template from VCS"),
 				}, apitype.TemplateMetadata{
 					Name:        "whatever-template",
 					Source:      "private",
 					Publisher:   "test-org",
-					Description: ptr("A template with special chars"),
+					Description: new("A template with special chars"),
 				})
 			},
 		},
@@ -1081,7 +1079,7 @@ func TestVersionedTemplateResolution(t *testing.T) {
 						Name:        name,
 						Source:      source,
 						Publisher:   publisher,
-						Description: ptr("A versioned template"),
+						Description: new("A versioned template"),
 					}, nil
 				}
 				return apitype.TemplateMetadata{}, backenderr.NotFoundError{}
@@ -1093,7 +1091,7 @@ func TestVersionedTemplateResolution(t *testing.T) {
 					Name:        "my-template",
 					Source:      "private",
 					Publisher:   "my-org",
-					Description: ptr("Latest version"),
+					Description: new("Latest version"),
 				})
 			},
 		},

--- a/pkg/codegen/convert/base_plugin_mapper_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_test.go
@@ -80,7 +80,7 @@ func TestBasePluginMapper_InstalledPluginMatches(t *testing.T) {
 			{
 				Name:    "provider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -133,7 +133,7 @@ func TestBasePluginMapper_EcosystemOverridesConversionKey(t *testing.T) {
 			{
 				Name:    "provider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -185,7 +185,7 @@ func TestBasePluginMapper_MappedNameDiffersFromPulumiName(t *testing.T) {
 			{
 				Name:    "pulumiProvider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -247,7 +247,7 @@ func TestBasePluginMapper_NoPluginMatches_ButCanBeInstalled(t *testing.T) {
 			{
 				Name:    "pulumiProvider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -308,12 +308,12 @@ func TestBasePluginMapper_UseMatchingNameFirst(t *testing.T) {
 			{
 				Name:    "otherProvider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 			{
 				Name:    "provider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -367,12 +367,12 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiName(t *testing.T) {
 			{
 				Name:    "pulumiProviderAws",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 			{
 				Name:    "pulumiProviderGcp",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -462,12 +462,12 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithHint(t *testing.T) 
 			{
 				Name:    "pulumiProviderAws",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 			{
 				Name:    "pulumiProviderGcp",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -524,12 +524,12 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithParameterizedHint(t
 			{
 				Name:    "pulumiProviderAws",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 			{
 				Name:    "terraform-provider",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -596,7 +596,7 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithUnusableParameteriz
 			{
 				Name:    "pulumiProviderAws",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -659,7 +659,7 @@ func TestBasePluginMapper_InfiniteLoopRegression(t *testing.T) {
 			{
 				Name:    "pulumiProviderAws",
 				Kind:    apitype.ResourcePlugin,
-				Version: semverMustParse("1.0.0"),
+				Version: new(semver.MustParse("1.0.0")),
 			},
 		},
 	}
@@ -751,9 +751,4 @@ func (prov *testProvider) GetMappings(
 	}
 	keys, err := prov.GetMappingsF(req.Key)
 	return plugin.GetMappingsResponse{Keys: keys}, err
-}
-
-func semverMustParse(s string) *semver.Version {
-	v := semver.MustParse(s)
-	return &v
 }

--- a/pkg/codegen/docs_integration_test.go
+++ b/pkg/codegen/docs_integration_test.go
@@ -239,7 +239,7 @@ func TestGetTypeName(t *testing.T) {
 			name:   "object",
 			schema: schema1,
 			typ:    mustToken(t, schema1.Types().Get, "pkg:index:simpleType"),
-			input:  ptr(true),
+			input:  new(true),
 
 			expected: map[language]string{
 				golang: "SimpleType",
@@ -251,7 +251,7 @@ func TestGetTypeName(t *testing.T) {
 			name:   "object",
 			schema: schema1,
 			typ:    mustToken(t, schema1.Types().Get, "pkg:index:simpleType"),
-			input:  ptr(false),
+			input:  new(false),
 
 			expected: map[language]string{
 				golang: "SimpleType",
@@ -263,7 +263,7 @@ func TestGetTypeName(t *testing.T) {
 			name:   "map-of-object",
 			schema: schema1,
 			typ:    &schema.MapType{ElementType: mustToken(t, schema1.Types().Get, "pkg:index:simpleType")},
-			input:  ptr(false),
+			input:  new(false),
 
 			expected: map[language]string{
 				golang: "map[string]SimpleType",
@@ -275,7 +275,7 @@ func TestGetTypeName(t *testing.T) {
 			name:   "module-object",
 			schema: schema1,
 			typ:    mustToken(t, schema1.Types().Get, "pkg:module:anotherType"),
-			input:  ptr(true),
+			input:  new(true),
 
 			expected: map[language]string{
 				golang: "module.AnotherType",
@@ -287,7 +287,7 @@ func TestGetTypeName(t *testing.T) {
 			name:   "module-object-from-module",
 			schema: schema1,
 			typ:    mustToken(t, schema1.Types().Get, "pkg:module:anotherType"),
-			input:  ptr(true),
+			input:  new(true),
 			module: "module",
 
 			expected: map[language]string{
@@ -312,7 +312,7 @@ func TestGetTypeName(t *testing.T) {
 			schema: schemaWithOverrides,
 			typ:    mustToken(t, schemaWithOverrides.Types().Get, "pkg:shouldoverride:simpleType"),
 			module: schemaWithOverrides.TokenToModule("pkg:shouldoverride:simpleType"),
-			input:  ptr(true),
+			input:  new(true),
 			expected: map[language]string{
 				golang: "SimpleType",
 				nodejs: "overridden.SimpleType",
@@ -323,7 +323,7 @@ func TestGetTypeName(t *testing.T) {
 			name:   "overridden-names",
 			schema: schemaWithOverrides,
 			typ:    mustToken(t, schemaWithOverrides.Types().Get, "pkg:shouldoverride:simpleType"),
-			input:  ptr(false),
+			input:  new(false),
 			expected: map[language]string{
 				golang: "overridden.SimpleType",
 				nodejs: "overridden.SimpleType",
@@ -830,8 +830,6 @@ func mustToken[T any](t *testing.T, get func(string) (T, bool, error), token str
 	require.True(t, ok)
 	return v
 }
-
-func ptr[T any](v T) *T { return &v }
 
 func marshalIntoRaw(t *testing.T, v any) schema.RawMessage {
 	b, err := json.Marshal(v)

--- a/pkg/engine/lifecycletest/destroy_test.go
+++ b/pkg/engine/lifecycletest/destroy_test.go
@@ -1224,7 +1224,7 @@ func TestDestroyV2TargetChildWithNewParent(t *testing.T) {
 		require.NoError(t, err)
 
 		res1, err := monitor.RegisterResource("pkgA:m:typA", "future-parent", false, deploytest.ResourceOptions{
-			RetainOnDelete: ptr(true),
+			RetainOnDelete: new(true),
 			Provider:       prov0Ref.String(),
 		})
 		require.NoError(t, err)

--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -738,10 +738,10 @@ func writeResourceRegistrationStatements(t require.TestingT, rs []*ResourceSpec)
 					}
 
 					if r.Protect {
-						g.writeLine("Protect: ptr(true),")
+						g.writeLine("Protect: new(true),")
 					}
 					if r.RetainOnDelete {
-						g.writeLine("RetainOnDelete: ptr(true),")
+						g.writeLine("RetainOnDelete: new(true),")
 					}
 
 					if r.Provider != "" {

--- a/pkg/engine/lifecycletest/protect_test.go
+++ b/pkg/engine/lifecycletest/protect_test.go
@@ -221,7 +221,7 @@ func TestProtectedDeleteChainsWithDuplicateDeletedResources(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:modA:typA", "resB", true, deploytest.ResourceOptions{
-			Protect:      ptr(true),
+			Protect:      new(true),
 			Dependencies: []resource.URN{resA.URN},
 		})
 		require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestProtectedDeleteChainsWithDuplicateDeletedResources(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = monitor.RegisterResource("pkgA:modA:typA", "resB", true, deploytest.ResourceOptions{
-			Protect:      ptr(true),
+			Protect:      new(true),
 			Dependencies: []resource.URN{resA.URN},
 		})
 		require.NoError(t, err)
@@ -350,12 +350,12 @@ func TestIgnoreProtect(t *testing.T) {
 
 		if creating {
 			_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
-				Protect: ptr(true),
+				Protect: new(true),
 			})
 			require.NoError(t, err)
 
 			_, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
-				Protect: ptr(true),
+				Protect: new(true),
 			})
 			require.NoError(t, err)
 		}
@@ -447,7 +447,7 @@ func TestIgnoreProtectReplace(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs:  inputsA,
-			Protect: ptr(true),
+			Protect: new(true),
 		})
 		require.NoError(t, err)
 
@@ -535,7 +535,7 @@ func TestIgnoreProtectDBRChain(t *testing.T) {
 			Inputs:       inputsB,
 			Dependencies: []resource.URN{respA.URN},
 			PropertyDeps: inputDepsB,
-			Protect:      ptr(true),
+			Protect:      new(true),
 		})
 		require.NoError(t, err)
 
@@ -593,7 +593,7 @@ func TestIgnoreProtectDestroy(t *testing.T) {
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
-			Protect: ptr(true),
+			Protect: new(true),
 		})
 		require.NoError(t, err)
 
@@ -629,8 +629,4 @@ func TestIgnoreProtectDestroy(t *testing.T) {
 		RunStep(p.GetProject(), p.GetTarget(t, snap), ignoreProtectOptions, false, p.BackendClient, nil, "2")
 	require.NoError(t, err)
 	require.Len(t, snap.Resources, 0)
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/pkg/engine/lifecycletest/update_test.go
+++ b/pkg/engine/lifecycletest/update_test.go
@@ -838,7 +838,7 @@ func TestTargetedUpdateRefreshWithDeletedParent(t *testing.T) {
 
 		_, err = monitor.RegisterResource("pkgA:m:TypeA", "res-shared", true, deploytest.ResourceOptions{
 			Provider:       provRef.String(),
-			RetainOnDelete: ptr(true),
+			RetainOnDelete: new(true),
 		})
 		require.NoError(t, err)
 
@@ -847,7 +847,7 @@ func TestTargetedUpdateRefreshWithDeletedParent(t *testing.T) {
 		// and so will be marked for deletion during the targeted update.
 		_, err = monitor.RegisterResource("pkgA:m:TypeB", "res-target", false, deploytest.ResourceOptions{
 			Provider:       provRef.String(),
-			RetainOnDelete: ptr(true),
+			RetainOnDelete: new(true),
 		})
 		require.NoError(t, err)
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -809,8 +809,7 @@ func loadPolicyAnalyzer(
 
 	analyzer, err = plugctx.Host.PolicyAnalyzer(plugctx, name, path, opts)
 	if err != nil {
-		var retryMe *workspace.MissingError
-		if errors.As(err, &retryMe) {
+		if retryMe, ok := errors.AsType[*workspace.MissingError](err); ok {
 			return nil, policyAnalyzerMissingError(name, retryMe)
 		}
 		return nil, err

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/pkg/v3
 
-go 1.25.11
+go 1.26.6
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -210,8 +210,7 @@ func GenerateHCL2Definition(
 		//
 		// https://github.com/pulumi/pulumi/issues/18271 tracks the issue of whether we can do a bit better here (e.g.
 		// allowing semver-compatible version differences but not any others).
-		var versionMismatchErr *schema.PackageReferenceVersionMismatchError
-		if !errors.As(err, &versionMismatchErr) {
+		if _, ok := errors.AsType[*schema.PackageReferenceVersionMismatchError](err); !ok {
 			return nil, nil, fmt.Errorf("loading package '%v': %w", pkgDesc, err)
 		}
 	}

--- a/pkg/pcl/runtime/evalContext.go
+++ b/pkg/pcl/runtime/evalContext.go
@@ -128,8 +128,7 @@ func (ectx *EvalContext) Evaluate(expr model.Expression) (resource.PropertyValue
 	}
 	pv, err := ctyToPropertyValue(value)
 	if err != nil {
-		var poison *poisonError
-		if errors.As(err, &poison) {
+		if poison, ok := errors.AsType[*poisonError](err); ok {
 			return resource.PropertyValue{}, &poison.name, nil
 		}
 		diags = append(diags, &hcl.Diagnostic{

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -393,8 +393,8 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 	// version of a plugin is required which are not picked up by initial pass of required plugin
 	// installations or because of bugs in GetRequiredPlugins. Instead of reporting an error, we first try to
 	// install the plugin now, and only error if we can't do that.
-	var me *workspace.MissingError
-	if !errors.As(err, &me) {
+	_, ok := errors.AsType[*workspace.MissingError](err)
+	if !ok {
 		// Not a MissingError, return the original error.
 		return nil, err
 	}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2560,14 +2560,6 @@ func TestRequestFromNodeJS(t *testing.T) {
 func TestTransformAliasForNodeJSCompat(t *testing.T) {
 	t.Parallel()
 
-	sptr := func(s string) *string {
-		return &s
-	}
-
-	bptr := func(b bool) *bool {
-		return &b
-	}
-
 	makeAlias := func(parent *string, noParent *bool, name string) *pulumirpc.Alias {
 		spec := &pulumirpc.Alias_Spec{
 			Name: name,
@@ -2593,33 +2585,33 @@ func TestTransformAliasForNodeJSCompat(t *testing.T) {
 	}{
 		{
 			name:     `{Parent: "", NoParent: true} (transformed)`,
-			input:    makeAlias(nil, bptr(true), ""),
+			input:    makeAlias(nil, new(true), ""),
 			expected: makeAlias(nil, nil, ""),
 		},
 		{
 			name:     `{Parent: "", NoParent: false} (transformed)`,
-			input:    makeAlias(sptr(""), nil, ""),
-			expected: makeAlias(nil, bptr(true), ""),
+			input:    makeAlias(new(""), nil, ""),
+			expected: makeAlias(nil, new(true), ""),
 		},
 		{
 			name:     `{Parent: "", NoParent: false, Name: "name"} (transformed)`,
-			input:    makeAlias(sptr(""), nil, "name"),
-			expected: makeAlias(nil, bptr(true), "name"),
+			input:    makeAlias(new(""), nil, "name"),
+			expected: makeAlias(nil, new(true), "name"),
 		},
 		{
 			name:     `{Parent: "", NoParent: true, Name: "name"} (transformed)`,
-			input:    makeAlias(nil, bptr(true), "name"),
+			input:    makeAlias(nil, new(true), "name"),
 			expected: makeAlias(nil, nil, "name"),
 		},
 		{
 			name:     `{Parent: "foo", NoParent: false} (no transform)`,
-			input:    makeAlias(sptr("foo"), nil, ""),
-			expected: makeAlias(sptr("foo"), nil, ""),
+			input:    makeAlias(new("foo"), nil, ""),
+			expected: makeAlias(new("foo"), nil, ""),
 		},
 		{
 			name:     `{Parent: "foo", NoParent: false, Name: "name"} (no transform)`,
-			input:    makeAlias(sptr("foo"), nil, "name"),
-			expected: makeAlias(sptr("foo"), nil, "name"),
+			input:    makeAlias(new("foo"), nil, "name"),
+			expected: makeAlias(new("foo"), nil, "name"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -417,8 +417,7 @@ func (se *stepExecutor) executeChain(workerID int, chain chain) {
 			se.log(workerID, "step %v on %v failed, signalling cancellation", step.Op(), step.URN())
 			se.cancelDueToError(err, step)
 
-			var saf StepApplyFailed
-			if !errors.As(err, &saf) {
+			if _, ok := errors.AsType[StepApplyFailed](err); !ok {
 				// Step application errors are recorded by the OnResourceStepPost callback. This is confusing,
 				// but it means that at this level we shouldn't be logging any errors that came from there.
 				//

--- a/pkg/resource/plugin/converter_plugin_test.go
+++ b/pkg/resource/plugin/converter_plugin_test.go
@@ -182,13 +182,17 @@ func TestConverterPlugin_State(t *testing.T) {
 	assert.Equal(t, "test:parent", res.Parent)
 	assert.Equal(t, []string{"prop1", "prop2"}, res.Properties)
 	assert.Equal(t, "test:provider", res.Provider)
-	assert.Equal(t, ptr(property.NewMap(map[string]property.Value{
+	assert.Equal(t, new(property.NewMap(map[string]property.Value{
 		"region": property.New("us-east-1"),
 		"secret": property.New("shh").WithSecret(true),
-	})), res.Inputs)
-	assert.Equal(t, ptr(property.NewMap(map[string]property.Value{
+	})),
+
+		res.Inputs)
+	assert.Equal(t, new(property.NewMap(map[string]property.Value{
 		"arn": property.New("test:arn"),
-	})), res.Outputs)
+	})),
+
+		res.Outputs)
 
 	diag := resp.Diagnostics[0]
 	assert.Equal(t, hcl.DiagError, diag.Severity)

--- a/pkg/resource/plugin/converter_server_test.go
+++ b/pkg/resource/plugin/converter_server_test.go
@@ -80,11 +80,12 @@ func (c *testConverter) ConvertState(
 				Parent:     "test:parent",
 				Properties: []string{"prop1", "prop2"},
 				Provider:   "test:provider",
-				Inputs: ptr(property.NewMap(map[string]property.Value{
+				Inputs: new(property.NewMap(map[string]property.Value{
 					"region": property.New("us-east-1"),
 					"secret": property.New("shh").WithSecret(true),
 				})),
-				Outputs: ptr(property.NewMap(map[string]property.Value{
+
+				Outputs: new(property.NewMap(map[string]property.Value{
 					"arn": property.New("test:arn"),
 				})),
 			},

--- a/pkg/resource/plugin/provider_plugin_test.go
+++ b/pkg/resource/plugin/provider_plugin_test.go
@@ -42,8 +42,6 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func TestAnnotateSecrets(t *testing.T) {
 	t.Parallel()
 
@@ -465,7 +463,7 @@ func TestProvider_DeleteRequests(t *testing.T) {
 			p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
 
 			// We have to configure before we can use Delete.
-			_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+			_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 			require.NoError(t, err, "Configure failed")
 
 			// Act.
@@ -541,10 +539,10 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "protect",
 			give: ConstructOptions{
-				Protect: ptr(true),
+				Protect: new(true),
 			},
 			want: &pulumirpc.ConstructRequest{
-				Protect: ptr(true),
+				Protect: new(true),
 			},
 		},
 		{
@@ -615,10 +613,10 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "delete before replace",
 			give: ConstructOptions{
-				DeleteBeforeReplace: ptr(true),
+				DeleteBeforeReplace: new(true),
 			},
 			want: &pulumirpc.ConstructRequest{
-				DeleteBeforeReplace: ptr(true),
+				DeleteBeforeReplace: new(true),
 			},
 		},
 		{
@@ -651,10 +649,10 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "retain on delete",
 			give: ConstructOptions{
-				RetainOnDelete: ptr(true),
+				RetainOnDelete: new(true),
 			},
 			want: &pulumirpc.ConstructRequest{
-				RetainOnDelete: ptr(true),
+				RetainOnDelete: new(true),
 			},
 		},
 	}
@@ -702,7 +700,7 @@ func TestProvider_ConstructOptions(t *testing.T) {
 			p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
 
 			// Must configure before we can use Construct.
-			_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+			_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 			require.NoError(t, err, "configure failed")
 
 			_, err = p.Construct(t.Context(),
@@ -780,7 +778,7 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 	// and then wait until Delete has finished.
 	<-deleting
 	_, err := p.Configure(t.Context(), ConfigureRequest{
-		Type:   ptr(tokens.Type("pulumi:providers:test")),
+		Type:   new(tokens.Type("pulumi:providers:test")),
 		Inputs: props,
 	})
 	require.NoError(t, err)
@@ -1047,7 +1045,7 @@ func TestProvider_List(t *testing.T) {
 			}
 
 			p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-			_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+			_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 			require.NoError(t, err)
 
 			stream, err := p.List(t.Context(), ListRequest{
@@ -1086,7 +1084,7 @@ func TestProvider_List_YieldsStreamError(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1133,7 +1131,7 @@ func TestProvider_List_EarlyBreakCancelsRPC(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1176,7 +1174,7 @@ func TestProvider_List_FullDrainCancelsRPC(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1205,7 +1203,7 @@ func TestProvider_List_StreamErrorCancelsRPC(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1240,7 +1238,7 @@ func TestProvider_List_StopsEarly(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1433,7 +1431,7 @@ func TestProvider_PartialFailure(t *testing.T) {
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
 
-	_, err = p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err = p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err, "configure failed")
 
 	var initErr *InitError

--- a/pkg/resource/plugin/rpc_test.go
+++ b/pkg/resource/plugin/rpc_test.go
@@ -1173,9 +1173,6 @@ func TestOutputValueMarshaling(t *testing.T) {
 func TestOutputValueUnmarshaling(t *testing.T) {
 	t.Parallel()
 
-	ptr := func(v resource.PropertyValue) *resource.PropertyValue {
-		return &v
-	}
 	tests := []struct {
 		name     string
 		opts     MarshalOptions
@@ -1213,7 +1210,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("hello")),
+			expected: new(resource.NewProperty("hello")),
 		},
 		{
 			name: "known with deps (default)",
@@ -1241,7 +1238,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("hello")),
+			expected: new(resource.NewProperty("hello")),
 		},
 		{
 			name: "secret (default)",
@@ -1262,7 +1259,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret with deps (default)",
@@ -1293,7 +1290,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "unknown secret (default)",
@@ -1355,7 +1352,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown with deps (KeepUnknowns)",
@@ -1381,7 +1378,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown secret (KeepUnknowns)",
@@ -1400,7 +1397,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown secret with deps (KeepUnknowns)",
@@ -1429,7 +1426,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "secret (KeepUnknowns)",
@@ -1451,7 +1448,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret with deps (KeepUnknowns)",
@@ -1483,7 +1480,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret (KeepSecrets)",
@@ -1505,7 +1502,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.NewProperty("shhh"))),
+			expected: new(resource.MakeSecret(resource.NewProperty("shhh"))),
 		},
 		{
 			name: "secret with deps (KeepSecrets)",
@@ -1537,7 +1534,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.NewProperty("shhh"))),
+			expected: new(resource.MakeSecret(resource.NewProperty("shhh"))),
 		},
 		{
 			name: "unknown secret (KeepUnknowns, KeepSecrets)",
@@ -1556,7 +1553,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
+			expected: new(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
 		},
 		{
 			name: "unknown secret with deps (KeepUnknowns, KeepSecrets)",
@@ -1585,7 +1582,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
+			expected: new(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/testing/pulumi-test-language/providers/call_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/call_provider.go
@@ -108,7 +108,7 @@ func (p *CallProvider) GetSchema(context.Context, plugin.GetSchemaRequest) (plug
 		Version:   "15.7.9",
 		Functions: map[string]schema.FunctionSpec{},
 		Resources: map[string]schema.ResourceSpec{},
-		Provider: ptr(customResource(
+		Provider: new(customResource(
 			"The `call` package's provider resource",
 			map[string]schema.PropertySpec{
 				"value": primitiveType("string"),

--- a/pkg/testing/pulumi-test-language/providers/config_enum_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_enum_provider.go
@@ -140,7 +140,7 @@ func (p *ConfigEnumProvider) Create(
 }
 
 func (p *ConfigEnumProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
-	return plugin.PluginInfo{Version: ptr(p.version())}, nil
+	return plugin.PluginInfo{Version: new(p.version())}, nil
 }
 
 func (p *ConfigEnumProvider) SignalCancellation(context.Context) error { return nil }

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_many_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_many_provider.go
@@ -172,7 +172,7 @@ func (p *DiscriminatedUnionManyProvider) CheckConfig(
 
 func (p *DiscriminatedUnionManyProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_marked_key_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_marked_key_provider.go
@@ -136,7 +136,7 @@ func (p *DiscriminatedUnionMarkedKeyProvider) CheckConfig(
 
 func (p *DiscriminatedUnionMarkedKeyProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_provider.go
@@ -140,7 +140,7 @@ func (p *DiscriminatedUnionProvider) CheckConfig(
 
 func (p *DiscriminatedUnionProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/enum_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/enum_provider.go
@@ -169,7 +169,7 @@ func (p *EnumProvider) CheckConfig(
 
 func (p *EnumProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/external_enum_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/external_enum_ref_provider.go
@@ -94,7 +94,7 @@ func (p *ExternalEnumRefProvider) CheckConfig(
 
 func (p *ExternalEnumRefProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/nested_collections_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/nested_collections_provider.go
@@ -174,7 +174,7 @@ func (p *NestedCollectionsProvider) Update(
 
 func (p *NestedCollectionsProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
@@ -283,7 +283,7 @@ func (p *NestedObjectProvider) Update(
 
 func (p *NestedObjectProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
@@ -79,7 +79,7 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 		},
 		Functions: map[string]schema.FunctionSpec{
 			"output-only-invoke:index:myInvoke": {
-				Plain: ptr(false),
+				Plain: new(false),
 				Inputs: &schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
@@ -106,7 +106,7 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 				},
 			},
 			"output-only-invoke:index:unit": {
-				Plain: ptr(false),
+				Plain: new(false),
 				Inputs: &schema.ObjectTypeSpec{
 					Type: "object",
 				},
@@ -125,7 +125,7 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 				},
 			},
 			"output-only-invoke:index:secretInvoke": {
-				Plain: ptr(false),
+				Plain: new(false),
 				Inputs: &schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{

--- a/pkg/testing/pulumi-test-language/providers/read_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/read_provider.go
@@ -151,7 +151,7 @@ func (p *ReadProvider) Read(_ context.Context, req plugin.ReadRequest) (plugin.R
 
 func (p *ReadProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(semver.MustParse("39.0.0")),
+		Version: new(semver.MustParse("39.0.0")),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/reserved_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/reserved_names_provider.go
@@ -135,7 +135,7 @@ func (p *ReservedNamesProvider) Update(
 
 func (p *ReservedNamesProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/simple_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_provider.go
@@ -197,7 +197,7 @@ func (p *SimpleProvider) Update(
 
 func (p *SimpleProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ptr(p.version()),
+		Version: new(p.version()),
 	}, nil
 }
 
@@ -255,5 +255,3 @@ func (p *SimpleProvider) Read(ctx context.Context, req plugin.ReadRequest) (plug
 		Status: resource.StatusOK,
 	}, nil
 }
-
-func ptr[T any](v T) *T { return &v }

--- a/pkg/util/nosleep/darwin.go
+++ b/pkg/util/nosleep/darwin.go
@@ -25,7 +25,6 @@ import (
 
 func keepRunning() DoneFunc {
 	// Run caffeinate to keep the system awake.
-	//nolint:gosec
 	cmd := exec.Command("caffeinate", "-i", "-w", strconv.Itoa(os.Getpid()))
 	// we intentionally ignore the error here.  If we can't keep the system awake we still want to continue.
 	err := cmd.Start()

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/v3
 
-go 1.25.11
+go 1.26.6
 
 replace golang.org/x/text => golang.org/x/text v0.39.0
 

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -233,8 +233,7 @@ func installWindows(ctx context.Context, version semver.Version, root string) er
 	cmd := exec.CommandContext(ctx, command, args...)
 	out, err := cmd.Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("installation failed with %w\nSTDOUT: %s\nSTDERR: %s", err, out, string(exitErr.Stderr))
 		}
 		return fmt.Errorf("installation failed with %w: %s", err, out)
@@ -256,8 +255,7 @@ func installPosix(ctx context.Context, version semver.Version, root string) erro
 	cmd := exec.CommandContext(ctx, scriptPath, args...)
 	out, err := cmd.Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("installation failed with %w\nSTDOUT: %s\nSTDERR: %s", err, out, string(exitErr.Stderr))
 		}
 		return fmt.Errorf("installation failed with %w: %s", err, out)

--- a/sdk/go/common/esc/ast/environment.go
+++ b/sdk/go/common/esc/ast/environment.go
@@ -359,8 +359,7 @@ func parseRecord(objName string, dest recordDecl, node syntax.Node, noMatchWarni
 
 		if !hasMatch && noMatchWarning {
 			var fieldNames []string
-			for i := 0; i < t.NumField(); i++ {
-				f := t.Field(i)
+			for f := range t.Fields() {
 				if f.IsExported() {
 					fieldNames = append(fieldNames, fmt.Sprintf("'%s'", camel(f.Name)))
 				}

--- a/sdk/go/common/esc/syntax/encoding/object_test.go
+++ b/sdk/go/common/esc/syntax/encoding/object_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func TestObjectBasic(t *testing.T) {
 	t.Parallel()
 	type Embedded struct {
@@ -80,7 +76,7 @@ func TestObjectBasic(t *testing.T) {
 		String:   "syntax",
 		Array:    []string{"hello", "world"},
 		Object:   map[string]string{"hello": "world"},
-		Ptr:      ptr("syntax"),
+		Ptr:      new("syntax"),
 		Any:      "value",
 	}
 
@@ -191,12 +187,12 @@ func TestInvalidEncode(t *testing.T) {
 		node syntax.Node
 		into any
 	}{
-		{syntax.Boolean(true), ptr(42)},
-		{syntax.Number(json.Number("3.14")), ptr(42)},
-		{syntax.Number(json.Number("3.14")), ptr("hello")},
-		{syntax.String("syntax"), ptr(42)},
-		{syntax.Array(syntax.String("hello"), syntax.String("world")), ptr(42)},
-		{syntax.Object(syntax.ObjectProperty(syntax.String("hello"), syntax.String("world"))), ptr(42)},
+		{syntax.Boolean(true), new(42)},
+		{syntax.Number(json.Number("3.14")), new(42)},
+		{syntax.Number(json.Number("3.14")), new("hello")},
+		{syntax.String("syntax"), new(42)},
+		{syntax.Array(syntax.String("hello"), syntax.String("world")), new(42)},
+		{syntax.Object(syntax.ObjectProperty(syntax.String("hello"), syntax.String("world"))), new(42)},
 	}
 	for _, c := range cases {
 		t.Run(c.node.String(), func(t *testing.T) {

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -42,8 +42,6 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func TestAnnotateSecrets(t *testing.T) {
 	t.Parallel()
 
@@ -465,7 +463,7 @@ func TestProvider_DeleteRequests(t *testing.T) {
 			p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
 
 			// We have to configure before we can use Delete.
-			_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+			_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 			require.NoError(t, err, "Configure failed")
 
 			// Act.
@@ -541,10 +539,10 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "protect",
 			give: ConstructOptions{
-				Protect: ptr(true),
+				Protect: new(true),
 			},
 			want: &pulumirpc.ConstructRequest{
-				Protect: ptr(true),
+				Protect: new(true),
 			},
 		},
 		{
@@ -615,10 +613,10 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "delete before replace",
 			give: ConstructOptions{
-				DeleteBeforeReplace: ptr(true),
+				DeleteBeforeReplace: new(true),
 			},
 			want: &pulumirpc.ConstructRequest{
-				DeleteBeforeReplace: ptr(true),
+				DeleteBeforeReplace: new(true),
 			},
 		},
 		{
@@ -651,10 +649,10 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "retain on delete",
 			give: ConstructOptions{
-				RetainOnDelete: ptr(true),
+				RetainOnDelete: new(true),
 			},
 			want: &pulumirpc.ConstructRequest{
-				RetainOnDelete: ptr(true),
+				RetainOnDelete: new(true),
 			},
 		},
 	}
@@ -702,7 +700,7 @@ func TestProvider_ConstructOptions(t *testing.T) {
 			p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
 
 			// Must configure before we can use Construct.
-			_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+			_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 			require.NoError(t, err, "configure failed")
 
 			_, err = p.Construct(t.Context(),
@@ -780,7 +778,7 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 	// and then wait until Delete has finished.
 	<-deleting
 	_, err := p.Configure(t.Context(), ConfigureRequest{
-		Type:   ptr(tokens.Type("pulumi:providers:test")),
+		Type:   new(tokens.Type("pulumi:providers:test")),
 		Inputs: props,
 	})
 	require.NoError(t, err)
@@ -1047,7 +1045,7 @@ func TestProvider_List(t *testing.T) {
 			}
 
 			p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-			_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+			_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 			require.NoError(t, err)
 
 			stream, err := p.List(t.Context(), ListRequest{
@@ -1086,7 +1084,7 @@ func TestProvider_List_YieldsStreamError(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1133,7 +1131,7 @@ func TestProvider_List_EarlyBreakCancelsRPC(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1176,7 +1174,7 @@ func TestProvider_List_FullDrainCancelsRPC(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1205,7 +1203,7 @@ func TestProvider_List_StreamErrorCancelsRPC(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1240,7 +1238,7 @@ func TestProvider_List_StopsEarly(t *testing.T) {
 	}
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err)
 
 	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
@@ -1429,7 +1427,7 @@ func TestProvider_PartialFailure_RefreshBeforeUpdate(t *testing.T) {
 
 	p := NewProviderWithClient(newTestContext(t), client, false /* disablePreview */)
 
-	_, err := p.Configure(t.Context(), ConfigureRequest{Type: ptr(tokens.Type("pulumi:providers:test"))})
+	_, err := p.Configure(t.Context(), ConfigureRequest{Type: new(tokens.Type("pulumi:providers:test"))})
 	require.NoError(t, err, "configure failed")
 
 	var initErr *InitError

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -1173,9 +1173,6 @@ func TestOutputValueMarshaling(t *testing.T) {
 func TestOutputValueUnmarshaling(t *testing.T) {
 	t.Parallel()
 
-	ptr := func(v resource.PropertyValue) *resource.PropertyValue {
-		return &v
-	}
 	tests := []struct {
 		name     string
 		opts     MarshalOptions
@@ -1213,7 +1210,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("hello")),
+			expected: new(resource.NewProperty("hello")),
 		},
 		{
 			name: "known with deps (default)",
@@ -1241,7 +1238,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("hello")),
+			expected: new(resource.NewProperty("hello")),
 		},
 		{
 			name: "secret (default)",
@@ -1262,7 +1259,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret with deps (default)",
@@ -1293,7 +1290,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "unknown secret (default)",
@@ -1355,7 +1352,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown with deps (KeepUnknowns)",
@@ -1381,7 +1378,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown secret (KeepUnknowns)",
@@ -1400,7 +1397,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "unknown secret with deps (KeepUnknowns)",
@@ -1429,7 +1426,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeComputed(resource.NewProperty(""))),
+			expected: new(resource.MakeComputed(resource.NewProperty(""))),
 		},
 		{
 			name: "secret (KeepUnknowns)",
@@ -1451,7 +1448,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret with deps (KeepUnknowns)",
@@ -1483,7 +1480,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.NewProperty("shhh")),
+			expected: new(resource.NewProperty("shhh")),
 		},
 		{
 			name: "secret (KeepSecrets)",
@@ -1505,7 +1502,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.NewProperty("shhh"))),
+			expected: new(resource.MakeSecret(resource.NewProperty("shhh"))),
 		},
 		{
 			name: "secret with deps (KeepSecrets)",
@@ -1537,7 +1534,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.NewProperty("shhh"))),
+			expected: new(resource.MakeSecret(resource.NewProperty("shhh"))),
 		},
 		{
 			name: "unknown secret (KeepUnknowns, KeepSecrets)",
@@ -1556,7 +1553,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
+			expected: new(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
 		},
 		{
 			name: "unknown secret with deps (KeepUnknowns, KeepSecrets)",
@@ -1585,7 +1582,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 					},
 				},
 			},
-			expected: ptr(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
+			expected: new(resource.MakeSecret(resource.MakeComputed(resource.NewProperty("")))),
 		},
 	}
 	for _, tt := range tests {

--- a/sdk/go/common/util/errutil/format_exiterr.go
+++ b/sdk/go/common/util/errutil/format_exiterr.go
@@ -26,8 +26,7 @@ func ErrorWithStderr(err error, message string) error {
 	if err == nil {
 		return nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		stderr := strings.TrimSpace(string(exitErr.Stderr))
 		if len(stderr) > 0 {
 			return fmt.Errorf("%s: %w: %s", message, exitErr, exitErr.Stderr)

--- a/sdk/go/common/util/executable/executable.go
+++ b/sdk/go/common/util/executable/executable.go
@@ -44,8 +44,7 @@ func FindExecutable(program string) (string, error) {
 		notFoundPaths := make([]string, 0, 3)
 		for _, suffix := range []string{".exe", ".cmd", ".ps1"} {
 			found, err := findExecutableWithSuffix(program, suffix)
-			var notFoundErr *NotFoundError
-			if errors.As(err, &notFoundErr) {
+			if notFoundErr, ok := errors.AsType[*NotFoundError](err); ok {
 				notFoundPaths = append(notFoundPaths, notFoundErr.Path)
 				continue
 			} else if err != nil {

--- a/sdk/go/common/util/mapper/mapper.go
+++ b/sdk/go/common/util/mapper/mapper.go
@@ -101,8 +101,8 @@ func structFields(t reflect.Type) []reflect.StructField {
 	for len(fldtypes) > 0 {
 		fldtype := fldtypes[0]
 		fldtypes = fldtypes[1:]
-		for i := 0; i < fldtype.NumField(); i++ {
-			if fldinfo := fldtype.Field(i); fldinfo.Anonymous {
+		for fldinfo := range fldtype.Fields() {
+			if fldinfo.Anonymous {
 				// If an embedded struct, push it onto the queue to visit.
 				if fldinfo.Type.Kind() == reflect.Struct {
 					fldtypes = append(fldtypes, fldinfo.Type)

--- a/sdk/go/common/util/securestore/keychainstatus_darwin.go
+++ b/sdk/go/common/util/securestore/keychainstatus_darwin.go
@@ -84,7 +84,7 @@ func withoutKeychainUI[T any](fn func() (T, error)) (T, error) {
 			ErrUnavailable, osStatusError(status))
 	}
 	// Leaving interaction disabled would break every later keychain user.
-	defer sec.keychainSetUserInteractionOK(true) //nolint:errcheck // best effort restore
+	defer sec.keychainSetUserInteractionOK(true)
 	return fn()
 }
 

--- a/sdk/go/common/util/securestore/probe_linux.go
+++ b/sdk/go/common/util/securestore/probe_linux.go
@@ -92,8 +92,7 @@ func probeSecretService(allowPrompt bool) (Outcome, error) {
 		}
 		return struct{}{}, nil
 	})
-	var locked lockedCollectionError
-	if errors.As(err, &locked) {
+	if locked, ok := errors.AsType[lockedCollectionError](err); ok {
 		unlockErr := unlockDefaultCollection(allowPrompt)
 		switch {
 		case unlockErr == nil:

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1864,8 +1864,7 @@ func (d *pluginDownloader) downloadToFileWithRetry(ctx context.Context, pkgPlugi
 			}
 
 			// If the readErr is a checksum error don't retry.
-			var checksumErr *checksumError
-			if errors.As(readErr, &checksumErr) {
+			if _, ok := errors.AsType[*checksumError](readErr); ok {
 				return false, "", readErr
 			}
 

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3
 
-go 1.25.11
+go 1.26.6
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -580,10 +580,6 @@ func assertOutputEqual(t *testing.T, value any, known bool, secret bool, deps ma
 func TestConstructInputsCopyTo(t *testing.T) {
 	t.Parallel()
 
-	stringPtr := func(v string) *string {
-		return &v
-	}
-
 	tests := []struct {
 		name          string
 		input         resource.PropertyValue

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -653,7 +653,7 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input: resource.NewProperty("hello"),
 			args:  &StringPtrArgs{},
 			assert: func(t *testing.T, actual any) {
-				assert.Equal(t, stringPtr("hello"), actual)
+				assert.Equal(t, new("hello"), actual)
 			},
 		},
 		{

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -254,10 +254,6 @@ func TestResourceOptionMergingDeleteBeforeReplace(t *testing.T) {
 func TestResourceOptionComposite(t *testing.T) {
 	t.Parallel()
 
-	ptr := func(b bool) *bool {
-		return &b
-	}
-
 	tests := []struct {
 		name  string
 		input []ResourceOption
@@ -274,7 +270,7 @@ func TestResourceOptionComposite(t *testing.T) {
 				DeleteBeforeReplace(true),
 			},
 			want: &resourceOptions{
-				DeleteBeforeReplace: ptr(true),
+				DeleteBeforeReplace: new(true),
 			},
 		},
 		{
@@ -284,7 +280,7 @@ func TestResourceOptionComposite(t *testing.T) {
 				DeleteBeforeReplace(false),
 			},
 			want: &resourceOptions{
-				DeleteBeforeReplace: ptr(false),
+				DeleteBeforeReplace: new(false),
 			},
 		},
 		{
@@ -295,7 +291,7 @@ func TestResourceOptionComposite(t *testing.T) {
 				DeleteBeforeReplace(true),
 			},
 			want: &resourceOptions{
-				DeleteBeforeReplace: ptr(true),
+				DeleteBeforeReplace: new(true),
 			},
 		},
 		{
@@ -305,8 +301,8 @@ func TestResourceOptionComposite(t *testing.T) {
 				Protect(true),
 			},
 			want: &resourceOptions{
-				DeleteBeforeReplace: ptr(true),
-				Protect:             ptr(true),
+				DeleteBeforeReplace: new(true),
+				Protect:             new(true),
 			},
 		},
 	}

--- a/sdk/go/pulumi/type_conversions.go
+++ b/sdk/go/pulumi/type_conversions.go
@@ -17,23 +17,23 @@ package pulumi
 // StringRef returns a pointer to its argument, used in cases where a parameter requires an optional
 // string.
 func StringRef(v string) *string {
-	return &v
+	return new(v)
 }
 
 // BoolRef returns a pointer to its argument, used in cases where a parameter requires an optional
 // bool.
 func BoolRef(v bool) *bool {
-	return &v
+	return new(v)
 }
 
 // IntRef returns a pointer to its argument, used in cases where a parameter requires an optional
 // int.
 func IntRef(v int) *int {
-	return &v
+	return new(v)
 }
 
 // Float64Ref returns a pointer to its argument, used in cases where a parameter requires an optional
 // float64.
 func Float64Ref(v float64) *float64 {
-	return &v
+	return new(v)
 }

--- a/sdk/go/pulumix/ptr.go
+++ b/sdk/go/pulumix/ptr.go
@@ -73,7 +73,7 @@ func Ptr[T any](v T) PtrOutput[T] {
 //	var s pulumi.StringOutput = ... // implements Input[string]
 //	ps := PtrOf(s)                  // implements Input[*string]
 func PtrOf[T any, I Input[T]](i I) PtrOutput[T] {
-	po := Apply[T](i, func(v T) *T { return &v })
+	po := Apply[T](i, func(v T) *T { return new(v) })
 	return Cast[PtrOutput[T], *T](po)
 }
 

--- a/sdk/go/tools/automation/tests/runtime/commands_test.go
+++ b/sdk/go/tools/automation/tests/runtime/commands_test.go
@@ -43,8 +43,6 @@ import (
 // keeps the public surface stable if we ever change the struct's fields.
 func newAPI() *automation.API { return automation.New(nil) }
 
-func ptr[T any](v T) *T { return &v }
-
 // runStdout invokes fn and returns the rendered CLI command line. It is a
 // thin wrapper that fails the test on error so individual cases stay
 // focussed on the command string they care about.
@@ -72,7 +70,7 @@ func TestCancel_Empty(t *testing.T) {
 func TestCancel_WithStackName(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Cancel(t.Context(), ptr("my-stack"))
+		r, err := api.Cancel(t.Context(), new("my-stack"))
 		return r.Stdout, err
 	})
 	want := "pulumi cancel --yes -- my-stack"

--- a/sdk/go/tools/automation/tests/runtime/go.mod
+++ b/sdk/go/tools/automation/tests/runtime/go.mod
@@ -6,7 +6,7 @@
 
 module github.com/pulumi/pulumi/sdk/v3/go/tools/automation/tests/runtime
 
-go 1.25.11
+go 1.26
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../..
 

--- a/sdk/go/tools/automation/tests/runtime/go.mod
+++ b/sdk/go/tools/automation/tests/runtime/go.mod
@@ -6,7 +6,7 @@
 
 module github.com/pulumi/pulumi/sdk/v3/go/tools/automation/tests/runtime
 
-go 1.26
+go 1.26.6
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../..
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
-go 1.25.11
+go 1.26.6
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1785,8 +1785,7 @@ func (host *nodeLanguageHost) RunPlugin(
 	}
 
 	if err := run(); err != nil {
-		var exiterr *exec.ExitError
-		if errors.As(err, &exiterr) {
+		if exiterr, ok := errors.AsType[*exec.ExitError](err); ok {
 			// The program ran, but exited with a non-zero error code.  This will happen often, since user
 			// errors will trigger this.  So, the error message should look as nice as possible.
 			if status, stok := exiterr.Sys().(syscall.WaitStatus); stok {

--- a/sdk/pcl/go.mod
+++ b/sdk/pcl/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/pcl/v3
 
-go 1.25.11
+go 1.26.6
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 
-go 1.25.11
+go 1.26.6
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -850,8 +850,7 @@ func determinePluginVersion(packageVersion string) (string, error) {
 func debugCommand(ctx context.Context, opts toolchain.PythonOptions) ([]string, *debugger, error) {
 	err := checkForPackage(ctx, "debugpy", opts)
 	if err != nil {
-		var installError *NotInstalledError
-		if errors.As(err, &installError) {
+		if installError, ok := errors.AsType[*NotInstalledError](err); ok {
 			return nil, nil, fmt.Errorf("debugpy is not installed. %s", installError.InstallMessage)
 		}
 		return nil, nil, err
@@ -1128,8 +1127,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		typecheckerCmd.Dir = req.Info.ProgramDirectory
 		err = checkForPackage(ctx, typechecker, opts)
 		if err != nil {
-			var installError *NotInstalledError
-			if errors.As(err, &installError) {
+			if installError, ok := errors.AsType[*NotInstalledError](err); ok {
 				return nil, fmt.Errorf("The typechecker option is set to %s, but %s is not installed. %s",
 					typechecker, typechecker, installError.InstallMessage)
 			}
@@ -1709,8 +1707,7 @@ func (host *pythonLanguageHost) RunPlugin(
 	}
 
 	if err = run(); err != nil {
-		var exiterr *exec.ExitError
-		if errors.As(err, &exiterr) {
+		if exiterr, ok := errors.AsType[*exec.ExitError](err); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				return server.Send(&pulumirpc.RunPluginResponse{
 					Output: &pulumirpc.RunPluginResponse_Exitcode{Exitcode: int32(status.ExitStatus())},

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests
 
-go 1.25.11
+go 1.26.6
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.8.3

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/construct_component_provider_propagation
 
-go 1.25.11
+go 1.26.6
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/construct_component_resource_options
 
-go 1.25.11
+go 1.26.6
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/construct_nested_component
 
-go 1.25.11
+go 1.26.6
 
 require github.com/pulumi/pulumi/sdk/v3 v3.225.1
 

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -32,10 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/python/toolchain"
 )
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 // TestEmptyPython simply tests that we can run an empty Python project.
 //
 //nolint:paralleltest // ProgramTest calls t.Parallel()
@@ -92,7 +88,7 @@ func TestDynamicPython(t *testing.T) {
 				}
 			},
 		}},
-		UseSharedVirtualEnv: ptr(false),
+		UseSharedVirtualEnv: new(false),
 	})
 }
 
@@ -121,7 +117,7 @@ func TestDynamicPythonReadInputs(t *testing.T) {
 				}
 			}
 		},
-		UseSharedVirtualEnv: ptr(false),
+		UseSharedVirtualEnv: new(false),
 	})
 }
 
@@ -184,7 +180,7 @@ func optsForConstructPython(
 			"secret": "this super secret is encrypted",
 		},
 		Quick:               true,
-		UseSharedVirtualEnv: ptr(false),
+		UseSharedVirtualEnv: new(false),
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			require.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -537,7 +537,7 @@ func TestDynamicPythonDisableSerializationAsSecret(t *testing.T) {
 				}
 			},
 		}},
-		UseSharedVirtualEnv: ptr(false),
+		UseSharedVirtualEnv: new(false),
 	})
 }
 

--- a/tests/integration/run_plugin/go/go.mod
+++ b/tests/integration/run_plugin/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/run_plugin
 
-go 1.25.11
+go 1.26.6
 
 require github.com/pulumi/pulumi/sdk/v3 v3.259.0
 

--- a/tests/testdata/codegen/regress-go-12971/go-extras/tests/codegen_test.go
+++ b/tests/testdata/codegen/regress-go-12971/go-extras/tests/codegen_test.go
@@ -58,13 +58,13 @@ func TestEnvironmentDefaults(t *testing.T) {
 			// We use zero values instead.
 			// We can modify want because it's passed by value.
 			if want.Name == nil {
-				want.Name = ptr("")
+				want.Name = new("")
 			}
 			if want.Populated == nil {
-				want.Populated = ptr(false)
+				want.Populated = new(false)
 			}
 			if want.RadiusKm == nil {
-				want.RadiusKm = ptr(0.0)
+				want.RadiusKm = new(0.0)
 			}
 
 			assert.Equal(t, *want.Name, config.GetName(ctx), "name")
@@ -115,32 +115,32 @@ func TestEnvironmentDefaults(t *testing.T) {
 		{
 			desc: "string",
 			env:  map[string]string{"WORLD_NAME": "Earth"},
-			want: example.World{Name: ptr("Earth")},
+			want: example.World{Name: new("Earth")},
 		},
 		{
 			desc: "string/empty",
 			env:  map[string]string{"WORLD_NAME": ""},
-			want: example.World{Name: ptr("")},
+			want: example.World{Name: new("")},
 		},
 		{
 			desc: "bool",
 			env:  map[string]string{"WORLD_POPULATED": "true"},
-			want: example.World{Populated: ptr(true)},
+			want: example.World{Populated: new(true)},
 		},
 		{
 			desc: "bool/false",
 			env:  map[string]string{"WORLD_POPULATED": "false"},
-			want: example.World{Populated: ptr(false)},
+			want: example.World{Populated: new(false)},
 		},
 		{
 			desc: "number",
 			env:  map[string]string{"WORLD_RADIUS_KM": "6378"},
-			want: example.World{RadiusKm: ptr(6378.0)},
+			want: example.World{RadiusKm: new(6378.0)},
 		},
 		{
 			desc: "number/zero",
 			env:  map[string]string{"WORLD_RADIUS_KM": "0"},
-			want: example.World{RadiusKm: ptr(0.0)},
+			want: example.World{RadiusKm: new(0.0)},
 		},
 		{
 			desc: "all",
@@ -150,9 +150,9 @@ func TestEnvironmentDefaults(t *testing.T) {
 				"WORLD_RADIUS_KM": "6378",
 			},
 			want: example.World{
-				Name:      ptr("Earth"),
-				Populated: ptr(true),
-				RadiusKm:  ptr(6378.0),
+				Name:      new("Earth"),
+				Populated: new(true),
+				RadiusKm:  new(6378.0),
 			},
 		},
 	}
@@ -218,9 +218,6 @@ func (m *mockResourceMonitor) NewResource(args pulumi.MockResourceArgs) (string,
 	}
 	return args.Name + "_id", args.Inputs, nil
 }
-
-// Returns a pointer to the given value.
-func ptr[T any](v T) *T { return &v }
 
 // waitForOutut blocks until the given output has resolved.
 // The test fails if the output does not resolve after a while.


### PR DESCRIPTION
Remove all our `ptr` helpers and just use `new(x)` instead, as allowed by Go 1.26.

This updates the go.mod files to require Go 1.26, and also fixes some lint issues with that where we need to use `errors.AsType` instead of `errors.As`.

