### PR TITLE
Allow `refresh`, `preview_refresh`, and `preview_destroy` to request rich diffs

### DIFF
--- a/changelog/pending/auto-python-improvement-20260824-165215.yaml
+++ b/changelog/pending/auto-python-improvement-20260824-165215.yaml
@@ -1,0 +1,4 @@
+component: auto/python
+kind: improvement
+body: Allow `refresh`, `preview_refresh`, and `preview_destroy` to request rich diffs
+time: 2026-08-24T16:52:15+02:00

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -645,6 +645,7 @@ class Stack:
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
         program: Optional[PulumiFn] = None,
+        diff: Optional[bool] = None,
     ) -> RefreshResult:
         """
         Compares the current stack’s resource state with the state known to exist in the actual
@@ -675,6 +676,7 @@ class Stack:
         :param run_program: Run the program in the workspace to refresh the stack
         :param config_file: Path to a Pulumi config file to use for this update.
         :param program: The inline program.
+        :param diff: Display operation as a rich diff showing the overall change.
         :returns: RefreshResult
         """
         program = program or self.workspace.program
@@ -774,6 +776,7 @@ class Stack:
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
         program: Optional[PulumiFn] = None,
+        diff: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run refresh of the stack, returning pending changes.
@@ -802,6 +805,7 @@ class Stack:
         :param run_program: Run the program in the workspace to refresh the stack
         :param config_file: Path to a Pulumi config file to use for this update.
         :param program: The inline program.
+        :param diff: Display operation as a rich diff showing the overall change.
         :returns: PreviewResult
         """
         program = program or self.workspace.program
@@ -1076,6 +1080,7 @@ class Stack:
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
         program: Optional[PulumiFn] = None,
+        diff: Optional[bool] = None,
     ) -> PreviewResult:
         """
         Performs a dry-run deletion of resources in a stack, leaving all history and configuration intact.
@@ -1104,6 +1109,7 @@ class Stack:
         :param run_program: Run the program in the workspace to destroy the stack
         :param config_file: Path to a Pulumi config file to use for this update.
         :param program: The inline program.
+        :param diff: Display operation as a rich diff showing the overall change.
         :returns: DestroyResult
         """
         program = program or self.workspace.program

--- a/sdk/python/lib/test/automation/test_stack.py
+++ b/sdk/python/lib/test/automation/test_stack.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import builtins
+import inspect
 import tempfile
 import time
 import unittest
@@ -115,6 +116,21 @@ class TestStack(unittest.IsolatedAsyncioTestCase):
                 self.assertFalse(True, "should have thrown")
             except Exception as e:
                 self.assertIn("unsupported color option", str(e))
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        Stack.up,
+        Stack.preview,
+        Stack.refresh,
+        Stack.preview_refresh,
+        Stack.destroy,
+        Stack.preview_destroy,
+    ],
+)
+def test_stack_operations_accept_diff(operation):
+    assert inspect.signature(operation).parameters["diff"].default is None
 
 
 class TestStackArgOrdering(unittest.TestCase):


### PR DESCRIPTION
Add the `diff` argument to more stack methods. Args are parsed generically, so that’s all that’s needed to get this working.

```python
def preview_refresh(self, ..., diff, ...):
  ...
  extra_args = _parse_extra_args(**locals())
```

Fixes https://github.com/pulumi/pulumi/issues/24237
