### PR TITLE
Cache provider mapping results on disk

### DIFF
--- a/changelog/pending/20260826--engine--mapping-disk-cache.yaml
+++ b/changelog/pending/20260826--engine--mapping-disk-cache.yaml
@@ -1,0 +1,5 @@
+component: engine
+kind: improvement
+body: Cache provider mapping results on disk so repeated plans do not boot a provider
+    to re-fetch an unchanged mapping
+time: 2026-08-26T00:00:00Z

--- a/pkg/codegen/convert/base_plugin_mapper.go
+++ b/pkg/codegen/convert/base_plugin_mapper.go
@@ -68,7 +68,7 @@ type basePluginMapper struct {
 
 // mapperCacheOptions is a bag of flags for tuning the caching behaviour of a basePluginMapper, for testing.
 type mapperCacheOptions struct {
-	// disableFileCache disables the on-disk mapping cache in ~/.pulumi/mappings.
+	// disableFileCache disables the on-disk mapping cache in $PULUMI_HOME/mappings.
 	disableFileCache bool
 }
 
@@ -209,7 +209,7 @@ func newBasePluginMapper(
 }
 
 // mappingFilePath returns the path to the mapping cache file for the given request. Mappings are cached in
-// ~/.pulumi/mappings/ with a filename encoding the conversion key, source provider, plugin name and version, and a
+// $PULUMI_HOME/mappings/ with a filename encoding the conversion key, source provider, plugin name and version, and a
 // hash of the parameterization so different sources remain distinct.
 func mappingFilePath(
 	key, provider, pluginName string,

--- a/pkg/codegen/convert/base_plugin_mapper.go
+++ b/pkg/codegen/convert/base_plugin_mapper.go
@@ -15,18 +15,25 @@
 package convert
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/blang/semver"
+	"github.com/natefinch/atomic"
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -38,6 +45,9 @@ type basePluginMapper struct {
 	// "terraform" is an example of a conversion key which identifies mapping requests where the results are expected to
 	// map Terraform resources to Pulumi resources, for instance.
 	conversionKey string
+
+	// The plugin storage context used to enumerate installed plugins.
+	pluginContext pluginstorage.Context
 
 	// A factory function that the mapper can use to instantiate provider plugins.
 	providerFactory ProviderFactory
@@ -51,11 +61,24 @@ type basePluginMapper struct {
 	// A list of hardcoded mappings read from files supplied to the mapper at construction time that will take priority
 	// over any mappings returned by plugins.
 	entries map[string][]byte
+
+	// Options for tuning caching behaviour, exposed for testing.
+	cacheOptions mapperCacheOptions
+}
+
+// mapperCacheOptions is a bag of flags for tuning the caching behaviour of a basePluginMapper, for testing.
+type mapperCacheOptions struct {
+	// disableFileCache disables the on-disk mapping cache in ~/.pulumi/mappings.
+	disableFileCache bool
 }
 
 type basePluginMapperSpec struct {
 	name    string
 	version semver.Version
+
+	// Metadata for the installed plugin, when known. Its install time governs the freshness of on-disk cached
+	// mappings; specs without metadata (e.g. providers attached via PULUMI_DEBUG_PROVIDERS) are never cached.
+	info *workspace.PluginInfo
 }
 
 // parseDebugProviderNames returns the provider names listed in a
@@ -84,6 +107,18 @@ func NewBasePluginMapper(
 	installPlugin func(pluginName string) *semver.Version,
 	mappings []string,
 ) (Mapper, error) {
+	return newBasePluginMapper(
+		pluginContext, conversionKey, providerFactory, installPlugin, mappings, mapperCacheOptions{})
+}
+
+func newBasePluginMapper(
+	pluginContext pluginstorage.Context,
+	conversionKey string,
+	providerFactory ProviderFactory,
+	installPlugin func(pluginName string) *semver.Version,
+	mappings []string,
+	cacheOptions mapperCacheOptions,
+) (Mapper, error) {
 	contract.Requiref(pluginContext != nil, "pluginContext", "must not be nil")
 	contract.Requiref(providerFactory != nil, "providerFactory", "must not be nil")
 
@@ -100,18 +135,14 @@ func NewBasePluginMapper(
 	// should in most cases be fine. If a user case comes up where this is not fine we can provide the manual workaround
 	// that this is based on what is locally installed, not what is published and so the user can just delete the higher
 	// version plugins from their cache.
-	latestVersions := make(map[string]semver.Version)
+	latestVersions := make(map[string]workspace.PluginInfo)
 	for _, plugin := range allPlugins {
 		if plugin.Kind != apitype.ResourcePlugin {
 			continue
 		}
 
-		if cur, has := latestVersions[plugin.Name]; has {
-			if plugin.Version.GT(cur) {
-				latestVersions[plugin.Name] = *plugin.Version
-			}
-		} else {
-			latestVersions[plugin.Name] = *plugin.Version
+		if cur, has := latestVersions[plugin.Name]; !has || plugin.Version.GT(*cur.Version) {
+			latestVersions[plugin.Name] = plugin
 		}
 	}
 
@@ -124,12 +155,13 @@ func NewBasePluginMapper(
 			continue
 		}
 
-		version, has := latestVersions[plugin.Name]
+		info, has := latestVersions[plugin.Name]
 		contract.Assertf(has, "latest version should be in map")
 
 		plugins = append(plugins, basePluginMapperSpec{
 			name:    plugin.Name,
-			version: version,
+			version: *info.Version,
+			info:    &info,
 		})
 		seen[plugin.Name] = true
 	}
@@ -167,11 +199,83 @@ func NewBasePluginMapper(
 
 	return &basePluginMapper{
 		conversionKey:   conversionKey,
+		pluginContext:   pluginContext,
 		providerFactory: providerFactory,
 		installPlugin:   installPlugin,
 		pluginSpecs:     plugins,
 		entries:         entries,
+		cacheOptions:    cacheOptions,
 	}, nil
+}
+
+// mappingFilePath returns the path to the mapping cache file for the given request. Mappings are cached in
+// ~/.pulumi/mappings/ with a filename encoding the conversion key, source provider, plugin name and version, and a
+// hash of the parameterization so different sources remain distinct.
+func mappingFilePath(
+	key, provider, pluginName string,
+	version semver.Version,
+	parameterization *workspace.Parameterization,
+) (string, error) {
+	fileName := fmt.Sprintf("%s-%s-%s-%s", key, provider, pluginName, version)
+	if parameterization != nil {
+		paramBytes, err := json.Marshal(parameterization)
+		contract.AssertNoErrorf(err, "Parameterization should be marshalable to JSON")
+		h := sha256.Sum256(paramBytes)
+		fileName += "-" + hex.EncodeToString(h[:6])
+	}
+	fileName += ".mapping"
+	return workspace.GetPulumiPath("mappings", fileName)
+}
+
+// loadCachedMapping reads a cached mapping from the given path. It returns false if the plugin's install time is
+// unknown, or if the cache file does not exist or predates the plugin's installation.
+func loadCachedMapping(path string, pluginInstallTime time.Time) ([]byte, bool) {
+	if pluginInstallTime.IsZero() {
+		return nil, false
+	}
+
+	stat, err := os.Stat(path)
+	if err != nil || pluginInstallTime.After(stat.ModTime()) {
+		return nil, false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// writeCachedMapping writes a mapping to the given cache path. Writes are best-effort, matching the schema cache in
+// pkg/codegen/schema: failures are logged and otherwise ignored.
+func writeCachedMapping(path string, data []byte) {
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		logging.V(3).Infof("failed to create mapping cache directory for %s: %v", path, err)
+		return
+	}
+	if err := atomic.WriteFile(path, bytes.NewReader(data)); err != nil {
+		logging.V(3).Infof("failed to cache mapping at %s: %v", path, err)
+	}
+}
+
+// findPluginInfo re-enumerates installed plugins to locate metadata for the named plugin at the given version,
+// typically after a mid-run install. It returns nil if the plugin cannot be found.
+func (m *basePluginMapper) findPluginInfo(
+	ctx context.Context, name string, version semver.Version,
+) *workspace.PluginInfo {
+	allPlugins, err := m.pluginContext.GetPlugins(ctx)
+	if err != nil {
+		return nil
+	}
+	for _, p := range allPlugins {
+		if p.Kind == apitype.ResourcePlugin && p.Name == name && p.Version != nil && p.Version.EQ(version) {
+			return &p
+		}
+	}
+	return nil
 }
 
 // Implements Mapper.GetMapping. A plugin mapper will try to resolve mappings by first building a list of candidate
@@ -250,6 +354,7 @@ func (m *basePluginMapper) GetMapping(
 			m.pluginSpecs = append(m.pluginSpecs, basePluginMapperSpec{
 				name:    pluginName,
 				version: *version,
+				info:    m.findPluginInfo(ctx, pluginName, *version),
 			})
 			m.pluginSpecs[0], m.pluginSpecs[i] = m.pluginSpecs[i], m.pluginSpecs[0]
 		}
@@ -268,6 +373,20 @@ func (m *basePluginMapper) GetMapping(
 		// parameterization information, we will pass that to the plugin as part of its instantiation.
 		if mapperSpec.name == pluginName && hint != nil && hint.Parameterization != nil {
 			descriptor.Parameterization = hint.Parameterization
+		}
+
+		// Successful mapping responses are cached on disk, since a mapping is fully determined by the plugin (with
+		// any parameterization) and the request. On a cache hit we can skip booting the plugin entirely.
+		var cachePath string
+		if !m.cacheOptions.disableFileCache && mapperSpec.info != nil {
+			cachePath, err = mappingFilePath(key, provider, mapperSpec.name, mapperSpec.version, descriptor.Parameterization)
+			if err != nil {
+				// Non-fatal: proceed without file caching.
+				cachePath = ""
+			}
+			if mapping, ok := loadCachedMapping(cachePath, mapperSpec.info.InstallTime()); ok {
+				return mapping, nil
+			}
 		}
 
 		providerPlugin, err := m.providerFactory(descriptor)
@@ -307,6 +426,7 @@ func (m *basePluginMapper) GetMapping(
 				)
 			}
 
+			writeCachedMapping(cachePath, mapping.Data)
 			return mapping.Data, nil
 		}
 
@@ -322,6 +442,7 @@ func (m *basePluginMapper) GetMapping(
 		}
 
 		if mapping.Provider == provider {
+			writeCachedMapping(cachePath, mapping.Data)
 			return mapping.Data, nil
 		}
 	}

--- a/pkg/codegen/convert/base_plugin_mapper_cache_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_cache_test.go
@@ -29,30 +29,30 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
 )
 
-// Tests that a mapping served by a plugin is cached on disk and that a subsequent mapper serves the same request
-// from that cache without instantiating the plugin.
-func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
-	t.Setenv("PULUMI_HOME", t.TempDir())
-
-	// Arrange.
+// cacheTestMapper builds a workspace holding a single plugin at version 1.0.0 that maps mappedProvider, and returns a
+// constructor for fresh mappers over it along with a count of provider instantiations. The payload is read at mapping
+// time, so tests can change it between calls.
+func cacheTestMapper(
+	t *testing.T, pluginName, pluginPath, mappedProvider string, payload *[]byte,
+) (func() Mapper, *int) {
 	ws := &testWorkspace{
 		infos: []workspace.PluginInfo{
 			{
-				Name:    "provider",
+				Name:    pluginName,
 				Kind:    apitype.ResourcePlugin,
 				Version: new(semver.MustParse("1.0.0")),
-				Path:    t.TempDir(),
+				Path:    pluginPath,
 			},
 		},
 	}
 
-	factoryCalls := 0
+	factoryCalls := new(int)
 	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
-		factoryCalls++
+		*factoryCalls++
 		return &testProvider{
-			pkg: "provider",
+			pkg: pluginName,
 			GetMappingF: func(key, provider string) ([]byte, string, error) {
-				return []byte("data"), "provider", nil
+				return *payload, mappedProvider, nil
 			},
 		}, nil
 	}
@@ -62,7 +62,7 @@ func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
 		return nil
 	}
 
-	newMapper := func() Mapper {
+	return func() Mapper {
 		mapper, err := NewBasePluginMapper(
 			ws,
 			"key", /*conversionKey*/
@@ -72,7 +72,17 @@ func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
 		)
 		require.NoError(t, err)
 		return mapper
-	}
+	}, factoryCalls
+}
+
+// Tests that a mapping served by a plugin is cached on disk and that a subsequent mapper serves the same request
+// from that cache without instantiating the plugin.
+func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	// Arrange.
+	payload := []byte("data")
+	newMapper, factoryCalls := cacheTestMapper(t, "provider", t.TempDir(), "provider", &payload)
 
 	// Act.
 	data, err := newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
@@ -80,7 +90,7 @@ func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
-	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 1, *factoryCalls)
 
 	// Act.
 	//
@@ -91,7 +101,7 @@ func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
-	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 1, *factoryCalls)
 }
 
 // Tests that cached mappings for parameterized plugins are keyed by their parameterization: the same
@@ -100,44 +110,8 @@ func TestBasePluginMapper_DiskCacheParameterization(t *testing.T) {
 	t.Setenv("PULUMI_HOME", t.TempDir())
 
 	// Arrange.
-	ws := &testWorkspace{
-		infos: []workspace.PluginInfo{
-			{
-				Name:    "terraform-provider",
-				Kind:    apitype.ResourcePlugin,
-				Version: new(semver.MustParse("1.0.0")),
-				Path:    t.TempDir(),
-			},
-		},
-	}
-
-	factoryCalls := 0
-	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
-		factoryCalls++
-		return &testProvider{
-			pkg: "terraform-provider",
-			GetMappingF: func(key, provider string) ([]byte, string, error) {
-				return []byte("datagcp"), "gcp", nil
-			},
-		}, nil
-	}
-
-	installPlugin := func(pluginName string) *semver.Version {
-		t.Fatal("should not be called")
-		return nil
-	}
-
-	newMapper := func() Mapper {
-		mapper, err := NewBasePluginMapper(
-			ws,
-			"key", /*conversionKey*/
-			providerFactory,
-			installPlugin,
-			nil, /*mappings*/
-		)
-		require.NoError(t, err)
-		return mapper
-	}
+	payload := []byte("datagcp")
+	newMapper, factoryCalls := cacheTestMapper(t, "terraform-provider", t.TempDir(), "gcp", &payload)
 
 	hint := &MapperPackageHint{
 		PluginName: "terraform-provider",
@@ -154,7 +128,7 @@ func TestBasePluginMapper_DiskCacheParameterization(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("datagcp"), data)
-	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 1, *factoryCalls)
 
 	// Act.
 	//
@@ -164,7 +138,7 @@ func TestBasePluginMapper_DiskCacheParameterization(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("datagcp"), data)
-	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 1, *factoryCalls)
 
 	// Act.
 	//
@@ -182,7 +156,7 @@ func TestBasePluginMapper_DiskCacheParameterization(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("datagcp"), data)
-	assert.Equal(t, 2, factoryCalls)
+	assert.Equal(t, 2, *factoryCalls)
 }
 
 // Tests that a cached mapping that predates the plugin's installation is discarded and refreshed.
@@ -190,45 +164,8 @@ func TestBasePluginMapper_DiskCacheStaleAfterReinstall(t *testing.T) {
 	t.Setenv("PULUMI_HOME", t.TempDir())
 
 	// Arrange.
-	ws := &testWorkspace{
-		infos: []workspace.PluginInfo{
-			{
-				Name:    "provider",
-				Kind:    apitype.ResourcePlugin,
-				Version: new(semver.MustParse("1.0.0")),
-				Path:    t.TempDir(),
-			},
-		},
-	}
-
 	payload := []byte("data1")
-	factoryCalls := 0
-	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
-		factoryCalls++
-		return &testProvider{
-			pkg: "provider",
-			GetMappingF: func(key, provider string) ([]byte, string, error) {
-				return payload, "provider", nil
-			},
-		}, nil
-	}
-
-	installPlugin := func(pluginName string) *semver.Version {
-		t.Fatal("should not be called")
-		return nil
-	}
-
-	newMapper := func() Mapper {
-		mapper, err := NewBasePluginMapper(
-			ws,
-			"key", /*conversionKey*/
-			providerFactory,
-			installPlugin,
-			nil, /*mappings*/
-		)
-		require.NoError(t, err)
-		return mapper
-	}
+	newMapper, factoryCalls := cacheTestMapper(t, "provider", t.TempDir(), "provider", &payload)
 
 	// Act.
 	data, err := newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
@@ -236,7 +173,7 @@ func TestBasePluginMapper_DiskCacheStaleAfterReinstall(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("data1"), data)
-	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 1, *factoryCalls)
 
 	// Arrange.
 	//
@@ -254,7 +191,7 @@ func TestBasePluginMapper_DiskCacheStaleAfterReinstall(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("data2"), data)
-	assert.Equal(t, 2, factoryCalls)
+	assert.Equal(t, 2, *factoryCalls)
 
 	content, err := os.ReadFile(cachePath)
 	require.NoError(t, err)
@@ -269,43 +206,8 @@ func TestBasePluginMapper_DiskCacheUnknownInstallTime(t *testing.T) {
 	// Arrange.
 	//
 	// The plugin has no path on disk, so its install time is unknown.
-	ws := &testWorkspace{
-		infos: []workspace.PluginInfo{
-			{
-				Name:    "provider",
-				Kind:    apitype.ResourcePlugin,
-				Version: new(semver.MustParse("1.0.0")),
-			},
-		},
-	}
-
-	factoryCalls := 0
-	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
-		factoryCalls++
-		return &testProvider{
-			pkg: "provider",
-			GetMappingF: func(key, provider string) ([]byte, string, error) {
-				return []byte("data"), "provider", nil
-			},
-		}, nil
-	}
-
-	installPlugin := func(pluginName string) *semver.Version {
-		t.Fatal("should not be called")
-		return nil
-	}
-
-	newMapper := func() Mapper {
-		mapper, err := NewBasePluginMapper(
-			ws,
-			"key", /*conversionKey*/
-			providerFactory,
-			installPlugin,
-			nil, /*mappings*/
-		)
-		require.NoError(t, err)
-		return mapper
-	}
+	payload := []byte("data")
+	newMapper, factoryCalls := cacheTestMapper(t, "provider", "" /*pluginPath*/, "provider", &payload)
 
 	// Act.
 	data, err := newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
@@ -313,7 +215,7 @@ func TestBasePluginMapper_DiskCacheUnknownInstallTime(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
-	assert.Equal(t, 1, factoryCalls)
+	assert.Equal(t, 1, *factoryCalls)
 
 	cachePath, err := mappingFilePath("key", "provider", "provider", semver.MustParse("1.0.0"), nil)
 	require.NoError(t, err)
@@ -329,5 +231,5 @@ func TestBasePluginMapper_DiskCacheUnknownInstallTime(t *testing.T) {
 	// Assert.
 	require.NoError(t, err)
 	assert.Equal(t, []byte("data"), data)
-	assert.Equal(t, 2, factoryCalls)
+	assert.Equal(t, 2, *factoryCalls)
 }

--- a/pkg/codegen/convert/base_plugin_mapper_cache_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_cache_test.go
@@ -1,0 +1,333 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+)
+
+// Tests that a mapping served by a plugin is cached on disk and that a subsequent mapper serves the same request
+// from that cache without instantiating the plugin.
+func TestBasePluginMapper_DiskCacheWarmHit(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	// Arrange.
+	ws := &testWorkspace{
+		infos: []workspace.PluginInfo{
+			{
+				Name:    "provider",
+				Kind:    apitype.ResourcePlugin,
+				Version: new(semver.MustParse("1.0.0")),
+				Path:    t.TempDir(),
+			},
+		},
+	}
+
+	factoryCalls := 0
+	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		factoryCalls++
+		return &testProvider{
+			pkg: "provider",
+			GetMappingF: func(key, provider string) ([]byte, string, error) {
+				return []byte("data"), "provider", nil
+			},
+		}, nil
+	}
+
+	installPlugin := func(pluginName string) *semver.Version {
+		t.Fatal("should not be called")
+		return nil
+	}
+
+	newMapper := func() Mapper {
+		mapper, err := NewBasePluginMapper(
+			ws,
+			"key", /*conversionKey*/
+			providerFactory,
+			installPlugin,
+			nil, /*mappings*/
+		)
+		require.NoError(t, err)
+		return mapper
+	}
+
+	// Act.
+	data, err := newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+	assert.Equal(t, 1, factoryCalls)
+
+	// Act.
+	//
+	// A fresh mapper models a new plan in a new process: the mapping must come from the disk cache without the
+	// plugin being instantiated.
+	data, err = newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+	assert.Equal(t, 1, factoryCalls)
+}
+
+// Tests that cached mappings for parameterized plugins are keyed by their parameterization: the same
+// parameterization is served from the disk cache, while a different one instantiates the plugin again.
+func TestBasePluginMapper_DiskCacheParameterization(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	// Arrange.
+	ws := &testWorkspace{
+		infos: []workspace.PluginInfo{
+			{
+				Name:    "terraform-provider",
+				Kind:    apitype.ResourcePlugin,
+				Version: new(semver.MustParse("1.0.0")),
+				Path:    t.TempDir(),
+			},
+		},
+	}
+
+	factoryCalls := 0
+	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		factoryCalls++
+		return &testProvider{
+			pkg: "terraform-provider",
+			GetMappingF: func(key, provider string) ([]byte, string, error) {
+				return []byte("datagcp"), "gcp", nil
+			},
+		}, nil
+	}
+
+	installPlugin := func(pluginName string) *semver.Version {
+		t.Fatal("should not be called")
+		return nil
+	}
+
+	newMapper := func() Mapper {
+		mapper, err := NewBasePluginMapper(
+			ws,
+			"key", /*conversionKey*/
+			providerFactory,
+			installPlugin,
+			nil, /*mappings*/
+		)
+		require.NoError(t, err)
+		return mapper
+	}
+
+	hint := &MapperPackageHint{
+		PluginName: "terraform-provider",
+		Parameterization: &workspace.Parameterization{
+			Name:    "gcp",
+			Version: semver.MustParse("2.0.0"),
+			Value:   []byte("value"),
+		},
+	}
+
+	// Act.
+	data, err := newMapper().GetMapping(t.Context(), "gcp", hint, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("datagcp"), data)
+	assert.Equal(t, 1, factoryCalls)
+
+	// Act.
+	//
+	// The same parameterization must be served from the disk cache.
+	data, err = newMapper().GetMapping(t.Context(), "gcp", hint, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("datagcp"), data)
+	assert.Equal(t, 1, factoryCalls)
+
+	// Act.
+	//
+	// A different parameterization must not hit the cache entry written for the first one.
+	otherHint := &MapperPackageHint{
+		PluginName: "terraform-provider",
+		Parameterization: &workspace.Parameterization{
+			Name:    "gcp",
+			Version: semver.MustParse("3.0.0"),
+			Value:   []byte("value"),
+		},
+	}
+	data, err = newMapper().GetMapping(t.Context(), "gcp", otherHint, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("datagcp"), data)
+	assert.Equal(t, 2, factoryCalls)
+}
+
+// Tests that a cached mapping that predates the plugin's installation is discarded and refreshed.
+func TestBasePluginMapper_DiskCacheStaleAfterReinstall(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	// Arrange.
+	ws := &testWorkspace{
+		infos: []workspace.PluginInfo{
+			{
+				Name:    "provider",
+				Kind:    apitype.ResourcePlugin,
+				Version: new(semver.MustParse("1.0.0")),
+				Path:    t.TempDir(),
+			},
+		},
+	}
+
+	payload := []byte("data1")
+	factoryCalls := 0
+	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		factoryCalls++
+		return &testProvider{
+			pkg: "provider",
+			GetMappingF: func(key, provider string) ([]byte, string, error) {
+				return payload, "provider", nil
+			},
+		}, nil
+	}
+
+	installPlugin := func(pluginName string) *semver.Version {
+		t.Fatal("should not be called")
+		return nil
+	}
+
+	newMapper := func() Mapper {
+		mapper, err := NewBasePluginMapper(
+			ws,
+			"key", /*conversionKey*/
+			providerFactory,
+			installPlugin,
+			nil, /*mappings*/
+		)
+		require.NoError(t, err)
+		return mapper
+	}
+
+	// Act.
+	data, err := newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data1"), data)
+	assert.Equal(t, 1, factoryCalls)
+
+	// Arrange.
+	//
+	// Backdate the cache file so that it predates the plugin's installation, as if the plugin had been reinstalled
+	// since the mapping was cached.
+	cachePath, err := mappingFilePath("key", "provider", "provider", semver.MustParse("1.0.0"), nil)
+	require.NoError(t, err)
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(cachePath, past, past))
+	payload = []byte("data2")
+
+	// Act.
+	data, err = newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data2"), data)
+	assert.Equal(t, 2, factoryCalls)
+
+	content, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data2"), content)
+}
+
+// Tests that mappings from plugins whose install time cannot be determined are still written to the disk cache, but
+// never read back from it, matching the behaviour of the schema cache.
+func TestBasePluginMapper_DiskCacheUnknownInstallTime(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	// Arrange.
+	//
+	// The plugin has no path on disk, so its install time is unknown.
+	ws := &testWorkspace{
+		infos: []workspace.PluginInfo{
+			{
+				Name:    "provider",
+				Kind:    apitype.ResourcePlugin,
+				Version: new(semver.MustParse("1.0.0")),
+			},
+		},
+	}
+
+	factoryCalls := 0
+	providerFactory := func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
+		factoryCalls++
+		return &testProvider{
+			pkg: "provider",
+			GetMappingF: func(key, provider string) ([]byte, string, error) {
+				return []byte("data"), "provider", nil
+			},
+		}, nil
+	}
+
+	installPlugin := func(pluginName string) *semver.Version {
+		t.Fatal("should not be called")
+		return nil
+	}
+
+	newMapper := func() Mapper {
+		mapper, err := NewBasePluginMapper(
+			ws,
+			"key", /*conversionKey*/
+			providerFactory,
+			installPlugin,
+			nil, /*mappings*/
+		)
+		require.NoError(t, err)
+		return mapper
+	}
+
+	// Act.
+	data, err := newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+	assert.Equal(t, 1, factoryCalls)
+
+	cachePath, err := mappingFilePath("key", "provider", "provider", semver.MustParse("1.0.0"), nil)
+	require.NoError(t, err)
+	content, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), content)
+
+	// Act.
+	//
+	// With no install time to validate freshness against, the cache must not be read back.
+	data, err = newMapper().GetMapping(t.Context(), "provider", nil /*hint*/, "" /*ecosystem*/)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, []byte("data"), data)
+	assert.Equal(t, 2, factoryCalls)
+}

--- a/pkg/codegen/convert/base_plugin_mapper_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_test.go
@@ -52,12 +52,13 @@ func TestBasePluginMapper_UsesEntries(t *testing.T) {
 	err := os.WriteFile(mappingFile, []byte("entrydata"), 0o600)
 	require.NoError(t, err)
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		[]string{mappingFile},
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -105,12 +106,13 @@ func TestBasePluginMapper_InstalledPluginMatches(t *testing.T) {
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -156,12 +158,13 @@ func TestBasePluginMapper_EcosystemOverridesConversionKey(t *testing.T) {
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -217,12 +220,13 @@ func TestBasePluginMapper_MappedNameDiffersFromPulumiName(t *testing.T) {
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -278,12 +282,13 @@ func TestBasePluginMapper_NoPluginMatches_ButCanBeInstalled(t *testing.T) {
 		return &ver
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -338,12 +343,13 @@ func TestBasePluginMapper_UseMatchingNameFirst(t *testing.T) {
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -424,12 +430,13 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiName(t *testing.T) {
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -492,12 +499,13 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithHint(t *testing.T) 
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -560,12 +568,13 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithParameterizedHint(t
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -624,12 +633,13 @@ func TestBasePluginMapper_MappedNamesDifferFromPulumiNameWithUnusableParameteriz
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)
@@ -691,12 +701,13 @@ func TestBasePluginMapper_InfiniteLoopRegression(t *testing.T) {
 		return nil
 	}
 
-	mapper, err := NewBasePluginMapper(
+	mapper, err := newBasePluginMapper(
 		ws,
 		"key", /*conversionKey*/
 		providerFactory,
 		installPlugin,
 		nil, /*mappings*/
+		mapperCacheOptions{disableFileCache: true},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, mapper)


### PR DESCRIPTION
Add Mapping/GetMapping file based caching, mirroring our existing schema file caching. This should improve Pulumi HCL's runtime perf. Running against a single-resource program:

```hcl
resource "aws_s3_bucket" "pet" {}
```

We see a noticeable improvement:

```
𝛌 hyperfine --warmup 1 -n Baseline "pulumi preview" -n "With #24462" "/Users/ianwahbe/go/src/github.com/pulumi/pulumi/bin/pulumi preview"
Benchmark 1: Baseline
  Time (mean ± σ):      9.589 s ±  0.659 s    [User: 2.876 s, System: 0.645 s]
  Range (min … max):    8.899 s … 11.206 s    10 runs

Benchmark 2: With #24462
  Time (mean ± σ):      8.596 s ±  0.674 s    [User: 1.764 s, System: 0.456 s]
  Range (min … max):    7.558 s …  9.632 s    10 runs

Summary
  With #24462 ran
    1.12 ± 0.12 times faster than Baseline
```

Fixes #24460.