### PR TITLE
harden zip-slip check in sanitizeArchivePath

### DIFF
--- a/changelog/pending/20260824--cli-new--zip-template-path-traversal.yaml
+++ b/changelog/pending/20260824--cli-new--zip-template-path-traversal.yaml
@@ -1,0 +1,4 @@
+component: cli/new
+kind: fix
+body: Reject zip template entries that resolve outside the extraction directory
+time: 2026-08-24T00:00:00Z

--- a/pkg/cmd/pulumi/templates/zip.go
+++ b/pkg/cmd/pulumi/templates/zip.go
@@ -35,8 +35,9 @@ var ErrPulumiCloudUnauthorized = errors.New("unauthorized")
 
 // Sanitize archive file pathing from "G305: Zip Slip vulnerability"
 func sanitizeArchivePath(d, t string) (v string, err error) {
-	v = filepath.Join(d, t)
-	if strings.HasPrefix(v, filepath.Clean(d)) {
+	cleanDir := filepath.Clean(d)
+	v = filepath.Join(cleanDir, t)
+	if v == cleanDir || strings.HasPrefix(v, cleanDir+string(os.PathSeparator)) {
 		return v, nil
 	}
 

--- a/pkg/cmd/pulumi/templates/zip_test.go
+++ b/pkg/cmd/pulumi/templates/zip_test.go
@@ -57,6 +57,14 @@ func TestSanitizeArchivePath(t *testing.T) {
 			fileName:   "../../../../../../../../../../tmp/bar",
 			shouldFail: true,
 		},
+		{
+			// A sibling directory that shares the destination as a string prefix
+			// must not be treated as inside it.
+			testName:   "sibling_prefix_escape",
+			dir:        "foo",
+			fileName:   "../foo-evil/bar",
+			shouldFail: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
1. `sanitizeArchivePath` gated zip template entries with `strings.HasPrefix(v, filepath.Clean(d))`, which has no trailing separator, so a sibling path that shares the destination as a string prefix passes (destination `foo`, entry `../foo-evil/bar` joins to `foo-evil/bar` and is accepted as inside).
2. A template zip fetched by `pulumi new <url>` is untrusted, so a crafted entry can land a file outside the extraction directory.

Switched to the separator-boundary check already used by the tar extractor in `sdk/go/common/util/archive/archive.go`, so the destination itself and only paths beneath `dest/` are allowed.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Added a `sibling_prefix_escape` case to `TestSanitizeArchivePath` that fails before this change and passes after.

## Validation
- [ ] `make lint` — clean
- [x] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Ran `go test ./pkg/cmd/pulumi/templates/` (pass) and `gofmt`/`go vet` on the touched files.

## Changelog
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
Extraction-only, and valid entries (`Pulumi.yaml`, nested files) are unchanged; the check now matches the tar extractor's behavior. No public API change.
