### PR TITLE
workflow: a durable workflow graph on top of fsa

### DIFF
--- a/pkg/workflow/testdata/arrival-order-resume.json
+++ b/pkg/workflow/testdata/arrival-order-resume.json
@@ -1,0 +1,180 @@
+[
+  {
+    "type": "Note",
+    "note": "resumed: the queued release settles and is overwritten by the release that committed beside it"
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start-good"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start-bad"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "staging"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "prod"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-bad"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "go",
+      "from": "start-good",
+      "to": "staging"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy-bad"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "promote",
+      "from": "staging",
+      "to": "prod"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy-bad",
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy-bad",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "promote",
+      "from": "staging",
+      "to": "prod",
+      "inputs": {
+        "version": "queued"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "promote",
+      "from": "staging",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "promote",
+      "from": "staging",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "promote",
+      "from": "staging",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c3",
+        "label": "queued"
+      },
+      "new": {
+        "id": "c1",
+        "label": "good"
+      },
+      "node": "staging"
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-bad",
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-bad",
+      "outputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start-good"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start-bad"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "staging"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "prod"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/arrival-order-state.json
+++ b/pkg/workflow/testdata/arrival-order-state.json
@@ -1,0 +1,30 @@
+{
+  "nextCursor": 3,
+  "cursors": [
+    {
+      "id": "c2",
+      "label": "bad",
+      "node": "start-bad",
+      "value": {
+        "version": "bad"
+      }
+    },
+    {
+      "id": "c3",
+      "label": "queued",
+      "node": "staging",
+      "value": {
+        "version": "queued"
+      }
+    },
+    {
+      "id": "c1",
+      "label": "good",
+      "node": "staging",
+      "value": {
+        "env": "staging",
+        "version": "good"
+      }
+    }
+  ]
+}

--- a/pkg/workflow/testdata/blue-green.json
+++ b/pkg/workflow/testdata/blue-green.json
@@ -1,0 +1,1036 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "release-requested"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-green"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-green"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "switch-traffic"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "decommission-blue"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "andEdges": [
+        {
+          "name": "healthy-and-approved[0]",
+          "from": "verify-green",
+          "to": "switch-traffic"
+        },
+        {
+          "name": "healthy-and-approved[1]",
+          "from": "verify-green",
+          "to": "switch-traffic"
+        }
+      ]
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "orEdges": [
+        {
+          "name": "unhealthy-or-timeout[0]",
+          "from": "verify-green",
+          "to": "rollback"
+        },
+        {
+          "name": "unhealthy-or-timeout[1]",
+          "from": "verify-green",
+          "to": "rollback"
+        }
+      ]
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "switched",
+      "from": "switch-traffic",
+      "to": "decommission-blue"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "release-requested",
+      "cursor": {
+        "id": "c1",
+        "label": "release 2.0"
+      },
+      "inputs": {
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green",
+      "inputs": {
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-green",
+      "inputs": {
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-green",
+      "outputs": {
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green",
+      "inputs": {
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-green",
+      "inputs": {
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-green",
+      "outputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved[1]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved[1]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout[0]",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout[0]",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout[1]",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout[1]",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "release-requested"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "switch-traffic"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "decommission-blue"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "operator approves the traffic switch"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved[1]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved[1]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "switch-traffic",
+      "inputs": {
+        "healthy": true,
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "switch-traffic",
+      "outputs": {
+        "healthy": true,
+        "live": "green",
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "switched",
+      "from": "switch-traffic",
+      "to": "decommission-blue",
+      "inputs": {
+        "healthy": true,
+        "live": "green",
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "switched",
+      "from": "switch-traffic",
+      "to": "decommission-blue",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "decommission-blue",
+      "inputs": {
+        "healthy": true,
+        "live": "green",
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "decommission-blue",
+      "outputs": {
+        "blue": "deleted",
+        "healthy": true,
+        "live": "green",
+        "url": "https://green.example.com/2.0",
+        "version": "2.0"
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "release-requested"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-green"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-green"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "release 2.0 done; a broken release 3.0 starts"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "release-requested",
+      "cursor": {
+        "id": "c2",
+        "label": "release 3.0"
+      },
+      "inputs": {
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green",
+      "inputs": {
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-green",
+      "inputs": {
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-green",
+      "outputs": {
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green",
+      "inputs": {
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-green",
+      "inputs": {
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-green",
+      "outputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout[0]",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout[0]",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "rollback",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "rollback",
+      "outputs": {
+        "healthy": false,
+        "live": "blue",
+        "url": "https://green.example.com/3.0",
+        "version": "3.0"
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "release-requested"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "switch-traffic"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "decommission-blue"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "release 3.1 stalls waiting for approval until the approval window times out"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "release-requested",
+      "cursor": {
+        "id": "c3",
+        "label": "release 3.1"
+      },
+      "inputs": {
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green",
+      "inputs": {
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "start",
+      "from": "release-requested",
+      "to": "deploy-green",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-green",
+      "inputs": {
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-green",
+      "outputs": {
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green",
+      "inputs": {
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-green",
+      "to": "verify-green",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-green",
+      "inputs": {
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-green",
+      "outputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved[0]",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-approved",
+      "from": "verify-green",
+      "to": "switch-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy-or-timeout[0]",
+      "from": "verify-green",
+      "to": "rollback",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout[0]",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy-or-timeout",
+      "from": "verify-green",
+      "to": "rollback",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "rollback",
+      "inputs": {
+        "healthy": false,
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "rollback",
+      "outputs": {
+        "healthy": false,
+        "live": "blue",
+        "url": "https://green.example.com/3.1",
+        "version": "3.1"
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c2",
+        "label": "release 3.0"
+      },
+      "new": {
+        "id": "c3",
+        "label": "release 3.1"
+      },
+      "node": "rollback"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "release-requested"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "switch-traffic"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "decommission-blue"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "release-requested"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-green"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-green"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "switch-traffic"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "decommission-blue"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/canary-loop.json
+++ b/pkg/workflow/testdata/canary-loop.json
@@ -1,0 +1,979 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "shift-traffic"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "observe"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "shift-traffic"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "andEdges": [
+        {
+          "name": "healthy-and-more-to-shift[0]",
+          "from": "observe",
+          "to": "shift-traffic"
+        },
+        {
+          "name": "healthy-and-more-to-shift[1]",
+          "from": "observe",
+          "to": "shift-traffic"
+        }
+      ]
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "andEdges": [
+        {
+          "name": "healthy-and-fully-shifted[0]",
+          "from": "observe",
+          "to": "done"
+        },
+        {
+          "name": "healthy-and-fully-shifted[1]",
+          "from": "observe",
+          "to": "done"
+        }
+      ]
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "canary"
+      },
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "shift-traffic",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "shift-traffic",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "shift-traffic",
+      "outputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "observe",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "observe",
+      "outputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "10% looks good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[1]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[1]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "shift-traffic",
+      "inputs": {
+        "percent": 10,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "shift-traffic",
+      "outputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "observe",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "observe",
+      "outputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "50% looks good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[1]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[1]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "shift-traffic",
+      "inputs": {
+        "percent": 50,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "shift-traffic",
+      "outputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "shifted",
+      "from": "shift-traffic",
+      "to": "observe",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "observe",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "observe",
+      "outputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "rollback"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "100% looks bad"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift[0]",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-more-to-shift",
+      "from": "observe",
+      "to": "shift-traffic",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted[0]",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "healthy-and-fully-shifted",
+      "from": "observe",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "unhealthy",
+      "from": "observe",
+      "to": "rollback",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "rollback",
+      "inputs": {
+        "percent": 100,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "rollback",
+      "outputs": {
+        "percent": 0,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "shift-traffic"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "observe"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/contended-environment-state.json
+++ b/pkg/workflow/testdata/contended-environment-state.json
@@ -1,0 +1,23 @@
+{
+  "nextCursor": 3,
+  "cursors": [
+    {
+      "id": "c2",
+      "label": "B",
+      "node": "prod",
+      "value": {
+        "env": "prod",
+        "version": "B"
+      }
+    },
+    {
+      "id": "c3",
+      "label": "C",
+      "node": "soak",
+      "value": {
+        "env": "staging",
+        "version": "C"
+      }
+    }
+  ]
+}

--- a/pkg/workflow/testdata/contended-environment.json
+++ b/pkg/workflow/testdata/contended-environment.json
@@ -1,0 +1,567 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "staging"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "soak"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "prod"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue",
+      "cursor": {
+        "id": "c1",
+        "label": "A"
+      },
+      "inputs": {
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging",
+      "inputs": {
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "staging",
+      "inputs": {
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "staging",
+      "outputs": {
+        "env": "staging",
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak",
+      "inputs": {
+        "env": "staging",
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "soak",
+      "inputs": {
+        "env": "staging",
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "soak",
+      "outputs": {
+        "env": "staging",
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "prod"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "B arrives while A is still soaking: A is superseded"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue",
+      "cursor": {
+        "id": "c2",
+        "label": "B"
+      },
+      "inputs": {
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "A"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging",
+      "inputs": {
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "staging",
+      "inputs": {
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "staging",
+      "outputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak",
+      "inputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "soak",
+      "inputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "soak",
+      "outputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c1",
+        "label": "A"
+      },
+      "new": {
+        "id": "c2",
+        "label": "B"
+      },
+      "node": "soak"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "prod"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "A finishes soaking, but it is gone"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "staging"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "soak"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "prod"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "B finishes soaking as C arrives: B moves on before C takes the soak environment"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue",
+      "cursor": {
+        "id": "c3",
+        "label": "C"
+      },
+      "inputs": {
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging",
+      "inputs": {
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deploy",
+      "from": "queue",
+      "to": "staging",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "prod",
+      "outputs": {
+        "env": "prod",
+        "version": "B"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "staging",
+      "inputs": {
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "staging",
+      "outputs": {
+        "env": "staging",
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak",
+      "inputs": {
+        "env": "staging",
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "staging",
+      "to": "soak",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "soak",
+      "inputs": {
+        "env": "staging",
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "soak",
+      "outputs": {
+        "env": "staging",
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "inputs": {
+        "env": "staging",
+        "version": "C"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "soaked",
+      "from": "soak",
+      "to": "prod",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/dynamic-graph.json
+++ b/pkg/workflow/testdata/dynamic-graph.json
@@ -1,0 +1,266 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "expanding"
+      },
+      "inputs": {
+        "here": "plan",
+        "remaining": [
+          "us",
+          "eu"
+        ]
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "here": "plan",
+        "remaining": [
+          "us",
+          "eu"
+        ]
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "here": "plan",
+        "remaining": [
+          "us",
+          "eu"
+        ]
+      }
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "next",
+      "from": "plan",
+      "to": "deploy-us"
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "here": "deploy-us",
+        "remaining": [
+          "eu"
+        ]
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "next",
+      "from": "plan",
+      "to": "deploy-us",
+      "inputs": {
+        "here": "deploy-us",
+        "remaining": [
+          "eu"
+        ]
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "next",
+      "from": "plan",
+      "to": "deploy-us",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us",
+      "inputs": {
+        "here": "deploy-us",
+        "remaining": [
+          "eu"
+        ]
+      }
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "next",
+      "from": "deploy-us",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us",
+      "outputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "next",
+      "from": "deploy-us",
+      "to": "deploy-eu",
+      "inputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "next",
+      "from": "deploy-us",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "finished",
+      "from": "deploy-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "finished",
+      "from": "deploy-eu",
+      "to": "done",
+      "inputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "finished",
+      "from": "deploy-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "here": "deploy-eu",
+        "remaining": []
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/edge-failure.json
+++ b/pkg/workflow/testdata/edge-failure.json
@@ -1,0 +1,112 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "metrics-ok",
+      "from": "start",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": ""
+      },
+      "inputs": {}
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "metrics-ok",
+      "from": "start",
+      "to": "done",
+      "inputs": {}
+    }
+  },
+  {
+    "type": "EdgeFailed",
+    "event": {
+      "name": "metrics-ok",
+      "from": "start",
+      "to": "done",
+      "error": "metrics backend unreachable"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned",
+    "error": "metrics backend unreachable"
+  },
+  {
+    "type": "Note",
+    "note": "metrics backend is back"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "metrics-ok",
+      "from": "start",
+      "to": "done",
+      "inputs": {}
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "metrics-ok",
+      "from": "start",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {}
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {}
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/join-abort-state.json
+++ b/pkg/workflow/testdata/join-abort-state.json
@@ -1,0 +1,36 @@
+{
+  "nextCursor": 3,
+  "cursors": [
+    {
+      "id": "c1",
+      "label": "v7",
+      "node": "plan",
+      "value": {
+        "phase": 1,
+        "version": "7"
+      }
+    },
+    {
+      "id": "c2",
+      "label": "us-west",
+      "node": "halt-us-west",
+      "value": {
+        "halted": true,
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    },
+    {
+      "id": "c3",
+      "label": "us-east",
+      "node": "halt-us-east",
+      "value": {
+        "halted": true,
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  ]
+}

--- a/pkg/workflow/testdata/join-abort.json
+++ b/pkg/workflow/testdata/join-abort.json
@@ -1,0 +1,740 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "halt-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-west",
+      "to": "halt-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "halt-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-east",
+      "to": "halt-us-east"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-west",
+      "to": "halt-us-west",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-west",
+      "to": "halt-us-west",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-east",
+      "to": "halt-us-east",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-east",
+      "to": "halt-us-east",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "halt-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "halt-us-east"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-east metrics look bad: both regions abort"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-west",
+      "to": "halt-us-west",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-west",
+      "to": "halt-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-east",
+      "to": "halt-us-east",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "abort",
+      "from": "verify-us-east",
+      "to": "halt-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "halt-us-west",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "halt-us-west",
+      "outputs": {
+        "halted": true,
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "halt-us-east",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "halt-us-east",
+      "outputs": {
+        "halted": true,
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/join-branch-retaken.json
+++ b/pkg/workflow/testdata/join-branch-retaken.json
@@ -1,0 +1,1060 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-west needs a hotfix before us-east's metrics come in"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c4",
+        "label": "us-west hotfix"
+      },
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "new": {
+        "id": "c4",
+        "label": "us-west hotfix"
+      },
+      "node": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-east and eu metrics look good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c4",
+          "label": "us-west hotfix"
+        },
+        {
+          "id": "c3",
+          "label": "us-east"
+        }
+      ],
+      "new": {
+        "id": "c5",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/join-commit-retried-state.json
+++ b/pkg/workflow/testdata/join-commit-retried-state.json
@@ -1,0 +1,35 @@
+{
+  "nextCursor": 4,
+  "cursors": [
+    {
+      "id": "c1",
+      "label": "v7",
+      "node": "plan",
+      "value": {
+        "phase": 1,
+        "version": "7"
+      }
+    },
+    {
+      "id": "c4",
+      "label": "merged",
+      "node": "verify-us-east",
+      "value": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      },
+      "merged": {
+        "join": "us-metrics-good",
+        "node": "verify-us-east"
+      }
+    }
+  ]
+}

--- a/pkg/workflow/testdata/join-commit-retried.json
+++ b/pkg/workflow/testdata/join-commit-retried.json
@@ -1,0 +1,773 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c2",
+          "label": "us-west"
+        },
+        {
+          "id": "c3",
+          "label": "us-east"
+        }
+      ],
+      "new": {
+        "id": "c4",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeFailed",
+    "event": {
+      "id": "deploy-eu",
+      "error": "deploy to eu failed"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned",
+    "error": "deploy to eu failed"
+  },
+  {
+    "type": "Note",
+    "note": "eu is fixed"
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/join-merge-rejected.json
+++ b/pkg/workflow/testdata/join-merge-rejected.json
@@ -1,0 +1,1474 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-west is hotfixed while us-east's metrics are pending"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c4",
+        "label": "us-west hotfix"
+      },
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "new": {
+        "id": "c4",
+        "label": "us-west hotfix"
+      },
+      "node": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-east metrics look good, but the versions differ"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-east gets the hotfix too, but the merge policy is down"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c5",
+        "label": "us-east hotfix"
+      },
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFailed",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "error": "merge policy unavailable"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned",
+    "error": "merge policy unavailable"
+  },
+  {
+    "type": "Note",
+    "note": "the merge policy is back"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "new": {
+        "id": "c5",
+        "label": "us-east hotfix"
+      },
+      "node": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7.1"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c4",
+          "label": "us-west hotfix"
+        },
+        {
+          "id": "c5",
+          "label": "us-east hotfix"
+        }
+      ],
+      "new": {
+        "id": "c6",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7.1"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7.1"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/join-reused.json
+++ b/pkg/workflow/testdata/join-reused.json
@@ -1,0 +1,1222 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c2",
+          "label": "us-west"
+        },
+        {
+          "id": "c3",
+          "label": "us-east"
+        }
+      ],
+      "new": {
+        "id": "c4",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "v8 follows v7 through the same graph"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c5",
+        "label": "v8"
+      },
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c6",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c7",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "new": {
+        "id": "c5",
+        "label": "v8"
+      },
+      "node": "plan"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "8"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c6",
+          "label": "us-west"
+        },
+        {
+          "id": "c7",
+          "label": "us-east"
+        }
+      ],
+      "new": {
+        "id": "c8",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "8"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "8"
+        }
+      }
+    }
+  },
+  {
+    "type": "CursorReplaced",
+    "event": {
+      "old": {
+        "id": "c4",
+        "label": "merged"
+      },
+      "new": {
+        "id": "c8",
+        "label": "merged"
+      },
+      "node": "done"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/node-failure-bystander-state.json
+++ b/pkg/workflow/testdata/node-failure-bystander-state.json
@@ -1,0 +1,21 @@
+{
+  "nextCursor": 2,
+  "cursors": [
+    {
+      "id": "c1",
+      "label": "bad",
+      "node": "start-bad",
+      "value": {
+        "version": "bad"
+      }
+    },
+    {
+      "id": "c2",
+      "label": "good",
+      "node": "start-good",
+      "value": {
+        "version": "good"
+      }
+    }
+  ]
+}

--- a/pkg/workflow/testdata/node-failure-bystander.json
+++ b/pkg/workflow/testdata/node-failure-bystander.json
@@ -1,0 +1,304 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start-bad"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start-good"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "build"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "go",
+      "from": "start-good",
+      "to": "build"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "built",
+      "from": "build",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start-bad",
+      "cursor": {
+        "id": "c1",
+        "label": "bad"
+      },
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start-good",
+      "cursor": {
+        "id": "c2",
+        "label": "good"
+      },
+      "inputs": {
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy",
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "go",
+      "from": "start-good",
+      "to": "build",
+      "inputs": {
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "go",
+      "from": "start-good",
+      "to": "build",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "NodeFailed",
+    "event": {
+      "id": "deploy",
+      "error": "deploy exploded"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start-bad"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start-good"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "build"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned",
+    "error": "deploy exploded"
+  },
+  {
+    "type": "Note",
+    "note": "the bad release is fixed"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy",
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "go",
+      "from": "start-bad",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "go",
+      "from": "start-good",
+      "to": "build",
+      "inputs": {
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "go",
+      "from": "start-good",
+      "to": "build",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy",
+      "outputs": {
+        "deployed": true,
+        "version": "bad"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "build",
+      "inputs": {
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "build",
+      "outputs": {
+        "built": true,
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "built",
+      "from": "build",
+      "to": "done",
+      "inputs": {
+        "built": true,
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "built",
+      "from": "build",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "built": true,
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "built": true,
+        "version": "good"
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start-bad"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start-good"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/node-failure.json
+++ b/pkg/workflow/testdata/node-failure.json
@@ -1,0 +1,75 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "boom"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "go",
+      "from": "start",
+      "to": "boom"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": ""
+      },
+      "inputs": {}
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "go",
+      "from": "start",
+      "to": "boom",
+      "inputs": {}
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "go",
+      "from": "start",
+      "to": "boom",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "boom",
+      "inputs": {}
+    }
+  },
+  {
+    "type": "NodeFailed",
+    "event": {
+      "id": "boom",
+      "error": "deploy exploded"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "ProgressReturned",
+    "error": "deploy exploded"
+  }
+]

--- a/pkg/workflow/testdata/phased-rollout-resume.json
+++ b/pkg/workflow/testdata/phased-rollout-resume.json
@@ -1,0 +1,617 @@
+[
+  {
+    "type": "NodeUndefined",
+    "event": {
+      "id": "plan",
+      "cursors": [
+        {
+          "id": "c1",
+          "label": "v7"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeUndefined",
+    "event": {
+      "id": "verify-us-east",
+      "cursors": [
+        {
+          "id": "c3",
+          "label": "us-east"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeUndefined",
+    "event": {
+      "id": "verify-us-west",
+      "cursors": [
+        {
+          "id": "c2",
+          "label": "us-west"
+        }
+      ]
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "resumed; us-east metrics look good"
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c2",
+          "label": "us-west"
+        },
+        {
+          "id": "c3",
+          "label": "us-east"
+        }
+      ],
+      "new": {
+        "id": "c4",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "eu metrics look good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/phased-rollout-state.json
+++ b/pkg/workflow/testdata/phased-rollout-state.json
@@ -1,0 +1,34 @@
+{
+  "nextCursor": 3,
+  "cursors": [
+    {
+      "id": "c1",
+      "label": "v7",
+      "node": "plan",
+      "value": {
+        "phase": 1,
+        "version": "7"
+      }
+    },
+    {
+      "id": "c2",
+      "label": "us-west",
+      "node": "verify-us-west",
+      "value": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    },
+    {
+      "id": "c3",
+      "label": "us-east",
+      "node": "verify-us-east",
+      "value": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  ]
+}

--- a/pkg/workflow/testdata/phased-rollout.json
+++ b/pkg/workflow/testdata/phased-rollout.json
@@ -1,0 +1,1008 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "queued",
+      "from": "queue-eu",
+      "to": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "joinEdges": [
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-west",
+          "to": "deploy-eu"
+        },
+        {
+          "name": "us-metrics-good",
+          "from": "verify-us-east",
+          "to": "deploy-eu"
+        }
+      ]
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done"
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "v7"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "planning",
+      "from": "start",
+      "to": "plan",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "plan",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-west",
+      "cursor": {
+        "id": "c2",
+        "label": "us-west"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "queue-us-east",
+      "cursor": {
+        "id": "c3",
+        "label": "us-east"
+      },
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "plan",
+      "outputs": {
+        "phase": 1,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-west",
+      "to": "deploy-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "queued",
+      "from": "queue-us-east",
+      "to": "deploy-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-west",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-west",
+      "outputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-us-east",
+      "inputs": {
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-us-east",
+      "outputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-west",
+      "to": "verify-us-west",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-us-east",
+      "to": "verify-us-east",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-west",
+      "inputs": {
+        "region": "us-west",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-west",
+      "outputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-us-east",
+      "inputs": {
+        "region": "us-east",
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-us-east",
+      "outputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-west metrics look good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "us-east metrics look good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-west",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-west",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "inputs": {
+        "region": "us-east",
+        "verified": true,
+        "version": "7"
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": "verify-us-east",
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "us-metrics-good",
+      "from": null,
+      "to": "deploy-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "CursorsJoined",
+    "event": {
+      "old": [
+        {
+          "id": "c2",
+          "label": "us-west"
+        },
+        {
+          "id": "c3",
+          "label": "us-east"
+        }
+      ],
+      "new": {
+        "id": "c4",
+        "label": "merged"
+      }
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy-eu",
+      "inputs": {
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy-eu",
+      "outputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "deployed",
+      "from": "deploy-eu",
+      "to": "verify-eu",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "verify-eu",
+      "inputs": {
+        "region": "eu",
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "verify-eu",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "eu metrics look good"
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "eu-metrics-good",
+      "from": "verify-eu",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "region": "eu",
+        "verified": true,
+        "verify-us-east": {
+          "region": "us-east",
+          "verified": true,
+          "version": "7"
+        },
+        "verify-us-west": {
+          "region": "us-west",
+          "verified": true,
+          "version": "7"
+        }
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-west"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-us-east"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "queue-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "deploy-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "verify-eu"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "plan"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/testdata/retry.json
+++ b/pkg/workflow/testdata/retry.json
@@ -1,0 +1,772 @@
+[
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "deploy"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "NodeDefined",
+    "event": {
+      "id": "give-up"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "deploy"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done"
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "andEdges": [
+        {
+          "name": "retry[0]",
+          "from": "deploy",
+          "to": "deploy"
+        },
+        {
+          "name": "retry[1]",
+          "from": "deploy",
+          "to": "deploy"
+        }
+      ]
+    }
+  },
+  {
+    "type": "EdgeDefined",
+    "event": {
+      "name": "exhausted",
+      "from": "deploy",
+      "to": "give-up",
+      "andEdges": [
+        {
+          "name": "exhausted[0]",
+          "from": "deploy",
+          "to": "give-up"
+        },
+        {
+          "name": "exhausted[1]",
+          "from": "deploy",
+          "to": "give-up"
+        }
+      ]
+    }
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c1",
+        "label": "three attempts"
+      },
+      "inputs": {
+        "maxAttempts": 3
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "deploy",
+      "inputs": {
+        "maxAttempts": 3
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "maxAttempts": 3
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy",
+      "outputs": {
+        "attempts": 1,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy",
+      "outputs": {
+        "attempts": 2,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 3,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy",
+      "outputs": {
+        "attempts": 3,
+        "maxAttempts": 3,
+        "ok": true
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "inputs": {
+        "attempts": 3,
+        "maxAttempts": 3,
+        "ok": true
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "done",
+      "inputs": {
+        "attempts": 3,
+        "maxAttempts": 3,
+        "ok": true
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "done",
+      "outputs": {
+        "attempts": 3,
+        "maxAttempts": 3,
+        "ok": true
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "give-up"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  },
+  {
+    "type": "Note",
+    "note": "a second release only gets two attempts"
+  },
+  {
+    "type": "CursorAdded",
+    "event": {
+      "node": "start",
+      "cursor": {
+        "id": "c2",
+        "label": "two attempts"
+      },
+      "inputs": {
+        "maxAttempts": 2
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "deploy",
+      "inputs": {
+        "maxAttempts": 2
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "start",
+      "from": "start",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "maxAttempts": 2
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy",
+      "outputs": {
+        "attempts": 1,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "deploy",
+      "inputs": {
+        "attempts": 1,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "deploy",
+      "outputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "succeeded",
+      "from": "deploy",
+      "to": "done",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[0]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry[1]",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "retry",
+      "from": "deploy",
+      "to": "deploy",
+      "pass": false
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "exhausted",
+      "from": "deploy",
+      "to": "give-up",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "exhausted[0]",
+      "from": "deploy",
+      "to": "give-up",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "exhausted[0]",
+      "from": "deploy",
+      "to": "give-up",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeStarted",
+    "event": {
+      "name": "exhausted[1]",
+      "from": "deploy",
+      "to": "give-up",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "exhausted[1]",
+      "from": "deploy",
+      "to": "give-up",
+      "pass": true
+    }
+  },
+  {
+    "type": "EdgeFinished",
+    "event": {
+      "name": "exhausted",
+      "from": "deploy",
+      "to": "give-up",
+      "pass": true
+    }
+  },
+  {
+    "type": "NodeStarted",
+    "event": {
+      "id": "give-up",
+      "inputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "NodeSucceeded",
+    "event": {
+      "id": "give-up",
+      "outputs": {
+        "attempts": 2,
+        "maxAttempts": 2,
+        "ok": false
+      }
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "start"
+    }
+  },
+  {
+    "type": "NodeUntouched",
+    "event": {
+      "id": "done"
+    }
+  },
+  {
+    "type": "ProgressReturned"
+  }
+]

--- a/pkg/workflow/updates.go
+++ b/pkg/workflow/updates.go
@@ -1,37 +1,94 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package workflow
 
-import "github.com/pulumi/pulumi/sdk/v3/go/property"
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
 
 type WorkflowUpdate interface {
 	isWorkflowUpdate()
 }
 
-func (NodeStarted) isWorkflowUpdate()   {}
-func (NodeSucceeded) isWorkflowUpdate() {}
-func (NodeFailed) isWorkflowUpdate()    {}
-func (EdgeStarted) isWorkflowUpdate()   {}
-func (EdgeFinished) isWorkflowUpdate()  {}
-func (EdgeFailed) isWorkflowUpdate()    {}
-func (NodeDefined) isWorkflowUpdate()   {}
-func (EdgeDefined) isWorkflowUpdate()   {}
+func (NodeStarted) isWorkflowUpdate()    {}
+func (NodeSucceeded) isWorkflowUpdate()  {}
+func (NodeFailed) isWorkflowUpdate()     {}
+func (EdgeStarted) isWorkflowUpdate()    {}
+func (EdgeFinished) isWorkflowUpdate()   {}
+func (EdgeFailed) isWorkflowUpdate()     {}
+func (NodeDefined) isWorkflowUpdate()    {}
+func (EdgeDefined) isWorkflowUpdate()    {}
+func (CursorAdded) isWorkflowUpdate()    {}
+func (CursorsJoined) isWorkflowUpdate()  {}
+func (NodeUndefined) isWorkflowUpdate()  {}
+func (CursorReplaced) isWorkflowUpdate() {}
+func (NodeUntouched) isWorkflowUpdate()  {}
 
 type NodeStarted struct {
-	ID     string
-	Inputs property.Map
+	ID     string       `json:"id"`
+	Inputs property.Map `json:"inputs"`
+}
+
+func (e NodeStarted) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID     string `json:"id"`
+		Inputs any    `json:"inputs"`
+	}{e.ID, propertyJSON(e.Inputs)})
 }
 
 type NodeSucceeded struct {
-	ID      string
-	Outputs property.Map
+	ID      string       `json:"id"`
+	Outputs property.Map `json:"outputs"`
+}
+
+func (e NodeSucceeded) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID      string `json:"id"`
+		Outputs any    `json:"outputs"`
+	}{e.ID, propertyJSON(e.Outputs)})
 }
 
 type NodeFailed struct {
-	ID    string
-	Error error
+	ID    string `json:"id"`
+	Error error  `json:"error"`
+}
+
+func (e NodeFailed) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID    string `json:"id"`
+		Error string `json:"error"`
+	}{e.ID, e.Error.Error()})
 }
 
 type NodeDefined struct {
-	ID string
+	ID string `json:"id"`
+}
+
+// NodeUndefined reports, at the end of a Progress, a node that restored cursors sit on but that has not
+// been defined. The cursors stay put until it is.
+type NodeUndefined struct {
+	ID      string   `json:"id"`
+	Cursors []Cursor `json:"cursors"`
+}
+
+// NodeUntouched reports, at the end of a Progress, a defined node whose function did not run.
+type NodeUntouched struct {
+	ID string `json:"id"`
 }
 
 type EdgeDefined struct {
@@ -39,44 +96,71 @@ type EdgeDefined struct {
 
 	// May be a simple edge definition, or one of the following may have length > 0.
 
-	AndEdges  []EdgeDefined
-	OrEdges   []EdgeDefined
-	JoinEdges []EdgeDefined
+	AndEdges  []EdgeDefined `json:"andEdges,omitempty"`
+	OrEdges   []EdgeDefined `json:"orEdges,omitempty"`
+	JoinEdges []EdgeDefined `json:"joinEdges,omitempty"`
 }
 
 type EdgeIdentity struct {
-	Name string
-	From Node
-	To   Node
+	Name string `json:"name"`
+	From Node   `json:"from"`
+	To   Node   `json:"to"`
 }
 
 type EdgeStarted struct {
 	EdgeIdentity
-	Inputs property.Map
+	Inputs property.Map `json:"inputs"`
+}
+
+func (e EdgeStarted) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		EdgeIdentity
+		Inputs any `json:"inputs"`
+	}{e.EdgeIdentity, propertyJSON(e.Inputs)})
 }
 
 type EdgeFinished struct {
 	EdgeIdentity
-	Pass bool
+	Pass bool `json:"pass"`
 }
 
 type EdgeFailed struct {
 	EdgeIdentity
-	Error error
+	Error error `json:"error"`
+}
+
+func (e EdgeFailed) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		EdgeIdentity
+		Error string `json:"error"`
+	}{e.EdgeIdentity, e.Error.Error()})
 }
 
 type CursorAdded struct {
-	Node   Node
-	Inputs property.Map
+	Node   Node         `json:"node"`
+	Cursor Cursor       `json:"cursor"`
+	Inputs property.Map `json:"inputs"`
 }
 
+func (e CursorAdded) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Node   Node   `json:"node"`
+		Cursor Cursor `json:"cursor"`
+		Inputs any    `json:"inputs"`
+	}{e.Node, e.Cursor, propertyJSON(e.Inputs)})
+}
+
+// CursorReplaced reports that Old, unable to move on from Node, was overwritten by New arriving there.
+// Every cursor ends in exactly one CursorReplaced or CursorsJoined.
 type CursorReplaced struct {
-	Old  Cursor
-	New  Cursor
-	Node Node
+	Old  Cursor `json:"old"`
+	New  Cursor `json:"new"`
+	Node Node   `json:"node"`
 }
 
 type CursorsJoined struct {
-	Old []Cursor
-	New Cursor
+	Old []Cursor `json:"old"`
+	New Cursor   `json:"new"`
 }
+
+func propertyJSON(m property.Map) any { return resource.ToResourcePropertyMap(m).Mappable() }

--- a/pkg/workflow/updates.go
+++ b/pkg/workflow/updates.go
@@ -1,0 +1,82 @@
+package workflow
+
+import "github.com/pulumi/pulumi/sdk/v3/go/property"
+
+type WorkflowUpdate interface {
+	isWorkflowUpdate()
+}
+
+func (NodeStarted) isWorkflowUpdate()   {}
+func (NodeSucceeded) isWorkflowUpdate() {}
+func (NodeFailed) isWorkflowUpdate()    {}
+func (EdgeStarted) isWorkflowUpdate()   {}
+func (EdgeFinished) isWorkflowUpdate()  {}
+func (EdgeFailed) isWorkflowUpdate()    {}
+func (NodeDefined) isWorkflowUpdate()   {}
+func (EdgeDefined) isWorkflowUpdate()   {}
+
+type NodeStarted struct {
+	ID     string
+	Inputs property.Map
+}
+
+type NodeSucceeded struct {
+	ID      string
+	Outputs property.Map
+}
+
+type NodeFailed struct {
+	ID    string
+	Error error
+}
+
+type NodeDefined struct {
+	ID string
+}
+
+type EdgeDefined struct {
+	EdgeIdentity
+
+	// May be a simple edge definition, or one of the following may have length > 0.
+
+	AndEdges  []EdgeDefined
+	OrEdges   []EdgeDefined
+	JoinEdges []EdgeDefined
+}
+
+type EdgeIdentity struct {
+	Name string
+	From Node
+	To   Node
+}
+
+type EdgeStarted struct {
+	EdgeIdentity
+	Inputs property.Map
+}
+
+type EdgeFinished struct {
+	EdgeIdentity
+	Pass bool
+}
+
+type EdgeFailed struct {
+	EdgeIdentity
+	Error error
+}
+
+type CursorAdded struct {
+	Node   Node
+	Inputs property.Map
+}
+
+type CursorReplaced struct {
+	Old  Cursor
+	New  Cursor
+	Node Node
+}
+
+type CursorsJoined struct {
+	Old []Cursor
+	New Cursor
+}

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -1,72 +1,615 @@
-// Package workflow provides an augmented view onto of [fsa] with richer semantics.
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package workflow provides an augmented view on top of [fsa] with richer semantics: nodes have string
+// identities and pass property maps along edges, edges compose (and, or, join), progress is reported as a
+// stream of [WorkflowUpdate] events, and cursor placement can be saved with [Workflow.State] and restored
+// with [FromState].
+//
+// The semantics of [fsa] leak through. Edge conditions are sampled at most once per visit, so an edge that
+// depends on external state is not re-asked until the next [Workflow.Progress]; run Progress in a loop. A
+// node's outgoing edges are asked in definition order and the first to pass is taken. A cursor arriving
+// at an occupied node overwrites an occupant that cannot move, and two cursors moving to the same node
+// in the same step is an error. A node function's error aborts the Progress: nothing further is
+// started, but node functions already running are waited for, and every node function that returns nil
+// has its cursor committed to that node — a successful deploy is never re-run. A cursor whose move had
+// not yet been decided stays where it was and moves on the next Progress.
+//
+// Every cursor's life is reported: it begins with [CursorAdded] or as the New cursor of a [CursorsJoined],
+// and ends with exactly one of [CursorReplaced] or [CursorsJoined].
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v3/util/fsa"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
-type Workflow struct {
+type Workflow struct{ *workflow }
+
+type workflow struct {
 	g fsa.FSA[cursor]
+
+	m          sync.Mutex
+	nodes      map[string]fsa.Node
+	nodeIDs    map[fsa.Node]string
+	defined    []string        // Node IDs in definition order
+	touched    map[string]bool // Nodes whose function ran during the current Progress
+	joins      map[string]bool // Join edge names, which must be unique
+	states     map[string]NodeState
+	nextCursor int
+	// Cursors from [FromState] awaiting the definition of the node they sit on, keyed by node ID.
+	restore map[string][]*cursorData
+
+	progressing bool
+	updates     chan<- WorkflowUpdate // Valid while progressing
+	pending     []WorkflowUpdate      // Emitted while not progressing; replayed by the next Progress
 }
 
 func New() Workflow {
-	return Workflow{fsa.New[cursor]()}
+	w := &workflow{
+		nodes:   map[string]fsa.Node{},
+		nodeIDs: map[fsa.Node]string{},
+		states:  map[string]NodeState{},
+		touched: map[string]bool{},
+		joins:   map[string]bool{},
+		restore: map[string][]*cursorData{},
+	}
+	w.g = fsa.New(fsa.OnReplace(w.replaced))
+	return Workflow{w}
 }
 
-func FromState(state json.RawMessage) Workflow {
-	panic("TODO")
+// Report a cursor overwritten by the FSA. A cursor merged by a join already ended in CursorsJoined and
+// left the machine; should a stale in-flight overwrite of it still arrive, it is not a second end.
+func (w *workflow) replaced(old, by cursor, at fsa.Node) {
+	w.m.Lock()
+	consumed := old.consumed
+	u := CursorReplaced{Old: old.Cursor(), New: by.Cursor(), Node: Node{w.nodeIDs[at]}}
+	w.m.Unlock()
+	if !consumed {
+		w.emit(u)
+	}
 }
 
-type NodeFunc = func(ctx context.Context, w Workflow, inputs property.Map) (property.Map, error)
-type EdgeFunc = func(ctx context.Context, w Workflow, inputs property.Map) (bool, error)
-type Node = fsa.Node
+// FromState builds a Workflow whose cursors are those saved by [Workflow.State]. Each cursor is placed as
+// soon as the node it sits on is defined; every [Workflow.Progress] reports cursors whose node is still
+// undefined with [NodeUndefined].
+func FromState(state json.RawMessage) (Workflow, error) {
+	var s savedState
+	dec := json.NewDecoder(bytes.NewReader(state))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&s); err != nil {
+		return Workflow{}, fmt.Errorf("invalid workflow state: %w", err)
+	}
+	w := New()
+	w.nextCursor = s.NextCursor
+	for _, c := range s.Cursors {
+		value, err := decodeProperties(c.Value)
+		if err != nil {
+			return Workflow{}, fmt.Errorf("invalid workflow state: cursor %q: %w", c.ID, err)
+		}
+		data := &cursorData{id: c.ID, label: c.Label, value: value}
+		if c.Merged != nil {
+			data.mergedJoin, data.mergedOn = c.Merged.Join, c.Merged.Node
+		}
+		w.restore[c.Node] = append(w.restore[c.Node], data)
+	}
+	return w, nil
+}
+
+type (
+	NodeFunc = func(ctx context.Context, w Workflow, inputs property.Map) (property.Map, error)
+	EdgeFunc = func(ctx context.Context, w Workflow, inputs property.Map) (bool, error)
+)
+
+// Node identifies a node of a Workflow. It serializes as the node's ID.
+type Node struct{ id string }
+
+func (n Node) ID() string { return n.id }
+
+func (n Node) MarshalJSON() ([]byte, error) {
+	if n.id == "" {
+		return []byte("null"), nil
+	}
+	return json.Marshal(n.id)
+}
+
 type Cursor struct {
-	ID    string
-	Label string
+	ID    string `json:"id"`
+	Label string `json:"label"`
 }
 
+// NewNode defines a node. f runs each time a cursor enters the node: it receives the outputs of the node
+// the cursor came from and its outputs become the cursor's value. Node IDs must be unique.
 func (w Workflow) NewNode(id string, f NodeFunc) Node {
-	panic("TODO")
+	contract.Assertf(id != "", "node IDs must not be empty")
+	w.emit(NodeDefined{ID: id})
+	w.register(id, w.g.NewNode(func(ctx context.Context, _ fsa.FSA[cursor], _ fsa.Edge, c cursor) error {
+		w.m.Lock()
+		w.touched[id] = true
+		inputs := c.value
+		clear(c.reached) // Entering a node starts a fresh visit
+		w.m.Unlock()
+		w.emit(NodeStarted{ID: id, Inputs: inputs})
+		outputs, err := f(ctx, w, inputs)
+		if err != nil {
+			w.emit(NodeFailed{ID: id, Error: err})
+			return err
+		}
+		w.m.Lock()
+		// The move may still be abandoned if the run fails, so the outputs become the cursor's value only
+		// once it is asked a question here, which proves it arrived.
+		c.pending, c.pendingFrom = outputs, id
+		w.states[id] = NodeState{LastRun: time.Now(), Inputs: inputs, Outputs: outputs}
+		w.m.Unlock()
+		w.emit(NodeSucceeded{ID: id, Outputs: outputs})
+		return nil
+	}))
+	w.m.Lock()
+	w.defined = append(w.defined, id)
+	w.m.Unlock()
+	return Node{id}
 }
 
+// AddCursor places a cursor with the given inputs on n. The node's function is not run. Placing is an
+// arrival: a cursor already on n is overwritten once it settles there without moving away.
+func (w Workflow) AddCursor(n Node, label string, inputs property.Map) {
+	fn := w.fsaNode(n)
+	w.m.Lock()
+	c := &cursorData{id: w.newCursorIDLocked(), label: label, value: inputs}
+	w.m.Unlock()
+	w.emit(CursorAdded{Node: n, Cursor: c.Cursor(), Inputs: inputs})
+	w.m.Lock()
+	c.ref = w.g.NewCursor(cursor{c}, fn) // Placed and referenced under one lock: no one sees it unreferenced
+	w.m.Unlock()
+}
+
+// NewEdge defines an edge from one node to another, taken when edge returns true.
+//
+// A node's outgoing edges are asked in definition order and the first to pass is taken.
 func (w Workflow) NewEdge(name string, from, to Node, edge EdgeFunc) {
-	panic("TODO")
+	ident := EdgeIdentity{Name: name, From: from, To: to}
+	w.addEdge(EdgeDefined{EdgeIdentity: ident}, from, func(ctx context.Context, c cursor) (bool, error) {
+		return w.eval(ctx, ident, edge, c.get(w.workflow))
+	})
 }
 
+// NewOrEdge defines an edge taken when any of edges returns true. Edges are asked in order and the first
+// true short-circuits.
 func (w Workflow) NewOrEdge(name string, from, to Node, edges ...EdgeFunc) {
-	panic("TODO")
+	w.composite(name, from, to, edges, false)
 }
 
+// NewAndEdge defines an edge taken when all of edges return true. Edges are asked in order and the first
+// false short-circuits.
 func (w Workflow) NewAndEdge(name string, from, to Node, edges ...EdgeFunc) {
-	panic("TODO")
+	w.composite(name, from, to, edges, true)
 }
 
-func (w Workflow) NewJoinEdge(name string, from []JoinEdgeArg, to Node) {
-	panic("TODO")
+func (w Workflow) composite(name string, from, to Node, edges []EdgeFunc, all bool) {
+	contract.Assertf(len(edges) > 0, "edge %q: at least one edge function is required", name)
+	ident := EdgeIdentity{Name: name, From: from, To: to}
+	def := EdgeDefined{EdgeIdentity: ident}
+	children := make([]EdgeIdentity, len(edges))
+	for i := range edges {
+		children[i] = EdgeIdentity{Name: fmt.Sprintf("%s[%d]", name, i), From: from, To: to}
+		if all {
+			def.AndEdges = append(def.AndEdges, EdgeDefined{EdgeIdentity: children[i]})
+		} else {
+			def.OrEdges = append(def.OrEdges, EdgeDefined{EdgeIdentity: children[i]})
+		}
+	}
+	w.addEdge(def, from, func(ctx context.Context, c cursor) (bool, error) {
+		inputs := c.get(w.workflow)
+		w.emit(EdgeStarted{EdgeIdentity: ident, Inputs: inputs})
+		pass := all
+		for i, e := range edges {
+			if err := ctx.Err(); err != nil {
+				return false, err // The run was aborted: ask nothing more
+			}
+			p, err := w.eval(ctx, children[i], e, inputs)
+			if err != nil {
+				w.emit(EdgeFailed{EdgeIdentity: ident, Error: err})
+				return false, err
+			}
+			if p != all {
+				pass = p
+				break
+			}
+		}
+		w.emit(EdgeFinished{EdgeIdentity: ident, Pass: pass})
+		return pass, nil
+	})
 }
 
 type JoinEdgeArg struct {
 	From Node
-	edge EdgeFunc
+	Edge EdgeFunc
 }
 
+// A MergeFunc decides a join once every branch's Edge has passed: true merges the candidates into one
+// cursor described by MergedCursor; false rejects the merge, leaving every candidate where it is to be
+// asked again later; an error fails the Progress.
+type MergeFunc = func(ctx context.Context, candidates []MergeCandidate) (bool, MergedCursor, error)
+
+// MergeCandidate is a cursor waiting on a join branch, in the order of the join's From nodes.
+type MergeCandidate struct {
+	From   Node
+	Cursor Cursor
+	Inputs property.Map
+}
+
+type MergedCursor struct {
+	Label  string
+	Inputs property.Map
+}
+
+// NewJoinEdge defines an edge that merges one cursor from each of from into a single cursor at to. The
+// join is taken only when every From node holds a cursor and, evaluated together at that moment, every
+// branch's Edge returns true for its cursor and merge accepts them; otherwise every cursor stays where
+// it is. The join's own [EdgeFinished] reports merge's decision.
+//
+// Each From node may have other outgoing edges, asked in definition order like any node's: a cursor is
+// only merged once the edges defined before the join have failed for it. Branch Edges and merge are
+// asked together on every attempt at the join, so unlike other edges they may be asked more than once
+// per visit. A join is decided exactly once: should the merged cursor's move to to be interrupted, it
+// is completed on a later Progress rather than re-decided. Join names must be unique within a Workflow
+// and From nodes distinct.
+func (w Workflow) NewJoinEdge(name string, from []JoinEdgeArg, to Node, merge MergeFunc) {
+	contract.Assertf(len(from) > 0, "edge %q: at least one branch is required", name)
+	contract.Assertf(merge != nil, "edge %q: a merge function is required", name)
+	w.m.Lock()
+	contract.Assertf(!w.joins[name], "join %q is already defined", name)
+	w.joins[name] = true
+	w.m.Unlock()
+	def := EdgeDefined{EdgeIdentity: EdgeIdentity{Name: name, To: to}}
+	j := &join{
+		ident: def.EdgeIdentity, from: from, merge: merge,
+		branches: make([]EdgeIdentity, len(from)), nodes: make([]fsa.Node, len(from)),
+	}
+	for i, arg := range from {
+		contract.Assertf(arg.From != to, "join %q: a join cannot target one of its own From nodes", name)
+		contract.Assertf(!slices.ContainsFunc(from[:i], func(o JoinEdgeArg) bool { return o.From == arg.From }),
+			"join %q: From node %q is listed twice", name, arg.From.id)
+		j.branches[i] = EdgeIdentity{Name: name, From: arg.From, To: to}
+		j.nodes[i] = w.fsaNode(arg.From)
+		def.JoinEdges = append(def.JoinEdges, EdgeDefined{EdgeIdentity: j.branches[i]})
+	}
+	target := w.fsaNode(to)
+	w.emit(def)
+	for i, arg := range from {
+		w.g.NewEdge(w.guard(arg.From, name, w.joinCond(j, i)), j.nodes[i], target)
+	}
+}
+
+type join struct {
+	ident    EdgeIdentity // Name and To; From is unset
+	from     []JoinEdgeArg
+	merge    MergeFunc
+	branches []EdgeIdentity
+	nodes    []fsa.Node // from[i].From
+}
+
+// The condition asked of a cursor on from[k]: pass for the cursor that finds every branch occupied and
+// every branch edge passing, merging the others into it.
+func (w Workflow) joinCond(j *join, k int) func(context.Context, cursor) (bool, error) {
+	return func(ctx context.Context, me cursor) (bool, error) {
+		w.m.Lock()
+		if me.mergedJoin == j.ident.Name && me.mergedOn == j.from[k].From.id {
+			w.m.Unlock()
+			return true, nil // Already decided; this is the interrupted move being completed
+		}
+		if me.reached == nil {
+			me.reached = map[*join]bool{}
+		}
+		me.reached[j] = true // Every edge before this join has failed for me this visit
+		present, ok := w.participantsLocked(j)
+		w.m.Unlock()
+		if !ok || present[k].cursorData != me.cursorData {
+			return false, nil
+		}
+		candidates := make([]MergeCandidate, len(present))
+		for i, p := range present {
+			if err := ctx.Err(); err != nil {
+				return false, err // The run was aborted: ask nothing more
+			}
+			pass, err := w.eval(ctx, j.branches[i], j.from[i].Edge, p.value)
+			if err != nil || !pass {
+				return false, err
+			}
+			candidates[i] = MergeCandidate{From: j.from[i].From, Cursor: p.ident, Inputs: p.value}
+		}
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		accept, merged, err := j.merge(ctx, candidates)
+		if err != nil {
+			w.emit(EdgeFailed{EdgeIdentity: j.ident, Error: err})
+			return false, err
+		}
+		w.emit(EdgeFinished{EdgeIdentity: j.ident, Pass: accept})
+		if !accept {
+			return false, nil
+		}
+
+		w.m.Lock()
+		// The branch edges ran without the lock: decide only if nothing changed underneath them.
+		again, ok := w.participantsLocked(j)
+		if !ok || me.consumed {
+			w.m.Unlock()
+			return false, nil
+		}
+		for i := range present {
+			if again[i].cursorData != present[i].cursorData || !again[i].value.Equals(present[i].value) {
+				w.m.Unlock()
+				return false, nil
+			}
+		}
+		// Merging is the others' move: they leave the machine now, atomically, so that nothing observes
+		// them as arrivals afterwards. If one is already gone the attempt is void.
+		var others []fsa.CursorRef
+		for _, p := range present {
+			if p.cursorData != me.cursorData {
+				others = append(others, p.ref)
+			}
+		}
+		if !w.g.Remove(others...) {
+			w.m.Unlock()
+			return false, nil
+		}
+		joined := CursorsJoined{New: Cursor{ID: w.newCursorIDLocked(), Label: merged.Label}}
+		for _, p := range present {
+			joined.Old = append(joined.Old, p.ident)
+			p.consumed = p.cursorData != me.cursorData // Its own in-flight conditions must not act
+		}
+		me.id, me.label, me.value = joined.New.ID, joined.New.Label, merged.Inputs
+		me.pending, me.pendingFrom = property.Map{}, ""
+		me.mergedJoin, me.mergedOn = j.ident.Name, j.from[k].From.id
+		me.leaving = true // Decided: no other join may take me from here on
+		w.m.Unlock()
+		w.emit(joined)
+		return true, nil
+	}
+}
+
+// A join participant: a live cursor on one of the join's From nodes, with its identity and value as
+// seen under the lock.
+type participant struct {
+	cursor
+	ident Cursor
+	value property.Map
+}
+
+// The participant on each of j's From nodes, if every node has one. A cursor participates once it has
+// reached the join this visit — every edge defined before it has failed — and is not moving away.
+func (w *workflow) participantsLocked(j *join) ([]participant, bool) {
+	present := make([]participant, len(j.nodes))
+	for c, n := range w.g.Cursors {
+		if c.consumed || c.leaving || c.mergedOn != "" || !c.reached[j] {
+			continue // Gone, going, committed to a decided join, or not yet at this join
+		}
+		if i := slices.Index(j.nodes, n); i >= 0 && present[i].cursorData == nil {
+			present[i] = participant{c, c.Cursor(), c.valueAt(j.from[i].From.id)}
+		}
+	}
+	for _, p := range present {
+		if p.cursorData == nil {
+			return nil, false
+		}
+	}
+	return present, true
+}
+
+func (w Workflow) addEdge(def EdgeDefined, from Node, cond func(context.Context, cursor) (bool, error)) {
+	fromNode, to := w.fsaNode(def.From), w.fsaNode(def.To)
+	w.emit(def)
+	w.g.NewEdge(w.guard(from, "", cond), fromNode, to)
+}
+
+// guard wraps a condition asked of cursors on from with the bookkeeping every edge shares: a cursor
+// merged away by a join never moves, a cursor whose join was decided here takes nothing but that join
+// (named by joinName for the join's own edges), and a pass is recorded atomically with the check so
+// that a join cannot merge a cursor that is leaving.
+func (w *workflow) guard(
+	from Node, joinName string, cond func(context.Context, cursor) (bool, error),
+) fsa.ConditionFunc[cursor] {
+	return func(ctx context.Context, _ fsa.FSA[cursor], c cursor) (fsa.ConditionResult, error) {
+		w.m.Lock()
+		c.leaving = false // Being asked here means the cursor is here
+		c.value = c.valueAt(from.id)
+		c.pending, c.pendingFrom = property.Map{}, ""
+		if c.mergedOn != "" && c.mergedOn != from.id {
+			c.mergedJoin, c.mergedOn = "", "" // Being asked elsewhere means the merged cursor's move completed
+		}
+		blocked := c.consumed || (c.mergedOn == from.id && c.mergedJoin != joinName)
+		w.m.Unlock()
+		if blocked {
+			return fsa.ConditionFail, nil
+		}
+		pass, err := cond(ctx, c)
+		if err != nil {
+			return fsa.ConditionUnknown, err
+		}
+		if !pass {
+			return fsa.ConditionFail, nil
+		}
+		w.m.Lock()
+		defer w.m.Unlock()
+		if c.consumed {
+			return fsa.ConditionFail, nil // Merged away while deciding; the merged cursor carries on
+		}
+		c.leaving = true
+		return fsa.ConditionPass, nil
+	}
+}
+
+// Ask edge, reporting the outcome as events.
+func (w Workflow) eval(ctx context.Context, ident EdgeIdentity, edge EdgeFunc, inputs property.Map) (bool, error) {
+	w.emit(EdgeStarted{EdgeIdentity: ident, Inputs: inputs})
+	pass, err := edge(ctx, w, inputs)
+	if err != nil {
+		w.emit(EdgeFailed{EdgeIdentity: ident, Error: err})
+		return false, err
+	}
+	w.emit(EdgeFinished{EdgeIdentity: ident, Pass: pass})
+	return pass, nil
+}
+
+// NodeByID looks up a defined node by its ID.
+func (w Workflow) NodeByID(id string) (Node, bool) {
+	w.m.Lock()
+	defer w.m.Unlock()
+	_, ok := w.nodes[id]
+	return Node{id}, ok
+}
+
+// GetState reports the last run of node; the zero value if it has not run.
 func (w Workflow) GetState(node Node) NodeState {
-	panic("TODO")
+	w.m.Lock()
+	defer w.m.Unlock()
+	return w.states[node.id]
 }
 
+// Progress iterates the workflow until no cursor can move, sending events to updates (which may be nil).
+// Events emitted before Progress (definitions, added cursors) are sent first. Once no cursor can move,
+// Progress reports each node holding restored cursors that is still undefined ([NodeUndefined]) and each
+// defined node whose function did not run ([NodeUntouched]).
 func (w Workflow) Progress(
 	ctx context.Context, runner fsa.Runner, updates chan<- WorkflowUpdate,
 ) error {
-	return w.g.Progress(ctx, runner)
+	w.m.Lock()
+	contract.Assertf(!w.progressing, "we can only progress one run at a time")
+	w.progressing, w.updates = true, updates
+	clear(w.touched)
+	for c := range w.g.Cursors {
+		// Every Progress starts a fresh visit: a move interrupted by a failed run is retried this run.
+		c.leaving = false
+		clear(c.reached)
+	}
+	pending := w.pending
+	w.pending = nil
+	w.m.Unlock()
+	defer func() {
+		w.m.Lock()
+		w.progressing, w.updates = false, nil
+		w.m.Unlock()
+	}()
+
+	if updates != nil {
+		for _, u := range pending {
+			updates <- u
+		}
+	}
+	err := w.g.Progress(ctx, runner)
+
+	w.m.Lock()
+	var summary []WorkflowUpdate
+	for _, id := range slices.Sorted(maps.Keys(w.restore)) {
+		u := NodeUndefined{ID: id}
+		for _, c := range w.restore[id] {
+			u.Cursors = append(u.Cursors, c.Cursor())
+		}
+		summary = append(summary, u)
+	}
+	for _, id := range w.defined {
+		if !w.touched[id] {
+			summary = append(summary, NodeUntouched{ID: id})
+		}
+	}
+	w.m.Unlock()
+	for _, u := range summary {
+		w.emit(u)
+	}
+	return err
 }
 
+// State serializes the workflow's cursors so that [FromState] can resume them once the same nodes and
+// edges are defined. Cursors sharing a node are listed in arrival order, which [FromState] preserves, so
+// a cursor that arrived beside an occupant still to settle keeps precedence over it. It must not be
+// called while Progress is running.
 func (w Workflow) State() json.RawMessage {
-	panic("TODO")
+	w.m.Lock()
+	defer w.m.Unlock()
+	contract.Assertf(!w.progressing, "State cannot be taken while progressing")
+	s := savedState{NextCursor: w.nextCursor}
+	save := func(c *cursorData, node string, value property.Map) {
+		sc := savedCursor{ID: c.id, Label: c.label, Node: node, Value: encodeProperties(value)}
+		if c.mergedOn != "" {
+			sc.Merged = &savedMerge{Join: c.mergedJoin, Node: c.mergedOn}
+		}
+		s.Cursors = append(s.Cursors, sc)
+	}
+	for c, n := range w.g.Cursors {
+		if !c.consumed {
+			save(c.cursorData, w.nodeIDs[n], c.valueAt(w.nodeIDs[n]))
+		}
+	}
+	for _, node := range slices.Sorted(maps.Keys(w.restore)) {
+		for _, c := range w.restore[node] {
+			save(c, node, c.value)
+		}
+	}
+	b, err := json.MarshalIndent(s, "", "  ")
+	contract.AssertNoErrorf(err, "state is always serializable")
+	return b
+}
+
+type savedState struct {
+	NextCursor int           `json:"nextCursor"`
+	Cursors    []savedCursor `json:"cursors"`
+}
+
+type savedCursor struct {
+	ID     string         `json:"id"`
+	Label  string         `json:"label"`
+	Node   string         `json:"node"`
+	Value  map[string]any `json:"value"`
+	Merged *savedMerge    `json:"merged,omitempty"`
+}
+
+type savedMerge struct {
+	Join string `json:"join"`
+	Node string `json:"node"`
+}
+
+// Property maps are stored in the format of a stack's deployment, which keeps secrets, unknowns,
+// assets, resource references and non-finite numbers. Secrets are stored in the clear.
+func encodeProperties(m property.Map) map[string]any {
+	v, err := stack.SerializeProperties(context.Background(),
+		resource.ToResourcePropertyMap(m), config.NopEncrypter, false /* showSecrets */)
+	contract.AssertNoErrorf(err, "property maps are always serializable")
+	return v
+}
+
+func decodeProperties(v map[string]any) (property.Map, error) {
+	m, err := stack.DeserializeProperties(v, config.NopDecrypter)
+	if err != nil {
+		return property.Map{}, err
+	}
+	return resource.FromResourcePropertyMap(m), nil
 }
 
 type NodeState struct {
@@ -75,6 +618,78 @@ type NodeState struct {
 	Outputs property.Map
 }
 
-type cursor struct {
-	value property.Map
+func (w *workflow) emit(u WorkflowUpdate) {
+	w.m.Lock()
+	if !w.progressing {
+		w.pending = append(w.pending, u)
+		w.m.Unlock()
+		return
+	}
+	ch := w.updates
+	w.m.Unlock()
+	if ch != nil {
+		ch <- u
+	}
 }
+
+// Record n under id, placing any restored cursors waiting for it.
+func (w *workflow) register(id string, n fsa.Node) {
+	w.m.Lock()
+	_, dup := w.nodes[id]
+	contract.Assertf(!dup, "node %q is already defined", id)
+	w.nodes[id], w.nodeIDs[n] = n, id
+	restored := w.restore[id]
+	delete(w.restore, id)
+	for _, c := range restored {
+		c.ref = w.g.NewCursor(cursor{c}, n) // In saved order, which is arrival order
+	}
+	w.m.Unlock()
+}
+
+func (w *workflow) fsaNode(n Node) fsa.Node {
+	w.m.Lock()
+	defer w.m.Unlock()
+	fn, ok := w.nodes[n.id]
+	contract.Assertf(ok, "node %q is not defined in this workflow", n.id)
+	return fn
+}
+
+func (w *workflow) newCursorIDLocked() string {
+	w.nextCursor++
+	return fmt.Sprintf("c%d", w.nextCursor)
+}
+
+// The FSA cursor. It is a pointer so that node functions, which receive the cursor by value, can update
+// it. Fields are guarded by workflow.m.
+type cursor struct{ *cursorData }
+
+type cursorData struct {
+	id, label string
+	ref       fsa.CursorRef // Valid once placed
+	value     property.Map
+	// The outputs of the node function that last ran for this cursor, and that node. They become value
+	// once the cursor is asked a question at pendingFrom, proving the move was committed.
+	pending     property.Map
+	pendingFrom string
+	consumed    bool           // Merged into another cursor by a join and removed; inert if still asked
+	leaving     bool           // A condition passed; the cursor is moving away and must not be merged
+	reached     map[*join]bool // Joins asked of this cursor during its current visit
+	mergedJoin  string         // With mergedOn: a join decided for this cursor while on that node, until it moves on
+	mergedOn    string
+}
+
+// The cursor's value as seen at node.
+func (c *cursorData) valueAt(node string) property.Map {
+	if c.pendingFrom == node {
+		return c.pending
+	}
+	return c.value
+}
+
+func (c cursor) get(w *workflow) property.Map {
+	w.m.Lock()
+	defer w.m.Unlock()
+	return c.value
+}
+
+func (c *cursorData) Cursor() Cursor { return Cursor{ID: c.id, Label: c.label} }

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -1,0 +1,80 @@
+// Package workflow provides an augmented view onto of [fsa] with richer semantics.
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/fsa"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+type Workflow struct {
+	g fsa.FSA[cursor]
+}
+
+func New() Workflow {
+	return Workflow{fsa.New[cursor]()}
+}
+
+func FromState(state json.RawMessage) Workflow {
+	panic("TODO")
+}
+
+type NodeFunc = func(ctx context.Context, w Workflow, inputs property.Map) (property.Map, error)
+type EdgeFunc = func(ctx context.Context, w Workflow, inputs property.Map) (bool, error)
+type Node = fsa.Node
+type Cursor struct {
+	ID    string
+	Label string
+}
+
+func (w Workflow) NewNode(id string, f NodeFunc) Node {
+	panic("TODO")
+}
+
+func (w Workflow) NewEdge(name string, from, to Node, edge EdgeFunc) {
+	panic("TODO")
+}
+
+func (w Workflow) NewOrEdge(name string, from, to Node, edges ...EdgeFunc) {
+	panic("TODO")
+}
+
+func (w Workflow) NewAndEdge(name string, from, to Node, edges ...EdgeFunc) {
+	panic("TODO")
+}
+
+func (w Workflow) NewJoinEdge(name string, from []JoinEdgeArg, to Node) {
+	panic("TODO")
+}
+
+type JoinEdgeArg struct {
+	From Node
+	edge EdgeFunc
+}
+
+func (w Workflow) GetState(node Node) NodeState {
+	panic("TODO")
+}
+
+func (w Workflow) Progress(
+	ctx context.Context, runner fsa.Runner, updates chan<- WorkflowUpdate,
+) error {
+	return w.g.Progress(ctx, runner)
+}
+
+func (w Workflow) State() json.RawMessage {
+	panic("TODO")
+}
+
+type NodeState struct {
+	LastRun time.Time
+	Inputs  property.Map
+	Outputs property.Map
+}
+
+type cursor struct {
+	value property.Map
+}

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -1,0 +1,791 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/fsa"
+	"github.com/pulumi/pulumi/pkg/v3/workflow"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// A recorder drives a workflow with the sync runner and records every event, interleaved with test
+// annotations, for comparison against a golden file.
+type recorder struct {
+	t      *testing.T
+	w      workflow.Workflow
+	events []recorded
+}
+
+type recorded struct {
+	Type  string `json:"type"`
+	Event any    `json:"event,omitempty"`
+	Note  string `json:"note,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+func (r *recorder) note(note string) {
+	r.events = append(r.events, recorded{Type: "Note", Note: note})
+}
+
+// Run Progress once, recording its events and its result.
+func (r *recorder) progress() error {
+	updates := make(chan workflow.WorkflowUpdate)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for u := range updates {
+			r.events = append(r.events, recorded{Type: strings.TrimPrefix(fmt.Sprintf("%T", u), "workflow."), Event: u})
+		}
+	}()
+	err := r.w.Progress(r.t.Context(), fsa.SyncRunner, updates)
+	close(updates)
+	<-done
+	rec := recorded{Type: "ProgressReturned"}
+	if err != nil {
+		rec.Error = err.Error()
+	}
+	r.events = append(r.events, rec)
+	return err
+}
+
+func (r *recorder) golden(name string) {
+	b, err := json.MarshalIndent(r.events, "", "  ")
+	require.NoError(r.t, err)
+	golden(r.t, name, b)
+}
+
+func golden(t *testing.T, name string, got []byte) {
+	path := filepath.Join("testdata", name+".json")
+	if cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT")) {
+		require.NoError(t, os.WriteFile(path, got, 0o600))
+		return
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err, "run with PULUMI_ACCEPT=1 to create the golden file")
+	require.Equal(t, string(want), string(got))
+}
+
+func str(s string) property.Value                   { return property.New(s) }
+func num(n float64) property.Value                  { return property.New(n) }
+func boolean(b bool) property.Value                 { return property.New(b) }
+func pmap(m map[string]property.Value) property.Map { return property.NewMap(m) }
+
+func mustNode(t *testing.T, w workflow.Workflow, id string) workflow.Node {
+	n, ok := w.NodeByID(id)
+	require.True(t, ok, "node %q is not defined", id)
+	return n
+}
+
+func always(context.Context, workflow.Workflow, property.Map) (bool, error) { return true, nil }
+
+// Passes when the value at key is a bool that is true.
+func flag(key string) workflow.EdgeFunc {
+	return func(_ context.Context, _ workflow.Workflow, in property.Map) (bool, error) {
+		v := in.Get(key)
+		return v.IsBool() && v.AsBool(), nil
+	}
+}
+
+func not(f workflow.EdgeFunc) workflow.EdgeFunc {
+	return func(ctx context.Context, w workflow.Workflow, in property.Map) (bool, error) {
+		ok, err := f(ctx, w, in)
+		return !ok, err
+	}
+}
+
+// Passes when *v is true; the test flips v to simulate the world changing between Progress calls.
+func external(v *bool) workflow.EdgeFunc {
+	return func(context.Context, workflow.Workflow, property.Map) (bool, error) { return *v, nil }
+}
+
+// A node that merges extra keys into its inputs.
+func with(extra map[string]property.Value) workflow.NodeFunc {
+	return func(_ context.Context, _ workflow.Workflow, in property.Map) (property.Map, error) {
+		out := in.AsMap()
+		maps.Copy(out, extra)
+		return property.NewMap(out), nil
+	}
+}
+
+// A blue/green deployment: deploy the green stack, verify it, wait for a human to approve the traffic
+// switch, then decommission blue. An unhealthy green stack (or an approval that times out) rolls back.
+func TestBlueGreen(t *testing.T) {
+	t.Parallel()
+	var approved, timedOut bool
+	w := workflow.New()
+
+	// AddCursor does not run the node it places the cursor on, so releases start on a node of their own.
+	requested := w.NewNode("release-requested", with(nil))
+	deploy := w.NewNode("deploy-green", func(_ context.Context, _ workflow.Workflow, in property.Map) (
+		property.Map, error,
+	) {
+		return pmap(map[string]property.Value{
+			"version": in.Get("version"),
+			"url":     str("https://green.example.com/" + in.Get("version").AsString()),
+		}), nil
+	})
+	verify := w.NewNode("verify-green", func(_ context.Context, _ workflow.Workflow, in property.Map) (
+		property.Map, error,
+	) {
+		// Only version 2.x is healthy in this simulation.
+		healthy := strings.HasPrefix(in.Get("version").AsString(), "2.")
+		return in.Set("healthy", boolean(healthy)), nil
+	})
+	switchTraffic := w.NewNode("switch-traffic", with(map[string]property.Value{"live": str("green")}))
+	decommission := w.NewNode("decommission-blue", with(map[string]property.Value{"blue": str("deleted")}))
+	rollback := w.NewNode("rollback", with(map[string]property.Value{"live": str("blue")}))
+
+	w.NewEdge("start", requested, deploy, always)
+	w.NewEdge("deployed", deploy, verify, always)
+	w.NewAndEdge("healthy-and-approved", verify, switchTraffic, flag("healthy"), external(&approved))
+	w.NewOrEdge("unhealthy-or-timeout", verify, rollback, not(flag("healthy")), external(&timedOut))
+	w.NewEdge("switched", switchTraffic, decommission, always)
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(requested, "release 2.0", pmap(map[string]property.Value{"version": str("2.0")}))
+	require.NoError(t, r.progress())
+	r.note("operator approves the traffic switch")
+	approved = true
+	require.NoError(t, r.progress())
+
+	r.note("release 2.0 done; a broken release 3.0 starts")
+	approved = false
+	w.AddCursor(requested, "release 3.0", pmap(map[string]property.Value{"version": str("3.0")}))
+	require.NoError(t, r.progress())
+
+	r.note("release 3.1 stalls waiting for approval until the approval window times out")
+	w.AddCursor(requested, "release 3.1", pmap(map[string]property.Value{"version": str("3.1")}))
+	require.NoError(t, r.progress())
+	timedOut = true
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, pmap(map[string]property.Value{
+		"version": str("2.0"),
+		"url":     str("https://green.example.com/2.0"),
+		"healthy": boolean(true),
+		"live":    str("green"),
+		"blue":    str("deleted"),
+	}), w.GetState(decommission).Outputs)
+	r.golden("blue-green")
+}
+
+// A phased rollout: a planning node fans out one cursor per US region, each region deploys and verifies,
+// and only once every US region's metrics look good (a join) does the EU deployment start.
+type rollout struct {
+	metricsGood map[string]*bool // region -> whether its post-deploy metrics are acceptable
+	broken      map[string]bool  // region -> whether deploying there fails
+	usRegions   []string
+	merge       workflow.MergeFunc
+}
+
+func newRollout() *rollout {
+	return &rollout{
+		metricsGood: map[string]*bool{"us-west": new(bool), "us-east": new(bool), "eu": new(bool)},
+		broken:      map[string]bool{},
+		usRegions:   []string{"us-west", "us-east"},
+		merge:       nestByFrom,
+	}
+}
+
+// A merge that nests each candidate's inputs under its From node's ID.
+func nestByFrom(_ context.Context, candidates []workflow.MergeCandidate) (bool, workflow.MergedCursor, error) {
+	merged := map[string]property.Value{}
+	for _, c := range candidates {
+		merged[c.From.ID()] = property.New(c.Inputs)
+	}
+	return true, workflow.MergedCursor{Label: "merged", Inputs: property.NewMap(merged)}, nil
+}
+
+func (ro *rollout) define(w workflow.Workflow) (start, done workflow.Node) {
+	queue := map[string]workflow.Node{} // Where plan places each region's cursor; AddCursor does not run the node
+	deploy := map[string]workflow.Node{}
+	verify := map[string]workflow.Node{}
+	for _, region := range append(ro.usRegions, "eu") {
+		queue[region] = w.NewNode("queue-"+region, with(nil))
+		deploy[region] = w.NewNode("deploy-"+region, func(ctx context.Context, w workflow.Workflow, in property.Map) (
+			property.Map, error,
+		) {
+			if ro.broken[region] {
+				return property.Map{}, fmt.Errorf("deploy to %s failed", region)
+			}
+			return with(map[string]property.Value{"region": str(region)})(ctx, w, in)
+		})
+		w.NewEdge("queued", queue[region], deploy[region], always)
+		verify[region] = w.NewNode("verify-"+region, with(map[string]property.Value{"verified": boolean(true)}))
+		w.NewEdge("deployed", deploy[region], verify[region], always)
+	}
+	start = w.NewNode("start", with(nil))
+	plan := w.NewNode("plan", func(_ context.Context, w workflow.Workflow, in property.Map) (property.Map, error) {
+		for _, region := range ro.usRegions {
+			w.AddCursor(queue[region], region, in)
+		}
+		return in.Set("phase", num(1)), nil
+	})
+	w.NewEdge("planning", start, plan, always)
+	branches := make([]workflow.JoinEdgeArg, 0, len(ro.usRegions))
+	for _, region := range ro.usRegions {
+		branches = append(branches, workflow.JoinEdgeArg{From: verify[region], Edge: external(ro.metricsGood[region])})
+	}
+	w.NewJoinEdge("us-metrics-good", branches, deploy["eu"], ro.merge)
+	done = w.NewNode("done", with(nil))
+	w.NewEdge("eu-metrics-good", verify["eu"], done, external(ro.metricsGood["eu"]))
+	return start, done
+}
+
+func TestPhasedRollout(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	w := workflow.New()
+	start, done := ro.define(w)
+	r := &recorder{t: t, w: w}
+
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	require.NoError(t, r.progress())
+	r.note("us-west metrics look good")
+	*ro.metricsGood["us-west"] = true
+	require.NoError(t, r.progress())
+	r.note("us-east metrics look good")
+	*ro.metricsGood["us-east"] = true
+	require.NoError(t, r.progress())
+	r.note("eu metrics look good")
+	*ro.metricsGood["eu"] = true
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, pmap(map[string]property.Value{
+		"verify-us-west": property.New(pmap(map[string]property.Value{
+			"version": str("7"), "region": str("us-west"), "verified": boolean(true),
+		})),
+		"verify-us-east": property.New(pmap(map[string]property.Value{
+			"version": str("7"), "region": str("us-east"), "verified": boolean(true),
+		})),
+		"region":   str("eu"),
+		"verified": boolean(true),
+	}), w.GetState(done).Outputs)
+	r.golden("phased-rollout")
+}
+
+// The phased rollout, saved to State while us-west waits on the join and resumed in a fresh workflow.
+func TestPhasedRolloutResume(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	w := workflow.New()
+	start, _ := ro.define(w)
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	require.NoError(t, r.progress())
+	*ro.metricsGood["us-west"] = true
+	require.NoError(t, r.progress())
+
+	state := w.State()
+	golden(t, "phased-rollout-state", state)
+
+	resumed, err := workflow.FromState(state)
+	require.NoError(t, err)
+	r2 := &recorder{t: t, w: resumed}
+	require.NoError(t, r2.progress()) // Reports the undefined nodes; nothing else happens
+	ro.define(resumed)
+
+	r2.note("resumed; us-east metrics look good")
+	*ro.metricsGood["us-east"] = true
+	require.NoError(t, r2.progress())
+	r2.note("eu metrics look good")
+	*ro.metricsGood["eu"] = true
+	require.NoError(t, r2.progress())
+	r2.golden("phased-rollout-resume")
+
+	// Driving the original workflow to completion ends in the same state.
+	require.NoError(t, r.progress())
+	require.NoError(t, r.progress())
+	// Restored cursors are re-created in node definition order, so State lists them in a different order.
+	var before, after map[string]any
+	require.NoError(t, json.Unmarshal(w.State(), &before))
+	require.NoError(t, json.Unmarshal(resumed.State(), &after))
+	assert.Equal(t, before["nextCursor"], after["nextCursor"])
+	assert.ElementsMatch(t, before["cursors"], after["cursors"])
+}
+
+func TestNodeFailure(t *testing.T) {
+	t.Parallel()
+	w := workflow.New()
+	start := w.NewNode("start", with(nil))
+	boom := w.NewNode("boom", func(context.Context, workflow.Workflow, property.Map) (property.Map, error) {
+		return property.Map{}, errors.New("deploy exploded")
+	})
+	w.NewEdge("go", start, boom, always)
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "", property.Map{})
+	err := r.progress()
+	assert.EqualError(t, err, "deploy exploded")
+	r.golden("node-failure")
+}
+
+func TestFromStateRejectsInvalid(t *testing.T) {
+	t.Parallel()
+	_, err := workflow.FromState([]byte(`{"nextCursor": 1, "cursors": [], "bogus": true}`))
+	assert.EqualError(t, err, `invalid workflow state: json: unknown field "bogus"`)
+	_, err = workflow.FromState([]byte(`not json`))
+	assert.ErrorContains(t, err, "invalid workflow state")
+}
+
+// The join must resolve correctly when branches are evaluated concurrently.
+func TestPhasedRolloutAsync(t *testing.T) {
+	t.Parallel()
+	for range 50 {
+		ro := newRollout()
+		for _, good := range ro.metricsGood {
+			*good = true
+		}
+		w := workflow.New()
+		start, done := ro.define(w)
+		w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+		var wg sync.WaitGroup
+		runner := func(ctx context.Context, f func(context.Context)) error {
+			wg.Go(func() { f(ctx) })
+			return nil
+		}
+		require.NoError(t, w.Progress(t.Context(), runner, nil))
+		wg.Wait()
+		assert.Equal(t, str("eu"), w.GetState(done).Outputs.Get("region"))
+	}
+}
+
+// A canary: traffic shifts 10% → 50% → 100% through a loop, each step waiting on the metrics observed at
+// that traffic level; bad metrics at any level roll back.
+func TestCanaryLoop(t *testing.T) {
+	t.Parallel()
+	metrics := map[float64]string{} // traffic percent -> "" (not yet observed), "good", or "bad"
+	steps := []float64{10, 50, 100}
+	w := workflow.New()
+
+	start := w.NewNode("start", with(nil))
+	shift := w.NewNode("shift-traffic", func(_ context.Context, _ workflow.Workflow, in property.Map) (
+		property.Map, error,
+	) {
+		percent := steps[0]
+		if in.Get("percent").IsNumber() {
+			percent = steps[slices.Index(steps, in.Get("percent").AsNumber())+1]
+		}
+		return in.Set("percent", num(percent)), nil
+	})
+	observe := w.NewNode("observe", with(nil))
+	done := w.NewNode("done", with(nil))
+	rollback := w.NewNode("rollback", with(map[string]property.Value{"percent": num(0)}))
+
+	metricsAre := func(want string) workflow.EdgeFunc {
+		return func(_ context.Context, _ workflow.Workflow, in property.Map) (bool, error) {
+			return metrics[in.Get("percent").AsNumber()] == want, nil
+		}
+	}
+	fullyShifted := func(_ context.Context, _ workflow.Workflow, in property.Map) (bool, error) {
+		return in.Get("percent").AsNumber() == 100, nil
+	}
+	w.NewEdge("start", start, shift, always)
+	w.NewEdge("shifted", shift, observe, always)
+	w.NewAndEdge("healthy-and-more-to-shift", observe, shift, metricsAre("good"), not(fullyShifted))
+	w.NewAndEdge("healthy-and-fully-shifted", observe, done, metricsAre("good"), fullyShifted)
+	w.NewEdge("unhealthy", observe, rollback, metricsAre("bad"))
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "canary", pmap(map[string]property.Value{"version": str("8")}))
+	require.NoError(t, r.progress())
+	r.note("10% looks good")
+	metrics[10] = "good"
+	require.NoError(t, r.progress())
+	r.note("50% looks good")
+	metrics[50] = "good"
+	require.NoError(t, r.progress())
+	r.note("100% looks bad")
+	metrics[100] = "bad"
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, pmap(map[string]property.Value{"version": str("8"), "percent": num(0)}),
+		w.GetState(rollback).Outputs)
+	r.golden("canary-loop")
+}
+
+// A flaky deploy retried up to maxAttempts times. A failure that should be retried is a node output, not
+// an error: a node error aborts the whole run.
+func TestRetry(t *testing.T) {
+	t.Parallel()
+	w := workflow.New()
+	start := w.NewNode("start", with(nil))
+	deploy := w.NewNode("deploy", func(_ context.Context, _ workflow.Workflow, in property.Map) (property.Map, error) {
+		attempts := float64(1)
+		if in.Get("attempts").IsNumber() {
+			attempts = in.Get("attempts").AsNumber() + 1
+		}
+		// The simulated deploy succeeds on its third attempt.
+		return in.Set("attempts", num(attempts)).Set("ok", boolean(attempts >= 3)), nil
+	})
+	done := w.NewNode("done", with(nil))
+	giveUp := w.NewNode("give-up", with(nil))
+
+	exhausted := func(_ context.Context, _ workflow.Workflow, in property.Map) (bool, error) {
+		return in.Get("attempts").AsNumber() >= in.Get("maxAttempts").AsNumber(), nil
+	}
+	w.NewEdge("start", start, deploy, always)
+	w.NewEdge("succeeded", deploy, done, flag("ok"))
+	w.NewAndEdge("retry", deploy, deploy, not(flag("ok")), not(exhausted))
+	w.NewAndEdge("exhausted", deploy, giveUp, not(flag("ok")), exhausted)
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "three attempts", pmap(map[string]property.Value{"maxAttempts": num(3)}))
+	require.NoError(t, r.progress())
+	r.note("a second release only gets two attempts")
+	w.AddCursor(start, "two attempts", pmap(map[string]property.Value{"maxAttempts": num(2)}))
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, num(3), w.GetState(done).Outputs.Get("attempts"))
+	assert.Equal(t, num(2), w.GetState(giveUp).Outputs.Get("attempts"))
+	r.golden("retry")
+}
+
+// Releases contend for a single soak environment. A release that arrives while another is soaking
+// replaces it if the incumbent cannot move on; an incumbent that can move on gets to first.
+func TestContendedEnvironment(t *testing.T) {
+	t.Parallel()
+	soaked := map[string]bool{}
+	w := workflow.New()
+	queue := w.NewNode("queue", with(nil))
+	staging := w.NewNode("staging", with(map[string]property.Value{"env": str("staging")}))
+	soak := w.NewNode("soak", with(nil))
+	prod := w.NewNode("prod", with(map[string]property.Value{"env": str("prod")}))
+	w.NewEdge("deploy", queue, staging, always)
+	w.NewEdge("deployed", staging, soak, always)
+	w.NewEdge("soaked", soak, prod, func(_ context.Context, _ workflow.Workflow, in property.Map) (bool, error) {
+		return soaked[in.Get("version").AsString()], nil
+	})
+	release := func(v string) property.Map { return pmap(map[string]property.Value{"version": str(v)}) }
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(queue, "A", release("A"))
+	require.NoError(t, r.progress())
+	r.note("B arrives while A is still soaking: A is superseded")
+	w.AddCursor(queue, "B", release("B"))
+	require.NoError(t, r.progress())
+	r.note("A finishes soaking, but it is gone")
+	soaked["A"] = true
+	require.NoError(t, r.progress())
+	r.note("B finishes soaking as C arrives: B moves on before C takes the soak environment")
+	soaked["B"] = true
+	w.AddCursor(queue, "C", release("C"))
+	require.NoError(t, r.progress())
+
+	golden(t, "contended-environment-state", w.State())
+	assert.Equal(t, str("B"), w.GetState(prod).Outputs.Get("version"))
+	r.golden("contended-environment")
+}
+
+// A second rollout through the same join. The cursors merged away by the first rollout linger on their
+// verify nodes until the second rollout's cursors overwrite them; that is not a second end for them, so
+// no CursorReplaced is reported.
+func TestJoinReused(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	for _, good := range ro.metricsGood {
+		*good = true
+	}
+	w := workflow.New()
+	start, _ := ro.define(w)
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	require.NoError(t, r.progress())
+	r.note("v8 follows v7 through the same graph")
+	w.AddCursor(start, "v8", pmap(map[string]property.Value{"version": str("8")}))
+	require.NoError(t, r.progress())
+	r.golden("join-reused")
+}
+
+// A hotfix for us-west arrives while us-west v7 is waiting at verify-us-west for us-east. The hotfix
+// replaces the waiting v7 cursor; the join then merges the hotfix with us-east v7.
+func TestJoinBranchRetaken(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	w := workflow.New()
+	start, done := ro.define(w)
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	*ro.metricsGood["us-west"] = true
+	require.NoError(t, r.progress())
+	r.note("us-west needs a hotfix before us-east's metrics come in")
+	w.AddCursor(mustNode(t, w, "queue-us-west"), "us-west hotfix", pmap(map[string]property.Value{"version": str("7.1")}))
+	require.NoError(t, r.progress())
+	r.note("us-east and eu metrics look good")
+	*ro.metricsGood["us-east"] = true
+	*ro.metricsGood["eu"] = true
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, str("7.1"), w.GetState(done).Outputs.Get("verify-us-west").AsMap().Get("version"))
+	assert.Equal(t, str("7"), w.GetState(done).Outputs.Get("verify-us-east").AsMap().Get("version"))
+	r.golden("join-branch-retaken")
+}
+
+// The graph is grown while it runs: each deploy node defines the next region's node and the edge to
+// it from the cursor's inputs.
+func TestDynamicGraph(t *testing.T) {
+	t.Parallel()
+	w := workflow.New()
+	done := w.NewNode("done", with(nil))
+	var expand func(context.Context, workflow.Workflow, property.Map) (property.Map, error)
+	expand = func(_ context.Context, w workflow.Workflow, in property.Map) (property.Map, error) {
+		remaining := in.Get("remaining").AsArray().AsSlice()
+		from, ok := w.NodeByID(in.Get("here").AsString())
+		require.True(t, ok)
+		if len(remaining) == 0 {
+			w.NewEdge("finished", from, done, always)
+			return in, nil
+		}
+		next := "deploy-" + remaining[0].AsString()
+		w.NewEdge("next", from, w.NewNode(next, expand), always)
+		return in.Set("remaining", property.New(remaining[1:])).Set("here", str(next)), nil
+	}
+	start := w.NewNode("start", with(nil))
+	plan := w.NewNode("plan", expand)
+	w.NewEdge("planning", start, plan, always)
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "expanding", pmap(map[string]property.Value{
+		"here":      str("plan"),
+		"remaining": property.New([]property.Value{str("us"), str("eu")}),
+	}))
+	require.NoError(t, r.progress())
+	assert.Equal(t, str("deploy-eu"), w.GetState(done).Outputs.Get("here"))
+	r.golden("dynamic-graph")
+}
+
+// One release's node fails while another release is mid-move. The failure aborts the run, but the
+// bystander's node function succeeded, so its move is committed and the next Progress carries on from
+// there rather than running the node again.
+func TestNodeFailureWithBystander(t *testing.T) {
+	t.Parallel()
+	broken := true
+	w := workflow.New()
+	// Two releases at one node that both move at once is a race, so each release has its own start.
+	startBad := w.NewNode("start-bad", with(nil))
+	startGood := w.NewNode("start-good", with(nil))
+	deploy := w.NewNode("deploy", func(_ context.Context, _ workflow.Workflow, in property.Map) (property.Map, error) {
+		if broken {
+			return property.Map{}, errors.New("deploy exploded")
+		}
+		return in.Set("deployed", boolean(true)), nil
+	})
+	build := w.NewNode("build", with(map[string]property.Value{"built": boolean(true)}))
+	done := w.NewNode("done", with(nil))
+	w.NewEdge("go", startBad, deploy, always)
+	w.NewEdge("go", startGood, build, always)
+	w.NewEdge("built", build, done, always)
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(startBad, "bad", pmap(map[string]property.Value{"version": str("bad")}))
+	w.AddCursor(startGood, "good", pmap(map[string]property.Value{"version": str("good")}))
+	assert.EqualError(t, r.progress(), "deploy exploded")
+	golden(t, "node-failure-bystander-state", w.State())
+	r.note("the bad release is fixed")
+	broken = false
+	require.NoError(t, r.progress())
+	r.golden("node-failure-bystander")
+}
+
+// An edge condition that errors aborts the run; once it stops erroring the workflow continues.
+func TestEdgeFailure(t *testing.T) {
+	t.Parallel()
+	metricsDown := true
+	w := workflow.New()
+	start := w.NewNode("start", with(nil))
+	done := w.NewNode("done", with(nil))
+	w.NewEdge("metrics-ok", start, done, func(context.Context, workflow.Workflow, property.Map) (bool, error) {
+		if metricsDown {
+			return false, errors.New("metrics backend unreachable")
+		}
+		return true, nil
+	})
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "", property.Map{})
+	assert.EqualError(t, r.progress(), "metrics backend unreachable")
+	r.note("metrics backend is back")
+	metricsDown = false
+	require.NoError(t, r.progress())
+	r.golden("edge-failure")
+}
+
+// us-east fails verification, so the join can never complete. Because the waiting cursors stay on their
+// verify nodes, an abort edge out of each verify node lets the rollout halt instead of waiting forever.
+func TestJoinAbort(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	metricsBad := map[string]*bool{"us-west": new(bool), "us-east": new(bool)}
+	anyBad := func(context.Context, workflow.Workflow, property.Map) (bool, error) {
+		return *metricsBad["us-west"] || *metricsBad["us-east"], nil
+	}
+	w := workflow.New()
+	start, done := ro.define(w)
+	// Both regions aborting into one node in the same step would be a race, so each has its own.
+	halt := map[string]workflow.Node{}
+	for _, region := range ro.usRegions {
+		halt[region] = w.NewNode("halt-"+region, with(map[string]property.Value{"halted": boolean(true)}))
+		w.NewEdge("abort", mustNode(t, w, "verify-"+region), halt[region], anyBad)
+	}
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	*ro.metricsGood["us-west"] = true
+	require.NoError(t, r.progress())
+	r.note("us-east metrics look bad: both regions abort")
+	*metricsBad["us-east"] = true
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, workflow.NodeState{}, w.GetState(done))
+	for _, region := range ro.usRegions {
+		assert.Equal(t, str(region), w.GetState(halt[region]).Outputs.Get("region"))
+	}
+	golden(t, "join-abort-state", w.State())
+	r.golden("join-abort")
+}
+
+// The join is decided, but deploying to eu fails, aborting the run before the merged cursor's move is
+// committed. The decision stands: the next Progress completes the move without re-evaluating the join.
+func TestJoinCommitRetried(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	for _, good := range ro.metricsGood {
+		*good = true
+	}
+	ro.broken["eu"] = true
+	w := workflow.New()
+	start, done := ro.define(w)
+
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	assert.EqualError(t, r.progress(), "deploy to eu failed")
+	golden(t, "join-commit-retried-state", w.State())
+	r.note("eu is fixed")
+	ro.broken["eu"] = false
+	require.NoError(t, r.progress())
+	assert.Equal(t, str("eu"), w.GetState(done).Outputs.Get("region"))
+	r.golden("join-commit-retried")
+}
+
+// The merge function rejects regions running different versions, so a hotfix to one region holds the
+// join until the other region catches up. A merge function error fails the run.
+func TestJoinMergeRejected(t *testing.T) {
+	t.Parallel()
+	ro := newRollout()
+	policyDown := false
+	ro.merge = func(ctx context.Context, candidates []workflow.MergeCandidate) (bool, workflow.MergedCursor, error) {
+		if policyDown {
+			return false, workflow.MergedCursor{}, errors.New("merge policy unavailable")
+		}
+		for _, c := range candidates[1:] {
+			if !c.Inputs.Get("version").Equals(candidates[0].Inputs.Get("version")) {
+				return false, workflow.MergedCursor{}, nil
+			}
+		}
+		return nestByFrom(ctx, candidates)
+	}
+	*ro.metricsGood["us-west"] = true
+	*ro.metricsGood["eu"] = true
+	w := workflow.New()
+	start, done := ro.define(w)
+	r := &recorder{t: t, w: w}
+	w.AddCursor(start, "v7", pmap(map[string]property.Value{"version": str("7")}))
+	require.NoError(t, r.progress())
+	r.note("us-west is hotfixed while us-east's metrics are pending")
+	w.AddCursor(mustNode(t, w, "queue-us-west"), "us-west hotfix", pmap(map[string]property.Value{"version": str("7.1")}))
+	require.NoError(t, r.progress())
+	r.note("us-east metrics look good, but the versions differ")
+	*ro.metricsGood["us-east"] = true
+	require.NoError(t, r.progress())
+	r.note("us-east gets the hotfix too, but the merge policy is down")
+	policyDown = true
+	w.AddCursor(mustNode(t, w, "queue-us-east"), "us-east hotfix", pmap(map[string]property.Value{"version": str("7.1")}))
+	assert.EqualError(t, r.progress(), "merge policy unavailable")
+	r.note("the merge policy is back")
+	policyDown = false
+	require.NoError(t, r.progress())
+
+	assert.Equal(t, str("7.1"), w.GetState(done).Outputs.Get("verify-us-west").AsMap().Get("version"))
+	assert.Equal(t, str("7.1"), w.GetState(done).Outputs.Get("verify-us-east").AsMap().Get("version"))
+	r.golden("join-merge-rejected")
+}
+
+// A failing run leaves an unsettled cursor beside one that committed after it. That arrival order
+// survives State/FromState: on the restored workflow the earlier cursor is overwritten once it settles,
+// exactly as on the original.
+func TestArrivalOrderSurvivesRestore(t *testing.T) {
+	t.Parallel()
+	broken := true
+	define := func(w workflow.Workflow) (startGood, startBad workflow.Node) {
+		startGood = w.NewNode("start-good", with(nil))
+		startBad = w.NewNode("start-bad", with(nil))
+		staging := w.NewNode("staging", with(map[string]property.Value{"env": str("staging")}))
+		prod := w.NewNode("prod", with(nil))
+		// Failing, this deploy first queues another release straight onto staging; the abort leaves that
+		// release unsettled there while the good release's entry into staging is committed beside it.
+		w.NewNode("deploy-bad", func(_ context.Context, w workflow.Workflow, in property.Map) (property.Map, error) {
+			if !broken {
+				return in, nil
+			}
+			w.AddCursor(staging, "queued", pmap(map[string]property.Value{"version": str("queued")}))
+			return property.Map{}, errors.New("deploy exploded")
+		})
+		w.NewEdge("go", startGood, staging, always)
+		w.NewEdge("go", startBad, mustNode(t, w, "deploy-bad"), always)
+		w.NewEdge("promote", staging, prod, flag("never"))
+		return startGood, startBad
+	}
+
+	w := workflow.New()
+	startGood, startBad := define(w)
+	r := &recorder{t: t, w: w}
+	w.AddCursor(startGood, "good", pmap(map[string]property.Value{"version": str("good")}))
+	w.AddCursor(startBad, "bad", pmap(map[string]property.Value{"version": str("bad")}))
+	assert.EqualError(t, r.progress(), "deploy exploded")
+	state := w.State()
+	golden(t, "arrival-order-state", state)
+
+	broken = false
+	resumed, err := workflow.FromState(state)
+	require.NoError(t, err)
+	define(resumed)
+	r2 := &recorder{t: t, w: resumed}
+	r2.note("resumed: the queued release settles and is overwritten by the release that committed beside it")
+	require.NoError(t, r2.progress())
+	r2.golden("arrival-order-resume")
+
+	require.NoError(t, r.progress())
+	// Restored cursors are re-created in node definition order, so State lists them in a different order.
+	var before, after map[string]any
+	require.NoError(t, json.Unmarshal(w.State(), &before))
+	require.NoError(t, json.Unmarshal(resumed.State(), &after))
+	assert.Equal(t, before["nextCursor"], after["nextCursor"])
+	assert.ElementsMatch(t, before["cursors"], after["cursors"])
+}

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -15,6 +15,7 @@
 package workflow_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -90,6 +91,8 @@ func golden(t *testing.T, name string, got []byte) {
 	}
 	want, err := os.ReadFile(path)
 	require.NoError(t, err, "run with PULUMI_ACCEPT=1 to create the golden file")
+	// A Windows checkout with autocrlf leaves the golden with CRLF line endings.
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
 	require.Equal(t, string(want), string(got))
 }
 


### PR DESCRIPTION
## Summary

The `pkg/workflow` package: a durable workflow graph built on `pkg/util/fsa` (#24287). Nodes have string identities and pass property maps along edges; edges compose (`and`, `or`, and joins with an explicit merge function) and may set or delete values on the cursor as it crosses (applied only if the cursor moves because of that answer). Node and edge functions receive the cursor they run for, and progress is reported as a stream of typed events carrying that identity. Cursors keep the values they entered their node with separate from what the node's function produced; `Reconcile` re-runs the function for parked cursors from the entered values. Cursor placement survives restarts via `State`/`FromState`.

Also adds `pkg/workflow/display`, which folds the event stream into a text diagram (one-line cursor summary first, then the graph and a line per cursor).

Part of the workflow-resource PoC; consumed by the engine in #24435.

## Testing

Golden-file tests drive deployment scenarios (blue-green, phased rollout with a join, canary loop, retry budgets, contended environments, edge overlays, reconcile) through `Progress` with a deterministic runner; `pkg/workflow/display` has its own rendering test.