### PR TITLE
redact secrets from logged config

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -1208,6 +1208,22 @@ func (rm *resmon) trackSettledResource(state *pkgresource.State, parent resource
 	rm.registrations.Track(urn, parent, custom, id != "")
 }
 
+func configLogValue(cfg map[config.Key]string, secretKeys []config.Key) resource.PropertyMap {
+	secret := make(map[config.Key]struct{}, len(secretKeys))
+	for _, k := range secretKeys {
+		secret[k] = struct{}{}
+	}
+	m := make(resource.PropertyMap, len(cfg))
+	for k, v := range cfg {
+		pv := resource.NewProperty(v)
+		if _, ok := secret[k]; ok {
+			pv = resource.MakeSecret(pv)
+		}
+		m[resource.PropertyKey(k.String())] = pv
+	}
+	return m
+}
+
 // Call dynamically executes a method in the provider associated with a component resource.
 func (rm *resmon) Call(ctx context.Context, req *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error) {
 	// Fetch the token and load up the resource provider if necessary.
@@ -1368,8 +1384,11 @@ func (rm *resmon) Call(ctx context.Context, req *pulumirpc.ResourceCallRequest) 
 	}
 
 	// Do the all and then return the arguments.
+	loggedInfo := info
+	loggedInfo.Config = nil
 	logging.V(5).Infof(
-		"ResourceMonitor.Call received: tok=%v #args=%v #info=%v #options=%v", tok, len(args), info, options,
+		"ResourceMonitor.Call received: tok=%v #args=%v #info=%v config=%v #options=%v",
+		tok, len(args), loggedInfo, configLogValue(info.Config, rm.constructInfo.ConfigSecretKeys), options,
 	)
 	ret, err := prov.Call(ctx, plugin.CallRequest{
 		Tok:     tok,

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -4224,3 +4224,23 @@ func TestDowngradeOutputValues(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigLogValue(t *testing.T) {
+	t.Parallel()
+
+	secretKey := config.MustMakeKey("proj", "dbPass")
+	plainKey := config.MustMakeKey("proj", "region")
+	cfg := map[config.Key]string{
+		secretKey: "hunter2",
+		plainKey:  "us-west-2",
+	}
+
+	m := configLogValue(cfg, []config.Key{secretKey})
+
+	require.True(t, m[resource.PropertyKey(secretKey.String())].IsSecret())
+	require.Equal(t, "us-west-2", m[resource.PropertyKey(plainKey.String())].StringValue())
+
+	redacted := m.RedactedLogValue().Any().(resource.PropertyMap)
+	require.Equal(t, "[secret]", redacted[resource.PropertyKey(secretKey.String())].StringValue())
+	require.Equal(t, "us-west-2", redacted[resource.PropertyKey(plainKey.String())].StringValue())
+}


### PR DESCRIPTION
In the engine we're currently logging the whole decrypted config at `V(5)`.  We're trying to not log any unredacted secrets by defaut with `--logtostderr`, only unmasking secret property values in `pulumi logs decrypt`, or in `pulumi logs share` when explicitly requested.

To be able to use the same mechanism, turn the config into a property map, that the logger already knows how to redact.  It's maybe slightly awkward to have to reformat this, but still feels like the simplest method.

Alternatively we could also simply redact values, but that loses the information and we can never get it back after the fact.
