### PR TITLE
Preserve all providers passed to remote components in Python programs

### DIFF
--- a/changelog/pending/sdk-python-fix-20260824-152142.yaml
+++ b/changelog/pending/sdk-python-fix-20260824-152142.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: fix
+body: Preserve all providers passed to remote components in Python programs
+time: 2026-08-24T15:21:42+02:00

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -1356,18 +1356,15 @@ def convert_providers(
     """
     Merge all providers opts (opts.provider and both list and dict forms of opts.providers) into a single dict.
     """
-    if provider is not None:
-        return convert_providers(None, [provider])
-
     if providers is None:
-        return {}
+        result: dict[str, ProviderResource] = {}
+    elif isinstance(providers, Mapping):
+        result = dict(providers)
+    else:
+        result = {p.package: p for p in providers}
 
-    if isinstance(providers, Mapping):
-        return providers
-
-    result = {}
-    for p in providers:
-        result[p.package] = p
+    if provider is not None:
+        result[provider.package] = provider
 
     return result
 

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -23,6 +23,7 @@ import pytest_asyncio
 from pulumi.resource import DependencyProviderResource
 from pulumi.runtime import settings, mocks
 from pulumi.runtime.proto import resource_pb2
+from pulumi.runtime.resource import convert_providers
 from pulumi import ResourceOptions
 from pulumi.runtime.rpc import ERROR_ON_DEPENDENCY_CYCLES_VAR
 import pulumi
@@ -37,6 +38,32 @@ async def test_get_package():
         "urn:pulumi:stack::project::pulumi:providers:aws::default_4_13_0"
     )
     assert "aws" == res.package
+
+
+def test_convert_providers_merges_provider_with_provider_mapping():
+    aws_provider = mock.Mock(package="aws")
+    old_component_provider = mock.Mock(package="component")
+    component_provider = mock.Mock(package="component")
+    providers = {
+        "aws": aws_provider,
+        "component": old_component_provider,
+    }
+
+    result = convert_providers(component_provider, providers)
+
+    assert result["aws"] is aws_provider
+    assert result["component"] is component_provider
+    assert providers["component"] is old_component_provider
+
+
+def test_convert_providers_merges_provider_with_provider_sequence():
+    aws_provider = mock.Mock(package="aws")
+    component_provider = mock.Mock(package="component")
+
+    result = convert_providers(component_provider, [aws_provider])
+
+    assert result["aws"] is aws_provider
+    assert result["component"] is component_provider
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/24423
