### PR TITLE
Use errors.AsType for error matching

### DIFF
--- a/.golangci/rules.go
+++ b/.golangci/rules.go
@@ -14,6 +14,11 @@ func deferIgnoreClose(m dsl.Matcher) {
 		Suggest("defer contract.IgnoreClose($x)")
 }
 
+func errorsAs(m dsl.Matcher) {
+	m.Match(`errors.As($err, $target)`).
+		Report("use errors.AsType[T] instead of errors.As")
+}
+
 // ptrHelper forbids private pointer-wrapper helpers whose body is just
 // `return &v`. Use Go 1.26's `new(expr)` instead of adding a helper like
 // `func ptr[T any](v T) *T { return &v }`.

--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -255,7 +255,8 @@ func (LoginRequiredError) Is(other error) bool {
 // authorization failure (login required, forbidden, or a missing env var
 // required for non-interactive auth).
 func IsAuthError(err error) bool {
-	return errors.As(err, &LoginRequiredError{}) ||
-		errors.As(err, &ForbiddenError{}) ||
-		errors.As(err, &MissingEnvVarForNonInteractiveError{})
+	_, isLoginRequired := errors.AsType[LoginRequiredError](err)
+	_, isForbidden := errors.AsType[ForbiddenError](err)
+	_, isMissingEnvVar := errors.AsType[MissingEnvVarForNonInteractiveError](err)
+	return isLoginRequired || isForbidden || isMissingEnvVar
 }

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -50,7 +50,7 @@ func (r registryClient) GetPackage(
 	ctx context.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.PackageMetadata, error) {
 	meta, err := r.c.GetPackage(ctx, source, publisher, name, version)
-	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == 404 {
+	if apiErr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apiErr.Code == 404 {
 		return meta, backenderr.NotFoundError{Err: err}
 	}
 	return meta, err
@@ -66,7 +66,7 @@ func (r registryClient) GetTemplate(
 	ctx context.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.TemplateMetadata, error) {
 	meta, err := r.c.GetTemplate(ctx, source, publisher, name, version)
-	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {
+	if apiErr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apiErr.Code == http.StatusNotFound {
 		return meta, backenderr.NotFoundError{Err: err}
 	}
 	return meta, err
@@ -74,7 +74,7 @@ func (r registryClient) GetTemplate(
 
 func (r registryClient) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
 	bytes, err := r.c.DownloadTemplate(ctx, downloadURL)
-	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {
+	if apiErr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apiErr.Code == http.StatusNotFound {
 		return bytes, backenderr.NotFoundError{Err: err}
 	}
 	return bytes, err

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -385,8 +385,7 @@ func (pc *Client) ValidateAgentClaim(ctx context.Context, claimToken string) (bo
 	if err == nil {
 		return true, nil
 	}
-	var errResp *apitype.ErrorResponse
-	if errors.As(err, &errResp) && errResp.Code == http.StatusNotFound {
+	if errResp, ok := errors.AsType[*apitype.ErrorResponse](err); ok && errResp.Code == http.StatusNotFound {
 		return false, nil
 	}
 	return false, err
@@ -2689,8 +2688,7 @@ func is404(err error) bool {
 	if err == nil {
 		return false
 	}
-	var errResp *apitype.ErrorResponse
-	if errors.As(err, &errResp) && errResp.Code == http.StatusNotFound {
+	if errResp, ok := errors.AsType[*apitype.ErrorResponse](err); ok && errResp.Code == http.StatusNotFound {
 		return true
 	}
 	return false

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -56,7 +56,7 @@ func (r *cloudRegistry) GetPackage(
 	ctx ctx.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.PackageMetadata, error) {
 	meta, err := r.cl.GetPackage(ctx, source, publisher, name, version)
-	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == 404 {
+	if apiErr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apiErr.Code == 404 {
 		return meta, backenderr.NotFoundError{Err: err}
 	}
 	return meta, err
@@ -72,7 +72,7 @@ func (r *cloudRegistry) GetTemplate(
 	ctx ctx.Context, source, publisher, name string, version *semver.Version,
 ) (apitype.TemplateMetadata, error) {
 	meta, err := r.cl.GetTemplate(ctx, source, publisher, name, version)
-	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {
+	if apiErr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apiErr.Code == http.StatusNotFound {
 		return meta, backenderr.NotFoundError{Err: err}
 	}
 	return meta, err
@@ -90,7 +90,7 @@ func (r *cloudRegistry) DeletePackageVersion(
 	ctx ctx.Context, source, publisher, name string, version semver.Version,
 ) error {
 	err := r.cl.DeletePackageVersion(ctx, source, publisher, name, version)
-	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {
+	if apiErr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apiErr.Code == http.StatusNotFound {
 		return backenderr.NotFoundError{Err: err}
 	}
 	return err

--- a/pkg/backend/httpstate/journal/snapshot.go
+++ b/pkg/backend/httpstate/journal/snapshot.go
@@ -167,9 +167,9 @@ func sendBatch(
 ) error {
 	// Try to send the batch as-is. If there's no error or if the error is _not_ a 413 Content Too Large,
 	// we're done. Otherwise, try to send two smaller batches. If the batch is too small to split, we're done.
-	var apiError *apitype.ErrorResponse
 	err := client.SaveJournalEntries(ctx, update, batch, tokenSource)
-	if err == nil || !errors.As(err, &apiError) || apiError.Code != http.StatusRequestEntityTooLarge || len(batch) <= 1 {
+	apiError, ok := errors.AsType[*apitype.ErrorResponse](err)
+	if err == nil || !ok || apiError.Code != http.StatusRequestEntityTooLarge || len(batch) <= 1 {
 		return err
 	}
 

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -130,8 +130,7 @@ func RenewLeaseFunc(
 			ctx, update, currentToken, duration)
 		if err != nil {
 			// Translate 403 status codes to expired token errors to stop the token refresh loop.
-			var apierr *apitype.ErrorResponse
-			if errors.As(err, &apierr) && apierr.Code == 403 {
+			if apierr, ok := errors.AsType[*apitype.ErrorResponse](err); ok && apierr.Code == 403 {
 				return "", time.Time{}, expiredTokenError{err}
 			}
 			return "", time.Time{}, err

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -1117,8 +1117,8 @@ func TestSnapshotAutoRepairErrorIsSurfacedWhenRepairFails(t *testing.T) {
 	err := sm.saveSnapshot()
 
 	require.ErrorContains(t, err, "failed to verify snapshot")
-	var sie *snapshot.SnapshotIntegrityError
-	require.True(t, errors.As(err, &sie))
+	sie, ok := errors.AsType[*snapshot.SnapshotIntegrityError](err)
+	require.True(t, ok)
 	require.NotNil(t, sie.AutoRepairErr)
 	event := <-events
 	assert.Equal(t, engine.ErrorEvent, event.Type)

--- a/pkg/cmd/esc/cli/client/client.go
+++ b/pkg/cmd/esc/cli/client/client.go
@@ -769,8 +769,7 @@ func (pc *client) UpdateEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && len(diags.Diagnostics) != 0 {
 			return diags.Diagnostics, 0, nil
 		}
 		return nil, 0, err
@@ -811,8 +810,7 @@ func (pc *client) CreateEnvironmentDraft(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err
@@ -863,8 +861,7 @@ func (pc *client) UpdateEnvironmentDraft(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && len(diags.Diagnostics) != 0 {
 			return diags.Diagnostics, nil
 		}
 		return nil, err
@@ -918,8 +915,7 @@ func (pc *client) OpenEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err
@@ -951,8 +947,7 @@ func (pc *client) OpenEnvironmentDraft(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err
@@ -981,8 +976,7 @@ func (pc *client) RotateEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return nil, diags.Diagnostics, nil
 		}
 		return nil, nil, err
@@ -1013,8 +1007,7 @@ func (pc *client) CheckYAMLEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return nil, diags.Diagnostics, nil
 		}
 		return nil, nil, err
@@ -1054,8 +1047,7 @@ func (pc *client) OpenYAMLEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err

--- a/pkg/cmd/esc/cli/client/client.go
+++ b/pkg/cmd/esc/cli/client/client.go
@@ -915,7 +915,8 @@ func (pc *client) OpenEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok &&
+			diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err
@@ -947,7 +948,8 @@ func (pc *client) OpenEnvironmentDraft(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok &&
+			diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err
@@ -976,7 +978,8 @@ func (pc *client) RotateEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok &&
+			diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return nil, diags.Diagnostics, nil
 		}
 		return nil, nil, err
@@ -1007,7 +1010,8 @@ func (pc *client) CheckYAMLEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok &&
+			diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return nil, diags.Diagnostics, nil
 		}
 		return nil, nil, err
@@ -1047,7 +1051,8 @@ func (pc *client) OpenYAMLEnvironment(
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if diags, ok := errors.AsType[*EnvironmentErrorResponse](err); ok &&
+			diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
 			return "", diags.Diagnostics, nil
 		}
 		return "", nil, err

--- a/pkg/cmd/esc/cli/env_clone.go
+++ b/pkg/cmd/esc/cli/env_clone.go
@@ -53,8 +53,7 @@ func newEnvCloneCmd(env *envCommand) *cobra.Command {
 			// also be returned in this case.
 			// If the original ref is using a legacy ID of just env name return an error
 			// Otherwise we will ignore any conflict errors and assume the user meant <project-name>/<env-name>
-			var ambiguousIdErr ambiguousIdentifierError
-			if err != nil && !errors.As(err, &ambiguousIdErr) {
+			if _, ok := errors.AsType[ambiguousIdentifierError](err); err != nil && !ok {
 				return err
 			}
 

--- a/pkg/cmd/esc/cli/env_rm.go
+++ b/pkg/cmd/esc/cli/env_rm.go
@@ -84,8 +84,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 
 				err = env.esc.client.DeleteEnvironment(ctx, ref.orgName, ref.projectName, ref.envName)
 				if err != nil {
-					var errResp *apitype.ErrorResponse
-					if errors.As(err, &errResp) && errResp.Code == http.StatusConflict &&
+					if errResp, ok := errors.AsType[*apitype.ErrorResponse](err); ok && errResp.Code == http.StatusConflict &&
 						strings.Contains(errResp.Message, "protect") {
 						return fmt.Errorf(
 							"cannot delete environment: deletion protection is enabled. Disable deletion protection with 'esc env settings set %s deletion-protected false' before deleting", //nolint:lll

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -360,8 +360,7 @@ func unwrapBucketOpenError(err error, cloudURL string) error {
 	// A file:// failure is a path error naming a location we have usually shown already, in
 	// which case only the reason is worth keeping. When the path differs from the configured
 	// URL — a `~` or relative path that got resolved — it is new information, so keep it.
-	var pathErr *fs.PathError
-	if errors.As(cause, &pathErr) && strings.Contains(cloudURL, pathErr.Path) {
+	if pathErr, ok := errors.AsType[*fs.PathError](cause); ok && strings.Contains(cloudURL, pathErr.Path) {
 		return pathErr.Err
 	}
 	return cause

--- a/pkg/cmd/pulumi/cloud/api_test.go
+++ b/pkg/cmd/pulumi/cloud/api_test.go
@@ -153,8 +153,8 @@ func TestResolveBindings_MissingParamErrorSuggestsFlag(t *testing.T) {
 	}
 	_, _, err := resolveBindings(mr, nil, nil)
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrMissingContext, apiErr.Envelope.Error.Code)
 	joined := strings.Join(apiErr.Envelope.Error.Suggestions, "|")
 	assert.Contains(t, joined, "-F poolId=")
@@ -175,8 +175,8 @@ func TestResolveBindings_NullFieldRejected(t *testing.T) {
 	}
 	_, _, err := resolveBindings(mr, fields, nil)
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 }
 
@@ -260,8 +260,8 @@ func TestNegotiateAccept_MarkdownNotDeclared(t *testing.T) {
 	}
 	_, err := negotiateAccept(op, "markdown")
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 	joined := strings.Join(apiErr.Envelope.Error.Suggestions, "|")
 	assert.Contains(t, joined, "application/json")
@@ -272,8 +272,8 @@ func TestNegotiateAccept_InvalidValue(t *testing.T) {
 	t.Parallel()
 	_, err := negotiateAccept(&Operation{}, "yaml")
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 }
 
@@ -544,8 +544,8 @@ func TestValidateFlagCombos_BodyAndInputMutuallyExclusive(t *testing.T) {
 		input:           "payload.json",
 	})
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 	assert.Equal(t, cmdutil.ExitConfigurationError, apiErr.ExitCode)
 }
@@ -562,8 +562,8 @@ func TestValidateFlagCombos_SilentAndVerboseMutuallyExclusive(t *testing.T) {
 		verbose:         true,
 	})
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 	assert.Equal(t, cmdutil.ExitConfigurationError, apiErr.ExitCode)
 }
@@ -819,16 +819,16 @@ func TestHandleResponse(t *testing.T) {
 		err := handleResponse(&buf, io.Discard, newResp(500, "application/json", `{"code":500}`),
 			&apiCommand{silent: true})
 		require.Error(t, err)
-		var apiErr *APIError
-		require.True(t, errors.As(err, &apiErr))
+		apiErr, ok := errors.AsType[*APIError](err)
+		require.True(t, ok)
 		assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
 	})
 	t.Run("4xx_returns_apierror", func(t *testing.T) {
 		t.Parallel()
 		err := handleResponse(io.Discard, io.Discard, newResp(404, "application/json", `{"code":404}`), &apiCommand{})
 		require.Error(t, err)
-		var apiErr *APIError
-		require.True(t, errors.As(err, &apiErr))
+		apiErr, ok := errors.AsType[*APIError](err)
+		require.True(t, ok)
 		assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
 		assert.Equal(t, ErrHTTP4xx, apiErr.Envelope.Error.Code)
 	})
@@ -836,8 +836,8 @@ func TestHandleResponse(t *testing.T) {
 		t.Parallel()
 		err := handleResponse(io.Discard, io.Discard, newResp(401, "application/json", `{"code":401}`), &apiCommand{})
 		require.Error(t, err)
-		var apiErr *APIError
-		require.True(t, errors.As(err, &apiErr))
+		apiErr, ok := errors.AsType[*APIError](err)
+		require.True(t, ok)
 		assert.Equal(t, cmdutil.ExitAuthenticationError, apiErr.ExitCode)
 	})
 }

--- a/pkg/cmd/pulumi/cloud/envelope.go
+++ b/pkg/cmd/pulumi/cloud/envelope.go
@@ -319,8 +319,8 @@ func runWithEnvelope(fn func(*cobra.Command, []string) error) func(*cobra.Comman
 		if err == nil {
 			return nil
 		}
-		var apiErr *APIError
-		if !errors.As(err, &apiErr) {
+		apiErr, ok := errors.AsType[*APIError](err)
+		if !ok {
 			apiErr = &APIError{
 				ExitCode: cmdutil.ExitInternalError,
 				Envelope: ErrorEnvelope{Error: *errorDetailFromErr(err)},

--- a/pkg/cmd/pulumi/cloud/envelope_test.go
+++ b/pkg/cmd/pulumi/cloud/envelope_test.go
@@ -122,8 +122,8 @@ func TestRunWithEnvelope_ReturnsErrorNotExit(t *testing.T) {
 
 	// Contract: error is returned, not swallowed by os.Exit.
 	require.Error(t, got, "wrapper must return the error, not call os.Exit")
-	var returned *APIError
-	require.True(t, errors.As(got, &returned))
+	returned, ok := errors.AsType[*APIError](got)
+	require.True(t, ok)
 	assert.Equal(t, cmdutil.ExitCodeError, returned.ExitCode)
 	// Envelope was written, and Silent is flipped so DisplayErrorMessage won't duplicate.
 	assert.True(t, returned.Silent, "runWithEnvelope must mark the error Silent after writing the envelope")
@@ -143,8 +143,8 @@ func TestRunWithEnvelope_WrapsGenericError(t *testing.T) {
 	cmd.SetErr(&bytes.Buffer{})
 	got := wrapped(cmd, nil)
 
-	var apiErr *APIError
-	require.True(t, errors.As(got, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](got)
+	require.True(t, ok)
 	assert.Equal(t, cmdutil.ExitInternalError, apiErr.ExitCode)
 	assert.True(t, apiErr.Silent)
 }

--- a/pkg/cmd/pulumi/cloud/list_test.go
+++ b/pkg/cmd/pulumi/cloud/list_test.go
@@ -96,8 +96,8 @@ func TestRunLs_RejectsRawAndMarkdown(t *testing.T) {
 			t.Parallel()
 			err := runLs(t.Context(), io.Discard, io.Discard, out, true, false, false)
 			require.Error(t, err)
-			var apiErr *APIError
-			require.True(t, errors.As(err, &apiErr))
+			apiErr, ok := errors.AsType[*APIError](err)
+			require.True(t, ok)
 			assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 			assert.Equal(t, cmdutil.ExitConfigurationError, apiErr.ExitCode)
 			assert.Equal(t, "output", apiErr.Envelope.Error.Field)

--- a/pkg/cmd/pulumi/cloud/paginate_test.go
+++ b/pkg/cmd/pulumi/cloud/paginate_test.go
@@ -332,8 +332,8 @@ func TestRunPaginate_TruncationEmitsPartialPaginationError(t *testing.T) {
 	var buf bytes.Buffer
 	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
 	assert.Equal(t, ErrPartialPagination, apiErr.Envelope.Error.Code)
 	assert.True(t, apiErr.Silent, "truncation error must be Silent so stderr is not double-written")
@@ -353,8 +353,8 @@ func TestRunPaginate_FirstPageShapeErrorEmitsEnvelope(t *testing.T) {
 	var buf bytes.Buffer
 	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 	assert.False(t, apiErr.Silent, "first-page failure must not be Silent; user needs the diagnostic on stderr")
@@ -374,8 +374,8 @@ func TestRunPaginate_FirstPageHTTPErrorEmitsEnvelope(t *testing.T) {
 	var buf bytes.Buffer
 	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.False(t, apiErr.Silent, "first-page HTTP failure must not be Silent")
 	assert.Empty(t, strings.TrimSpace(buf.String()), "first-page HTTP failure must not write to stdout")
 }
@@ -398,8 +398,8 @@ func TestRunPaginate_LaterPageErrorStaysSilent(t *testing.T) {
 	var buf bytes.Buffer
 	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.True(t, apiErr.Silent, "partial failure with accumulated pages must stay Silent")
 	assert.Contains(t, buf.String(), `"items"`, "partial failure must flush accumulated pages to stdout")
 	assert.Contains(t, buf.String(), `"id":"a"`)

--- a/pkg/cmd/pulumi/cloud/pathmatch_test.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch_test.go
@@ -93,8 +93,8 @@ func TestMatchPath_MethodMismatch(t *testing.T) {
 		&Operation{Method: "POST", Path: "/api/user"},
 	)
 	_, err := MatchPath(idx, "GET", "/api/user")
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
 	assert.Equal(t, ErrNoMatch, apiErr.Envelope.Error.Code)
 }
@@ -158,8 +158,8 @@ func TestMatchByOperationID_NoMatch(t *testing.T) {
 	)
 	_, err := MatchByOperationID(idx, "Nonexistent")
 	assert.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	assert.Equal(t, ErrNoMatch, apiErr.Envelope.Error.Code)
 }
 
@@ -342,8 +342,8 @@ func TestMatchPath_SuggestsOperationIDWhenInputLooksLikeOne(t *testing.T) {
 	)
 	_, err := MatchPath(idx, "GET", "ListAccounts")
 	require.Error(t, err)
-	var apiErr *APIError
-	require.True(t, errors.As(err, &apiErr))
+	apiErr, ok := errors.AsType[*APIError](err)
+	require.True(t, ok)
 	// The suggestion mentioning operation-ID usage should be present.
 	found := false
 	for _, s := range apiErr.Envelope.Error.Suggestions {

--- a/pkg/cmd/pulumi/cmd/cmd.go
+++ b/pkg/cmd/pulumi/cmd/cmd.go
@@ -75,9 +75,8 @@ func processCmdErrors(ctx context.Context, err error, stderr io.Writer) error {
 	// `pulumi api` errors have already had their structured envelope
 	// written to stderr by runWithEnvelope, so suppress the generic
 	// message print. ExitCodeFor still recovers the semantic exit code via
-	// errors.As.
-	var apiErr *cloud.APIError
-	if errors.As(err, &apiErr) && apiErr.Silent {
+	// errors.AsType.
+	if apiErr, ok := errors.AsType[*cloud.APIError](err); ok && apiErr.Silent {
 		return result.BailError(err)
 	}
 
@@ -109,10 +108,10 @@ func processCmdErrors(ctx context.Context, err error, stderr io.Writer) error {
 }
 
 func isAuthRequiredError(err error) bool {
-	var apiErr *apitype.ErrorResponse
+	apiErr, ok := errors.AsType[*apitype.ErrorResponse](err)
 	return errors.Is(err, backenderr.LoginRequiredError{}) ||
 		errors.Is(err, httpstate.ErrUnauthorized) ||
-		errors.As(err, &apiErr) && apiErr.Code == http.StatusUnauthorized
+		ok && apiErr.Code == http.StatusUnauthorized
 }
 
 // A type-specific handler for engine.DecryptErrors that prints out help text

--- a/pkg/cmd/pulumi/cmd/exit_codes.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes.go
@@ -89,31 +89,32 @@ func ExitCodeFor(err error) int {
 	}
 
 	// Stack context problems.
+	_, isStackNotFound := errors.AsType[backenderr.StackNotFoundError](err)
+	_, isNoStacks := errors.AsType[backenderr.NoStacksError](err)
+	_, isNoStackSelected := errors.AsType[backenderr.NoStackSelectedError](err)
+	_, isStackStateNotFound := errors.AsType[backenderr.StackStateNotFoundError](err)
 	switch {
-	case errors.As(err, &backenderr.StackNotFoundError{}),
-		errors.As(err, &backenderr.NoStacksError{}),
-		errors.As(err, &backenderr.NoStackSelectedError{}),
-		errors.As(err, &backenderr.StackStateNotFoundError{}):
+	case isStackNotFound, isNoStacks, isNoStackSelected, isStackStateNotFound:
 		return ExitStackNotFound
 	}
 
 	// User-initiated cancellation.
-	if errors.As(err, &backenderr.CancelledError{}) {
+	if _, ok := errors.AsType[backenderr.CancelledError](err); ok {
 		return ExitCancelled
 	}
 
 	// Expectation / invariant failures like --expect-no-changes.
-	if errors.As(err, &backenderr.NoChangesExpectedError{}) {
+	if _, ok := errors.AsType[backenderr.NoChangesExpectedError](err); ok {
 		return ExitNoChanges
 	}
 
 	// Non-interactive mode without confirmation flags.
-	if errors.As(err, &backenderr.NoConfirmationInNonInteractiveError{}) {
+	if _, ok := errors.AsType[backenderr.NoConfirmationInNonInteractiveError](err); ok {
 		return ExitConfigurationError
 	}
 
 	// Command was invoked with malformed input
-	if errors.As(err, &ConfigurationError{}) {
+	if _, ok := errors.AsType[ConfigurationError](err); ok {
 		return ExitConfigurationError
 	}
 

--- a/pkg/cmd/pulumi/convert/io.go
+++ b/pkg/cmd/pulumi/convert/io.go
@@ -43,8 +43,8 @@ func LoadConverterPlugin(
 	if err != nil {
 		// If NewConverter returns a MissingError, we can try and install the plugin if it was missing and try again,
 		// unless auto plugin installs are turned off.
-		var me *workspace.MissingError
-		if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
+		_, ok := errors.AsType[*workspace.MissingError](err)
+		if !ok || env.DisableAutomaticPluginAcquisition.Value() {
 			// Not a MissingError, return the original error.
 			return nil, fmt.Errorf("load %q: %w", name, err)
 		}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -117,8 +117,8 @@ func entityDroppedWarning(orgName, projectName, stackRefName string, err error) 
 // rejection. Matched on the message because the service doesn't expose a stable
 // error code for this case.
 func isInvalidEntitiesError(err error) bool {
-	var errResp *apitype.ErrorResponse
-	if !errors.As(err, &errResp) {
+	errResp, ok := errors.AsType[*apitype.ErrorResponse](err)
+	if !ok {
 		return false
 	}
 	return strings.Contains(strings.ToLower(errResp.Message), "invalid entit")

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -245,8 +245,7 @@ func isTransientStreamError(err error) bool {
 		errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
-	var ne net.Error
-	if errors.As(err, &ne) && ne.Timeout() {
+	if ne, ok := errors.AsType[net.Error](err); ok && ne.Timeout() {
 		return true
 	}
 	if ue, ok := errors.AsType[*url.Error](err); ok {
@@ -260,8 +259,8 @@ func isTransientStreamError(err error) bool {
 		}
 		return false
 	}
-	var oe *net.OpError
-	return errors.As(err, &oe)
+	_, ok := errors.AsType[*net.OpError](err)
+	return ok
 }
 
 // backoffDelay returns the wait before the Nth (1-based) reconnect attempt: exponential

--- a/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
+++ b/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
@@ -143,11 +143,10 @@ type RunPlugin = func(ctx context.Context, wd string) (plugin.Provider, error)
 // if it's unset.
 //
 // If a cyclic dependency is found, then an instance of [ErrorCyclicDependencies] will be
-// returned. It can be accessed with [errors.As]:
+// returned. It can be accessed with [errors.AsType]:
 //
 //	_, err := packageinstallation.InstallPlugin(...)
-//	var cycle packageinstallation.ErrorCyclicDependencies
-//	if errors.As(err, &cycle) {
+//	if cycle, ok := errors.AsType[packageinstallation.ErrorCyclicDependencies](err); ok {
 //		fmt.Println(cycle.Cycle)
 //	}
 func InstallPlugin(
@@ -313,8 +312,8 @@ func (ErrorCyclicDependencies) Error() string { return "cyclic dependency" }
 func (err ErrorCyclicDependencies) Unwrap() error { return err.underlying }
 
 func wrapCycleError(err error) error {
-	var cycle pdag.ErrorCycle[step]
-	if !errors.As(err, &cycle) {
+	cycle, ok := errors.AsType[pdag.ErrorCycle[step]](err)
+	if !ok {
 		return err
 	}
 	steps := cycle.Cycle

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -86,8 +86,8 @@ func newPluginRunCmd() *cobra.Command {
 				pluginPath, err = workspace.GetPluginPath(ctx, d, pluginSpec, nil)
 				if err != nil {
 					// Try to install the plugin, unless auto plugin installs are turned off.
-					var me *workspace.MissingError
-					if !errors.As(err, &me) || env.DisableAutomaticPluginAcquisition.Value() {
+					_, ok := errors.AsType[*workspace.MissingError](err)
+					if !ok || env.DisableAutomaticPluginAcquisition.Value() {
 						// Not a MissingError, return the original error.
 						return fmt.Errorf("could not get plugin path: %w", err)
 					}

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -145,7 +145,7 @@ func InstallPackagesFromProject(
 		Concurrency: parallelism,
 	}
 	continuation, err := packageinstallation.InstallProjectPlugins(ctx, proj, root, opts, registry, ws)
-	if e := (packageinstallation.ErrorCyclicDependencies{}); errors.As(err, &e) {
+	if e, ok := errors.AsType[packageinstallation.ErrorCyclicDependencies](err); ok {
 		err = cmdDiag.FormatCyclicInstallError(ctx, e, root)
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_output_fuzz_test.go
+++ b/pkg/cmd/pulumi/stack/stack_output_fuzz_test.go
@@ -63,8 +63,7 @@ func FuzzBashStackOutputWriter(f *testing.F) {
 		got, err := exec.Command(bash, file.Name()).Output()
 		//nolint:forbidigo // We enhance the error message show if the test fails
 		if !assert.NoError(t, err, "Failed script:\n%s", buff.String()) {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && len(exitErr.Stderr) > 0 {
 				t.Logf("stderr:\n%s", exitErr.Stderr)
 			}
 			t.FailNow()
@@ -109,8 +108,7 @@ func FuzzPowershellStackOutputWriter(f *testing.F) {
 		got, err := exec.Command(pwsh, "-File", file.Name()).Output()
 		//nolint:forbidigo // We enhance the error message show if the test fails
 		if !assert.NoError(t, err, "Failed script:\n%s", buff.String()) {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && len(exitErr.Stderr) > 0 {
 				t.Logf("stderr:\n%s", exitErr.Stderr)
 			}
 		}

--- a/pkg/cmd/pulumi/templates/cloud.go
+++ b/pkg/cmd/pulumi/templates/cloud.go
@@ -366,7 +366,7 @@ func (f *fetch) listOrgTemplates(ctx context.Context, templateName string, e env
 	handleOrg := func(org string) {
 		slog.InfoContext(ctx, "Checking for templates", "org", org)
 		orgTemplates, err := b.ListTemplates(ctx, org)
-		if apiError := new(apitype.ErrorResponse); errors.As(err, &apiError) {
+		if apiError, ok := errors.AsType[*apitype.ErrorResponse](err); ok {
 			// This is what happens when we try to access org templates for an org that hasn't enabled org templates.
 			if apiError.Code == 402 {
 				slog.InfoContext(ctx, "does not have access to org templates", "org", org, "code", apiError.Code)

--- a/pkg/cmd/pulumi/templates/workspace.go
+++ b/pkg/cmd/pulumi/templates/workspace.go
@@ -34,7 +34,7 @@ func (f *fetch) listProjectTemplates(
 ) {
 	repo, err := get(ctx, templateNamePathOrURL, scope == ScopeLocal, templateKind)
 	if err != nil {
-		if notFound := (TemplateNotFoundError{}); errors.As(err, &notFound) {
+		if notFound, ok := errors.AsType[TemplateNotFoundError](err); ok {
 			f.addErrorOnEmpty(notFound)
 			return
 		}

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -494,8 +494,8 @@ func (l *pluginLoader) loadSchemaBytes(
 	pluginInfo, err := l.pctx.Host.ResolvePlugin(l.pctx, pluginSpecFromPackageDescriptor(descriptor))
 	if err != nil {
 		// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.
-		var missingError *workspace.MissingError
-		if !errors.As(err, &missingError) || env.DisableAutomaticPluginAcquisition.Value() {
+		_, ok := errors.AsType[*workspace.MissingError](err)
+		if !ok || env.DisableAutomaticPluginAcquisition.Value() {
 			return nil, nil, err
 		}
 

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -45,7 +45,5 @@ func (d DecryptError) Error() string {
 // will be the first DecryptError in the tree. In the event that there is no such
 // DecryptError, the first element will be nil.
 func AsDecryptError(err error) (*DecryptError, bool) {
-	var de *DecryptError
-	ok := errors.As(err, &de)
-	return de, ok
+	return errors.AsType[*DecryptError](err)
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -788,8 +788,8 @@ func loadPolicyAnalyzer(
 		return analyzer, nil
 	}
 
-	var me *workspace.MissingError
-	if !errors.As(err, &me) {
+	me, ok := errors.AsType[*workspace.MissingError](err)
+	if !ok {
 		return nil, err
 	}
 

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -185,8 +185,8 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 		assert.ErrorContains(t, err, "required analyzer plugin has not been installed")
 
 		// The original MissingError should be wrapped, not replaced.
-		var me *workspace.MissingError
-		assert.True(t, errors.As(err, &me))
+		_, ok := errors.AsType[*workspace.MissingError](err)
+		assert.True(t, ok)
 	})
 
 	t.Run("MissingError with auto-install retries and succeeds", func(t *testing.T) {
@@ -260,8 +260,8 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to automatically install analyzer plugin")
 
 		// The original MissingError should be wrapped.
-		var me *workspace.MissingError
-		assert.True(t, errors.As(err, &me))
+		_, ok := errors.AsType[*workspace.MissingError](err)
+		assert.True(t, ok)
 	})
 
 	t.Run("MissingError after successful install wraps retry error", func(t *testing.T) {
@@ -296,8 +296,8 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			`could not start policy pack "my-policy" because the built-in analyzer `+
 				`plugin that runs policy plugins is missing`)
 
-		var me *workspace.MissingError
-		assert.True(t, errors.As(err, &me))
+		_, ok := errors.AsType[*workspace.MissingError](err)
+		assert.True(t, ok)
 	})
 }
 

--- a/pkg/pcl/runtime/builtinFunctions.go
+++ b/pkg/pcl/runtime/builtinFunctions.go
@@ -117,8 +117,8 @@ func recoverExpression(
 		return propertyValueToCty(context.TODO(), getResource, pv)
 	}
 
-	var poison *poisonError
-	if !errors.As(err, &poison) {
+	poison, ok := errors.AsType[*poisonError](err)
+	if !ok {
 		return cty.NilVal, err
 	}
 

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -152,8 +152,7 @@ func ResolvePackageFromName(
 }
 
 func GetSuggestedPackages(err error) []apitype.PackageMetadata {
-	var suggestions errorSuggestedPackages
-	errors.As(err, &suggestions)
+	suggestions, _ := errors.AsType[errorSuggestedPackages](err)
 	return suggestions.packages
 }
 

--- a/pkg/registry/resolve_test.go
+++ b/pkg/registry/resolve_test.go
@@ -653,8 +653,8 @@ func TestResolvePackageFromName(t *testing.T) {
 				t.Parallel()
 				_, err := ResolvePackageFromName(ctx, mockReg, tc, nil)
 				assert.Error(t, err)
-				var invalidErr InvalidIdentifierError
-				assert.True(t, errors.As(err, &invalidErr))
+				_, ok := errors.AsType[InvalidIdentifierError](err)
+				assert.True(t, ok)
 				assert.Contains(t, err.Error(), tc)
 			})
 		}
@@ -945,7 +945,7 @@ func TestResolveTemplateFromName(t *testing.T) {
 
 		_, err := ResolveTemplateFromName(ctx, mockReg, "a/b/c/d", nil)
 		assert.Error(t, err)
-		var invalidErr InvalidIdentifierError
-		assert.True(t, errors.As(err, &invalidErr))
+		_, ok := errors.AsType[InvalidIdentifierError](err)
+		assert.True(t, ok)
 	})
 }

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -443,7 +443,7 @@ func (se *stepExecutor) cancelDueToError(err error, step Step) {
 	// these are deletes there's nothing replied to the user program, it's safe to continue past them. There
 	// are no observable effects in the user program, its just the CLI will be able to continue past and
 	// report any other issues.
-	if errors.As(err, &deleteProtectedError{}) {
+	if _, ok := errors.AsType[deleteProtectedError](err); ok {
 		continueOnError = true
 	}
 

--- a/pkg/resource/plugin/host.go
+++ b/pkg/resource/plugin/host.go
@@ -127,8 +127,7 @@ func IsLocalPluginPath(ctx context.Context, source string) bool {
 	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
 	// and check if it has a download URL.
 	pluginSpec, err := workspace.NewPluginDescriptor(ctx, source, apitype.ResourcePlugin, nil, "", nil)
-	var pluginErr workspace.PluginVersionNotFoundError
-	if err != nil && !errors.As(err, &pluginErr) {
+	if _, ok := errors.AsType[workspace.PluginVersionNotFoundError](err); err != nil && !ok {
 		// If we can't parse it as a plugin spec, assume it's a local path
 		return true
 	}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -1214,15 +1214,15 @@ func secretPropertyValueFromPlaintext(plaintext string) (resource.PropertyValue,
 // FormatDeploymentDeserializationError formats deployment-related errors into user-friendly messages.
 // It handles version compatibility errors and unsupported feature errors.
 func FormatDeploymentDeserializationError(err error, stackName string) error {
-	var unsupportedErr *ErrDeploymentUnsupportedFeatures
-
-	switch {
-	case errors.As(err, &unsupportedErr):
+	if unsupportedErr, ok := errors.AsType[*ErrDeploymentUnsupportedFeatures](err); ok {
 		return fmt.Errorf(
 			"the stack '%s' uses features that are not supported by this version of the Pulumi CLI: %s. "+
 				"Please update your version of the Pulumi CLI",
 			stackName, strings.Join(unsupportedErr.Features, ", "),
 		)
+	}
+
+	switch {
 	case errors.Is(err, ErrDeploymentSchemaVersionTooOld):
 		return fmt.Errorf("the stack '%s' is too old to be used by this version of the Pulumi CLI",
 			stackName)

--- a/pkg/resource/stack/snapshot/integrity.go
+++ b/pkg/resource/stack/snapshot/integrity.go
@@ -265,7 +265,5 @@ func (s *SnapshotIntegrityError) ForReadWithMetadata(
 // event that there is no such SnapshotIntegrityError, the first element will be
 // nil.
 func AsSnapshotIntegrityError(err error) (*SnapshotIntegrityError, bool) {
-	var sie *SnapshotIntegrityError
-	ok := errors.As(err, &sie)
-	return sie, ok
+	return errors.AsType[*SnapshotIntegrityError](err)
 }

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -132,8 +132,7 @@ func IsLocalPluginPath(ctx context.Context, source string) bool {
 	// For other cases, we need to be careful about how we interpret the source, so let's parse the spec
 	// and check if it has a download URL.
 	pluginSpec, err := workspace.NewPluginDescriptor(ctx, source, apitype.ResourcePlugin, nil, "", nil)
-	var pluginErr workspace.PluginVersionNotFoundError
-	if err != nil && !errors.As(err, &pluginErr) {
+	if _, ok := errors.AsType[workspace.PluginVersionNotFoundError](err); err != nil && !ok {
 		// If we can't parse it as a plugin spec, assume it's a local path
 		return true
 	}

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -471,7 +471,7 @@ func getSSHPublicKeys(user string, host string, sshConfig sshUserSettings) (*git
 	// Attempt to load the key. If this is an interactive session and the key
 	// is passphrase-protected we will prompt the user to enter a passphrase.
 	signer, err := ssh.ParsePrivateKey(privateKeyBytes)
-	if errors.As(err, new(*ssh.PassphraseMissingError)) {
+	if _, ok := errors.AsType[*ssh.PassphraseMissingError](err); ok {
 		passphrase := env.GitSSHPassphrase.Value()
 
 		if passphrase == "" && cmdutil.Interactive() {

--- a/sdk/go/common/util/result/result.go
+++ b/sdk/go/common/util/result/result.go
@@ -61,8 +61,7 @@ func IsBail(err error) bool {
 		return false
 	}
 
-	var bail *bailError
-	ok := errors.As(err, &bail)
+	_, ok := errors.AsType[*bailError](err)
 	return ok
 }
 

--- a/sdk/go/common/util/rpcutil/rpcerror/rpcerror.go
+++ b/sdk/go/common/util/rpcutil/rpcerror/rpcerror.go
@@ -29,9 +29,10 @@
 package rpcerror
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/runtime/protoiface"
@@ -155,8 +156,7 @@ func Wrapf(code codes.Code, err error, messageFormat string, args ...any) error 
 }
 
 func WrapDetailedError(err error) error {
-	var iperr *perrors.InputPropertiesError
-	if errors.As(err, &iperr) {
+	if iperr, ok := errors.AsType[*perrors.InputPropertiesError](err); ok {
 		status := status.New(codes.InvalidArgument, iperr.Message)
 		errorDetails := pulumirpc.InputPropertiesError{}
 		for _, e := range iperr.Errors {
@@ -240,7 +240,7 @@ func serializeErrorCause(err error) *pulumirpc.ErrorCause {
 	// The pkg/errors documentation actually encourages this pattern (!) so
 	// that's what we're doing here to get at the error's stack trace.
 	type stackTracer interface {
-		StackTrace() errors.StackTrace
+		StackTrace() pkgerrors.StackTrace
 	}
 
 	message := err.Error()

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -435,8 +435,8 @@ func (e *UndecryptableCredentialsError) Error() string { return e.Err.Error() }
 func (e *UndecryptableCredentialsError) Unwrap() error { return e.Err }
 
 func IsUndecryptableCredentials(err error) bool {
-	var undecryptable *UndecryptableCredentialsError
-	return errors.As(err, &undecryptable)
+	_, ok := errors.AsType[*UndecryptableCredentialsError](err)
+	return ok
 }
 
 func decryptCredentials(credsFile string, data []byte) ([]byte, error) {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -574,8 +574,8 @@ func (source *githubSource) getHTTPResponse(
 	//   and trying again.  This can be useful for example if the user has a fine grained token, which when set doesn't
 	//   allow access to public repositories.
 	// All other errors are returned as is.
-	var downErr *downloadError
-	if !errors.As(err, &downErr) || !isRateLimitError(downErr) {
+	downErr, ok := errors.AsType[*downloadError](err)
+	if !ok || !isRateLimitError(downErr) {
 		// If we see a 401 or 403 error and we're using a token we'll disable that token and try again
 		if downErr != nil && (downErr.code == 401 || downErr.code == 403) && source.token != "" {
 			source.token = ""
@@ -1869,8 +1869,8 @@ func (d *pluginDownloader) downloadToFileWithRetry(ctx context.Context, pkgPlugi
 			}
 
 			// Don't retry, since the request was processed and rejected.
-			var downloadErr *downloadError
-			if errors.As(readErr, &downloadErr) && (downloadErr.code == 404 || downloadErr.code == 403) {
+			if downloadErr, ok := errors.AsType[*downloadError](readErr); ok &&
+				(downloadErr.code == 404 || downloadErr.code == 403) {
 				return false, "", readErr
 			}
 


### PR DESCRIPTION
Replace existing `errors.As` call sites with `errors.AsType` and add a ruleguard lint rule to prevent new `errors.As` usage.

The release notes (https://go.dev/doc/go1.26#errorspkgerrors) describe `AsType` as "type-safe, faster, and, in most cases, easier to use".
