### PR TITLE
improve performance for `pulumi api`

### DIFF
--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -225,7 +225,16 @@ func runAPI(cmd *cobra.Command, args []string, api *apiCommand) error {
 	}
 	userArg := strings.TrimSpace(args[0])
 
-	idx, err := LoadIndex(cmd.Context(), cmd.ErrOrStderr(), api.refreshSpec)
+	// Resolve cloud context up front so the backend-aware default org is
+	// available to template-var resolution. ResolveContext is non-interactive
+	// and returns a usable (anonymous) context when the user isn't logged in.
+	resolvedCtx, err := ResolveContext(cmd.Context())
+	if err != nil {
+		return NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+			fmt.Sprintf("resolving cloud context: %v", err))
+	}
+
+	idx, err := LoadIndex(cmd.Context(), resolvedCtx, cmd.ErrOrStderr(), api.refreshSpec)
 	if err != nil {
 		return err
 	}
@@ -239,15 +248,6 @@ func runAPI(cmd *cobra.Command, args []string, api *apiCommand) error {
 	fields, err := parseFields(api.fields, api.rawFields, os.Stdin)
 	if err != nil {
 		return err
-	}
-
-	// Resolve cloud context up front so the backend-aware default org is
-	// available to template-var resolution. ResolveContext is non-interactive
-	// and returns a usable (anonymous) context when the user isn't logged in.
-	resolvedCtx, err := ResolveContext(cmd.Context())
-	if err != nil {
-		return NewAPIError(cmdutil.ExitInternalError, ErrToolError,
-			fmt.Sprintf("resolving cloud context: %v", err))
 	}
 
 	bindings, fields, err := resolveBindings(mr, fields, resolvedCtx)

--- a/pkg/cmd/pulumi/cloud/describe.go
+++ b/pkg/cmd/pulumi/cloud/describe.go
@@ -83,7 +83,13 @@ func runDescribe(
 		return err
 	}
 
-	idx, err := LoadIndex(ctx, warnW, refresh)
+	resolved, err := ResolveContext(ctx)
+	if err != nil {
+		return NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+			fmt.Sprintf("resolving cloud context: %v", err))
+	}
+
+	idx, err := LoadIndex(ctx, resolved, warnW, refresh)
 	if err != nil {
 		return err
 	}
@@ -139,6 +145,7 @@ func emitDescribeMarkdown(w io.Writer, op *Operation) error {
 }
 
 func emitDescribeJSON(w io.Writer, op *Operation) error {
+	op.ensureSchemas()
 	payload := describedOp{
 		OperationID:  op.OperationID,
 		Method:       op.Method,
@@ -187,6 +194,7 @@ func emitDescribeText(w io.Writer, op *Operation) error {
 // returns it as a string. Used by emitDescribeText for the CLI and by the
 // TUI's Browse tab to fill the details viewport.
 func RenderDescribeText(op *Operation) string {
+	op.ensureSchemas()
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s %s\n", op.Method, op.Path)
 	if op.Tag != "" {

--- a/pkg/cmd/pulumi/cloud/describe_markdown.go
+++ b/pkg/cmd/pulumi/cloud/describe_markdown.go
@@ -29,6 +29,7 @@ import (
 // markdown suitable for `describe --output=markdown`; callers piping to a
 // terminal may further pass it through glow or similar for ANSI rendering.
 func RenderDescribeMarkdown(op *Operation) string {
+	op.ensureSchemas()
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "# `%s` %s\n\n", op.Method, op.Path)

--- a/pkg/cmd/pulumi/cloud/list.go
+++ b/pkg/cmd/pulumi/cloud/list.go
@@ -111,7 +111,13 @@ func runLs(
 		mode = outputJSON
 	}
 
-	idx, err := LoadIndex(ctx, warnW, refresh)
+	resolved, err := ResolveContext(ctx)
+	if err != nil {
+		return NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+			fmt.Sprintf("resolving cloud context: %v", err))
+	}
+
+	idx, err := LoadIndex(ctx, resolved, warnW, refresh)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/cloud/pathmatch.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch.go
@@ -95,6 +95,7 @@ func MatchByOperationID(idx *Index, id string) (*MatchResult, error) {
 	op := matches[0]
 	mr, err := MatchPath(idx, op.Method, op.Path)
 	if err != nil {
+		op.ensureSchemas()
 		return &MatchResult{Op: op, Bindings: map[string]Binding{}}, nil
 	}
 	return mr, nil
@@ -142,6 +143,7 @@ func MatchPath(idx *Index, method, userPath string) (*MatchResult, error) {
 		if idx.router.Match(req, &rm) {
 			op := idx.ByKey[rm.Route.GetName()]
 			if op != nil {
+				op.ensureSchemas()
 				return &MatchResult{Op: op, Bindings: varsToBindings(rm.Vars)}, nil
 			}
 		}

--- a/pkg/cmd/pulumi/cloud/spec.go
+++ b/pkg/cmd/pulumi/cloud/spec.go
@@ -106,6 +106,26 @@ type Operation struct {
 	// SupersededBy is the operationId of the replacement route when
 	// x-pulumi-route-property.SupersededBy is set on a deprecated op.
 	SupersededBy string
+
+	// hydrate fills the rendered schema fields (Body/Response SchemaText,
+	// SchemaMarkdown, SchemaJSON and the per-response copies in
+	// InlineResponses) on first ensureSchemas call. Rendering is deferred
+	// because it dominates spec-parse time and only `describe` reads these
+	// fields, for a single operation. nil once run, or when the Operation
+	// was built without a parsed spec (tests).
+	hydrate func(*Operation)
+}
+
+// ensureSchemas renders the schema-bearing fields of the operation.
+// Idempotent; must be called before reading BodySchemaText/Markdown/JSON,
+// ResponseSchemaText/JSON, or the schema fields of InlineResponses.
+func (o *Operation) ensureSchemas() {
+	if o.hydrate == nil {
+		return
+	}
+	h := o.hydrate
+	o.hydrate = nil
+	h(o)
 }
 
 // Index is the parsed OpenAPI spec with lookup aids.
@@ -125,11 +145,12 @@ var methodPrecedence = map[string]int{
 }
 
 // LoadIndex returns the parsed OpenAPI spec, fetching it from Pulumi Cloud on
-// cache miss and writing the result to the per-user cache. Pass refresh=true
-// to force a re-fetch even when the cache has a copy. Warnings (stale-cache
-// fallback, cache-write failure) are written to warnW.
-func LoadIndex(ctx context.Context, warnW io.Writer, refresh bool) (*Index, error) {
-	data, err := ensureSpec(ctx, warnW, refresh)
+// cache miss and writing the result to the per-user cache. resolved supplies
+// the cloud URL and client used for the fetch. Pass refresh=true to force a
+// re-fetch even when the cache has a copy. Warnings (stale-cache fallback,
+// cache-write failure) are written to warnW.
+func LoadIndex(ctx context.Context, resolved *ResolvedContext, warnW io.Writer, refresh bool) (*Index, error) {
+	data, err := ensureSpec(ctx, resolved, warnW, refresh)
 	if err != nil {
 		return nil, err
 	}
@@ -257,20 +278,39 @@ func parseOperation(path, method string, op *v3high.Operation, renderer *schemaR
 		}
 		out.Params = append(out.Params, pp)
 	}
+	var bodySchema *base.Schema
 	if op.RequestBody != nil && op.RequestBody.Content != nil {
 		out.HasBody = true
 		out.BodyContentType = preferContentType(op.RequestBody.Content)
 		if out.BodyContentType != "" {
 			if ct, ok := op.RequestBody.Content.Get(out.BodyContentType); ok && ct != nil && ct.Schema != nil {
-				if resolved := ct.Schema.Schema(); resolved != nil {
-					out.BodySchemaText = renderer.renderBodySchema(resolved)
-					out.BodySchemaMarkdown = renderer.renderSchemaMarkdown(resolved)
-					out.BodySchemaJSON = schemaToJSON(resolved)
-				}
+				bodySchema = ct.Schema.Schema()
 			}
 		}
 	}
-	populateResponses(out, op, renderer)
+	respSchemas, primary := populateResponses(out, op)
+	out.hydrate = func(o *Operation) {
+		if bodySchema != nil {
+			o.BodySchemaText = renderer.renderBodySchema(bodySchema)
+			o.BodySchemaMarkdown = renderer.renderSchemaMarkdown(bodySchema)
+			o.BodySchemaJSON = schemaToJSON(bodySchema)
+		}
+		for i, schema := range respSchemas {
+			if schema == nil {
+				continue
+			}
+			r := &o.InlineResponses[i]
+			r.SchemaText = renderer.renderResponseSchema(schema)
+			r.SchemaMarkdown = renderer.renderSchemaMarkdown(schema)
+			r.SchemaJSON = schemaToJSON(schema)
+		}
+		// Mirror the primary response into the flat fields so the text
+		// and `--output=json` outputs both still see the "primary" body.
+		if primary >= 0 {
+			o.ResponseSchemaText = o.InlineResponses[primary].SchemaText
+			o.ResponseSchemaJSON = o.InlineResponses[primary].SchemaJSON
+		}
+	}
 	return out
 }
 
@@ -279,9 +319,15 @@ func parseOperation(path, method string, op *v3high.Operation, renderer *schemaR
 // 2xx success response is also duplicated into the flat
 // ResponseContentType/ResponseSchemaText/ResponseSchemaJSON fields so the
 // `describe` text and `--output=json` outputs both have a primary body.
-func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRenderer) {
+//
+// Schema rendering is deferred to Operation.ensureSchemas: the returned
+// slice carries the resolved schema for each InlineResponses entry (nil for
+// schemaless entries), and the int is the index of the primary response in
+// InlineResponses (-1 when none).
+func populateResponses(out *Operation, op *v3high.Operation) ([]*base.Schema, int) {
+	primary := -1
 	if op.Responses == nil {
-		return
+		return nil, primary
 	}
 
 	type codeEntry struct {
@@ -299,6 +345,7 @@ func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRen
 		entries = append(entries, codeEntry{status: "default", resp: op.Responses.Default})
 	}
 
+	var schemas []*base.Schema
 	for _, e := range entries {
 		if e.resp == nil {
 			continue
@@ -321,6 +368,7 @@ func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRen
 					Status:      e.status,
 					Description: e.resp.Description,
 				})
+				schemas = append(schemas, nil)
 			} else {
 				out.StockErrors = append(out.StockErrors, ErrorRef{
 					Status:      e.status,
@@ -330,41 +378,36 @@ func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRen
 			continue
 		}
 
-		spec := ResponseSpec{
-			Status:         e.status,
-			Description:    e.resp.Description,
-			ContentType:    ct,
-			SchemaText:     renderer.renderResponseSchema(resolved),
-			SchemaMarkdown: renderer.renderSchemaMarkdown(resolved),
-			SchemaJSON:     schemaToJSON(resolved),
-		}
-		out.InlineResponses = append(out.InlineResponses, spec)
+		out.InlineResponses = append(out.InlineResponses, ResponseSpec{
+			Status:      e.status,
+			Description: e.resp.Description,
+			ContentType: ct,
+		})
+		schemas = append(schemas, resolved)
 
-		// Mirror the first success response into the flat fields so the text
-		// and `--output=json` outputs both still see the "primary" body.
+		// Pick the first success response with a schema as the primary one.
 		// Also snapshot the full list of content types the spec declares for
 		// that response — the dispatcher uses it to drive --output-based
 		// content negotiation.
-		if out.ResponseSchemaText == "" && isSuccessStatus(e.status) {
-			out.ResponseContentType = spec.ContentType
-			out.ResponseSchemaText = spec.SchemaText
-			out.ResponseSchemaJSON = spec.SchemaJSON
+		if primary < 0 && isSuccessStatus(e.status) {
+			primary = len(out.InlineResponses) - 1
+			out.ResponseContentType = ct
 			out.SuccessContentTypes = contentTypes(e.resp.Content)
 		}
 	}
 
 	// Fallback: if no success response had a schema, prefer the `default` block
 	// so the text and JSON outputs still surface something — matches prior behavior.
-	if out.ResponseSchemaText == "" {
-		for _, spec := range out.InlineResponses {
+	if primary < 0 {
+		for i, spec := range out.InlineResponses {
 			if spec.Status == "default" {
+				primary = i
 				out.ResponseContentType = spec.ContentType
-				out.ResponseSchemaText = spec.SchemaText
-				out.ResponseSchemaJSON = spec.SchemaJSON
 				break
 			}
 		}
 	}
+	return schemas, primary
 }
 
 func isSuccessStatus(s string) bool {

--- a/pkg/cmd/pulumi/cloud/spec_fetch.go
+++ b/pkg/cmd/pulumi/cloud/spec_fetch.go
@@ -45,13 +45,7 @@ var specCacheTTL = 24 * time.Hour
 // When refresh is false and the network fetch fails, ensureSpec falls back
 // to the cached copy (if any) and writes a warning to warnW. When refresh
 // is true the fetch error is returned.
-func ensureSpec(ctx context.Context, warnW io.Writer, refresh bool) ([]byte, error) {
-	resolved, err := ResolveContext(ctx)
-	if err != nil {
-		return nil, NewAPIError(cmdutil.ExitInternalError, ErrToolError,
-			fmt.Sprintf("resolving cloud context: %v", err))
-	}
-
+func ensureSpec(ctx context.Context, resolved *ResolvedContext, warnW io.Writer, refresh bool) ([]byte, error) {
 	cachePath, err := specCachePath(resolved.CloudURL)
 	if err != nil {
 		return nil, NewAPIError(cmdutil.ExitInternalError, ErrToolError,

--- a/pkg/cmd/pulumi/cloud/spec_fetch_test.go
+++ b/pkg/cmd/pulumi/cloud/spec_fetch_test.go
@@ -84,6 +84,13 @@ func clearAgentEnv(t *testing.T) {
 	}
 }
 
+func resolveTestContext(t *testing.T) *ResolvedContext {
+	t.Helper()
+	resolved, err := ResolveContext(t.Context())
+	require.NoError(t, err)
+	return resolved
+}
+
 // seedSpecCache writes data to the cache path that ensureSpec would use for
 // cloudURL, sets its mtime to now-age, and returns the resolved path. Assumes
 // PULUMI_HOME is already pointing at an isolated tempdir.
@@ -125,7 +132,7 @@ func TestEnsureSpec_CacheHitUnderTTL(t *testing.T) {
 
 	_ = seedSpecCache(t, srv.URL, cached, time.Hour)
 
-	data, err := ensureSpec(t.Context(), io.Discard, false)
+	data, err := ensureSpec(t.Context(), resolveTestContext(t), io.Discard, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"cached":true}`, string(data))
 	assert.Zero(t, hits.Load(), "cache hit under TTL must not touch the network")
@@ -147,7 +154,7 @@ func TestEnsureSpec_TTLExpiryTriggersFetch(t *testing.T) {
 
 	path := seedSpecCache(t, srv.URL, []byte(`{"stale":true}`), 2*time.Hour)
 
-	data, err := ensureSpec(t.Context(), io.Discard, false)
+	data, err := ensureSpec(t.Context(), resolveTestContext(t), io.Discard, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"fresh":true}`, string(data))
 	assert.Equal(t, int64(1), hits.Load())
@@ -168,7 +175,7 @@ func TestEnsureSpec_RefreshForcesFetch(t *testing.T) {
 
 	_ = seedSpecCache(t, srv.URL, []byte(`{"cached":true}`), time.Minute)
 
-	data, err := ensureSpec(t.Context(), io.Discard, true)
+	data, err := ensureSpec(t.Context(), resolveTestContext(t), io.Discard, true)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"fresh":true}`, string(data))
 	assert.Equal(t, int64(1), hits.Load())
@@ -193,7 +200,7 @@ func TestEnsureSpec_StaleFallbackOnFetchFailure(t *testing.T) {
 	_ = seedSpecCache(t, srv.URL, []byte(`{"stale":true}`), 2*time.Hour)
 
 	var warnings bytes.Buffer
-	data, err := ensureSpec(t.Context(), &warnings, false)
+	data, err := ensureSpec(t.Context(), resolveTestContext(t), &warnings, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"stale":true}`, string(data))
 	assert.Contains(t, warnings.String(), "using cached spec")
@@ -216,7 +223,7 @@ func TestEnsureSpec_RefreshFlagFailsHardOnFetchError(t *testing.T) {
 	_ = seedSpecCache(t, srv.URL, []byte(`{"stale":true}`), time.Minute)
 
 	var warnings bytes.Buffer
-	_, err := ensureSpec(t.Context(), &warnings, true)
+	_, err := ensureSpec(t.Context(), resolveTestContext(t), &warnings, true)
 	require.Error(t, err, "refresh=true must fail hard rather than serve stale")
 	assert.Empty(t, warnings.String(), "no fallback warning when refresh=true")
 }


### PR DESCRIPTION
This command is quite slow current (running `pulumi api GetGraphSchema -F=pulumi` takes about 3 seconds).  There's two parts to it being slow, 1) we're calling `GetCapabilities` twice, and 2) the bigger part is loading and rendering the whole schema for the API.  A lot of it are fields that only `pulumi api describe` reads, but not generally necessary.

We don't need to load all of it for every command, but can lazily load it instead when we need it.

Similarly, we can avoid the duplicate `GetCapabilities` call, by calling `ResolveContext` first, and then passing that context into `LoadIndex`, which avoids the duplicate `GetCapabilities` call.

/cc @fallimic 