### PR TITLE
Point at CLI commands when an env already has a draft

### DIFF
--- a/changelog/pending/cli-improvement-env-draft-conflict.yaml
+++ b/changelog/pending/cli-improvement-env-draft-conflict.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: '`pulumi env set --draft` now prints the CLI commands to update, submit, or discard an existing draft instead of raw API endpoints'
 time: 2026-08-20T00:00:00+00:00
 custom:
-  PR: ""
+  PR: "24444"

--- a/changelog/pending/cli-improvement-env-draft-conflict.yaml
+++ b/changelog/pending/cli-improvement-env-draft-conflict.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: '`pulumi env set --draft` now prints the CLI commands to update, submit, or discard an existing draft instead of raw API endpoints'
+time: 2026-08-20T00:00:00+00:00
+custom:
+  PR: ""

--- a/pkg/cmd/esc/cli/env.go
+++ b/pkg/cmd/esc/cli/env.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -447,6 +448,39 @@ func (esc *escCommand) changeRequestURL(ref environmentRef, changeRequestID stri
 	return path + "?version=" + changeRequestID
 }
 
+// draftAlreadyExistsRegexp matches the service's error for an environment that already holds an open
+// draft, capturing the ID of the change request that holds it.
+var draftAlreadyExistsRegexp = regexp.MustCompile(`a draft already exists for this environment \(change request ([^)]+)\)`) //nolint:lll
+
+// draftConflictError rewrites the service's "a draft already exists" error, which points at raw REST
+// endpoints, into an error that spells out the CLI commands that resolve the conflict. It returns nil
+// if err is not a draft conflict.
+func (esc *escCommand) draftConflictError(ref environmentRef, err error) error {
+	var errResp *client.EnvironmentErrorResponse
+	if !errors.As(err, &errResp) {
+		return nil
+	}
+	match := draftAlreadyExistsRegexp.FindStringSubmatch(errResp.Message)
+	if match == nil {
+		return nil
+	}
+	changeRequestID := match[1]
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%v already has a draft (change request %v)\n\n", ref.String(), changeRequestID)
+	fmt.Fprintf(&b, "To update that draft, re-run this command with --draft=%v\n\n", changeRequestID)
+	fmt.Fprintf(&b, "To submit it for approval, run:\n")
+	fmt.Fprintf(&b, "    %v api /api/change-requests/%v/%v/submit -X POST --body '{}'\n\n",
+		esc.command, ref.orgName, changeRequestID)
+	fmt.Fprintf(&b, "To discard it and clear the lock, run:\n")
+	fmt.Fprintf(&b, "    %v api /api/change-requests/%v/%v/close -X POST --body '{}'",
+		esc.command, ref.orgName, changeRequestID)
+	if url := esc.changeRequestURL(ref, changeRequestID); url != "" {
+		fmt.Fprintf(&b, "\n\nChange request URL: %v", url)
+	}
+	return errors.New(b.String())
+}
+
 // updateEnvironment updates an environment.
 // If draft is empty, the environment is directly updated.
 // If draft is "new", a change request is created and submitted.
@@ -470,6 +504,9 @@ func (esc *escCommand) updateEnvironment(
 			tag,
 		)
 		if err != nil {
+			if conflict := esc.draftConflictError(ref, err); conflict != nil {
+				return nil, conflict
+			}
 			return nil, fmt.Errorf("creating environment draft: %w", err)
 		}
 		if !client.DiagnosticsHaveErrors(diags) {

--- a/pkg/cmd/esc/cli/env_test.go
+++ b/pkg/cmd/esc/cli/env_test.go
@@ -15,10 +15,12 @@
 package cli
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/esc/cli/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetEnvRef(t *testing.T) {
@@ -87,5 +89,43 @@ func TestGetEnvRef(t *testing.T) {
 		assert.Equal(t, ref.envName, "rel-env")
 		assert.Equal(t, ref.version, "v1")
 		assert.Equal(t, isRelative, true)
+	})
+}
+
+func TestDraftConflictError(t *testing.T) {
+	t.Parallel()
+	esc := &escCommand{command: "pulumi", client: &testPulumiClient{}}
+	ref := environmentRef{orgName: "org", projectName: "project", envName: "env"}
+
+	t.Run("draft conflict", func(t *testing.T) {
+		t.Parallel()
+		err := esc.draftConflictError(ref, &client.EnvironmentErrorResponse{
+			Code: 400,
+			Message: "Bad Request: a draft already exists for this environment (change request cr-id); " +
+				"submit it for approval via POST /api/change-requests/org/cr-id/submit, or close it via " +
+				"POST /api/change-requests/org/cr-id/close to clear the lock",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "org/project/env already has a draft (change request cr-id)")
+		assert.Contains(t, err.Error(), "--draft=cr-id")
+		assert.Contains(t, err.Error(), "pulumi api /api/change-requests/org/cr-id/submit -X POST --body '{}'")
+		assert.Contains(t, err.Error(), "pulumi api /api/change-requests/org/cr-id/close -X POST --body '{}'")
+		assert.NotContains(t, err.Error(), "via POST")
+	})
+
+	t.Run("unrelated environment error", func(t *testing.T) {
+		t.Parallel()
+		err := esc.draftConflictError(ref, &client.EnvironmentErrorResponse{
+			Code:    409,
+			Message: `"org" does not support approvals. An organization is required.`,
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, esc.draftConflictError(ref, errors.New("boom")))
 	})
 }


### PR DESCRIPTION
### Description

Running `pulumi env set --draft` against an environment that already holds a draft returns a raw api response instead of a descriptive message to follow up.

```
error: creating environment draft: [400] Bad Request: a draft already exists for this environment
(change request ee17841d-…); submit it for approval via POST /api/change-requests/acme/ee17841d-…/submit,
or close it via POST /api/change-requests/acme/ee17841d-…/close to clear the lock
```

This rewrites that one error to name the commands that actually resolve the conflict:

```
error: acme/default/my-env already has a draft (change request ee17841d-…)

To update that draft, re-run this command with --draft=ee17841d-…

To submit it for approval, run:
    pulumi api /api/change-requests/acme/ee17841d-…/submit -X POST --body '{}'

To discard it and clear the lock, run:
    pulumi api /api/change-requests/acme/ee17841d-…/close -X POST --body '{}'

Change request URL: https://app.pulumi.com/acme/esc/default/my-env?version=ee17841d-…
```

Notes for reviewers:

- There is no native `env` command for submit/close, right now relying on api messages from the cli. Will follow up on specific commands for submit / close.

- `--draft` with no value creates *and* submits the change request, and a submitted request still holds the lock, so the usual way to hit this error is running `--draft` twice.

### Testing

Verified against the live service with a locally built CLI: reproduced the conflict on a throwaway environment, then confirmed each suggested command works — `--draft=<id>` updates the draft, `close` clears the lock so a subsequent `--draft` succeeds, and `submit` reaches the endpoint. Unit test covers the rewritten message plus two non-conflict errors that must pass through untouched. `make lint` and `go test ./cmd/esc/cli/...` pass.

## Checklist

- [x] I have added tests that provide code coverage for the fix
- [x] I have added a changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)