### PR TITLE
Document imperative changelog style in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ All commands assume you're at the repo root.
   - Use `mise exec -- make work` to create a `go.work` file for cross-module development.
 - Proto-generated files must stay in sync with `proto/*.proto`. CI enforces via `mise exec -- make check_proto`.
 - `pkg/codegen/schema/pulumi.json` is the metaschema. It must be valid JSON Schema and pass biome formatting.
-- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. Try to keep changelog entries to one sentence and focus on user-visible changes. Do not include implementation details. Do not end changelog entries with punctuation.
+- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. Try to keep changelog entries to one sentence and focus on user-visible changes. Do not include implementation details. Write them in the active imperative form ("Fix ...", "Add ...", not "Fixes ..." or "Added ..."). Do not end changelog entries with punctuation. Check style locally with `mise exec -- make lint_changelog_style`.
 - PRs are squash-merged — the PR description becomes the commit message.
 - Integration tests need the CLI and SDKs built first. `bin/` must be on `PATH`.
 - Copyright headers for new files should always be stamped with the current year.


### PR DESCRIPTION
The changelog style linter added in #24420 flags entries that aren't in the active imperative form, but AGENTS.md only mentioned the sentence-count and punctuation rules. Add the imperative rule and point to `make lint_changelog_style` so agents get it right the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)