### PR TITLE
Activate journal v2 state migrations

### DIFF
--- a/changelog/pending/backend-service-feat-20260825-164001.yaml
+++ b/changelog/pending/backend-service-feat-20260825-164001.yaml
@@ -1,0 +1,4 @@
+component: backend/service
+kind: feat
+body: Enable component state migrations for Pulumi Cloud updates using journal v2
+time: 2026-08-25T16:40:01.60475+02:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1865,6 +1865,12 @@ func (b *cloudBackend) createAndStartUpdate(
 	}, nil
 }
 
+// cloudPersistenceSupportsStateMigrations reports whether the persistence mode selected for an update can store a state
+// migration. Journal v1 cannot, while legacy snapshot persistence and journal v2 can.
+func cloudPersistenceSupportsStateMigrations(journalVersion int64, journalingDisabled bool) bool {
+	return journalingDisabled || journalVersion < 1 || journalVersion >= 2
+}
+
 // apply actually performs the provided type of update on a stack hosted in the Pulumi Cloud.
 func (b *cloudBackend) apply(
 	ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
@@ -2025,14 +2031,17 @@ func (b *cloudBackend) runEngineAction(
 			}
 		},
 	}
+	journalingDisabled := env.DisableJournaling.Value()
 	if kind != apitype.PreviewUpdate && !dryRun {
-		// Note that we intentionally only accept version 1 of the journal here.  If we ever want to evolve the API,
-		// we can send a newer version than 1, and switch out the API completely on the server side, while the client
-		// will continue working with the non-journaling snapshotter. This will be slower but won't be a breaking change
-		// for older clients.
-		if journalVersion == 1 && !env.DisableJournaling.Value() {
+		// Note that we accept version 1 or newer of the journal here. Journal version 2 adds state migration
+		// entries. If the service negotiates a version lower than an entry kind requires, the corresponding
+		// feature is rejected at the point it is used, while the client continues working with the
+		// non-journaling snapshotter for version 0. This will be slower but won't be a breaking change for
+		// older clients.
+		if journalVersion >= 1 && !journalingDisabled {
 			snapshotJournaler := journal.NewJournaler(ctx, b.client, update, tokenSource, op.SecretsManager)
-			journalManager, err := engine.NewJournalSnapshotManager(snapshotJournaler, u.Target.Snapshot, op.SecretsManager)
+			journalManager, err := engine.NewJournalSnapshotManagerWithVersion(
+				snapshotJournaler, u.Target.Snapshot, op.SecretsManager, journalVersion)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2046,7 +2055,10 @@ func (b *cloudBackend) runEngineAction(
 			if err != nil {
 				return nil, nil, err
 			}
-			journalManager, err := engine.NewJournalSnapshotManager(snapshotJournaler, u.Target.Snapshot, op.SecretsManager)
+			// The shadow journal is local-only (it validates snapshots against the legacy snapshot manager),
+			// so it always supports the latest journal version.
+			journalManager, err := engine.NewJournalSnapshotManagerWithVersion(
+				snapshotJournaler, u.Target.Snapshot, op.SecretsManager, apitype.LatestJournalVersion)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2066,6 +2078,9 @@ func (b *cloudBackend) runEngineAction(
 		Cancel:        cancellationScope.Context(),
 		Events:        engineEvents,
 		BackendClient: httpstateBackendClient{backend: backend.NewBackendClient(b, op.SecretsProvider)},
+		SnapshotManagerCapabilities: engine.SnapshotManagerCapabilities{
+			StateMigrations: cloudPersistenceSupportsStateMigrations(journalVersion, journalingDisabled),
+		},
 		FinalizeUpdateFunc: func() {
 			if snapshotManager == nil || journalPersister == nil {
 				return

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -2950,6 +2950,29 @@ func TestRunEngineActionPropagatesJournalManagerError(t *testing.T) {
 	}
 }
 
+func TestCloudPersistenceSupportsStateMigrations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		journalVersion     int64
+		journalingDisabled bool
+		expected           bool
+	}{
+		{name: "legacy snapshot", journalVersion: 0, expected: true},
+		{name: "journal v1", journalVersion: 1},
+		{name: "journal v2", journalVersion: 2, expected: true},
+		{name: "journal v1 disabled", journalVersion: 1, journalingDisabled: true, expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected,
+				cloudPersistenceSupportsStateMigrations(tt.journalVersion, tt.journalingDisabled))
+		})
+	}
+}
+
 type runEngineActionFixture struct {
 	backend  *cloudBackend
 	stackRef cloudBackendReference

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1612,7 +1612,7 @@ func (pc *Client) StartUpdate(ctx context.Context, update UpdateIdentifier,
 	}
 
 	if !env.DisableJournaling.Value() {
-		req.JournalVersion = 1
+		req.JournalVersion = apitype.LatestJournalVersion
 	}
 
 	var resp apitype.StartUpdateResponse

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -98,6 +98,40 @@ func newMockClient(server *httptest.Server) *Client {
 	}
 }
 
+func TestStartUpdateRequestsLatestJournalVersion(t *testing.T) {
+	t.Setenv("PULUMI_DISABLE_JOURNALING", "false")
+
+	var request apitype.StartUpdateRequest
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "/api/stacks/organization/project/stack/update/update-id", req.URL.Path)
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&request))
+		require.NoError(t, json.NewEncoder(rw).Encode(apitype.StartUpdateResponse{
+			Version:        42,
+			Token:          "update-token",
+			JournalVersion: apitype.LatestJournalVersion,
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newMockClient(server)
+	version, token, journalVersion, err := client.StartUpdate(t.Context(), UpdateIdentifier{
+		StackIdentifier: StackIdentifier{
+			Owner:   "organization",
+			Project: "project",
+			Stack:   tokens.MustParseStackName("stack"),
+		},
+		UpdateKind: apitype.UpdateUpdate,
+		UpdateID:   "update-id",
+	}, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, apitype.LatestJournalVersion, request.JournalVersion)
+	assert.Equal(t, 42, version)
+	assert.Equal(t, "update-token", token)
+	assert.Equal(t, apitype.LatestJournalVersion, journalVersion)
+}
+
 func TestSignupAgent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Pass the API version through to the engine so that we can activate state migrations when the service is on the matching version.

Needs https://github.com/pulumi/pulumi-service/pull/49631 on the service side.