### PR TITLE
Fix l1-expand-final for NodeJS

### DIFF
--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -656,6 +656,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			if i > 0 {
 				g.Fgen(w, ", ")
 			}
+			if expr.ExpandFinal && i == len(expr.Args)-1 {
+				g.Fgen(w, "...")
+			}
 			g.Fgenf(w, "%v", arg)
 		}
 		g.Fgen(w, ")")
@@ -664,6 +667,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		for i, arg := range expr.Args {
 			if i > 0 {
 				g.Fgen(w, ", ")
+			}
+			if expr.ExpandFinal && i == len(expr.Args)-1 {
+				g.Fgen(w, "...")
 			}
 			g.Fgenf(w, "%v", arg)
 		}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -98,7 +98,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
-	"l1-expand-final":                    "Node.js program generation does not support `...` argument expansion",
 	"l3-deferred-outputs":                "Cannot find name '_arg0_'.",
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 	"l2-resource-schema-secret":          "does not preserve schema-secret unknown outputs",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-expand-final
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/index.ts
@@ -1,0 +1,12 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const expandedMax = Math.max(...[
+    1,
+    2,
+    3,
+]);
+export const expandedMaxWithPrefix = Math.max(0, ...[
+    1,
+    2,
+    3,
+]);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "l1-expand-final",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-expand-final/tsconfig.json
@@ -1,0 +1,29 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l1-expand-final
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/index.ts
@@ -1,0 +1,12 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const expandedMax = Math.max(...[
+    1,
+    2,
+    3,
+]);
+export const expandedMaxWithPrefix = Math.max(0, ...[
+    1,
+    2,
+    3,
+]);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "l1-expand-final",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-expand-final/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-expand-final
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/index.ts
@@ -1,0 +1,12 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const expandedMax = Math.max(...[
+    1,
+    2,
+    3,
+]);
+export const expandedMaxWithPrefix = Math.max(0, ...[
+    1,
+    2,
+    3,
+]);

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "l1-expand-final",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-expand-final/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+	]
+}


### PR DESCRIPTION
Stacked on top of @julienp's fix for Python. This fixes node programgen to emit `...` so final arg expansion works.