### PR TITLE
🤖🤖🤖 fix(policy): recover interrupted policy pack installs

### DIFF
--- a/changelog/pending/20260819--cli--policy-pack-install-recovery.yaml
+++ b/changelog/pending/20260819--cli--policy-pack-install-recovery.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Retry interrupted policy pack installations and prevent concurrent installs from exposing incomplete policy packs
+time: 2026-08-19T10:07:01Z

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/nodejs/npm"
@@ -497,6 +498,12 @@ func (pack *cloudPolicyPack) Remove(ctx context.Context, op backend.PolicyPackOp
 const packageDir = "package"
 
 func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadCloser, stdout, stderr io.Writer) error {
+	return installRequiredPolicyWithHook(ctx, finalDir, tgz, stdout, stderr, nil)
+}
+
+func installRequiredPolicyWithHook(
+	ctx *plugin.Context, finalDir string, tgz io.ReadCloser, stdout, stderr io.Writer, beforeLock func(),
+) error {
 	// If part of the directory tree is missing, os.MkdirTemp will return an error, so make sure
 	// the path we're going to create the temporary folder in actually exists.
 	if err := os.MkdirAll(filepath.Dir(finalDir), 0o700); err != nil {
@@ -514,9 +521,11 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("creating plugin root: %w", err)
 	}
 
-	// If we early out of this function, try to remove the temp folder we created.
+	// Cleanup is best effort: returning a cleanup error could hide the installation error.
 	defer func() {
-		contract.IgnoreError(os.RemoveAll(tempDir))
+		if err := os.RemoveAll(tempDir); err != nil {
+			logging.V(7).Infof("Failed to clean up temporary policy pack directory %q: %v", tempDir, err)
+		}
 	}()
 
 	// Uncompress the policy pack.
@@ -529,18 +538,50 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 	// "Installing policy pack" progress bar before dependency installation begins.
 	contract.IgnoreClose(tgz)
 
-	logging.V(7).Infof("Unpacking policy pack %q %q\n", tempDir, finalDir)
+	if beforeLock != nil {
+		beforeLock()
+	}
+	mutex := fsutil.NewFileMutex(finalDir + ".lock")
+	if err := mutex.Lock(); err != nil {
+		return fmt.Errorf("locking policy pack installation: %w", err)
+	}
+	defer func() {
+		if err := mutex.Unlock(); err != nil {
+			logging.V(7).Infof("Failed to unlock policy pack installation %q: %v", finalDir, err)
+		}
+	}()
 
-	// If two calls to `plugin install` for the same plugin are racing, the second one will be
-	// unable to rename the directory. That's OK, just ignore the error. The temp directory created
-	// as part of the install will be cleaned up when we exit by the defer above.
-	//
-	//nolint:forbidigo // historic os.Rename usage
-	if err := os.Rename(tempPackageDir, finalDir); err != nil && !os.IsExist(err) {
-		return fmt.Errorf("moving plugin: %w", err)
+	partialPath := finalDir + ".partial"
+	projPath := filepath.Join(finalDir, "PulumiPolicy.yaml")
+	if file, err := os.Stat(projPath); err == nil && !file.IsDir() {
+		if _, err := os.Stat(partialPath); os.IsNotExist(err) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("checking partial policy pack installation: %w", err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checking policy pack installation: %w", err)
 	}
 
-	projPath := filepath.Join(finalDir, "PulumiPolicy.yaml")
+	if err := os.WriteFile(partialPath, nil, 0o600); err != nil {
+		return fmt.Errorf("marking policy pack installation partial: %w", err)
+	}
+	if err := os.RemoveAll(finalDir); err != nil {
+		return fmt.Errorf("removing partial policy pack installation: %w", err)
+	}
+	//nolint:forbidigo // finalDir must retain its stable path while language dependencies are installed
+	if err := os.Rename(tempPackageDir, finalDir); err != nil {
+		return fmt.Errorf("moving plugin: %w", err)
+	}
+	installComplete := false
+	defer func() {
+		if !installComplete {
+			if err := os.RemoveAll(finalDir); err != nil {
+				logging.V(7).Infof("Failed to clean up partial policy pack directory %q: %v", finalDir, err)
+			}
+		}
+	}()
+
 	proj, err := workspace.LoadPolicyPack(projPath)
 	if err != nil {
 		return fmt.Errorf("failed to load policy project at %s: %w", finalDir, err)
@@ -573,5 +614,9 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		return fmt.Errorf("installing dependencies: %w", err)
 	}
 
+	if err := os.Remove(partialPath); err != nil {
+		return fmt.Errorf("marking policy pack installation complete: %w", err)
+	}
+	installComplete = true
 	return nil
 }

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -553,8 +553,8 @@ func installRequiredPolicyWithHook(
 
 	partialPath := finalDir + ".partial"
 	projPath := filepath.Join(finalDir, "PulumiPolicy.yaml")
-	if file, err := os.Stat(projPath); err == nil && !file.IsDir() {
-		if _, err := os.Stat(partialPath); os.IsNotExist(err) {
+	if file, err := os.Lstat(projPath); err == nil && file.Mode().IsRegular() {
+		if _, err := os.Lstat(partialPath); os.IsNotExist(err) {
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("checking partial policy pack installation: %w", err)
@@ -563,8 +563,15 @@ func installRequiredPolicyWithHook(
 		return fmt.Errorf("checking policy pack installation: %w", err)
 	}
 
-	if err := os.WriteFile(partialPath, nil, 0o600); err != nil {
+	if err := os.Remove(partialPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale partial policy pack marker: %w", err)
+	}
+	marker, err := os.OpenFile(partialPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
 		return fmt.Errorf("marking policy pack installation partial: %w", err)
+	}
+	if err := marker.Close(); err != nil {
+		return fmt.Errorf("closing partial policy pack marker: %w", err)
 	}
 	if err := os.RemoveAll(finalDir); err != nil {
 		return fmt.Errorf("removing partial policy pack installation: %w", err)

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -15,15 +15,22 @@
 package httpstate
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/archive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -684,4 +691,175 @@ func TestLocalPolicyEnvironmentResolver(t *testing.T) {
 		assert.Nil(t, result.Config)
 		assert.Equal(t, map[string]string{"KEY": "val"}, result.EnvironmentVariables)
 	})
+}
+
+type failingDependencyLanguageRuntime struct {
+	plugin.LanguageRuntime
+	installCalls int
+}
+
+func (r *failingDependencyLanguageRuntime) InstallDependencies(
+	context.Context, plugin.InstallDependenciesRequest,
+) (io.Reader, io.Reader, <-chan error, error) {
+	r.installCalls++
+	done := make(chan error, 1)
+	done <- errors.New("dependency install failed")
+	close(done)
+	return strings.NewReader(""), strings.NewReader(""), done, nil
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/24306.
+func TestInstallRequiredPolicyCleansUpDependencyFailure(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sourceDir, "PulumiPolicy.yaml"), []byte("runtime: test\n"), 0o600))
+	tgz, err := archive.TGZ(sourceDir, packageDir, false)
+	require.NoError(t, err)
+
+	runtime := &failingDependencyLanguageRuntime{}
+	host := &plugin.MockHost{
+		LanguageRuntimeF: func(_ *plugin.Context, name string) (plugin.LanguageRuntime, error) {
+			assert.Equal(t, "test", name)
+			return runtime, nil
+		},
+	}
+	ctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, sourceDir, sourceDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ctx.Close()) })
+
+	finalDir := filepath.Join(t.TempDir(), "policy")
+	for range 2 {
+		err = installRequiredPolicy(ctx, finalDir, io.NopCloser(bytes.NewReader(tgz)), io.Discard, io.Discard)
+		require.ErrorContains(t, err, "installing dependencies: dependency install failed")
+		_, statErr := os.Stat(finalDir)
+		assert.True(t, os.IsNotExist(statErr), "a failed install must not poison the policy cache")
+	}
+	assert.Equal(t, 2, runtime.installCalls, "a second install should retry dependency installation")
+}
+
+func TestInstallRequiredPolicyUsesCompletedConcurrentInstall(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sourceDir, "PulumiPolicy.yaml"), []byte("runtime: test\n"), 0o600))
+	tgz, err := archive.TGZ(sourceDir, packageDir, false)
+	require.NoError(t, err)
+
+	runtime := &failingDependencyLanguageRuntime{}
+	host := &plugin.MockHost{
+		LanguageRuntimeF: func(_ *plugin.Context, name string) (plugin.LanguageRuntime, error) {
+			assert.Equal(t, "test", name)
+			return runtime, nil
+		},
+	}
+	ctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, sourceDir, sourceDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ctx.Close()) })
+
+	finalDir := filepath.Join(t.TempDir(), "policy")
+	require.NoError(t, os.Mkdir(finalDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(finalDir, "PulumiPolicy.yaml"), []byte("runtime: test\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(finalDir, "concurrent-install"), nil, 0o600))
+
+	err = installRequiredPolicy(ctx, finalDir, io.NopCloser(bytes.NewReader(tgz)), io.Discard, io.Discard)
+	require.NoError(t, err)
+	assert.Zero(t, runtime.installCalls)
+	assert.FileExists(t, filepath.Join(finalDir, "concurrent-install"),
+		"an install must not replace a completed concurrent installation")
+}
+
+type coordinatedDependencyLanguageRuntime struct {
+	plugin.LanguageRuntime
+	calls         atomic.Int32
+	firstStarted  chan struct{}
+	secondStarted chan struct{}
+	releaseFirst  chan struct{}
+	releaseSecond chan struct{}
+}
+
+func (r *coordinatedDependencyLanguageRuntime) InstallDependencies(
+	context.Context, plugin.InstallDependenciesRequest,
+) (io.Reader, io.Reader, <-chan error, error) {
+	done := make(chan error, 1)
+	switch r.calls.Add(1) {
+	case 1:
+		close(r.firstStarted)
+		go func() {
+			<-r.releaseFirst
+			done <- errors.New("dependency install failed")
+			close(done)
+		}()
+	case 2:
+		close(r.secondStarted)
+		go func() {
+			<-r.releaseSecond
+			close(done)
+		}()
+	default:
+		panic("unexpected dependency installation")
+	}
+	return strings.NewReader(""), strings.NewReader(""), done, nil
+}
+
+// Regression test for two overlapping installs where the first publisher fails after the second succeeds.
+func TestInstallRequiredPolicyConcurrentWinnerFailurePreservesSuccessfulInstall(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sourceDir, "PulumiPolicy.yaml"), []byte("runtime: test\n"), 0o600))
+	tgz, err := archive.TGZ(sourceDir, packageDir, false)
+	require.NoError(t, err)
+
+	runtime := &coordinatedDependencyLanguageRuntime{
+		firstStarted:  make(chan struct{}),
+		secondStarted: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+		releaseSecond: make(chan struct{}),
+	}
+	host := &plugin.MockHost{
+		LanguageRuntimeF: func(_ *plugin.Context, name string) (plugin.LanguageRuntime, error) {
+			assert.Equal(t, "test", name)
+			return runtime, nil
+		},
+	}
+	ctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, sourceDir, sourceDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ctx.Close()) })
+
+	finalDir := filepath.Join(t.TempDir(), "policy")
+	firstBeforeLock := make(chan struct{})
+	secondBeforeLock := make(chan struct{})
+	releaseFirstLock := make(chan struct{})
+	releaseSecondLock := make(chan struct{})
+	install := func(beforeLock, releaseLock chan struct{}) error {
+		return installRequiredPolicyWithHook(
+			ctx, finalDir, io.NopCloser(bytes.NewReader(tgz)), io.Discard, io.Discard,
+			func() {
+				close(beforeLock)
+				<-releaseLock
+			})
+	}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- install(firstBeforeLock, releaseFirstLock) }()
+	<-firstBeforeLock
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- install(secondBeforeLock, releaseSecondLock) }()
+	<-secondBeforeLock
+
+	close(releaseFirstLock)
+	<-runtime.firstStarted
+	close(releaseSecondLock)
+
+	close(runtime.releaseFirst)
+	require.ErrorContains(t, <-firstDone, "installing dependencies: dependency install failed")
+	<-runtime.secondStarted
+	close(runtime.releaseSecond)
+	require.NoError(t, <-secondDone)
+	assert.FileExists(t, filepath.Join(finalDir, "PulumiPolicy.yaml"))
+	assert.NoFileExists(t, finalDir+".partial")
 }

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -739,6 +739,38 @@ func TestInstallRequiredPolicyCleansUpDependencyFailure(t *testing.T) {
 	assert.Equal(t, 2, runtime.installCalls, "a second install should retry dependency installation")
 }
 
+func TestInstallRequiredPolicyReplacesDanglingPartialMarkerSymlink(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sourceDir, "PulumiPolicy.yaml"), []byte("runtime: test\n"), 0o600))
+	tgz, err := archive.TGZ(sourceDir, packageDir, false)
+	require.NoError(t, err)
+
+	runtime := &failingDependencyLanguageRuntime{}
+	host := &plugin.MockHost{
+		LanguageRuntimeF: func(_ *plugin.Context, name string) (plugin.LanguageRuntime, error) {
+			assert.Equal(t, "test", name)
+			return runtime, nil
+		},
+	}
+	ctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, sourceDir, sourceDir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ctx.Close()) })
+
+	finalDir := filepath.Join(t.TempDir(), "policy")
+	markerTarget := filepath.Join(t.TempDir(), "marker-target")
+	if err := os.Symlink(markerTarget, finalDir+".partial"); err != nil {
+		t.Skipf("creating symlink: %v", err)
+	}
+
+	err = installRequiredPolicy(ctx, finalDir, io.NopCloser(bytes.NewReader(tgz)), io.Discard, io.Discard)
+	require.ErrorContains(t, err, "installing dependencies: dependency install failed")
+	_, statErr := os.Stat(markerTarget)
+	assert.True(t, os.IsNotExist(statErr), "install must not follow a stale marker symlink")
+}
+
 func TestInstallRequiredPolicyUsesCompletedConcurrentInstall(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1993,8 +1993,8 @@ func GetPolicyDir(orgName string) (string, error) {
 	return GetPulumiPath(PolicyDir, orgName)
 }
 
-// GetPolicyPath finds a PolicyPack by its name version, as well as a bool marked true if the path
-// already exists and is a directory.
+// GetPolicyPath finds a PolicyPack by its name and version, as well as a bool marked true if the path
+// contains a policy project file.
 func GetPolicyPath(orgName, name, version string) (string, bool, error) {
 	policiesDir, err := GetPolicyDir(orgName)
 	if err != nil {
@@ -2003,16 +2003,23 @@ func GetPolicyPath(orgName, name, version string) (string, bool, error) {
 
 	policyPackPath := path.Join(policiesDir, fmt.Sprintf("pulumi-analyzer-%s-v%s", name, version))
 
-	file, err := os.Stat(policyPackPath)
-	if err == nil && file.IsDir() {
-		// PolicyPack exists. Return.
+	projectPath := filepath.Join(policyPackPath, "PulumiPolicy.yaml")
+	file, err := os.Stat(projectPath)
+	if err == nil {
+		if file.IsDir() {
+			return policyPackPath, false, nil
+		}
+		if _, err := os.Stat(policyPackPath + ".partial"); err == nil {
+			return policyPackPath, false, nil
+		} else if !os.IsNotExist(err) {
+			return "", false, err
+		}
 		return policyPackPath, true, nil
-	} else if err != nil && !os.IsNotExist(err) {
-		// Error trying to inspect PolicyPack FS entry. Return error.
+	}
+	if !os.IsNotExist(err) {
 		return "", false, err
 	}
 
-	// Not found. Return empty path.
 	return policyPackPath, false, nil
 }
 

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2004,12 +2004,12 @@ func GetPolicyPath(orgName, name, version string) (string, bool, error) {
 	policyPackPath := path.Join(policiesDir, fmt.Sprintf("pulumi-analyzer-%s-v%s", name, version))
 
 	projectPath := filepath.Join(policyPackPath, "PulumiPolicy.yaml")
-	file, err := os.Stat(projectPath)
+	file, err := os.Lstat(projectPath)
 	if err == nil {
-		if file.IsDir() {
+		if !file.Mode().IsRegular() {
 			return policyPackPath, false, nil
 		}
-		if _, err := os.Stat(policyPackPath + ".partial"); err == nil {
+		if _, err := os.Lstat(policyPackPath + ".partial"); err == nil {
 			return policyPackPath, false, nil
 		} else if !os.IsNotExist(err) {
 			return "", false, err

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -2322,3 +2322,83 @@ func TestIsExternalURL(t *testing.T) {
 	isnot(".hidden")
 	isnot("local.exe")
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/24306.
+func TestGetPolicyPathRequiresPolicyProjectFile(t *testing.T) {
+	const (
+		org     = "example-org"
+		name    = "example-policy"
+		version = "1.0.0"
+	)
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, policyPath string)
+		installed bool
+		wantError bool
+	}{
+		{name: "missing"},
+		{
+			name: "policy path is file",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(filepath.Dir(policyPath), 0o700))
+				require.NoError(t, os.WriteFile(policyPath, nil, 0o600))
+			},
+			wantError: true,
+		},
+		{
+			name: "empty directory",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(policyPath, 0o700))
+			},
+		},
+		{
+			name: "project path is directory",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(policyPath, "PulumiPolicy.yaml"), 0o700))
+			},
+		},
+		{
+			name: "project path is file",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(policyPath, 0o700))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(policyPath, "PulumiPolicy.yaml"), []byte("runtime: nodejs\n"), 0o600))
+			},
+			installed: true,
+		},
+		{
+			name: "project file with partial marker",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(policyPath, 0o700))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(policyPath, "PulumiPolicy.yaml"), []byte("runtime: nodejs\n"), 0o600))
+				require.NoError(t, os.WriteFile(policyPath+".partial", nil, 0o600))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("PULUMI_HOME", home)
+			policyPath, installed, err := GetPolicyPath(org, name, version)
+			require.NoError(t, err)
+			require.False(t, installed)
+			if tt.setup != nil {
+				tt.setup(t, policyPath)
+			}
+
+			actualPath, installed, err := GetPolicyPath(org, name, version)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Empty(t, actualPath)
+				assert.False(t, installed)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, policyPath, actualPath)
+			assert.Equal(t, tt.installed, installed)
+		})
+	}
+}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -2359,6 +2359,17 @@ func TestGetPolicyPathRequiresPolicyProjectFile(t *testing.T) {
 			},
 		},
 		{
+			name: "project path is symlink",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(policyPath, 0o700))
+				target := filepath.Join(t.TempDir(), "PulumiPolicy.yaml")
+				require.NoError(t, os.WriteFile(target, []byte("runtime: nodejs\n"), 0o600))
+				if err := os.Symlink(target, filepath.Join(policyPath, "PulumiPolicy.yaml")); err != nil {
+					t.Skipf("creating symlink: %v", err)
+				}
+			},
+		},
+		{
 			name: "project path is file",
 			setup: func(t *testing.T, policyPath string) {
 				require.NoError(t, os.MkdirAll(policyPath, 0o700))
@@ -2374,6 +2385,17 @@ func TestGetPolicyPathRequiresPolicyProjectFile(t *testing.T) {
 				require.NoError(t, os.WriteFile(
 					filepath.Join(policyPath, "PulumiPolicy.yaml"), []byte("runtime: nodejs\n"), 0o600))
 				require.NoError(t, os.WriteFile(policyPath+".partial", nil, 0o600))
+			},
+		},
+		{
+			name: "project file with dangling partial marker symlink",
+			setup: func(t *testing.T, policyPath string) {
+				require.NoError(t, os.MkdirAll(policyPath, 0o700))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(policyPath, "PulumiPolicy.yaml"), []byte("runtime: nodejs\n"), 0o600))
+				if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), policyPath+".partial"); err != nil {
+					t.Skipf("creating symlink: %v", err)
+				}
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #24306.

Required policy packs are now considered installed only when their cache contains a regular `PulumiPolicy.yaml` and has no `.partial` marker. Installation of the same pack is serialized with a per-policy filesystem lock, incomplete installs are marked explicitly, and failed installs are removed while the lock is held so a waiting installer can retry safely.

This prevents interrupted dependency installation from permanently poisoning the policy cache while preserving a stable final path during language dependency setup.

AI assistance was used to help investigate the issue, implement the change, and develop tests. I reviewed the complete diff, understand the behavior and risks, and take responsibility for the contribution.

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Tests cover incomplete-cache detection, `.partial` markers, regular-file requirements, cleanup and sequential retry after dependency failure, completed concurrent-install reuse, and a deterministic concurrent first-installer-fails/second-installer-succeeds case.

## Validation

- [ ] `make lint` — clean (the SDK target is blocked locally by the unavailable custom `requiredfield` golangci-lint plugin; package-specific golangci-lint previously reported zero issues)
- [ ] `make test_fast` — all pass (attempted; unrelated tests require `pulumi-language-yaml` on `PATH`)
- [ ] `make tidy_fix` — clean (no module changes)
- [x] `make format` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (no proto changes)

Additional validation:

- Full affected `backend/httpstate` and `common/workspace` package tests
- Focused concurrency race test, 100 repetitions
- Workspace race tests, 10 repetitions
- `go vet` for both affected packages
- `git diff --check`
- Windows test-binary cross-compilation for both affected packages
- `make lint_changelog`

## Changelog

- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk

`GetPolicyPath` is exported, so this intentionally narrows its installed boolean: a policy cache is complete only when `PulumiPolicy.yaml` is a regular file and the `.partial` marker is absent. The function signature and computed-path behavior are unchanged.

The installer retains the stable final path required by language runtimes. A per-policy filesystem lock serializes concurrent publishers. If a process terminates during installation, the stable `.partial` marker makes the incomplete cache fail closed and allows the next installer to remove and retry it under the lock. A timeout after the full fast suite was caused by an unrelated missing `pulumi-language-yaml` executable; affected package suites passed independently.

## Exact focused validation output

```text
$ cd pkg && mise exec -- go test -count=1 -tags all ./backend/httpstate
ok  	github.com/pulumi/pulumi/pkg/v3/backend/httpstate	10.201s

$ cd sdk && mise exec -- go test -count=1 -tags all ./go/common/workspace
ok  	github.com/pulumi/pulumi/sdk/v3/go/common/workspace	0.787s

$ cd pkg && mise exec -- go test -count=20 -race ./backend/httpstate -run 'TestInstallRequiredPolicy(CleansUpDependencyFailure|ReplacesDanglingPartialMarkerSymlink|UsesCompletedConcurrentInstall|ConcurrentWinnerFailurePreservesSuccessfulInstall)'
ok  	github.com/pulumi/pulumi/pkg/v3/backend/httpstate	1.453s

$ cd sdk && mise exec -- go test -count=20 -race ./go/common/workspace -run TestGetPolicyPathRequiresPolicyProjectFile
ok  	github.com/pulumi/pulumi/sdk/v3/go/common/workspace	1.184s

$ cd pkg && mise exec -- go vet ./backend/httpstate
# no output; exit 0

$ cd sdk && mise exec -- go vet ./go/common/workspace
# no output; exit 0

$ git diff --check origin/master...HEAD
# no output; exit 0
```
