### PR TITLE
Print the Go import path that matches the generated SDK

### DIFF
--- a/changelog/pending/cli-package-fix-20260824-105117.yaml
+++ b/changelog/pending/cli-package-fix-20260824-105117.yaml
@@ -1,0 +1,4 @@
+component: cli/package
+kind: fix
+body: Print the Go import path of the generated SDK when the schema sets a Go module path or import base path
+time: 2026-08-24T10:51:17.000000-07:00

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4200,35 +4200,30 @@ func ExtractImportBasePath(extPkg schema.PackageReference) string {
 }
 
 // ModuleAndImportPath returns the Go module path and the root import path of the SDK that
-// GeneratePackage writes for pkg. The module path is the module statement of the generated go.mod
-// file. The import path addresses the directory that holds the root package of that module.
+// GeneratePackage writes for pkg. The module path is the path of the module that holds the SDK. The
+// import path addresses the directory of the root package inside that module.
 //
-// ExtractModulePath and ExtractImportBasePath derive both paths from the package reference alone,
-// so they disagree with the SDK on disk when the schema sets modulePath or importBasePath. Use this
-// function instead when the paths must match an SDK that GeneratePackage wrote.
-func ModuleAndImportPath(pkg *schema.Package) (string, string) {
-	var info GoPackageInfo
-	if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
-		info = goInfo
+// ExtractModulePath and ExtractImportBasePath build both paths from the package reference alone, so
+// they disagree with the generated SDK when the schema sets modulePath or importBasePath. Use this
+// function when the paths must match an SDK that GeneratePackage wrote.
+//
+// The caller must import the Go language info of pkg first, with ImportLanguages. GeneratePackage
+// writes a go.mod file only for a package that supports packing, so pkg.SupportPack must be true.
+func ModuleAndImportPath(pkg *schema.Package) (string, string, error) {
+	if !pkg.SupportPack {
+		return "", "", fmt.Errorf(
+			"package %q does not support packing, so GeneratePackage writes no Go module for it", pkg.Name)
 	}
+
+	goInfo, _ := pkg.Language["go"].(GoPackageInfo)
 
 	modulePath := ExtractModulePath(pkg.Reference())
-	if info.ModulePath != "" {
-		modulePath = info.ModulePath
-	} else if info.ImportBasePath != "" {
+	if goInfo.ModulePath != "" {
+		modulePath = goInfo.ModulePath
+	} else if goInfo.ImportBasePath != "" {
 		// The go.mod file sits one directory above the root package, so the module path is the
 		// import base path without its last element.
-		modulePath = path.Dir(info.ImportBasePath)
-	}
-
-	if !pkg.SupportPack {
-		// A legacy SDK gets no generated go.mod file. Its root package sits under the "go"
-		// directory of a module that the package author writes, so the import path does not
-		// derive from the module path.
-		if info.ImportBasePath != "" {
-			return modulePath, info.ImportBasePath
-		}
-		return modulePath, ExtractImportBasePath(pkg.Reference())
+		modulePath = path.Dir(goInfo.ImportBasePath)
 	}
 
 	if pkg.ExtensionParameterization != nil {
@@ -4237,7 +4232,7 @@ func ModuleAndImportPath(pkg *schema.Package) (string, string) {
 
 	root, err := packageRoot(pkg.Reference())
 	contract.AssertNoErrorf(err, "We generated the ref from a pkg, so we know its a valid ref")
-	return modulePath, path.Join(modulePath, root)
+	return modulePath, path.Join(modulePath, root), nil
 }
 
 func (pkg *pkgContext) getImports(member any, importsAndAliases map[string]string) {
@@ -5531,7 +5526,10 @@ func GeneratePackage(tool string,
 
 	// create a go.mod file with references to local dependencies
 	if pkg.SupportPack {
-		modulePath, _ := ModuleAndImportPath(pkg)
+		modulePath, _, err := ModuleAndImportPath(pkg)
+		if err != nil {
+			return nil, err
+		}
 
 		var gomod modfile.File
 		err = gomod.AddModuleStmt(modulePath)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4199,6 +4199,47 @@ func ExtractImportBasePath(extPkg schema.PackageReference) string {
 	return fmt.Sprintf("%s/go/%s", modpath, name)
 }
 
+// ModuleAndImportPath returns the Go module path and the root import path of the SDK that
+// GeneratePackage writes for pkg. The module path is the module statement of the generated go.mod
+// file. The import path addresses the directory that holds the root package of that module.
+//
+// ExtractModulePath and ExtractImportBasePath derive both paths from the package reference alone,
+// so they disagree with the SDK on disk when the schema sets modulePath or importBasePath. Use this
+// function instead when the paths must match an SDK that GeneratePackage wrote.
+func ModuleAndImportPath(pkg *schema.Package) (string, string) {
+	var info GoPackageInfo
+	if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
+		info = goInfo
+	}
+
+	modulePath := ExtractModulePath(pkg.Reference())
+	if info.ModulePath != "" {
+		modulePath = info.ModulePath
+	} else if info.ImportBasePath != "" {
+		// The go.mod file sits one directory above the root package, so the module path is the
+		// import base path without its last element.
+		modulePath = path.Dir(info.ImportBasePath)
+	}
+
+	if !pkg.SupportPack {
+		// A legacy SDK gets no generated go.mod file. Its root package sits under the "go"
+		// directory of a module that the package author writes, so the import path does not
+		// derive from the module path.
+		if info.ImportBasePath != "" {
+			return modulePath, info.ImportBasePath
+		}
+		return modulePath, ExtractImportBasePath(pkg.Reference())
+	}
+
+	if pkg.ExtensionParameterization != nil {
+		modulePath = pkg.Name
+	}
+
+	root, err := packageRoot(pkg.Reference())
+	contract.AssertNoErrorf(err, "We generated the ref from a pkg, so we know its a valid ref")
+	return modulePath, path.Join(modulePath, root)
+}
+
 func (pkg *pkgContext) getImports(member any, importsAndAliases map[string]string) {
 	seen := map[schema.Type]struct{}{}
 	switch member := member.(type) {
@@ -5490,20 +5531,7 @@ func GeneratePackage(tool string,
 
 	// create a go.mod file with references to local dependencies
 	if pkg.SupportPack {
-		modulePath := ExtractModulePath(pkg.Reference())
-		if langInfo, found := pkg.Language["go"]; found {
-			goInfo, ok := langInfo.(GoPackageInfo)
-			if ok && goInfo.ModulePath != "" {
-				modulePath = goInfo.ModulePath
-			} else if ok && goInfo.ImportBasePath != "" {
-				// if support pack is enabled we can infer the module path from the
-				// import base path, which is one up from the import base (ie without the package name).
-				modulePath = path.Dir(goInfo.ImportBasePath)
-			}
-		}
-		if pkg.ExtensionParameterization != nil {
-			modulePath = pkg.Name
-		}
+		modulePath, _ := ModuleAndImportPath(pkg)
 
 		var gomod modfile.File
 		err = gomod.AddModuleStmt(modulePath)

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -1667,7 +1667,10 @@ func (host *goLanguageHost) Link(
 		// Resolve both paths the way the SDK generator does, so that the replace directive
 		// addresses the generated module and the printed import path addresses the package
 		// directory inside it.
-		modulePath, importPath := codegen.ModuleAndImportPath(pkg)
+		modulePath, importPath, err := codegen.ModuleAndImportPath(pkg)
+		if err != nil {
+			return nil, err
+		}
 
 		modules[modulePath] = dep.Path
 		// The relative path used in the replace directive must start with `./` or `.\`.

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -1665,20 +1664,10 @@ func (host *goLanguageHost) Link(
 		if err := pkg.ImportLanguages(map[string]schema.Language{"go": codegen.Importer}); err != nil {
 			return nil, err
 		}
-		var modulePath string
-		if info, ok := pkg.Language["go"]; ok {
-			if info, ok := info.(codegen.GoPackageInfo); ok {
-				modulePath = info.ModulePath
-				if modulePath == "" {
-					if info.ImportBasePath != "" {
-						modulePath = path.Dir(info.ImportBasePath)
-					}
-				}
-			}
-		}
-		if modulePath == "" {
-			modulePath = codegen.ExtractModulePath(pkg.Reference())
-		}
+		// Resolve both paths the way the SDK generator does, so that the replace directive
+		// addresses the generated module and the printed import path addresses the package
+		// directory inside it.
+		modulePath, importPath := codegen.ModuleAndImportPath(pkg)
 
 		modules[modulePath] = dep.Path
 		// The relative path used in the replace directive must start with `./` or `.\`.
@@ -1690,7 +1679,7 @@ func (host *goLanguageHost) Link(
 		if !strings.HasPrefix(dep.Path, start) {
 			modules[modulePath] = start + dep.Path
 		}
-		fmt.Fprintf(&imports, "    \"%s\"\n", codegen.ExtractImportBasePath(pkg.Reference()))
+		fmt.Fprintf(&imports, "    \"%s\"\n", importPath)
 	}
 	instructions += imports.String()
 	instructions += "  )\n"

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -25,7 +25,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -634,8 +633,24 @@ func TestLinkImportInstructions(t *testing.T) {
 			expectedModule: "github.com/example/File/sdk/go",
 		},
 		{
+			// The import base path replaces the default that the namespace builds, so the
+			// absent namespace makes no difference.
+			name:           "import base path only and no namespace",
+			goInfo:         map[string]any{"importBasePath": "github.com/example/File/sdk/go/File"},
+			expectedImport: "github.com/example/File/sdk/go/File",
+			expectedModule: "github.com/example/File/sdk/go",
+		},
+		{
 			name:           "module path only",
 			namespace:      "example",
+			goInfo:         map[string]any{"modulePath": "github.com/example/File/sdk/go"},
+			expectedImport: "github.com/example/File/sdk/go/file",
+			expectedModule: "github.com/example/File/sdk/go",
+		},
+		{
+			// The module path replaces the default that the namespace builds, and the package
+			// name still gives the directory of the root package.
+			name:           "module path only and no namespace",
 			goInfo:         map[string]any{"modulePath": "github.com/example/File/sdk/go"},
 			expectedImport: "github.com/example/File/sdk/go/file",
 			expectedModule: "github.com/example/File/sdk/go",
@@ -686,10 +701,7 @@ func TestLinkImportInstructions(t *testing.T) {
 
 	// The replace directive uses a relative path, which must start with the separator of the
 	// host platform. Build the same prefix that Link builds.
-	relativeStart := "./"
-	if runtime.GOOS == "windows" {
-		relativeStart = ".\\"
-	}
+	relativeStart := "." + string(filepath.Separator)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -17,19 +17,29 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
+	gocodegen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -548,4 +558,203 @@ func main() {
 		require.ErrorContains(t, err, "unable to run `go build`: exit status 1")
 		require.Contains(t, stderr.String(), "main.go:3:1: syntax error")
 	})
+}
+
+// testSchemaLoader serves a single bound package over the loader RPC. It has no other packages,
+// so external references cannot be resolved against it.
+type testSchemaLoader struct {
+	pkg *schema.Package
+}
+
+func (l *testSchemaLoader) load() (*schema.Package, error) {
+	if l.pkg == nil {
+		return nil, errors.New("no packages available")
+	}
+	return l.pkg, nil
+}
+
+func (l *testSchemaLoader) LoadPackage(string, *semver.Version) (*schema.Package, error) {
+	return l.load()
+}
+
+func (l *testSchemaLoader) LoadPackageV2(
+	context.Context, *schema.PackageDescriptor,
+) (*schema.Package, error) {
+	return l.load()
+}
+
+func (l *testSchemaLoader) LoadPackageReference(string, *semver.Version) (schema.PackageReference, error) {
+	pkg, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+	return pkg.Reference(), nil
+}
+
+func (l *testSchemaLoader) LoadPackageReferenceV2(
+	context.Context, *schema.PackageDescriptor,
+) (schema.PackageReference, error) {
+	pkg, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+	return pkg.Reference(), nil
+}
+
+func TestLinkImportInstructions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// namespace is the schema's namespace, which the default module path is built from.
+		namespace string
+		// goInfo is the "go" entry of the schema's language map.
+		goInfo map[string]any
+		// expectedImport is the import path Link is expected to print.
+		expectedImport string
+		// expectedModule is the module path Link is expected to add a replace directive for.
+		expectedModule string
+	}{
+		{
+			name:           "no go language info",
+			namespace:      "example",
+			expectedImport: "github.com/example/pulumi-file/sdk/go/file",
+			expectedModule: "github.com/example/pulumi-file/sdk/go",
+		},
+		{
+			name:           "no go language info and no namespace",
+			expectedImport: "example.com/pulumi-file/sdk/go/file",
+			expectedModule: "example.com/pulumi-file/sdk/go",
+		},
+		{
+			name:           "import base path only",
+			namespace:      "example",
+			goInfo:         map[string]any{"importBasePath": "github.com/example/File/sdk/go/File"},
+			expectedImport: "github.com/example/File/sdk/go/File",
+			expectedModule: "github.com/example/File/sdk/go",
+		},
+		{
+			name:           "module path only",
+			namespace:      "example",
+			goInfo:         map[string]any{"modulePath": "github.com/example/File/sdk/go"},
+			expectedImport: "github.com/example/File/sdk/go/file",
+			expectedModule: "github.com/example/File/sdk/go",
+		},
+		{
+			name:      "module path and import base path",
+			namespace: "example",
+			goInfo: map[string]any{
+				"modulePath":     "github.com/example/File/sdk/go",
+				"importBasePath": "github.com/example/File/sdk/go/File",
+			},
+			expectedImport: "github.com/example/File/sdk/go/File",
+			expectedModule: "github.com/example/File/sdk/go",
+		},
+		{
+			// The module path wins over the import base path, so the generated SDK holds its
+			// root package one directory below the module root. The printed import path must
+			// address that directory, not the import base path.
+			name:      "module path that disagrees with the import base path",
+			namespace: "example",
+			goInfo: map[string]any{
+				"modulePath":     "github.com/example/File/sdk",
+				"importBasePath": "github.com/example/File/sdk/go/File",
+			},
+			expectedImport: "github.com/example/File/sdk/File",
+			expectedModule: "github.com/example/File/sdk",
+		},
+	}
+
+	bind := func(t *testing.T, namespace string, goInfo map[string]any) *schema.Package {
+		t.Helper()
+		spec := schema.PackageSpec{
+			Name:      "file",
+			Namespace: namespace,
+			Version:   "0.1.0",
+			Meta:      &schema.MetadataSpec{SupportPack: true},
+		}
+		if goInfo != nil {
+			raw, err := json.Marshal(goInfo)
+			require.NoError(t, err)
+			spec.Language = map[string]schema.RawMessage{"go": raw}
+		}
+		pkg, diags, err := schema.BindSpec(spec, &testSchemaLoader{}, schema.ValidationOptions{})
+		require.NoError(t, err)
+		require.False(t, diags.HasErrors(), "%v", diags)
+		return pkg
+	}
+
+	// The replace directive uses a relative path, which must start with the separator of the
+	// host platform. Build the same prefix that Link builds.
+	relativeStart := "./"
+	if runtime.GOOS == "windows" {
+		relativeStart = ".\\"
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cancel := make(chan bool)
+			t.Cleanup(func() { close(cancel) })
+			handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+				Init: func(srv *grpc.Server) error {
+					loader := &testSchemaLoader{pkg: bind(t, tt.namespace, tt.goInfo)}
+					schema.LoaderRegistration(schema.NewLoaderServer(loader))(srv)
+					return nil
+				},
+				Cancel: cancel,
+			})
+			require.NoError(t, err)
+
+			programDir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(programDir, "go.mod"),
+				[]byte("module example.com/program\n\ngo 1.25\n"), 0o600))
+
+			host := &goLanguageHost{}
+			resp, err := host.Link(t.Context(), &pulumirpc.LinkRequest{
+				Info: &pulumirpc.ProgramInfo{
+					RootDirectory:    programDir,
+					ProgramDirectory: programDir,
+				},
+				LoaderTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
+				Packages: []*pulumirpc.LinkRequest_LinkDependency{{
+					Package: &pulumirpc.PackageDependency{Name: "file", Version: "0.1.0"},
+					Path:    "sdks/example-file",
+				}},
+			})
+			require.NoError(t, err)
+			require.Contains(t, resp.ImportInstructions, "\""+tt.expectedImport+"\"")
+
+			gomodContent, err := os.ReadFile(filepath.Join(programDir, "go.mod"))
+			require.NoError(t, err)
+			gomod, err := modfile.Parse("go.mod", gomodContent, nil)
+			require.NoError(t, err)
+			replaced := map[string]string{}
+			for _, replace := range gomod.Replace {
+				replaced[replace.Old.Path] = replace.New.Path
+			}
+			require.Equal(t, relativeStart+"sdks/example-file", replaced[tt.expectedModule])
+
+			// The printed import path must address the root package of the SDK that the
+			// generator writes, so that a program which follows the instructions compiles
+			// against the linked SDK.
+			files, err := gocodegen.GeneratePackage("pulumi-language-go", bind(t, tt.namespace, tt.goInfo), nil)
+			require.NoError(t, err)
+			generated, err := modfile.Parse("go.mod", files["go.mod"], nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedModule, generated.Module.Mod.Path)
+
+			// The generator writes exactly one pulumi-plugin.json, in the directory of the
+			// root package. Read that directory from it.
+			var rootDirs []string
+			for file := range files {
+				if path.Base(file) == "pulumi-plugin.json" {
+					rootDirs = append(rootDirs, path.Dir(file))
+				}
+			}
+			require.Len(t, rootDirs, 1)
+			require.Equal(t, tt.expectedImport, path.Join(generated.Module.Mod.Path, rootDirs[0]))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

#24433

`pulumi package add` printed a Go import path derived from the package name, which
does not match the path the generated SDK is actually importable under whenever the
schema sets a Go `importBasePath` or `modulePath`. Following the printed instruction
gave an import that does not resolve.

- Add a helper that resolves the Go SDK module and import path from the schema,
  preferring `modulePath`, then `importBasePath`, then the package name.
- Print the import path that matches the generated SDK.
- Make `ModuleAndImportPath` reject a package without pack support rather than
  returning a path that cannot be produced.

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestLinkImportInstructions` covers the eight schema shapes: no Go language info,
`importBasePath` only, `modulePath` only, both together, a `modulePath` that disagrees
with the `importBasePath`, and each of those without a namespace.

## Validation

- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes) — no proto changes

```
$ make format
Formatted 1 file in 6ms. No fixes applied.
exit=0

$ make lint
0 issues.
0 issues.
0 issues.
0 issues.
0 issues.
exit=0

$ make tidy_fix
exit=0
```

```
$ cd sdk/go/pulumi-language-go && go test ./... -count=1 -v -run TestLinkImportInstructions
--- PASS: TestLinkImportInstructions (0.00s)
    --- PASS: TestLinkImportInstructions/no_go_language_info (0.01s)
    --- PASS: TestLinkImportInstructions/no_go_language_info_and_no_namespace (0.01s)
    --- PASS: TestLinkImportInstructions/import_base_path_only (0.01s)
    --- PASS: TestLinkImportInstructions/import_base_path_only_and_no_namespace (0.01s)
    --- PASS: TestLinkImportInstructions/module_path_only (0.01s)
    --- PASS: TestLinkImportInstructions/module_path_only_and_no_namespace (0.01s)
    --- PASS: TestLinkImportInstructions/module_path_and_import_base_path (0.01s)
    --- PASS: TestLinkImportInstructions/module_path_that_disagrees_with_the_import_base_path (0.01s)
PASS
ok  	github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3	0.038s
ok  	github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3/buildutil	0.005s [no tests to run]
ok  	github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3/goversion	0.003s [no tests to run]
exit=0

$ cd pkg && go test ./codegen/go/ -count=1
ok  	github.com/pulumi/pulumi/pkg/v3/codegen/go	22.538s
exit=0

$ make test_fast
(107 packages ok, 0 FAIL)
ok  	github.com/pulumi/pulumi/pkg/v3/workspace	7.692s
exit=0
```

Run on linux/arm64, go1.26.7.

## Changelog

- [x] Changelog entry added.

`changelog/pending/cli-package-fix-20260824-105117.yaml`

## Risk

Low. The change is confined to how the Go import path is computed and printed for
`pulumi package add`; it does not alter generated SDK contents. The path was already
wrong for any schema setting `importBasePath` or `modulePath`, so the blast radius is
schemas that currently print an unusable instruction. `ModuleAndImportPath` now returns
an error for a package without pack support instead of a path that cannot be produced —
callers must handle that error. No public API change.
