### PR TITLE
Stop the local Neo tool immediately on cancel and report it as cancelled

### DIFF
--- a/changelog/pending/20260827--cli--neo-cancel-local-tool.yaml
+++ b/changelog/pending/20260827--cli--neo-cancel-local-tool.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Cancelling a Neo task now stops the running local tool immediately and reports it as cancelled
+time: 2026-08-27T00:00:00Z

--- a/changelog/pending/20260827--cli-neo--cancel-local-tool.yaml
+++ b/changelog/pending/20260827--cli-neo--cancel-local-tool.yaml
@@ -1,4 +1,4 @@
 component: cli/neo
 kind: fix
-body: Cancelling a Neo task now stops the running local tool immediately and reports it as cancelled
+body: Stop the running local tool immediately when a Neo task is cancelled and report it as cancelled
 time: 2026-08-27T00:00:00Z

--- a/changelog/pending/20260827--cli-neo--cancel-local-tool.yaml
+++ b/changelog/pending/20260827--cli-neo--cancel-local-tool.yaml
@@ -1,4 +1,4 @@
-component: cli
+component: cli/neo
 kind: fix
 body: Cancelling a Neo task now stops the running local tool immediately and reports it as cancelled
 time: 2026-08-27T00:00:00Z

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -503,7 +501,7 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 		if opts.printMode {
 			session.Output = stdout
 		}
-		return runNonInteractiveSession(ctx, session, stderr)
+		return session.Run(ctx)
 	}
 
 	uiCh := make(chan UIEvent, 64)
@@ -732,44 +730,6 @@ func runNeoResume(
 		LastEventID: lastEventID,
 		Log:         stderr,
 	}
-	return runNonInteractiveSession(ctx, session, stderr)
-}
-
-// runNonInteractiveSession runs the session with Ctrl+C wired the way the TUI's
-// ESC is: the first interrupt posts a user_cancel so the agent stops the turn
-// (and, via the echoed event, kills any running local tool and reports it
-// cancelled); a second interrupt, or a failed post, tears the session down.
-func runNonInteractiveSession(ctx context.Context, session *Session, stderr io.Writer) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			return
-		case <-sigCh:
-		}
-		fmt.Fprintln(stderr, "Cancelling... (press Ctrl+C again to exit immediately)")
-		postCtx, postCancel := context.WithTimeout(ctx, 10*time.Second)
-		defer postCancel()
-		err := session.Client.PostNeoTaskUserEvent(
-			postCtx, session.OrgName, session.TaskID, apitype.AgentUserEventCancel{Type: userEventUserCancel})
-		if err != nil {
-			fmt.Fprintf(stderr, "error: cancel not sent: %v\n", err)
-			cancel()
-			return
-		}
-		select {
-		case <-ctx.Done():
-		case <-sigCh:
-			cancel()
-		}
-	}()
-
 	return session.Run(ctx)
 }
 
@@ -951,7 +911,7 @@ func historyUIEventsFromUserInput(
 		}
 		return events
 	default:
-		return uiEventsFromUserInput(eventBody)
+		return uiEventsFromUserInput(eventBody, nil)
 	}
 }
 

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -65,10 +67,9 @@ var (
 	userMessageRetryMaxBackoff     = 30 * time.Second
 
 	// cancelMaxPostAttempts bounds the total user_cancel posts (the initial
-	// one plus automatic retries). With userMessageRetryDelay backoff, 8
-	// posts span roughly 90 seconds — enough to outlast most local tool calls
-	// (during which the service 409s cancels because the task is parked)
-	// without retrying forever against a task that will never accept one.
+	// one plus automatic retries). The service accepts cancels while the task
+	// is parked on a local tool call, so retries only cover transient failures;
+	// with userMessageRetryDelay backoff, 8 posts span roughly 90 seconds.
 	cancelMaxPostAttempts = 8
 )
 
@@ -502,7 +503,7 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 		if opts.printMode {
 			session.Output = stdout
 		}
-		return session.Run(ctx)
+		return runNonInteractiveSession(ctx, session, stderr)
 	}
 
 	uiCh := make(chan UIEvent, 64)
@@ -731,6 +732,44 @@ func runNeoResume(
 		LastEventID: lastEventID,
 		Log:         stderr,
 	}
+	return runNonInteractiveSession(ctx, session, stderr)
+}
+
+// runNonInteractiveSession runs the session with Ctrl+C wired the way the TUI's
+// ESC is: the first interrupt posts a user_cancel so the agent stops the turn
+// (and, via the echoed event, kills any running local tool and reports it
+// cancelled); a second interrupt, or a failed post, tears the session down.
+func runNonInteractiveSession(ctx context.Context, session *Session, stderr io.Writer) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sigCh:
+		}
+		fmt.Fprintln(stderr, "Cancelling... (press Ctrl+C again to exit immediately)")
+		postCtx, postCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer postCancel()
+		err := session.Client.PostNeoTaskUserEvent(
+			postCtx, session.OrgName, session.TaskID, apitype.AgentUserEventCancel{Type: userEventUserCancel})
+		if err != nil {
+			fmt.Fprintf(stderr, "error: cancel not sent: %v\n", err)
+			cancel()
+			return
+		}
+		select {
+		case <-ctx.Done():
+		case <-sigCh:
+			cancel()
+		}
+	}()
+
 	return session.Run(ctx)
 }
 
@@ -1099,10 +1138,8 @@ func dispatchUserEvents(
 
 // cancelRetry is the dispatcher's single-slot retry state for the in-flight
 // user_cancel. A failed post is retried on its own timer rather than being
-// dropped: the service rejects cancels while the task is parked on a local
-// tool call, and the retry is what eventually lands the cancel once the tool
-// result posts. Repeated ESC presses while a cancel is pending are
-// deduplicated against the one slot.
+// dropped, so a transient error doesn't lose the user's cancel. Repeated ESC
+// presses while a cancel is pending are deduplicated against the one slot.
 type cancelRetry struct {
 	pending  bool
 	failures int

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -461,10 +461,12 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 			}
 			if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
 				// A post failure caused by cancellation is not session-fatal.
-				if ctx.Err() != nil {
-					return nil
+				// A post failure caused by cancellation is not session-fatal:
+				// fall through so invokeToolCall reports this call cancelled
+				// like any other and the batch still posts its tool_result.
+				if ctx.Err() == nil {
+					return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
 				}
-				return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
 			}
 		}
 

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -130,11 +130,6 @@ func cancelledContent() map[string]any {
 	return map[string]any{"error": "cancelled by the user", "cancelled": true}
 }
 
-// toolResultPostTimeout bounds the tool_result post once the batch context is
-// cancelled: that post is what resumes the parked turn, so it must survive the
-// cancel but not hang shutdown.
-const toolResultPostTimeout = 30 * time.Second
-
 // Run drives the loop. It blocks until ctx is cancelled (clean shutdown, returns nil),
 // the stream ends cleanly (returns nil), or an unrecoverable error occurs (returns the
 // error). Mid-stream network drops are reopened silently with Last-Event-ID so the
@@ -496,9 +491,9 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 	}
 	// Post on a context that survives the cancel: the runtime is parked on
 	// this result, and receiving it (with the calls marked cancelled) is what
-	// lets it end the turn immediately instead of after its grace period.
-	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), toolResultPostTimeout)
-	defer cancel()
+	// lets it end the turn immediately instead of after its grace period. The
+	// client bounds the request with its own timeout, so this cannot hang shutdown.
+	postCtx := context.WithoutCancel(ctx)
 	if err := s.Client.PostNeoTaskUserEvent(postCtx, s.OrgName, s.TaskID, result); err != nil {
 		s.logf("error: posting tool_result: %v", err)
 	}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -23,7 +23,6 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/url"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -116,10 +115,11 @@ type Session struct {
 	// event. Only the Run goroutine touches them, so no locking is needed.
 	batchCtx    context.Context
 	batchCancel context.CancelFunc
-	// batchSeq is the SSE sequence of the assistant_message that enqueued the
-	// current batch. A user_cancel replayed from before it must not kill a
-	// later tool.
-	batchSeq int64
+	// ownCalls holds the tool_call_ids this session executes. The service
+	// echoes every posted user event back on the stream; echoes of our own
+	// exec_tool_call/tool_result would otherwise render as a second tool
+	// block in the TUI. Only the Run goroutine touches it.
+	ownCalls map[string]struct{}
 }
 
 // cancelledContent is the tool_result content for a call the user cancelled
@@ -240,7 +240,7 @@ func (s *Session) drainStream(
 				*lastEventID = evt.ID
 			}
 			gotEvent = true
-			if err := s.handleEvent(ctx, evt.ID, evt.Data); err != nil {
+			if err := s.handleEvent(ctx, evt.Data); err != nil {
 				return gotEvent, err
 			}
 		}
@@ -304,7 +304,7 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	}
 }
 
-func (s *Session) handleEvent(ctx context.Context, eventID string, raw []byte) error {
+func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 	var env apitype.AgentConsoleEvent
 	if err := json.Unmarshal(raw, &env); err != nil {
 		s.logf("warning: skipping malformed Neo console event: %v", err)
@@ -315,12 +315,16 @@ func (s *Session) handleEvent(ctx context.Context, eventID string, raw []byte) e
 		// the API's) on the stream. Stop the in-flight batch right away rather
 		// than waiting for the runtime's parked-cancel grace to expire; runBatch
 		// then posts the cancelled tool_result that resumes and ends the turn.
-		if isUserCancelBody(env.EventBody) && s.batchCancel != nil && !s.cancelPredatesBatch(eventID) {
+		// Events arrive in stream order and reconnects resume after the last
+		// processed event, so a cancel seen here always postdates the batch.
+		if isUserCancelBody(env.EventBody) && s.batchCancel != nil {
 			s.batchCancel()
 			s.batchCancel = nil
 		}
 		// Forward user input echoes to the TUI so the user's messages are visible.
-		s.forwardUserInputToUI(env.EventBody)
+		if body, ok := s.stripOwnToolEchoes(env.EventBody); ok {
+			s.forwardUserInputToUI(body)
+		}
 		return nil
 	}
 
@@ -382,7 +386,7 @@ func (s *Session) handleEvent(ctx context.Context, eventID string, raw []byte) e
 		}
 		return nil
 	}
-	return s.enqueueBatch(ctx, eventID, cliCalls)
+	return s.enqueueBatch(ctx, cliCalls)
 }
 
 func isUserCancelBody(eventBody json.RawMessage) bool {
@@ -390,32 +394,66 @@ func isUserCancelBody(eventBody json.RawMessage) bool {
 	return json.Unmarshal(eventBody, &head) == nil && head.Type == userEventUserCancel
 }
 
-// cancelPredatesBatch reports whether a user_cancel carrying eventID was
-// emitted before the current batch's assistant_message, i.e. it belongs to an
-// earlier turn (replayed on reconnect) and must not kill the running tool.
-// Unparseable ids are treated as fresh.
-func (s *Session) cancelPredatesBatch(eventID string) bool {
-	seq, ok := parseEventSeq(eventID)
-	return ok && seq < s.batchSeq
-}
-
-func parseEventSeq(eventID string) (int64, bool) {
-	seq, err := strconv.ParseInt(eventID, 10, 64)
-	return seq, err == nil
+// stripOwnToolEchoes drops the echoes of this session's own exec_tool_call and
+// tool_result posts from a userInput body before it reaches the TUI, which has
+// already rendered those calls from runBatch. Tool events from other clients
+// pass through; the second return is false when nothing is left to forward.
+func (s *Session) stripOwnToolEchoes(eventBody json.RawMessage) (json.RawMessage, bool) {
+	var head apitype.AgentBackendEventHeader
+	if err := json.Unmarshal(eventBody, &head); err != nil {
+		return eventBody, true
+	}
+	switch head.Type {
+	case userEventExecToolCall:
+		var evt apitype.AgentUserEventExecToolCall
+		if err := json.Unmarshal(eventBody, &evt); err != nil {
+			return eventBody, true
+		}
+		if _, own := s.ownCalls[evt.ToolCallID]; own {
+			return nil, false
+		}
+	case userEventToolResult:
+		var evt apitype.AgentUserEventToolResult
+		if err := json.Unmarshal(eventBody, &evt); err != nil {
+			return eventBody, true
+		}
+		foreign := evt.ToolResults[:0:0]
+		for _, item := range evt.ToolResults {
+			if _, own := s.ownCalls[item.ToolCallID]; own {
+				delete(s.ownCalls, item.ToolCallID)
+				continue
+			}
+			foreign = append(foreign, item)
+		}
+		if len(foreign) == len(evt.ToolResults) {
+			return eventBody, true
+		}
+		if len(foreign) == 0 {
+			return nil, false
+		}
+		evt.ToolResults = foreign
+		body, err := json.Marshal(evt)
+		if err != nil {
+			return eventBody, true
+		}
+		return body, true
+	}
+	return eventBody, true
 }
 
 // enqueueBatch hands the batch to the tool worker so the drain loop keeps reading
 // the stream while tools run. Every batch since the last cancelled event shares
 // one context: a single cancel stops the running batch and everything queued
 // behind it.
-func (s *Session) enqueueBatch(
-	ctx context.Context, eventID string, calls []apitype.AgentBackendEventToolCall,
-) error {
+func (s *Session) enqueueBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	if s.batchCancel == nil {
 		s.batchCtx, s.batchCancel = context.WithCancel(ctx)
 	}
-	if seq, ok := parseEventSeq(eventID); ok {
-		s.batchSeq = seq
+	if s.ownCalls == nil {
+		s.ownCalls = map[string]struct{}{}
+	}
+	for _, call := range calls {
+		s.ownCalls[call.ToolCallID] = struct{}{}
 	}
 	select {
 	case s.batches <- toolBatch{ctx: s.batchCtx, calls: calls}:

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -455,7 +455,6 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 				Name:       call.Name,
 			}
 			if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
-				// A post failure caused by cancellation is not session-fatal.
 				// A post failure caused by cancellation is not session-fatal:
 				// fall through so invokeToolCall reports this call cancelled
 				// like any other and the batch still posts its tool_result.

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -23,6 +23,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -115,7 +116,21 @@ type Session struct {
 	// event. Only the Run goroutine touches them, so no locking is needed.
 	batchCtx    context.Context
 	batchCancel context.CancelFunc
+	// batchSeq is the SSE sequence of the assistant_message that enqueued the
+	// current batch. A user_cancel replayed from before it must not kill a
+	// later tool.
+	batchSeq int64
 }
+
+// cancelledContent is the tool_result content for a call the user cancelled
+// before it produced its own result (never started, or a handler with no
+// cancelled marker of its own).
+var cancelledContent = map[string]any{"error": "cancelled by the user", "cancelled": true}
+
+// toolResultPostTimeout bounds the tool_result post once the batch context is
+// cancelled: that post is what resumes the parked turn, so it must survive the
+// cancel but not hang shutdown.
+const toolResultPostTimeout = 30 * time.Second
 
 // Run drives the loop. It blocks until ctx is cancelled (clean shutdown, returns nil),
 // the stream ends cleanly (returns nil), or an unrecoverable error occurs (returns the
@@ -225,7 +240,7 @@ func (s *Session) drainStream(
 				*lastEventID = evt.ID
 			}
 			gotEvent = true
-			if err := s.handleEvent(ctx, evt.Data); err != nil {
+			if err := s.handleEvent(ctx, evt.ID, evt.Data); err != nil {
 				return gotEvent, err
 			}
 		}
@@ -289,14 +304,22 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	}
 }
 
-func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
+func (s *Session) handleEvent(ctx context.Context, eventID string, raw []byte) error {
 	var env apitype.AgentConsoleEvent
 	if err := json.Unmarshal(raw, &env); err != nil {
 		s.logf("warning: skipping malformed Neo console event: %v", err)
 		return nil
 	}
-	// Forward user input echoes to the TUI so the user's messages are visible.
 	if env.Type == consoleEventUserInput && len(env.EventBody) > 0 {
+		// The service persists and echoes every user_cancel (ours, the console's,
+		// the API's) on the stream. Stop the in-flight batch right away rather
+		// than waiting for the runtime's parked-cancel grace to expire; runBatch
+		// then posts the cancelled tool_result that resumes and ends the turn.
+		if isUserCancelBody(env.EventBody) && s.batchCancel != nil && !s.cancelPredatesBatch(eventID) {
+			s.batchCancel()
+			s.batchCancel = nil
+		}
+		// Forward user input echoes to the TUI so the user's messages are visible.
 		s.forwardUserInputToUI(env.EventBody)
 		return nil
 	}
@@ -318,6 +341,11 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		if s.batchCancel != nil {
 			s.batchCancel()
 			s.batchCancel = nil
+		}
+		// A cancelled turn never produces a final assistant message, so the
+		// single-shot session would otherwise wait on the open stream forever.
+		if s.Output != nil {
+			return errSessionDone
 		}
 		return nil
 	}
@@ -354,16 +382,40 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		}
 		return nil
 	}
-	return s.enqueueBatch(ctx, cliCalls)
+	return s.enqueueBatch(ctx, eventID, cliCalls)
+}
+
+func isUserCancelBody(eventBody json.RawMessage) bool {
+	var head apitype.AgentBackendEventHeader
+	return json.Unmarshal(eventBody, &head) == nil && head.Type == userEventUserCancel
+}
+
+// cancelPredatesBatch reports whether a user_cancel carrying eventID was
+// emitted before the current batch's assistant_message, i.e. it belongs to an
+// earlier turn (replayed on reconnect) and must not kill the running tool.
+// Unparseable ids are treated as fresh.
+func (s *Session) cancelPredatesBatch(eventID string) bool {
+	seq, ok := parseEventSeq(eventID)
+	return ok && seq < s.batchSeq
+}
+
+func parseEventSeq(eventID string) (int64, bool) {
+	seq, err := strconv.ParseInt(eventID, 10, 64)
+	return seq, err == nil
 }
 
 // enqueueBatch hands the batch to the tool worker so the drain loop keeps reading
 // the stream while tools run. Every batch since the last cancelled event shares
 // one context: a single cancel stops the running batch and everything queued
 // behind it.
-func (s *Session) enqueueBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
+func (s *Session) enqueueBatch(
+	ctx context.Context, eventID string, calls []apitype.AgentBackendEventToolCall,
+) error {
 	if s.batchCancel == nil {
 		s.batchCtx, s.batchCancel = context.WithCancel(ctx)
+	}
+	if seq, ok := parseEventSeq(eventID); ok {
+		s.batchSeq = seq
 	}
 	select {
 	case s.batches <- toolBatch{ctx: s.batchCtx, calls: calls}:
@@ -394,30 +446,35 @@ func (s *Session) toolWorker(done chan<- struct{}) {
 func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	items := make([]apitype.AgentUserEventToolResultItem, 0, len(calls))
 	for _, call := range calls {
-		// The agent isn't waiting for results from a cancelled turn.
+		var result apitype.AgentUserEventToolResultItem
 		if ctx.Err() != nil {
-			return nil
-		}
-		sendUI(s.UIEvents, UIToolStarted{Name: call.Name, Args: call.Args})
-
-		// The agent runtime relies on exec_tool_call to transition the call into its
-		// "running" state. If this post fails, the agent will believe the tool never
-		// started, so any tool_result we'd send later would be rejected or mis-attributed.
-		// Abort the batch and let the session loop surface the error.
-		execEvt := apitype.AgentUserEventExecToolCall{
-			Type:       userEventExecToolCall,
-			ToolCallID: call.ToolCallID,
-			Name:       call.Name,
-		}
-		if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
-			// A post failure caused by cancellation is not session-fatal.
-			if ctx.Err() != nil {
-				return nil
+			// The user cancelled the turn: report the remaining calls as cancelled
+			// rather than starting them, so every tool_call_id gets a result.
+			result = apitype.AgentUserEventToolResultItem{
+				ToolCallID: call.ToolCallID, Name: call.Name, IsError: true, Content: cancelledContent,
 			}
-			return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
-		}
+		} else {
+			sendUI(s.UIEvents, UIToolStarted{Name: call.Name, Args: call.Args})
 
-		result := s.invokeToolCall(ctx, call)
+			// The agent runtime relies on exec_tool_call to transition the call into its
+			// "running" state. If this post fails, the agent will believe the tool never
+			// started, so any tool_result we'd send later would be rejected or mis-attributed.
+			// Abort the batch and let the session loop surface the error.
+			execEvt := apitype.AgentUserEventExecToolCall{
+				Type:       userEventExecToolCall,
+				ToolCallID: call.ToolCallID,
+				Name:       call.Name,
+			}
+			if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
+				// A post failure caused by cancellation is not session-fatal.
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
+			}
+
+			result = s.invokeToolCall(ctx, call)
+		}
 		items = append(items, result)
 
 		// Marshal a JSON copy for the overlay. A failure shouldn't abort the
@@ -437,14 +494,16 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		})
 	}
 
-	if ctx.Err() != nil {
-		return nil
-	}
 	result := apitype.AgentUserEventToolResult{
 		Type:        userEventToolResult,
 		ToolResults: items,
 	}
-	if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, result); err != nil {
+	// Post on a context that survives the cancel: the runtime is parked on
+	// this result, and receiving it (with the calls marked cancelled) is what
+	// lets it end the turn immediately instead of after its grace period.
+	postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), toolResultPostTimeout)
+	defer cancel()
+	if err := s.Client.PostNeoTaskUserEvent(postCtx, s.OrgName, s.TaskID, result); err != nil {
 		s.logf("error: posting tool_result: %v", err)
 	}
 
@@ -479,10 +538,20 @@ func (s *Session) invokeToolCall(
 		// timeout). Prefer that value so the agent sees what was captured.
 		if value != nil {
 			res.Content = value
+		} else if errors.Is(ctx.Err(), context.Canceled) {
+			res.Content = cancelledContent
 		} else {
 			res.Content = map[string]string{"error": err.Error()}
 		}
 		return res
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		// The handler finished (or was killed) after the user cancelled; the
+		// agent must not treat whatever it returned as a completed call.
+		res.IsError = true
+		if value == nil {
+			value = cancelledContent
+		}
 	}
 	res.Content = value
 	return res

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -115,17 +115,20 @@ type Session struct {
 	// event. Only the Run goroutine touches them, so no locking is needed.
 	batchCtx    context.Context
 	batchCancel context.CancelFunc
-	// ownCalls holds the tool_call_ids this session executes. The service
-	// echoes every posted user event back on the stream; echoes of our own
-	// exec_tool_call/tool_result would otherwise render as a second tool
-	// block in the TUI. Only the Run goroutine touches it.
+	// ownCalls holds the tool_call_ids this session executes and has not yet
+	// seen echoed back as a tool_result. The service echoes every posted user
+	// event on the stream; echoes of our own exec_tool_call/tool_result would
+	// otherwise render as a second tool block in the TUI, so it is only
+	// maintained when UIEvents is set. Only the Run goroutine touches it.
 	ownCalls map[string]struct{}
 }
 
-// cancelledContent is the tool_result content for a call the user cancelled
-// before it produced its own result (never started, or a handler with no
-// cancelled marker of its own).
-var cancelledContent = map[string]any{"error": "cancelled by the user", "cancelled": true}
+// cancelledContent returns the tool_result content for a call the user
+// cancelled before it produced its own result (never started, or a handler
+// with no cancelled marker of its own). It mirrors tools.ShellResult's shape.
+func cancelledContent() map[string]any {
+	return map[string]any{"error": "cancelled by the user", "cancelled": true}
+}
 
 // toolResultPostTimeout bounds the tool_result post once the batch context is
 // cancelled: that post is what resumes the parked turn, so it must survive the
@@ -322,9 +325,7 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 			s.batchCancel = nil
 		}
 		// Forward user input echoes to the TUI so the user's messages are visible.
-		if body, ok := s.stripOwnToolEchoes(env.EventBody); ok {
-			s.forwardUserInputToUI(body)
-		}
+		s.forwardUserInputToUI(env.EventBody)
 		return nil
 	}
 
@@ -346,12 +347,8 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 			s.batchCancel()
 			s.batchCancel = nil
 		}
-		// A cancelled turn never produces a final assistant message, so the
-		// single-shot session would otherwise wait on the open stream forever.
-		if s.Output != nil {
-			return errSessionDone
-		}
-		return nil
+		// A cancelled turn never produces a final assistant message.
+		return s.turnEnded("")
 	}
 	if head.Type != backendEventAssistantMessage {
 		return nil
@@ -377,68 +374,29 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		// the turn is complete and the TUI can re-enable input.
 		if msg.IsFinal {
 			sendUI(s.UIEvents, UITaskIdle{})
-			if s.Output != nil {
-				if msg.Content != "" {
-					fmt.Fprintln(s.Output, msg.Content)
-				}
-				return errSessionDone
-			}
+			return s.turnEnded(msg.Content)
 		}
 		return nil
 	}
 	return s.enqueueBatch(ctx, cliCalls)
 }
 
+// turnEnded is called once the agent's turn is over, with the final message
+// content if there was one. A single-shot session (Output set) prints it and
+// ends; an interactive session keeps draining the stream for the next turn.
+func (s *Session) turnEnded(content string) error {
+	if s.Output == nil {
+		return nil
+	}
+	if content != "" {
+		fmt.Fprintln(s.Output, content)
+	}
+	return errSessionDone
+}
+
 func isUserCancelBody(eventBody json.RawMessage) bool {
 	var head apitype.AgentBackendEventHeader
 	return json.Unmarshal(eventBody, &head) == nil && head.Type == userEventUserCancel
-}
-
-// stripOwnToolEchoes drops the echoes of this session's own exec_tool_call and
-// tool_result posts from a userInput body before it reaches the TUI, which has
-// already rendered those calls from runBatch. Tool events from other clients
-// pass through; the second return is false when nothing is left to forward.
-func (s *Session) stripOwnToolEchoes(eventBody json.RawMessage) (json.RawMessage, bool) {
-	var head apitype.AgentBackendEventHeader
-	if err := json.Unmarshal(eventBody, &head); err != nil {
-		return eventBody, true
-	}
-	switch head.Type {
-	case userEventExecToolCall:
-		var evt apitype.AgentUserEventExecToolCall
-		if err := json.Unmarshal(eventBody, &evt); err != nil {
-			return eventBody, true
-		}
-		if _, own := s.ownCalls[evt.ToolCallID]; own {
-			return nil, false
-		}
-	case userEventToolResult:
-		var evt apitype.AgentUserEventToolResult
-		if err := json.Unmarshal(eventBody, &evt); err != nil {
-			return eventBody, true
-		}
-		foreign := evt.ToolResults[:0:0]
-		for _, item := range evt.ToolResults {
-			if _, own := s.ownCalls[item.ToolCallID]; own {
-				delete(s.ownCalls, item.ToolCallID)
-				continue
-			}
-			foreign = append(foreign, item)
-		}
-		if len(foreign) == len(evt.ToolResults) {
-			return eventBody, true
-		}
-		if len(foreign) == 0 {
-			return nil, false
-		}
-		evt.ToolResults = foreign
-		body, err := json.Marshal(evt)
-		if err != nil {
-			return eventBody, true
-		}
-		return body, true
-	}
-	return eventBody, true
 }
 
 // enqueueBatch hands the batch to the tool worker so the drain loop keeps reading
@@ -449,11 +407,13 @@ func (s *Session) enqueueBatch(ctx context.Context, calls []apitype.AgentBackend
 	if s.batchCancel == nil {
 		s.batchCtx, s.batchCancel = context.WithCancel(ctx)
 	}
-	if s.ownCalls == nil {
-		s.ownCalls = map[string]struct{}{}
-	}
-	for _, call := range calls {
-		s.ownCalls[call.ToolCallID] = struct{}{}
+	if s.UIEvents != nil {
+		if s.ownCalls == nil {
+			s.ownCalls = map[string]struct{}{}
+		}
+		for _, call := range calls {
+			s.ownCalls[call.ToolCallID] = struct{}{}
+		}
 	}
 	select {
 	case s.batches <- toolBatch{ctx: s.batchCtx, calls: calls}:
@@ -484,14 +444,10 @@ func (s *Session) toolWorker(done chan<- struct{}) {
 func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEventToolCall) error {
 	items := make([]apitype.AgentUserEventToolResultItem, 0, len(calls))
 	for _, call := range calls {
-		var result apitype.AgentUserEventToolResultItem
-		if ctx.Err() != nil {
-			// The user cancelled the turn: report the remaining calls as cancelled
-			// rather than starting them, so every tool_call_id gets a result.
-			result = apitype.AgentUserEventToolResultItem{
-				ToolCallID: call.ToolCallID, Name: call.Name, IsError: true, Content: cancelledContent,
-			}
-		} else {
+		// Once the user has cancelled the turn the remaining calls are not
+		// started; invokeToolCall reports them cancelled so every tool_call_id
+		// still gets a result.
+		if ctx.Err() == nil {
 			sendUI(s.UIEvents, UIToolStarted{Name: call.Name, Args: call.Args})
 
 			// The agent runtime relies on exec_tool_call to transition the call into its
@@ -510,9 +466,9 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 				}
 				return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
 			}
-
-			result = s.invokeToolCall(ctx, call)
 		}
+
+		result := s.invokeToolCall(ctx, call)
 		items = append(items, result)
 
 		// Marshal a JSON copy for the overlay. A failure shouldn't abort the
@@ -551,11 +507,18 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 // invokeToolCall dispatches a single tool call to the appropriate handler by splitting
 // the tool name on "__" into server and method. Errors are returned as
 // AgentUserEventToolResultItem with IsError=true rather than propagated, so the agent can
-// retry or report.
+// retry or report. A call whose context is cancelled — before it starts or while the
+// handler runs — is always reported as an error, with whatever partial value the
+// handler captured, so the agent never mistakes it for a completed call.
 func (s *Session) invokeToolCall(
 	ctx context.Context, call apitype.AgentBackendEventToolCall,
 ) apitype.AgentUserEventToolResultItem {
 	res := apitype.AgentUserEventToolResultItem{ToolCallID: call.ToolCallID, Name: call.Name}
+	if ctx.Err() != nil {
+		res.IsError = true
+		res.Content = cancelledContent()
+		return res
+	}
 
 	server, method, ok := strings.Cut(call.Name, "__")
 	if !ok {
@@ -570,28 +533,18 @@ func (s *Session) invokeToolCall(
 		return res
 	}
 	value, err := handler.Invoke(ctx, method, call.Args)
-	if err != nil {
-		res.IsError = true
+	cancelled := errors.Is(ctx.Err(), context.Canceled)
+	res.IsError = err != nil || cancelled
+	switch {
+	case value != nil:
 		// Handlers may return a partial value alongside an error (e.g. shell
-		// timeout). Prefer that value so the agent sees what was captured.
-		if value != nil {
-			res.Content = value
-		} else if errors.Is(ctx.Err(), context.Canceled) {
-			res.Content = cancelledContent
-		} else {
-			res.Content = map[string]string{"error": err.Error()}
-		}
-		return res
+		// timeout or cancel). Prefer it so the agent sees what was captured.
+		res.Content = value
+	case cancelled:
+		res.Content = cancelledContent()
+	case err != nil:
+		res.Content = map[string]string{"error": err.Error()}
 	}
-	if errors.Is(ctx.Err(), context.Canceled) {
-		// The handler finished (or was killed) after the user cancelled; the
-		// agent must not treat whatever it returned as a completed call.
-		res.IsError = true
-		if value == nil {
-			value = cancelledContent
-		}
-	}
-	res.Content = value
 	return res
 }
 
@@ -718,12 +671,16 @@ func (s *Session) forwardUserInputToUI(eventBody json.RawMessage) {
 		return
 	}
 
-	for _, event := range uiEventsFromUserInput(eventBody) {
+	for _, event := range uiEventsFromUserInput(eventBody, s.ownCalls) {
 		sendUI(s.UIEvents, event)
 	}
 }
 
-func uiEventsFromUserInput(eventBody json.RawMessage) []UIEvent {
+// uiEventsFromUserInput translates an echoed user event into UI events. Echoes
+// of the calls in ownCalls (this session's own exec_tool_call/tool_result posts,
+// already rendered by runBatch) are skipped and their tool_result echo removes
+// them from the set; a nil set forwards everything.
+func uiEventsFromUserInput(eventBody json.RawMessage, ownCalls map[string]struct{}) []UIEvent {
 	// Peek at the inner type; we reuse AgentBackendEventHeader because it's just
 	// a Type field and the JSON shape on the user-input side matches.
 	var head apitype.AgentBackendEventHeader
@@ -754,6 +711,9 @@ func uiEventsFromUserInput(eventBody json.RawMessage) []UIEvent {
 		if err := json.Unmarshal(eventBody, &evt); err != nil {
 			return nil
 		}
+		if _, own := ownCalls[evt.ToolCallID]; own {
+			return nil
+		}
 		return []UIEvent{UIToolStarted{Name: evt.Name}}
 	case userEventToolResult:
 		var evt apitype.AgentUserEventToolResult
@@ -762,6 +722,10 @@ func uiEventsFromUserInput(eventBody json.RawMessage) []UIEvent {
 		}
 		events := make([]UIEvent, 0, len(evt.ToolResults))
 		for _, result := range evt.ToolResults {
+			if _, own := ownCalls[result.ToolCallID]; own {
+				delete(ownCalls, result.ToolCallID)
+				continue
+			}
 			resultRaw, err := json.Marshal(result.Content)
 			if err != nil {
 				resultRaw, _ = json.Marshal(map[string]string{

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1981,3 +1981,68 @@ func TestSession_BatchesRunSeriallyAcrossAssistantMessages(t *testing.T) {
 	require.Len(t, res2.ToolResults, 1)
 	assert.Equal(t, "c2", res2.ToolResults[0].ToolCallID)
 }
+
+// cancellingStreamer cancels the batch context from inside the first
+// exec_tool_call post and reports that post as failed, mimicking a request
+// torn down by the user's cancel mid-flight.
+type cancellingStreamer struct {
+	fakeStreamer
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (c *cancellingStreamer) PostNeoTaskUserEvent(ctx context.Context, org, task string, body any) error {
+	if _, ok := body.(apitype.AgentUserEventExecToolCall); ok {
+		var cancelled bool
+		c.once.Do(func() {
+			c.cancel()
+			cancelled = true
+		})
+		if cancelled {
+			_ = c.fakeStreamer.PostNeoTaskUserEvent(ctx, org, task, body)
+			return errors.New("connection reset")
+		}
+	}
+	return c.fakeStreamer.PostNeoTaskUserEvent(ctx, org, task, body)
+}
+
+// TestSession_ExecToolCallPostFailureUnderCancelStillPostsToolResult pins the
+// behaviour of a failed exec_tool_call post when the failure is caused by the
+// batch being cancelled: the batch must not abort, both calls are reported
+// cancelled, and a single tool_result covering every call is still posted so
+// the parked runtime can end the turn.
+func TestSession_ExecToolCallPostFailureUnderCancelStillPostsToolResult(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	streamer := &cancellingStreamer{fakeStreamer: *newFakeStreamer(), cancel: cancel}
+	ran := false
+	handlers := map[string]ToolHandler{
+		"probe": &probeHandler{invoke: func(context.Context) (any, error) {
+			ran = true
+			return map[string]any{"ok": true}, nil
+		}},
+	}
+	s := &Session{Client: streamer, Handlers: handlers, OrgName: "org", TaskID: "task"}
+
+	err := s.runBatch(ctx, []apitype.AgentBackendEventToolCall{
+		{ToolCallID: "c1", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+		{ToolCallID: "c2", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+	})
+	require.NoError(t, err, "a cancel-induced exec_tool_call failure must not be session-fatal")
+	assert.False(t, ran, "no handler may run once the batch context is cancelled")
+
+	streamer.mu.Lock()
+	defer streamer.mu.Unlock()
+	require.Len(t, streamer.posted, 2, "one failed exec_tool_call, then the tool_result")
+	_, ok := streamer.posted[0].(apitype.AgentUserEventExecToolCall)
+	require.True(t, ok)
+	result, ok := streamer.posted[1].(apitype.AgentUserEventToolResult)
+	require.True(t, ok)
+	require.Len(t, result.ToolResults, 2)
+	for _, item := range result.ToolResults {
+		assert.True(t, item.IsError, "%s must be reported as an error", item.ToolCallID)
+		assert.Equal(t, cancelledContent(), item.Content)
+	}
+}

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1819,7 +1819,7 @@ func TestSession_UserCancelEventCancelsInFlightBatch(t *testing.T) {
 		"partial output captured before the cancel must reach the agent")
 	assert.Equal(t, "c2", result.ToolResults[1].ToolCallID)
 	assert.True(t, result.ToolResults[1].IsError)
-	assert.Equal(t, cancelledContent, result.ToolResults[1].Content)
+	assert.Equal(t, cancelledContent(), result.ToolResults[1].Content)
 	select {
 	case <-secondRan:
 		t.Fatal("a call queued behind the cancelled one must not start")

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1740,13 +1740,13 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 	assert.Equal(t, []string{"c1"}, errorIDs)
 }
 
-func mustUserInputEnvelope(t *testing.T, id string, inner any) []byte {
+func mustUserInputEnvelope(t *testing.T, inner any) []byte {
 	t.Helper()
 	body, err := json.Marshal(inner)
 	require.NoError(t, err)
 	out, err := json.Marshal(apitype.AgentConsoleEvent{
 		Type:      consoleEventUserInput,
-		ID:        id,
+		ID:        "evt-2",
 		EventBody: body,
 	})
 	require.NoError(t, err)
@@ -1783,25 +1783,20 @@ func TestSession_UserCancelEventCancelsInFlightBatch(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- s.Run(t.Context()) }()
 
-	streamer.stream <- client.NeoStreamEvent{ID: "10", Data: mustAgentResponseEnvelope(t,
-		apitype.AgentBackendEventAssistantMessage{
-			Type: backendEventAssistantMessage,
-			ToolCalls: []apitype.AgentBackendEventToolCall{
-				{ToolCallID: "c1", Name: "blocking__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
-				{ToolCallID: "c2", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
-			},
-		})}
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type: backendEventAssistantMessage,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{ToolCallID: "c1", Name: "blocking__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+			{ToolCallID: "c2", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+		},
+	})}
 	select {
 	case <-started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("tool handler never started")
 	}
 
-	// A stale cancel replayed from before this turn must be ignored.
-	streamer.stream <- client.NeoStreamEvent{ID: "3", Data: mustUserInputEnvelope(t, "3",
-		apitype.AgentUserEventCancel{Type: userEventUserCancel})}
-	// A fresh one stops the batch.
-	streamer.stream <- client.NeoStreamEvent{ID: "11", Data: mustUserInputEnvelope(t, "11",
+	streamer.stream <- client.NeoStreamEvent{Data: mustUserInputEnvelope(t,
 		apitype.AgentUserEventCancel{Type: userEventUserCancel})}
 
 	var result apitype.AgentUserEventToolResult
@@ -1840,61 +1835,69 @@ func TestSession_UserCancelEventCancelsInFlightBatch(t *testing.T) {
 	}
 }
 
-// TestSession_StaleUserCancelIgnored verifies that a user_cancel replayed from
-// an earlier turn does not kill a later tool.
-func TestSession_StaleUserCancelIgnored(t *testing.T) {
+// TestSession_OwnToolEchoesNotForwardedToUI verifies that the service's echo
+// of this session's own exec_tool_call/tool_result posts does not reach the
+// TUI (which already rendered the call from runBatch), while the same events
+// from another client still do.
+func TestSession_OwnToolEchoesNotForwardedToUI(t *testing.T) {
 	t.Parallel()
 
 	streamer := newFakeStreamer()
-	started := make(chan struct{})
-	release := make(chan struct{})
-	ctxErr := make(chan error, 1)
-	h := &probeHandler{invoke: func(ctx context.Context) (any, error) {
-		close(started)
-		<-release
-		ctxErr <- ctx.Err()
-		return map[string]any{"ok": true}, nil
-	}}
+	uiCh := make(chan UIEvent, 32)
 	s := &Session{
 		Client:   streamer,
-		Handlers: map[string]ToolHandler{"probe": h},
+		Handlers: map[string]ToolHandler{"probe": &fakeHandler{wantMethod: "run", result: map[string]any{"ok": true}}},
 		OrgName:  "org",
 		TaskID:   "task",
+		UIEvents: uiCh,
 	}
-
 	done := make(chan error, 1)
 	go func() { done <- s.Run(t.Context()) }()
 
-	streamer.stream <- client.NeoStreamEvent{ID: "10", Data: mustAgentResponseEnvelope(t,
-		apitype.AgentBackendEventAssistantMessage{
-			Type: backendEventAssistantMessage,
-			ToolCalls: []apitype.AgentBackendEventToolCall{
-				{ToolCallID: "c1", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
-			},
-		})}
-	select {
-	case <-started:
-	case <-time.After(5 * time.Second):
-		t.Fatal("tool handler never started")
-	}
-	streamer.stream <- client.NeoStreamEvent{ID: "3", Data: mustUserInputEnvelope(t, "3",
-		apitype.AgentUserEventCancel{Type: userEventUserCancel})}
-	// Give the drain loop a chance to (wrongly) act on the stale cancel.
-	time.Sleep(50 * time.Millisecond)
-	close(release)
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type: backendEventAssistantMessage,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{ToolCallID: "c1", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+		},
+	})}
+	require.Eventually(t, func() bool {
+		streamer.mu.Lock()
+		defer streamer.mu.Unlock()
+		return len(streamer.posted) == 2
+	}, 2*time.Second, 10*time.Millisecond)
 
-	select {
-	case err := <-ctxErr:
-		require.NoError(t, err, "a stale user_cancel must not cancel the tool context")
-	case <-time.After(5 * time.Second):
-		t.Fatal("tool never finished")
-	}
+	// Echoes of our own posts, then the same events from a foreign client.
+	streamer.stream <- client.NeoStreamEvent{Data: mustUserInputEnvelope(t,
+		apitype.AgentUserEventExecToolCall{Type: userEventExecToolCall, ToolCallID: "c1", Name: "probe__run"})}
+	streamer.stream <- client.NeoStreamEvent{Data: mustUserInputEnvelope(t, apitype.AgentUserEventToolResult{
+		Type:        userEventToolResult,
+		ToolResults: []apitype.AgentUserEventToolResultItem{{ToolCallID: "c1", Name: "probe__run", Content: "x"}},
+	})}
+	streamer.stream <- client.NeoStreamEvent{Data: mustUserInputEnvelope(t,
+		apitype.AgentUserEventExecToolCall{Type: userEventExecToolCall, ToolCallID: "other", Name: "foreign__run"})}
+	streamer.stream <- client.NeoStreamEvent{Data: mustUserInputEnvelope(t, apitype.AgentUserEventToolResult{
+		Type:        userEventToolResult,
+		ToolResults: []apitype.AgentUserEventToolResultItem{{ToolCallID: "other", Name: "foreign__run", Content: "y"}},
+	})}
 	close(streamer.stream)
 	select {
-	case <-done:
+	case err := <-done:
+		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("session did not exit")
 	}
+	close(uiCh)
+
+	var names []string
+	for ev := range uiCh {
+		switch e := ev.(type) {
+		case UIToolStarted:
+			names = append(names, "start:"+e.Name)
+		case UIToolCompleted:
+			names = append(names, "done:"+e.Name)
+		}
+	}
+	assert.Equal(t, []string{"start:probe__run", "done:probe__run", "start:foreign__run", "done:foreign__run"}, names)
 }
 
 // TestSession_BatchesRunSeriallyAcrossAssistantMessages locks down that tool

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -1642,9 +1642,9 @@ func TestSession_CancelledEventDeliveredWhileLocalToolRuns(t *testing.T) {
 }
 
 // TestSession_CancelledEventCancelsInFlightBatchContext verifies that a
-// server-side cancelled event cancels the running tool's context, that no
-// tool_result is posted for the cancelled turn, and that the next turn's
-// batch runs with a fresh context.
+// server-side cancelled event cancels the running tool's context, that the
+// cancelled turn still posts an error tool_result for the interrupted call,
+// and that the next turn's batch runs with a fresh context.
 func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 	t.Parallel()
 
@@ -1715,12 +1715,13 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		t.Fatal("session did not exit")
 	}
 
-	// The cancelled turn posts exec_tool_call but no tool_result; the fresh
-	// turn posts both.
+	// Both turns post exec_tool_call and a tool_result; the cancelled one is
+	// flagged as an error so the agent doesn't treat it as completed.
 	streamer.mu.Lock()
 	defer streamer.mu.Unlock()
 	var execNames []string
 	var resultIDs []string
+	var errorIDs []string
 	for _, p := range streamer.posted {
 		switch evt := p.(type) {
 		case apitype.AgentUserEventExecToolCall:
@@ -1728,11 +1729,172 @@ func TestSession_CancelledEventCancelsInFlightBatchContext(t *testing.T) {
 		case apitype.AgentUserEventToolResult:
 			for _, item := range evt.ToolResults {
 				resultIDs = append(resultIDs, item.ToolCallID)
+				if item.IsError {
+					errorIDs = append(errorIDs, item.ToolCallID)
+				}
 			}
 		}
 	}
 	assert.Equal(t, []string{"blocking__run", "probe__run"}, execNames)
-	assert.Equal(t, []string{"c2"}, resultIDs)
+	assert.Equal(t, []string{"c1", "c2"}, resultIDs)
+	assert.Equal(t, []string{"c1"}, errorIDs)
+}
+
+func mustUserInputEnvelope(t *testing.T, id string, inner any) []byte {
+	t.Helper()
+	body, err := json.Marshal(inner)
+	require.NoError(t, err)
+	out, err := json.Marshal(apitype.AgentConsoleEvent{
+		Type:      consoleEventUserInput,
+		ID:        id,
+		EventBody: body,
+	})
+	require.NoError(t, err)
+	return out
+}
+
+// TestSession_UserCancelEventCancelsInFlightBatch verifies that a user_cancel
+// echoed on the stream (from ESC, the console, or the API) stops the running
+// local tool immediately and posts a tool_result marking every call in the
+// batch cancelled, so the runtime can end the turn without waiting for its
+// parked-cancel grace period.
+func TestSession_UserCancelEventCancelsInFlightBatch(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+	started := make(chan struct{})
+	blocking := &probeHandler{invoke: func(ctx context.Context) (any, error) {
+		close(started)
+		<-ctx.Done()
+		return map[string]any{"stdout": "partial"}, ctx.Err()
+	}}
+	secondRan := make(chan struct{}, 1)
+	second := &probeHandler{invoke: func(ctx context.Context) (any, error) {
+		secondRan <- struct{}{}
+		return map[string]any{"ok": true}, nil
+	}}
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{"blocking": blocking, "probe": second},
+		OrgName:  "org",
+		TaskID:   "task",
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	streamer.stream <- client.NeoStreamEvent{ID: "10", Data: mustAgentResponseEnvelope(t,
+		apitype.AgentBackendEventAssistantMessage{
+			Type: backendEventAssistantMessage,
+			ToolCalls: []apitype.AgentBackendEventToolCall{
+				{ToolCallID: "c1", Name: "blocking__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+				{ToolCallID: "c2", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+			},
+		})}
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool handler never started")
+	}
+
+	// A stale cancel replayed from before this turn must be ignored.
+	streamer.stream <- client.NeoStreamEvent{ID: "3", Data: mustUserInputEnvelope(t, "3",
+		apitype.AgentUserEventCancel{Type: userEventUserCancel})}
+	// A fresh one stops the batch.
+	streamer.stream <- client.NeoStreamEvent{ID: "11", Data: mustUserInputEnvelope(t, "11",
+		apitype.AgentUserEventCancel{Type: userEventUserCancel})}
+
+	var result apitype.AgentUserEventToolResult
+	require.Eventually(t, func() bool {
+		streamer.mu.Lock()
+		defer streamer.mu.Unlock()
+		for _, p := range streamer.posted {
+			if r, ok := p.(apitype.AgentUserEventToolResult); ok {
+				result = r
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "user_cancel must produce a tool_result promptly")
+
+	require.Len(t, result.ToolResults, 2)
+	assert.Equal(t, "c1", result.ToolResults[0].ToolCallID)
+	assert.True(t, result.ToolResults[0].IsError)
+	assert.Equal(t, map[string]any{"stdout": "partial"}, result.ToolResults[0].Content,
+		"partial output captured before the cancel must reach the agent")
+	assert.Equal(t, "c2", result.ToolResults[1].ToolCallID)
+	assert.True(t, result.ToolResults[1].IsError)
+	assert.Equal(t, cancelledContent, result.ToolResults[1].Content)
+	select {
+	case <-secondRan:
+		t.Fatal("a call queued behind the cancelled one must not start")
+	default:
+	}
+
+	close(streamer.stream)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not exit")
+	}
+}
+
+// TestSession_StaleUserCancelIgnored verifies that a user_cancel replayed from
+// an earlier turn does not kill a later tool.
+func TestSession_StaleUserCancelIgnored(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ctxErr := make(chan error, 1)
+	h := &probeHandler{invoke: func(ctx context.Context) (any, error) {
+		close(started)
+		<-release
+		ctxErr <- ctx.Err()
+		return map[string]any{"ok": true}, nil
+	}}
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{"probe": h},
+		OrgName:  "org",
+		TaskID:   "task",
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	streamer.stream <- client.NeoStreamEvent{ID: "10", Data: mustAgentResponseEnvelope(t,
+		apitype.AgentBackendEventAssistantMessage{
+			Type: backendEventAssistantMessage,
+			ToolCalls: []apitype.AgentBackendEventToolCall{
+				{ToolCallID: "c1", Name: "probe__run", Args: json.RawMessage(`{}`), ExecutionMode: toolExecutionModeCLI},
+			},
+		})}
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool handler never started")
+	}
+	streamer.stream <- client.NeoStreamEvent{ID: "3", Data: mustUserInputEnvelope(t, "3",
+		apitype.AgentUserEventCancel{Type: userEventUserCancel})}
+	// Give the drain loop a chance to (wrongly) act on the stale cancel.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	select {
+	case err := <-ctxErr:
+		require.NoError(t, err, "a stale user_cancel must not cancel the tool context")
+	case <-time.After(5 * time.Second):
+		t.Fatal("tool never finished")
+	}
+	close(streamer.stream)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not exit")
+	}
 }
 
 // TestSession_BatchesRunSeriallyAcrossAssistantMessages locks down that tool

--- a/pkg/cmd/pulumi/neo/tools/filesystem.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem.go
@@ -117,6 +117,10 @@ func NewFilesystem(root string, extraRoots ...string) (*Filesystem, error) {
 
 // Invoke dispatches a single filesystem method call.
 func (f *Filesystem) Invoke(ctx context.Context, method string, args json.RawMessage) (any, error) {
+	// Operations are short, so a cancel is only observed between calls.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	switch method {
 	case "read":
 		var p struct {

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -155,7 +155,14 @@ type ShellResult struct {
 	Err       string `json:"error,omitempty"`
 	Truncated bool   `json:"truncated,omitempty"`
 	TimedOut  bool   `json:"timed_out,omitempty"`
+	// Cancelled is set when the user cancelled the turn while the command was
+	// running; the process tree was killed and stdout/stderr hold partial output.
+	Cancelled bool `json:"cancelled,omitempty"`
 }
+
+// ErrCancelled is the error the shell tool returns when the user cancels the
+// turn while a command is running.
+var ErrCancelled = errors.New("shell command cancelled by the user")
 
 // TimeoutError is the error the shell tool returns when a command exceeds its
 // timeout. Both the local runner and the Neo ACP editor-terminal runner return
@@ -235,6 +242,11 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
 		res.TimedOut = true
 		return res, TimeoutError(timeout)
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		res.Cancelled = true
+		res.Err = ErrCancelled.Error()
+		return res, ErrCancelled
 	}
 	return res, nil
 }

--- a/pkg/cmd/pulumi/neo/tools/shell_test.go
+++ b/pkg/cmd/pulumi/neo/tools/shell_test.go
@@ -15,6 +15,7 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -57,6 +58,30 @@ func TestShell_ExecuteHonorsTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "timed out")
 	require.NotNil(t, res, "partial result must still be returned alongside the timeout error")
 	assert.True(t, res.(ShellResult).TimedOut)
+}
+
+func TestShell_ExecuteReportsCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh semantics")
+	}
+	t.Parallel()
+
+	sh, err := NewShell(t.TempDir())
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	res, err := sh.Invoke(ctx, "shell_execute", json.RawMessage(`{"command":"echo started; sleep 30"}`))
+	require.ErrorIs(t, err, ErrCancelled)
+	assert.Less(t, time.Since(start), 5*time.Second, "cancel must kill the command promptly")
+	require.NotNil(t, res)
+	r := res.(ShellResult)
+	assert.True(t, r.Cancelled)
+	assert.False(t, r.TimedOut)
+	assert.Equal(t, "started\n", r.Stdout, "partial output must be preserved")
 }
 
 func TestShell_ExecuteHonorsAgentTimeout(t *testing.T) {


### PR DESCRIPTION
Cancelling a Neo task while the CLI runs a local tool (e.g. `sleep 60`) did nothing until the tool finished on its own, then the runtime waited out its parked-cancel grace period.

- `Session` consumes the `user_cancel` echoed on the SSE stream (ESC, console, or API), cancels the in-flight batch, and posts a `tool_result` marking every call in the batch cancelled (`is_error: true`, with any partial value the handler captured) so the runtime ends the turn immediately. The post uses a context that survives the cancel, since receiving it is what unparks the runtime.
- Echoes of the CLI's own `exec_tool_call`/`tool_result` events are dropped before reaching the TUI, which already rendered them; tool events from other clients still pass through.
- `shell` reports `cancelled: true` with any partial output; `filesystem` refuses to start on a cancelled context.

Ctrl+C handling for `--print`/`resume` is split out into #24472, stacked on this PR.

Part of pulumi/pulumi-service#44059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
