### PR TITLE
CI copy of https://github.com/pulumi/pulumi/pull/24197

### DIFF
--- a/changelog/pending/20260805--auto-go--wrapped-error-predicates.yaml
+++ b/changelog/pending/20260805--auto-go--wrapped-error-predicates.yaml
@@ -1,0 +1,7 @@
+component: auto/go
+kind: fix
+body: Match wrapped errors in the Automation API error predicates, and unwrap the underlying
+  cause
+time: 2026-08-05T10:38:51+02:00
+custom:
+  PR: "24197"

--- a/sdk/go/auto/errors.go
+++ b/sdk/go/auto/errors.go
@@ -15,6 +15,7 @@
 package auto
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -40,10 +41,14 @@ func (ae autoError) Error() string {
 	return fmt.Sprintf("%s\ncode: %d\nstdout: %s\nstderr: %s\n", ae.err, ae.code, ae.stdout, ae.stderr)
 }
 
+func (ae autoError) Unwrap() error {
+	return ae.err
+}
+
 // IsConcurrentUpdateError returns true if the error was a result of a conflicting update locking the stack.
 func IsConcurrentUpdateError(e error) bool {
-	ae, ok := e.(autoError)
-	if !ok {
+	var ae autoError
+	if !errors.As(e, &ae) {
 		return false
 	}
 
@@ -54,8 +59,8 @@ func IsConcurrentUpdateError(e error) bool {
 
 // IsSelectStack404Error returns true if the error was a result of selecting a stack that does not exist.
 func IsSelectStack404Error(e error) bool {
-	ae, ok := e.(autoError)
-	if !ok {
+	var ae autoError
+	if !errors.As(e, &ae) {
 		return false
 	}
 
@@ -65,8 +70,8 @@ func IsSelectStack404Error(e error) bool {
 
 // IsCreateStack409Error returns true if the error was a result of creating a stack that already exists.
 func IsCreateStack409Error(e error) bool {
-	ae, ok := e.(autoError)
-	if !ok {
+	var ae autoError
+	if !errors.As(e, &ae) {
 		return false
 	}
 
@@ -76,8 +81,8 @@ func IsCreateStack409Error(e error) bool {
 
 // IsCompilationError returns true if the program failed at the build/run step (only Typescript, Go, .NET)
 func IsCompilationError(e error) bool {
-	as, ok := e.(autoError)
-	if !ok {
+	var as autoError
+	if !errors.As(e, &as) {
 		return false
 	}
 
@@ -106,8 +111,8 @@ func IsCompilationError(e error) bool {
 
 // IsRuntimeError returns true if there was an error in the user program at during execution.
 func IsRuntimeError(e error) bool {
-	as, ok := e.(autoError)
-	if !ok {
+	var as autoError
+	if !errors.As(e, &as) {
 		return false
 	}
 
@@ -138,8 +143,8 @@ func IsRuntimeError(e error) bool {
 // IsUnexpectedEngineError returns true if the pulumi core engine encountered an error (most likely a bug).
 func IsUnexpectedEngineError(e error) bool {
 	// TODO: figure out how to write a test for this
-	as, ok := e.(autoError)
-	if !ok {
+	var as autoError
+	if !errors.As(e, &as) {
 		return false
 	}
 

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -15,6 +15,8 @@
 package auto
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -542,4 +544,110 @@ func TestRuntimeErrorDotnet(t *testing.T) {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()
 	}
+}
+
+// errPredicate pairs one of the exported error predicates with an autoError it is expected to match.
+type errPredicate struct {
+	name    string
+	matches func(error) bool
+	err     autoError
+}
+
+func errPredicates() []errPredicate {
+	cause := errors.New("exit status 255")
+	return []errPredicate{
+		{
+			name:    "IsConcurrentUpdateError",
+			matches: IsConcurrentUpdateError,
+			err: newAutoError(cause, "",
+				"error: [409] Conflict: Another update is currently in progress.", 255),
+		},
+		{
+			name:    "IsSelectStack404Error",
+			matches: IsSelectStack404Error,
+			err:     newAutoError(cause, "", "error: no stack named 'dev' found", 255),
+		},
+		{
+			name:    "IsCreateStack409Error",
+			matches: IsCreateStack409Error,
+			err:     newAutoError(cause, "", "error: stack 'dev' already exists", 255),
+		},
+		{
+			name:    "IsCompilationError",
+			matches: IsCompilationError,
+			err:     newAutoError(cause, "Build FAILED.", "", 255),
+		},
+		{
+			name:    "IsRuntimeError",
+			matches: IsRuntimeError,
+			err:     newAutoError(cause, "pulumi:pulumi:Stack failed with an unhandled exception:", "", 255),
+		},
+		{
+			name:    "IsUnexpectedEngineError",
+			matches: IsUnexpectedEngineError,
+			err: newAutoError(cause,
+				"The Pulumi CLI encountered a fatal error. This is a bug!", "", 255),
+		},
+	}
+}
+
+func TestErrorPredicatesMatchUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range errPredicates() {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, p.matches(p.err), "%s did not match its own autoError", p.name)
+		})
+	}
+}
+
+// Wrapping an error with fmt.Errorf("...: %w", err) is the standard Go idiom, and autoError is
+// unexported so callers cannot reach it with errors.As themselves. The predicates must therefore
+// look through wrapping.
+func TestErrorPredicatesMatchWrapped(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range errPredicates() {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+
+			wrapped := fmt.Errorf("stack operation failed: %w", p.err)
+			assert.True(t, p.matches(wrapped), "%s did not match a singly wrapped autoError", p.name)
+
+			doubleWrapped := fmt.Errorf("deploy: %w", wrapped)
+			assert.True(t, p.matches(doubleWrapped), "%s did not match a doubly wrapped autoError", p.name)
+		})
+	}
+}
+
+// autoError must unwrap to the error it was created from so that errors.Is and errors.As can reach
+// the underlying cause.
+func TestAutoErrorUnwrapsCause(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	var ae error = newAutoError(sentinel, "", "", 255)
+
+	assert.ErrorIs(t, ae, sentinel)
+	assert.ErrorIs(t, fmt.Errorf("stack operation failed: %w", ae), sentinel)
+}
+
+type causeError struct{ msg string }
+
+func (e *causeError) Error() string { return e.msg }
+
+func TestAutoErrorAsCause(t *testing.T) {
+	t.Parallel()
+
+	cause := &causeError{msg: "boom"}
+	var ae error = newAutoError(cause, "", "", 255)
+
+	var target *causeError
+	require.ErrorAs(t, ae, &target)
+	assert.Equal(t, cause, target)
+
+	target = nil
+	require.ErrorAs(t, fmt.Errorf("stack operation failed: %w", ae), &target)
+	assert.Equal(t, cause, target)
 }


### PR DESCRIPTION
The six exported error predicates detected autoError with a plain type assertion, so a single fmt.Errorf("...: %w", err) — the standard way to add context in Go — made every one of them silently return false. autoError is unexported, so callers could not work around it with errors.As themselves. autoError also had no Unwrap, so errors.Is/errors.As could not reach the cause it was built from.

Use errors.As in each predicate and add autoError.Unwrap. No exported API changes, and unwrapped errors behave exactly as before.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
