### PR TITLE
improve python provider stack traces 

### DIFF
--- a/changelog/pending/sdk-python-improvement-20260826-155447.yaml
+++ b/changelog/pending/sdk-python-improvement-20260826-155447.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: improvement
+body: Improve stack traces for providers
+time: 2026-08-26T15:54:47.461724848+02:00

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -19,6 +19,7 @@ from threading import Event, Lock
 from typing import Any, Optional
 import os
 import sys
+import traceback
 import dill
 import grpc
 from google.protobuf import empty_pb2
@@ -77,6 +78,16 @@ def get_provider(props: dict[str, Any], config: dict[str, Any]) -> ResourceProvi
     return provider
 
 
+def _abort_with_traceback(fn):
+    def wrapper(self, request, context):
+        try:
+            return fn(self, request, context)
+        except Exception:  # noqa
+            context.abort(grpc.StatusCode.UNKNOWN, traceback.format_exc())
+
+    return wrapper
+
+
 class DynamicResourceProviderServicer(ResourceProviderServicer):
     _config: dict[str, Any] = {}
 
@@ -99,6 +110,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         context.set_details("Invoke is not implemented by the dynamic provider")
         raise NotImplementedError(f"unknown function {request.token}")
 
+    @_abort_with_traceback
     def Diff(self, request, context):
         olds = rpc.deserialize_properties(request.olds, True)
         news = rpc.deserialize_properties(request.news, True)
@@ -121,6 +133,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
             fields["deleteBeforeReplace"] = result.delete_before_replace
         return proto.DiffResponse(**fields)
 
+    @_abort_with_traceback
     def Update(self, request, context):
         olds = rpc.deserialize_properties(request.olds)
         news = rpc.deserialize_properties(request.news)
@@ -139,6 +152,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         fields = {"properties": outs_proto}
         return proto.UpdateResponse(**fields)
 
+    @_abort_with_traceback
     def Delete(self, request, context):
         id_ = request.id
         props = rpc.deserialize_properties(request.properties)
@@ -149,6 +163,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
     def Cancel(self, request, context):
         return empty_pb2.Empty()
 
+    @_abort_with_traceback
     def Create(self, request, context):
         props = rpc.deserialize_properties(request.properties)
         provider = get_provider(props, self._config)
@@ -163,6 +178,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         fields = {"id": result.id, "properties": outs_proto}
         return proto.CreateResponse(**fields)
 
+    @_abort_with_traceback
     def Check(self, request, context):
         olds = rpc.deserialize_properties(request.olds, True)
         news = rpc.deserialize_properties(request.news, True)
@@ -209,6 +225,7 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
             "GetSchema is not implemented by the dynamic provider"
         )
 
+    @_abort_with_traceback
     def Read(self, request, context):
         id_ = request.id
         props = rpc.deserialize_properties(request.properties)

--- a/sdk/python/lib/pulumi/provider/experimental/server.py
+++ b/sdk/python/lib/pulumi/provider/experimental/server.py
@@ -71,6 +71,20 @@ class ComponentInitError(Exception):
         self.inner = inner
 
 
+def _raise_with_traceback(fn):
+    async def wrapper(self, request, context):
+        try:
+            return await fn(self, request, context)
+        except NotImplementedError:
+            raise
+        except Exception as e:  # noqa
+            stack = traceback.extract_tb(e.__traceback__)[:]
+            pretty_stack = "".join(traceback.format_list(stack))
+            raise Exception(f"{str(e)}:\n{pretty_stack}")
+
+    return wrapper
+
+
 class ProviderServicer(ResourceProviderServicer):
     """Implements a subset of `ResourceProvider` methods to support
     `Construct` and other methods invoked by the engine when the user
@@ -297,6 +311,10 @@ class ProviderServicer(ResourceProviderServicer):
             await context.abort_with_status(status)
             # We already aborted at this point
             raise
+        except Exception as e:  # noqa
+            stack = traceback.extract_tb(e.__traceback__)[:]
+            pretty_stack = "".join(traceback.format_list(stack))
+            raise Exception(f"{str(e)}:\n{pretty_stack}")
 
     async def _call(self, request: proto.CallRequest, context):
         assert isinstance(request, proto.CallRequest), (
@@ -385,6 +403,7 @@ class ProviderServicer(ResourceProviderServicer):
         getattr(resp, "return").CopyFrom(return_value)
         return resp
 
+    @_raise_with_traceback
     async def Parameterize(
         self, request: proto.ParameterizeRequest, context
     ) -> proto.ParameterizeResponse:
@@ -410,6 +429,7 @@ class ProviderServicer(ResourceProviderServicer):
             version=resp.version,
         )
 
+    @_raise_with_traceback
     async def Invoke(
         self, request: proto.InvokeRequest, context
     ) -> proto.InvokeResponse:
@@ -432,6 +452,7 @@ class ProviderServicer(ResourceProviderServicer):
             ]
         return proto.InvokeResponse(**ret)
 
+    @_raise_with_traceback
     async def GetSchema(
         self, request: proto.GetSchemaRequest, context
     ) -> proto.GetSchemaResponse:
@@ -444,6 +465,7 @@ class ProviderServicer(ResourceProviderServicer):
         )
         return proto.GetSchemaResponse(schema=resp.schema or "")
 
+    @_raise_with_traceback
     async def CheckConfig(self, request: pulumi.runtime.proto.CheckRequest, context):
         resp = await self._provider.check_config(
             provider.CheckRequest(
@@ -465,6 +487,7 @@ class ProviderServicer(ResourceProviderServicer):
             else None,
         )
 
+    @_raise_with_traceback
     async def DiffConfig(self, request, context):
         resp = await self._provider.diff_config(
             provider.DiffRequest(
@@ -488,6 +511,7 @@ class ProviderServicer(ResourceProviderServicer):
             hasDetailedDiff=True,
         )
 
+    @_raise_with_traceback
     async def Configure(
         self, request: proto.ConfigureRequest, context
     ) -> proto.ConfigureResponse:
@@ -506,6 +530,7 @@ class ProviderServicer(ResourceProviderServicer):
             supportsPreview=resp.supports_preview,
         )
 
+    @_raise_with_traceback
     async def Check(self, request: proto.CheckRequest, context):
         resp = await self._provider.check(
             provider.CheckRequest(
@@ -530,6 +555,7 @@ class ProviderServicer(ResourceProviderServicer):
             failures=failures,
         )
 
+    @_raise_with_traceback
     async def Diff(self, request: proto.DiffRequest, context):
         resp = await self._provider.diff(
             provider.DiffRequest(
@@ -570,6 +596,7 @@ class ProviderServicer(ResourceProviderServicer):
             hasDetailedDiff=True,
         )
 
+    @_raise_with_traceback
     async def Create(self, request, context):
         resp = await self._provider.create(
             provider.CreateRequest(
@@ -584,6 +611,7 @@ class ProviderServicer(ResourceProviderServicer):
             properties=PropertyValue.marshal_map(resp.properties),
         )
 
+    @_raise_with_traceback
     async def Update(self, request, context):
         resp = await self._provider.update(
             provider.UpdateRequest(
@@ -600,6 +628,7 @@ class ProviderServicer(ResourceProviderServicer):
             properties=PropertyValue.marshal_map(resp.properties),
         )
 
+    @_raise_with_traceback
     async def Delete(self, request, context):
         await self._provider.delete(
             provider.DeleteRequest(
@@ -611,6 +640,7 @@ class ProviderServicer(ResourceProviderServicer):
         )
         return empty_pb2.Empty()
 
+    @_raise_with_traceback
     async def Read(self, request, context):
         resp = await self._provider.read(
             provider.ReadRequest(

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -357,6 +357,12 @@ class ProviderServicer(ResourceProviderServicer):
             await context.abort_with_status(status)
             # We already aborted at this point
             raise
+        except RunError:
+            raise
+        except Exception as e:  # noqa
+            stack = traceback.extract_tb(e.__traceback__)[:]
+            pretty_stack = "".join(traceback.format_list(stack))
+            raise Exception(f"{str(e)}:\n{pretty_stack}")
 
     async def _call(self, request: proto.CallRequest, context):
         assert isinstance(request, proto.CallRequest), (
@@ -460,10 +466,17 @@ class ProviderServicer(ResourceProviderServicer):
     async def Invoke(
         self, request: proto.InvokeRequest, context
     ) -> proto.InvokeResponse:
-        args = rpc.deserialize_properties(request.args, keep_unknowns=False)
-        result = self.provider.invoke(token=request.tok, args=args)
-        response = await self._invoke_response(result)
-        return response
+        try:
+            args = rpc.deserialize_properties(request.args, keep_unknowns=False)
+            result = self.provider.invoke(token=request.tok, args=args)
+            response = await self._invoke_response(result)
+            return response
+        except RunError:
+            raise
+        except Exception as e:  # noqa
+            stack = traceback.extract_tb(e.__traceback__)[:]
+            pretty_stack = "".join(traceback.format_list(stack))
+            raise Exception(f"{str(e)}:\n{pretty_stack}")
 
     async def Configure(self, request, context) -> proto.ConfigureResponse:
         return proto.ConfigureResponse(

--- a/sdk/python/lib/test/provider/experimental/test_server.py
+++ b/sdk/python/lib/test/provider/experimental/test_server.py
@@ -15,6 +15,7 @@
 import asyncio
 from typing import Optional
 
+import grpc
 import pytest
 
 from pulumi.provider.experimental import provider
@@ -84,3 +85,61 @@ async def test_construct_and_call_can_run_concurrently():
         assert construct_response.urn.endswith("::test-resource")
         assert test_provider.construct_stack_after_call == "construct-stack"
         assert test_provider.construct_config_after_call == "construct-config"
+
+
+class ThrowingCallProvider(provider.Provider):
+    async def call(self, request: provider.CallRequest) -> provider.CallResponse:
+        raise ValueError("oops in call")
+
+    async def create(self, request: provider.CreateRequest) -> provider.CreateResponse:
+        raise ValueError("oops in create")
+
+
+@pytest.mark.asyncio
+async def test_call_error_includes_stack_trace():
+    test_provider = ThrowingCallProvider()
+    servicer = ProviderServicer([], "1.0.0", test_provider, "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        request = proto.CallRequest(tok="test:index:call")
+
+        try:
+            await stub.Call(request)
+            assert False, "Expected error to be raised"
+        except grpc.aio.AioRpcError as e:
+            assert e.code() == grpc.StatusCode.UNKNOWN
+            assert "oops in call" in e.details()
+            assert 'raise ValueError("oops in call")' in e.details()
+
+
+@pytest.mark.asyncio
+async def test_create_error_includes_stack_trace():
+    test_provider = ThrowingCallProvider()
+    servicer = ProviderServicer([], "1.0.0", test_provider, "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        request = proto.CreateRequest()
+
+        try:
+            await stub.Create(request)
+            assert False, "Expected error to be raised"
+        except grpc.aio.AioRpcError as e:
+            assert e.code() == grpc.StatusCode.UNKNOWN
+            assert "oops in create" in e.details()
+            assert 'raise ValueError("oops in create")' in e.details()
+
+
+@pytest.mark.asyncio
+async def test_not_implemented_passes_through():
+    test_provider = ThrowingCallProvider()
+    servicer = ProviderServicer([], "1.0.0", test_provider, "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        request = proto.DeleteRequest()
+
+        try:
+            await stub.Delete(request)
+            assert False, "Expected error to be raised"
+        except grpc.aio.AioRpcError as e:
+            assert "The method 'delete' is not implemented" in e.details()
+            assert "Traceback" not in e.details()

--- a/sdk/python/lib/test/provider/test_server.py
+++ b/sdk/python/lib/test/provider/test_server.py
@@ -831,6 +831,51 @@ async def test_construct_component_init_error():
             assert "Component initialization failed" in e.details()
 
 
+class ThrowingCallProvider(Provider):
+    def __init__(self):
+        super().__init__("1.0.0")
+
+    def call(self, token: str, args: Inputs) -> CallResult:
+        raise ValueError("oops in call")
+
+    def invoke(self, token: str, args):
+        raise ValueError("oops in invoke")
+
+
+@pytest.mark.asyncio
+async def test_call_error_includes_stack_trace():
+    provider = ThrowingCallProvider()
+    servicer = ProviderServicer(provider, [], "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        request = proto.CallRequest(tok="test:index:call")
+
+        try:
+            await stub.Call(request)
+            assert False, "Expected error to be raised"
+        except grpc.aio.AioRpcError as e:
+            assert e.code() == grpc.StatusCode.UNKNOWN
+            assert "oops in call" in e.details()
+            assert 'raise ValueError("oops in call")' in e.details()
+
+
+@pytest.mark.asyncio
+async def test_invoke_error_includes_stack_trace():
+    provider = ThrowingCallProvider()
+    servicer = ProviderServicer(provider, [], "")
+
+    async with provider_servicer_stub(servicer) as stub:
+        request = proto.InvokeRequest(tok="test:index:fn")
+
+        try:
+            await stub.Invoke(request)
+            assert False, "Expected error to be raised"
+        except grpc.aio.AioRpcError as e:
+            assert e.code() == grpc.StatusCode.UNKNOWN
+            assert "oops in invoke" in e.details()
+            assert 'raise ValueError("oops in invoke")' in e.details()
+
+
 def parse_grpc_error_details(grpc_error: grpc.aio.AioRpcError) -> dict:
     error_details = {
         "message": grpc_error.details(),


### PR DESCRIPTION
In python providers, we currently don't provide the whole stack trace for exceptions. Similar to
https://github.com/pulumi/pulumi-policy/pull/459, improve the stack traces we're getting back here.
