### PR TITLE
allow changelog linter to comment on PRs

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -185,6 +185,10 @@ jobs:
   changelog:
     name: Lint changelog entries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # To comment changelog style findings on PRs.
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -211,6 +215,7 @@ jobs:
           version: 3.17.1
           files: changelog/pending
           sync: false
+          reporter: github-pr-review
 
   pulumi-json:
     name: Lint pulumi.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,10 @@ jobs:
     needs: [setup]
     if: ${{ inputs.lint }}
     uses: ./.github/workflows/ci-lint.yml
+    permissions:
+      contents: read
+      # To comment changelog style findings on PRs.
+      pull-requests: write
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
     with:

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -27,6 +27,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # Requested by the changelog lint job; unused on scheduled runs.
+      pull-requests: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -38,6 +38,8 @@ jobs:
       contents: read
       # To sign artifacts.
       id-token: write
+      # Requested by the changelog lint job; unused on push events.
+      pull-requests: write
     with:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -43,6 +43,8 @@ jobs:
       contents: read
       # To sign artifacts.
       id-token: write
+      # To comment changelog style findings on PRs.
+      pull-requests: write
     with:
       ref: ${{ github.head_ref }}
       version: ${{ needs.info.outputs.version }}

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -57,6 +57,8 @@ jobs:
       contents: read
       # To sign artifacts.
       id-token: write
+      # Requested by the changelog lint job; unused on dispatch runs.
+      pull-requests: write
     with:
       ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
       version: ${{ needs.info.outputs.version }}


### PR DESCRIPTION
Right now the changelog linter works, but is completely invisible because it's only advisory.  It should at least comment on PRs.  Make it do so.
