### PR TITLE
avoid logging RPC object unless requested

### DIFF
--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -261,7 +261,7 @@ async function invokeAsync(
         }
 
         log.debug(
-            `Invoke RPC prepared: tok=${tok}` + excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``,
+            `Invoke RPC prepared: tok=${tok}` + (excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``),
         );
 
         // Fetch the monitor and make an RPC request.
@@ -469,7 +469,8 @@ function callAsync<T>(
                     throw err;
                 }
                 log.debug(
-                    `Call RPC prepared: tok=${tok}` + excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``,
+                    `Call RPC prepared: tok=${tok}` +
+                        (excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``),
                 );
 
                 const req = await createCallRequest(


### PR DESCRIPTION
In these log lines we're trying to only log the stringified RPC object when `excessiveDebugOutput` is set.  That variable is set to `false` by default, and needs to be turned on manually in code.  However, we're running afoul of operator precedence rules here.

Since the `+` binds stronger than `?`, we end up with a string on the left side of the expression, meaning we always print the object, but not the start of the log line, as we should have.  Fix that with some braces.
