### PR TITLE
Print secret provider info in pulumi stack

### DIFF
--- a/changelog/pending/cli-improvement-20260824-083917.yaml
+++ b/changelog/pending/cli-improvement-20260824-083917.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Print secret provider information with other stack information
+time: 2026-08-24T08:39:17.539846+01:00

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -190,6 +190,13 @@ func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stac
 		if snap.Manifest.Version != "" {
 			fmt.Fprintf(out, "    Pulumi version used: %s\n", snap.Manifest.Version)
 		}
+		var typ string
+		if snap.SecretsManager != nil {
+			typ = snap.SecretsManager.Type()
+		}
+		if typ != "" {
+			fmt.Fprintf(out, "    Secrets provider: %s\n", typ)
+		}
 		for _, p := range snap.Manifest.Plugins {
 			var pluginVersion string
 			if p.Version == nil {

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -206,6 +206,12 @@ func TestBuildStackJSON_WithSnapshot(t *testing.T) {
 		Resources: []*pkgresource.State{
 			{URN: urn, Type: "aws:s3/bucket:Bucket", ID: "bucket-id-1"},
 		},
+		SecretsManager: &secrets.MockSecretsManager{
+			TypeF: func() string { return "cloud" },
+			StateF: func() json.RawMessage {
+				return json.RawMessage(`{"opaque":"provider-state","nested":{"value":42}}`)
+			},
+		},
 	}
 
 	in := sampleIdentityInputs()
@@ -226,6 +232,44 @@ func TestBuildStackJSON_WithSnapshot(t *testing.T) {
 	assert.Equal(t, "aws:s3/bucket:Bucket", env.Resources[0].Type)
 	assert.Equal(t, "my-bucket", env.Resources[0].Name)
 	assert.Equal(t, "bucket-id-1", env.Resources[0].ID)
+
+	require.NotNil(t, env.SecretsProvider)
+	assert.Equal(t, "cloud", env.SecretsProvider.Type)
+	assert.JSONEq(t, `{"opaque":"provider-state","nested":{"value":42}}`,
+		string(env.SecretsProvider.State))
+
+	var buf bytes.Buffer
+	require.NoError(t, renderStackJSON(&buf, env))
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	sp, ok := got["secretsProvider"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "cloud", sp["type"])
+	state, ok := sp["state"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "provider-state", state["opaque"])
+}
+
+func TestRunStackText_PrintsSecretsProvider(t *testing.T) {
+	t.Parallel()
+
+	snap := &deploy.Snapshot{
+		SecretsManager: &secrets.MockSecretsManager{
+			TypeF: func() string { return "cloud" },
+			StateF: func() json.RawMessage {
+				return json.RawMessage(`{"opaque":"provider-state"}`)
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := runStackText(t.Context(), newMockStack(snap, nil), &buf, stackArgs{})
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Secrets provider: cloud")
+	assert.NotContains(t, out, "provider-state")
+	assert.NotContains(t, out, "opaque")
 }
 
 func TestCapitalizeFirst(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_json.go
+++ b/pkg/cmd/pulumi/stack/stack_json.go
@@ -29,6 +29,7 @@ import (
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // stackJSONEnvelope is the stable, machine-readable shape emitted by
@@ -39,18 +40,19 @@ import (
 // precision, UTC) to match the convention already established by
 // `pulumi stack history --json` and `pulumi stack ls --json`.
 type stackJSONEnvelope struct {
-	Organization     string              `json:"organization,omitempty"`
-	Project          string              `json:"project,omitempty"`
-	Stack            string              `json:"stack"`
-	Backend          string              `json:"backend"`
-	Version          *int                `json:"version,omitempty"`
-	ActiveUpdate     string              `json:"activeUpdate,omitempty"`
-	CurrentOperation *stackOperationJSON `json:"currentOperation,omitempty"`
-	Tags             map[string]string   `json:"tags"`
-	Manifest         *stackManifestJSON  `json:"manifest,omitempty"`
-	Resources        []stackResourceJSON `json:"resources"`
-	Outputs          map[string]any      `json:"outputs"`
-	ConsoleURL       string              `json:"consoleUrl,omitempty"`
+	Organization     string                    `json:"organization,omitempty"`
+	Project          string                    `json:"project,omitempty"`
+	Stack            string                    `json:"stack"`
+	Backend          string                    `json:"backend"`
+	Version          *int                      `json:"version,omitempty"`
+	ActiveUpdate     string                    `json:"activeUpdate,omitempty"`
+	CurrentOperation *stackOperationJSON       `json:"currentOperation,omitempty"`
+	Tags             map[string]string         `json:"tags"`
+	Manifest         *stackManifestJSON        `json:"manifest,omitempty"`
+	SecretsProvider  *stackSecretsProviderJSON `json:"secretsProvider,omitempty"`
+	Resources        []stackResourceJSON       `json:"resources"`
+	Outputs          map[string]any            `json:"outputs"`
+	ConsoleURL       string                    `json:"consoleUrl,omitempty"`
 }
 
 type stackOperationJSON struct {
@@ -69,6 +71,11 @@ type stackPluginJSON struct {
 	Name    string `json:"name"`
 	Kind    string `json:"kind"`
 	Version string `json:"version,omitempty"`
+}
+
+type stackSecretsProviderJSON struct {
+	Type  string          `json:"type"`
+	State json.RawMessage `json:"state,omitempty"`
 }
 
 type stackResourceJSON struct {
@@ -156,6 +163,7 @@ func buildStackJSON(in stackJSONInputs) *stackJSONEnvelope {
 				Version: version,
 			})
 		}
+		env.SecretsProvider = snapshotSecretsProviderJSON(snap)
 
 		env.Resources = make([]stackResourceJSON, 0, len(snap.Resources))
 		for _, r := range snap.Resources {
@@ -168,6 +176,18 @@ func buildStackJSON(in stackJSONInputs) *stackJSONEnvelope {
 	}
 
 	return env
+}
+
+func snapshotSecretsProviderJSON(snap *deploy.Snapshot) *stackSecretsProviderJSON {
+	contract.Requiref(snap != nil, "snap", "snapshot must be non-nil")
+	if snap.SecretsManager == nil {
+		return nil
+	}
+
+	return &stackSecretsProviderJSON{
+		Type:  snap.SecretsManager.Type(),
+		State: snap.SecretsManager.State(),
+	}
 }
 
 func snapshotResourceJSON(r *pkgresource.State) stackResourceJSON {


### PR DESCRIPTION
Raised in community slack.

Small fix to print the secret provider information when doing `pulumi stack`.
In text mode just prints the type, in json mode prints the type and the JSON state data.