### PR TITLE
[pcl] Handle integer constant properties when binding schemas

### DIFF
--- a/changelog/pending/20260827--pcl--integer-const-properties.yaml
+++ b/changelog/pending/20260827--pcl--integer-const-properties.yaml
@@ -1,0 +1,4 @@
+component: pcl
+kind: fix
+body: Fix a crash when binding a schema property with an integer constant value
+time: 2026-08-27T00:00:00+00:00

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -544,6 +544,8 @@ func (b *binder) schemaTypeToTypeOrConst(typ schema.Type, prop *schema.Property)
 		switch v := prop.ConstValue.(type) {
 		case bool:
 			value = cty.BoolVal(v)
+		case int32:
+			value = cty.NumberIntVal(int64(v))
 		case float64:
 			value = cty.NumberFloatVal(v)
 		case string:

--- a/pkg/testing/pulumi-test-language/providers/const_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/const_provider.go
@@ -59,6 +59,18 @@ func (p *ConstProvider) GetSchema(
 			Const:    "Constant",
 			TypeSpec: schema.TypeSpec{Type: "string"},
 		},
+		"flag": {
+			Const:    true,
+			TypeSpec: schema.TypeSpec{Type: "boolean"},
+		},
+		"count": {
+			Const:    3,
+			TypeSpec: schema.TypeSpec{Type: "integer"},
+		},
+		"ratio": {
+			Const:    1.5,
+			TypeSpec: schema.TypeSpec{Type: "number"},
+		},
 	}
 
 	pkg := schema.PackageSpec{
@@ -71,7 +83,7 @@ func (p *ConstProvider) GetSchema(
 					Properties: properties,
 				},
 				InputProperties: properties,
-				RequiredInputs:  []string{"kind"},
+				RequiredInputs:  []string{"count", "flag", "kind", "ratio"},
 			},
 		},
 	}
@@ -95,16 +107,27 @@ func (p *ConstProvider) Check(
 		}, nil
 	}
 
-	kind, ok := req.News["kind"]
-	if !ok {
-		return plugin.CheckResponse{
-			Failures: makeCheckFailure("kind", "missing value"),
-		}, nil
+	constants := []struct {
+		name resource.PropertyKey
+		want resource.PropertyValue
+	}{
+		{"kind", resource.NewProperty("Constant")},
+		{"flag", resource.NewProperty(true)},
+		{"count", resource.NewProperty(3.0)},
+		{"ratio", resource.NewProperty(1.5)},
 	}
-	if !kind.IsString() || kind.StringValue() != "Constant" {
-		return plugin.CheckResponse{
-			Failures: makeCheckFailure("kind", fmt.Sprintf("value is not the constant \"Constant\": %v", kind)),
-		}, nil
+	for _, c := range constants {
+		v, ok := req.News[c.name]
+		if !ok {
+			return plugin.CheckResponse{
+				Failures: makeCheckFailure(c.name, "missing value"),
+			}, nil
+		}
+		if !v.DeepEquals(c.want) {
+			return plugin.CheckResponse{
+				Failures: makeCheckFailure(c.name, fmt.Sprintf("value is not the constant %v: %v", c.want, v)),
+			}, nil
+		}
 	}
 
 	return plugin.CheckResponse{Properties: req.News}, nil

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_const.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_const.go
@@ -35,6 +35,9 @@ func init() {
 					RequireSingleResource(l, res.Snap.Resources, "constant:index:Resource")
 
 					AssertPropertyMapMember(l, stack.Outputs, "kind", resource.NewProperty("Constant"))
+					AssertPropertyMapMember(l, stack.Outputs, "flag", resource.NewProperty(true))
+					AssertPropertyMapMember(l, stack.Outputs, "count", resource.NewProperty(3.0))
+					AssertPropertyMapMember(l, stack.Outputs, "ratio", resource.NewProperty(1.5))
 				},
 			},
 		},

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-const/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-const/main.pp
@@ -1,8 +1,24 @@
 resource "first" "constant:index:Resource" {
     kind = "Constant"
+    flag = true
+    count = 3
+    ratio = 1.5
 }
 
-// `kind` has a constant value in the schema; reading it must bind without type errors.
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
 output "kind" {
     value = first.kind
+}
+
+output "flag" {
+    value = first.flag
+}
+
+output "count" {
+    value = first.count
+}
+
+output "ratio" {
+    value = first.ratio
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-const/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-const/main.go
@@ -8,12 +8,18 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		first, err := constant.NewResource(ctx, "first", &constant.ResourceArgs{
-			Kind: pulumi.String("Constant"),
+			Kind:  pulumi.String("Constant"),
+			Flag:  pulumi.Bool(true),
+			Count: pulumi.Int(3),
+			Ratio: pulumi.Float64(1.5),
 		})
 		if err != nil {
 			return err
 		}
 		ctx.Export("kind", first.Kind)
+		ctx.Export("flag", first.Flag)
+		ctx.Export("count", first.Count)
+		ctx.Export("ratio", first.Ratio)
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/constant-43.0.0/constant/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/constant-43.0.0/constant/resource.go
@@ -15,7 +15,10 @@ import (
 type Resource struct {
 	pulumi.CustomResourceState
 
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Count pulumi.IntPtrOutput     `pulumi:"count"`
+	Flag  pulumi.BoolPtrOutput    `pulumi:"flag"`
+	Kind  pulumi.StringPtrOutput  `pulumi:"kind"`
+	Ratio pulumi.Float64PtrOutput `pulumi:"ratio"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -25,10 +28,22 @@ func NewResource(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Count == nil {
+		return nil, errors.New("invalid value for required argument 'Count'")
+	}
+	if args.Flag == nil {
+		return nil, errors.New("invalid value for required argument 'Flag'")
+	}
 	if args.Kind == nil {
 		return nil, errors.New("invalid value for required argument 'Kind'")
 	}
+	if args.Ratio == nil {
+		return nil, errors.New("invalid value for required argument 'Ratio'")
+	}
+	args.Count = pulumi.Int(3)
+	args.Flag = pulumi.Bool(true)
 	args.Kind = pulumi.String("Constant")
+	args.Ratio = pulumi.Float64(1.5)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Resource
 	err := ctx.RegisterResource("constant:index:Resource", name, args, &resource, opts...)
@@ -62,12 +77,18 @@ func (ResourceState) ElementType() reflect.Type {
 }
 
 type resourceArgs struct {
-	Kind string `pulumi:"kind"`
+	Count int     `pulumi:"count"`
+	Flag  bool    `pulumi:"flag"`
+	Kind  string  `pulumi:"kind"`
+	Ratio float64 `pulumi:"ratio"`
 }
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Kind pulumi.StringInput
+	Count pulumi.IntInput
+	Flag  pulumi.BoolInput
+	Kind  pulumi.StringInput
+	Ratio pulumi.Float64Input
 }
 
 func (ResourceArgs) ElementType() reflect.Type {
@@ -157,8 +178,20 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Count() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.IntPtrOutput { return v.Count }).(pulumi.IntPtrOutput)
+}
+
+func (o ResourceOutput) Flag() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.BoolPtrOutput { return v.Flag }).(pulumi.BoolPtrOutput)
+}
+
 func (o ResourceOutput) Kind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Kind }).(pulumi.StringPtrOutput)
+}
+
+func (o ResourceOutput) Ratio() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.Float64PtrOutput { return v.Ratio }).(pulumi.Float64PtrOutput)
 }
 
 type ResourceArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-const/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-const/main.go
@@ -8,12 +8,18 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		first, err := constant.NewResource(ctx, "first", &constant.ResourceArgs{
-			Kind: pulumi.String("Constant"),
+			Kind:  pulumi.String("Constant"),
+			Flag:  pulumi.Bool(true),
+			Count: pulumi.Int(3),
+			Ratio: pulumi.Float64(1.5),
 		})
 		if err != nil {
 			return err
 		}
 		ctx.Export("kind", first.Kind)
+		ctx.Export("flag", first.Flag)
+		ctx.Export("count", first.Count)
+		ctx.Export("ratio", first.Ratio)
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-const/sdks/constant-43.0.0/constant/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-const/sdks/constant-43.0.0/constant/resource.go
@@ -15,7 +15,10 @@ import (
 type Resource struct {
 	pulumi.CustomResourceState
 
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Count pulumi.IntPtrOutput     `pulumi:"count"`
+	Flag  pulumi.BoolPtrOutput    `pulumi:"flag"`
+	Kind  pulumi.StringPtrOutput  `pulumi:"kind"`
+	Ratio pulumi.Float64PtrOutput `pulumi:"ratio"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -25,10 +28,22 @@ func NewResource(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Count == nil {
+		return nil, errors.New("invalid value for required argument 'Count'")
+	}
+	if args.Flag == nil {
+		return nil, errors.New("invalid value for required argument 'Flag'")
+	}
 	if args.Kind == nil {
 		return nil, errors.New("invalid value for required argument 'Kind'")
 	}
+	if args.Ratio == nil {
+		return nil, errors.New("invalid value for required argument 'Ratio'")
+	}
+	args.Count = pulumi.Int(3)
+	args.Flag = pulumi.Bool(true)
 	args.Kind = pulumi.String("Constant")
+	args.Ratio = pulumi.Float64(1.5)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Resource
 	err := ctx.RegisterResource("constant:index:Resource", name, args, &resource, opts...)
@@ -62,12 +77,18 @@ func (ResourceState) ElementType() reflect.Type {
 }
 
 type resourceArgs struct {
-	Kind string `pulumi:"kind"`
+	Count int     `pulumi:"count"`
+	Flag  bool    `pulumi:"flag"`
+	Kind  string  `pulumi:"kind"`
+	Ratio float64 `pulumi:"ratio"`
 }
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Kind pulumi.StringInput
+	Count pulumi.IntInput
+	Flag  pulumi.BoolInput
+	Kind  pulumi.StringInput
+	Ratio pulumi.Float64Input
 }
 
 func (ResourceArgs) ElementType() reflect.Type {
@@ -107,8 +128,20 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Count() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.IntPtrOutput { return v.Count }).(pulumi.IntPtrOutput)
+}
+
+func (o ResourceOutput) Flag() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.BoolPtrOutput { return v.Flag }).(pulumi.BoolPtrOutput)
+}
+
 func (o ResourceOutput) Kind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Kind }).(pulumi.StringPtrOutput)
+}
+
+func (o ResourceOutput) Ratio() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.Float64PtrOutput { return v.Ratio }).(pulumi.Float64PtrOutput)
 }
 
 func init() {

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-const/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-const/main.go
@@ -8,12 +8,18 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		first, err := constant.NewResource(ctx, "first", &constant.ResourceArgs{
-			Kind: pulumi.String("Constant"),
+			Kind:  pulumi.String("Constant"),
+			Flag:  pulumi.Bool(true),
+			Count: pulumi.Int(3),
+			Ratio: pulumi.Float64(1.5),
 		})
 		if err != nil {
 			return err
 		}
 		ctx.Export("kind", first.Kind)
+		ctx.Export("flag", first.Flag)
+		ctx.Export("count", first.Count)
+		ctx.Export("ratio", first.Ratio)
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/constant-43.0.0/constant/resource.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/constant-43.0.0/constant/resource.go
@@ -15,7 +15,10 @@ import (
 type Resource struct {
 	pulumi.CustomResourceState
 
-	Kind pulumi.StringPtrOutput `pulumi:"kind"`
+	Count pulumi.IntPtrOutput     `pulumi:"count"`
+	Flag  pulumi.BoolPtrOutput    `pulumi:"flag"`
+	Kind  pulumi.StringPtrOutput  `pulumi:"kind"`
+	Ratio pulumi.Float64PtrOutput `pulumi:"ratio"`
 }
 
 // NewResource registers a new resource with the given unique name, arguments, and options.
@@ -25,10 +28,22 @@ func NewResource(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Count == nil {
+		return nil, errors.New("invalid value for required argument 'Count'")
+	}
+	if args.Flag == nil {
+		return nil, errors.New("invalid value for required argument 'Flag'")
+	}
 	if args.Kind == nil {
 		return nil, errors.New("invalid value for required argument 'Kind'")
 	}
+	if args.Ratio == nil {
+		return nil, errors.New("invalid value for required argument 'Ratio'")
+	}
+	args.Count = pulumi.Int(3)
+	args.Flag = pulumi.Bool(true)
 	args.Kind = pulumi.String("Constant")
+	args.Ratio = pulumi.Float64(1.5)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Resource
 	err := ctx.RegisterResource("constant:index:Resource", name, args, &resource, opts...)
@@ -62,12 +77,18 @@ func (ResourceState) ElementType() reflect.Type {
 }
 
 type resourceArgs struct {
-	Kind string `pulumi:"kind"`
+	Count int     `pulumi:"count"`
+	Flag  bool    `pulumi:"flag"`
+	Kind  string  `pulumi:"kind"`
+	Ratio float64 `pulumi:"ratio"`
 }
 
 // The set of arguments for constructing a Resource resource.
 type ResourceArgs struct {
-	Kind pulumi.StringInput
+	Count pulumi.IntInput
+	Flag  pulumi.BoolInput
+	Kind  pulumi.StringInput
+	Ratio pulumi.Float64Input
 }
 
 func (ResourceArgs) ElementType() reflect.Type {
@@ -107,8 +128,20 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+func (o ResourceOutput) Count() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.IntPtrOutput { return v.Count }).(pulumi.IntPtrOutput)
+}
+
+func (o ResourceOutput) Flag() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.BoolPtrOutput { return v.Flag }).(pulumi.BoolPtrOutput)
+}
+
 func (o ResourceOutput) Kind() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Resource) pulumi.StringPtrOutput { return v.Kind }).(pulumi.StringPtrOutput)
+}
+
+func (o ResourceOutput) Ratio() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Resource) pulumi.Float64PtrOutput { return v.Ratio }).(pulumi.Float64PtrOutput)
 }
 
 func init() {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-const/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-const/index.ts
@@ -1,5 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as constant from "@pulumi/constant";
 
-const first = new constant.Resource("first", {kind: "Constant"});
+const first = new constant.Resource("first", {
+    kind: "Constant",
+    flag: true,
+    count: 3,
+    ratio: 1.5,
+});
 export const kind = first.kind;
+export const flag = first.flag;
+export const count = first.count;
+export const ratio = first.ratio;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/constant-43.0.0/resource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/constant-43.0.0/resource.ts
@@ -31,7 +31,10 @@ export class Resource extends pulumi.CustomResource {
         return obj['__pulumiType'] === Resource.__pulumiType;
     }
 
+    declare public readonly count: pulumi.Output<number | undefined>;
+    declare public readonly flag: pulumi.Output<boolean | undefined>;
     declare public readonly kind: pulumi.Output<"Constant" | undefined>;
+    declare public readonly ratio: pulumi.Output<number | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -44,12 +47,27 @@ export class Resource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if (args?.count === undefined && !opts.urn) {
+                throw new Error("Missing required property 'count'");
+            }
+            if (args?.flag === undefined && !opts.urn) {
+                throw new Error("Missing required property 'flag'");
+            }
             if (args?.kind === undefined && !opts.urn) {
                 throw new Error("Missing required property 'kind'");
             }
+            if (args?.ratio === undefined && !opts.urn) {
+                throw new Error("Missing required property 'ratio'");
+            }
+            resourceInputs["count"] = 3;
+            resourceInputs["flag"] = true;
             resourceInputs["kind"] = "Constant";
+            resourceInputs["ratio"] = 1.5;
         } else {
+            resourceInputs["count"] = undefined /*out*/;
+            resourceInputs["flag"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
+            resourceInputs["ratio"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
@@ -60,5 +78,8 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
+    count: pulumi.Input<number>;
+    flag: pulumi.Input<boolean>;
     kind: pulumi.Input<"Constant">;
+    ratio: pulumi.Input<number>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-const/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-const/index.ts
@@ -1,5 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as constant from "@pulumi/constant";
 
-const first = new constant.Resource("first", {kind: "Constant"});
+const first = new constant.Resource("first", {
+    kind: "Constant",
+    flag: true,
+    count: 3,
+    ratio: 1.5,
+});
 export const kind = first.kind;
+export const flag = first.flag;
+export const count = first.count;
+export const ratio = first.ratio;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/constant-43.0.0/resource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/constant-43.0.0/resource.ts
@@ -31,7 +31,10 @@ export class Resource extends pulumi.CustomResource {
         return obj['__pulumiType'] === Resource.__pulumiType;
     }
 
+    declare public readonly count: pulumi.Output<number | undefined>;
+    declare public readonly flag: pulumi.Output<boolean | undefined>;
     declare public readonly kind: pulumi.Output<"Constant" | undefined>;
+    declare public readonly ratio: pulumi.Output<number | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -44,12 +47,27 @@ export class Resource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if (args?.count === undefined && !opts.urn) {
+                throw new Error("Missing required property 'count'");
+            }
+            if (args?.flag === undefined && !opts.urn) {
+                throw new Error("Missing required property 'flag'");
+            }
             if (args?.kind === undefined && !opts.urn) {
                 throw new Error("Missing required property 'kind'");
             }
+            if (args?.ratio === undefined && !opts.urn) {
+                throw new Error("Missing required property 'ratio'");
+            }
+            resourceInputs["count"] = 3;
+            resourceInputs["flag"] = true;
             resourceInputs["kind"] = "Constant";
+            resourceInputs["ratio"] = 1.5;
         } else {
+            resourceInputs["count"] = undefined /*out*/;
+            resourceInputs["flag"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
+            resourceInputs["ratio"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
@@ -60,5 +78,8 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
+    count: pulumi.Input<number>;
+    flag: pulumi.Input<boolean>;
     kind: pulumi.Input<"Constant">;
+    ratio: pulumi.Input<number>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-const/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-const/index.ts
@@ -1,5 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as constant from "@pulumi/constant";
 
-const first = new constant.Resource("first", {kind: "Constant"});
+const first = new constant.Resource("first", {
+    kind: "Constant",
+    flag: true,
+    count: 3,
+    ratio: 1.5,
+});
 export const kind = first.kind;
+export const flag = first.flag;
+export const count = first.count;
+export const ratio = first.ratio;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/constant-43.0.0/resource.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/constant-43.0.0/resource.ts
@@ -31,7 +31,10 @@ export class Resource extends pulumi.CustomResource {
         return obj['__pulumiType'] === Resource.__pulumiType;
     }
 
+    declare public readonly count: pulumi.Output<number | undefined>;
+    declare public readonly flag: pulumi.Output<boolean | undefined>;
     declare public readonly kind: pulumi.Output<"Constant" | undefined>;
+    declare public readonly ratio: pulumi.Output<number | undefined>;
 
     /**
      * Create a Resource resource with the given unique name, arguments, and options.
@@ -44,12 +47,27 @@ export class Resource extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if (args?.count === undefined && !opts.urn) {
+                throw new Error("Missing required property 'count'");
+            }
+            if (args?.flag === undefined && !opts.urn) {
+                throw new Error("Missing required property 'flag'");
+            }
             if (args?.kind === undefined && !opts.urn) {
                 throw new Error("Missing required property 'kind'");
             }
+            if (args?.ratio === undefined && !opts.urn) {
+                throw new Error("Missing required property 'ratio'");
+            }
+            resourceInputs["count"] = 3;
+            resourceInputs["flag"] = true;
             resourceInputs["kind"] = "Constant";
+            resourceInputs["ratio"] = 1.5;
         } else {
+            resourceInputs["count"] = undefined /*out*/;
+            resourceInputs["flag"] = undefined /*out*/;
             resourceInputs["kind"] = undefined /*out*/;
+            resourceInputs["ratio"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Resource.__pulumiType, name, resourceInputs, opts);
@@ -60,5 +78,8 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
+    count: pulumi.Input<number>;
+    flag: pulumi.Input<boolean>;
     kind: pulumi.Input<"Constant">;
+    ratio: pulumi.Input<number>;
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-const/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-const/main.pp
@@ -1,8 +1,24 @@
 resource "first" "constant:index:Resource" {
     kind = "Constant"
+    flag = true
+    count = 3
+    ratio = 1.5
 }
 
-// `kind` has a constant value in the schema; reading it must bind without type errors.
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
 output "kind" {
     value = first.kind
+}
+
+output "flag" {
+    value = first.flag
+}
+
+output "count" {
+    value = first.count
+}
+
+output "ratio" {
+    value = first.ratio
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-const/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-const/main.pp
@@ -1,8 +1,24 @@
 resource "first" "constant:index:Resource" {
     kind = "Constant"
+    flag = true
+    count = 3
+    ratio = 1.5
 }
 
-// `kind` has a constant value in the schema; reading it must bind without type errors.
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
 output "kind" {
     value = first.kind
+}
+
+output "flag" {
+    value = first.flag
+}
+
+output "count" {
+    value = first.count
+}
+
+output "ratio" {
+    value = first.ratio
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-const/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-const/main.pp
@@ -1,8 +1,24 @@
 resource "first" "constant:index:Resource" {
     kind = "Constant"
+    flag = true
+    count = 3
+    ratio = 1.5
 }
 
-// `kind` has a constant value in the schema; reading it must bind without type errors.
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
 output "kind" {
     value = first.kind
+}
+
+output "flag" {
+    value = first.flag
+}
+
+output "count" {
+    value = first.count
+}
+
+output "ratio" {
+    value = first.ratio
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-resource-const/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-resource-const/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
 import pulumi_constant as constant
 
-first = constant.Resource("first", kind="Constant")
+first = constant.Resource("first",
+    kind="Constant",
+    flag=True,
+    count=3,
+    ratio=1.5)
 pulumi.export("kind", first.kind)
+pulumi.export("flag", first.flag)
+pulumi.export("count", first.count)
+pulumi.export("ratio", first.ratio)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/constant-43.0.0/pulumi_constant/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/constant-43.0.0/pulumi_constant/resource.py
@@ -14,11 +14,35 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 kind: pulumi.Input[Literal['Constant']]):
+                 count: pulumi.Input[Literal[3]],
+                 flag: pulumi.Input[Literal[True]],
+                 kind: pulumi.Input[Literal['Constant']],
+                 ratio: pulumi.Input[_builtins.float]):
         """
         The set of arguments for constructing a Resource resource.
         """
+        pulumi.set(__self__, "count", 3)
+        pulumi.set(__self__, "flag", True)
         pulumi.set(__self__, "kind", 'Constant')
+        pulumi.set(__self__, "ratio", 1.5)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Input[Literal[3]]:
+        return pulumi.get(self, "count")
+
+    @count.setter
+    def count(self, value: pulumi.Input[Literal[3]]):
+        pulumi.set(self, "count", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Input[Literal[True]]:
+        return pulumi.get(self, "flag")
+
+    @flag.setter
+    def flag(self, value: pulumi.Input[Literal[True]]):
+        pulumi.set(self, "flag", value)
 
     @_builtins.property
     @pulumi.getter
@@ -29,6 +53,15 @@ class ResourceArgs:
     def kind(self, value: pulumi.Input[Literal['Constant']]):
         pulumi.set(self, "kind", value)
 
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Input[_builtins.float]:
+        return pulumi.get(self, "ratio")
+
+    @ratio.setter
+    def ratio(self, value: pulumi.Input[_builtins.float]):
+        pulumi.set(self, "ratio", value)
+
 
 @pulumi.type_token("constant:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -36,7 +69,10 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -68,7 +104,10 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -78,9 +117,18 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
+            if count is None and not opts.urn:
+                raise TypeError("Missing required property 'count'")
+            __props__.__dict__["count"] = 3
+            if flag is None and not opts.urn:
+                raise TypeError("Missing required property 'flag'")
+            __props__.__dict__["flag"] = True
             if kind is None and not opts.urn:
                 raise TypeError("Missing required property 'kind'")
             __props__.__dict__["kind"] = 'Constant'
+            if ratio is None and not opts.urn:
+                raise TypeError("Missing required property 'ratio'")
+            __props__.__dict__["ratio"] = 1.5
         super(Resource, __self__).__init__(
             'constant:index:Resource',
             resource_name,
@@ -103,11 +151,29 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
+        __props__.__dict__["count"] = None
+        __props__.__dict__["flag"] = None
         __props__.__dict__["kind"] = None
+        __props__.__dict__["ratio"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Output[Optional[Literal[3]]]:
+        return pulumi.get(self, "count")
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Output[Optional[Literal[True]]]:
+        return pulumi.get(self, "flag")
 
     @_builtins.property
     @pulumi.getter
     def kind(self) -> pulumi.Output[Optional[Literal['Constant']]]:
         return pulumi.get(self, "kind")
+
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Output[Optional[_builtins.float]]:
+        return pulumi.get(self, "ratio")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-resource-const/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-resource-const/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
 import pulumi_constant as constant
 
-first = constant.Resource("first", kind="Constant")
+first = constant.Resource("first",
+    kind="Constant",
+    flag=True,
+    count=3,
+    ratio=1.5)
 pulumi.export("kind", first.kind)
+pulumi.export("flag", first.flag)
+pulumi.export("count", first.count)
+pulumi.export("ratio", first.ratio)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/constant-43.0.0/pulumi_constant/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/constant-43.0.0/pulumi_constant/resource.py
@@ -14,11 +14,35 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 kind: pulumi.Input[Literal['Constant']]):
+                 count: pulumi.Input[Literal[3]],
+                 flag: pulumi.Input[Literal[True]],
+                 kind: pulumi.Input[Literal['Constant']],
+                 ratio: pulumi.Input[_builtins.float]):
         """
         The set of arguments for constructing a Resource resource.
         """
+        pulumi.set(__self__, "count", 3)
+        pulumi.set(__self__, "flag", True)
         pulumi.set(__self__, "kind", 'Constant')
+        pulumi.set(__self__, "ratio", 1.5)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Input[Literal[3]]:
+        return pulumi.get(self, "count")
+
+    @count.setter
+    def count(self, value: pulumi.Input[Literal[3]]):
+        pulumi.set(self, "count", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Input[Literal[True]]:
+        return pulumi.get(self, "flag")
+
+    @flag.setter
+    def flag(self, value: pulumi.Input[Literal[True]]):
+        pulumi.set(self, "flag", value)
 
     @_builtins.property
     @pulumi.getter
@@ -29,6 +53,15 @@ class ResourceArgs:
     def kind(self, value: pulumi.Input[Literal['Constant']]):
         pulumi.set(self, "kind", value)
 
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Input[_builtins.float]:
+        return pulumi.get(self, "ratio")
+
+    @ratio.setter
+    def ratio(self, value: pulumi.Input[_builtins.float]):
+        pulumi.set(self, "ratio", value)
+
 
 @pulumi.type_token("constant:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -36,7 +69,10 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -68,7 +104,10 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -78,9 +117,18 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
+            if count is None and not opts.urn:
+                raise TypeError("Missing required property 'count'")
+            __props__.__dict__["count"] = 3
+            if flag is None and not opts.urn:
+                raise TypeError("Missing required property 'flag'")
+            __props__.__dict__["flag"] = True
             if kind is None and not opts.urn:
                 raise TypeError("Missing required property 'kind'")
             __props__.__dict__["kind"] = 'Constant'
+            if ratio is None and not opts.urn:
+                raise TypeError("Missing required property 'ratio'")
+            __props__.__dict__["ratio"] = 1.5
         super(Resource, __self__).__init__(
             'constant:index:Resource',
             resource_name,
@@ -103,11 +151,29 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
+        __props__.__dict__["count"] = None
+        __props__.__dict__["flag"] = None
         __props__.__dict__["kind"] = None
+        __props__.__dict__["ratio"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Output[Optional[Literal[3]]]:
+        return pulumi.get(self, "count")
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Output[Optional[Literal[True]]]:
+        return pulumi.get(self, "flag")
 
     @_builtins.property
     @pulumi.getter
     def kind(self) -> pulumi.Output[Optional[Literal['Constant']]]:
         return pulumi.get(self, "kind")
+
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Output[Optional[_builtins.float]]:
+        return pulumi.get(self, "ratio")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-resource-const/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-resource-const/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
 import pulumi_constant as constant
 
-first = constant.Resource("first", kind="Constant")
+first = constant.Resource("first",
+    kind="Constant",
+    flag=True,
+    count=3,
+    ratio=1.5)
 pulumi.export("kind", first.kind)
+pulumi.export("flag", first.flag)
+pulumi.export("count", first.count)
+pulumi.export("ratio", first.ratio)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/constant-43.0.0/pulumi_constant/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/constant-43.0.0/pulumi_constant/resource.py
@@ -19,11 +19,35 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 kind: pulumi.Input[Literal['Constant']]):
+                 count: pulumi.Input[Literal[3]],
+                 flag: pulumi.Input[Literal[True]],
+                 kind: pulumi.Input[Literal['Constant']],
+                 ratio: pulumi.Input[_builtins.float]):
         """
         The set of arguments for constructing a Resource resource.
         """
+        pulumi.set(__self__, "count", 3)
+        pulumi.set(__self__, "flag", True)
         pulumi.set(__self__, "kind", 'Constant')
+        pulumi.set(__self__, "ratio", 1.5)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Input[Literal[3]]:
+        return pulumi.get(self, "count")
+
+    @count.setter
+    def count(self, value: pulumi.Input[Literal[3]]):
+        pulumi.set(self, "count", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Input[Literal[True]]:
+        return pulumi.get(self, "flag")
+
+    @flag.setter
+    def flag(self, value: pulumi.Input[Literal[True]]):
+        pulumi.set(self, "flag", value)
 
     @_builtins.property
     @pulumi.getter
@@ -34,6 +58,15 @@ class ResourceArgs:
     def kind(self, value: pulumi.Input[Literal['Constant']]):
         pulumi.set(self, "kind", value)
 
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Input[_builtins.float]:
+        return pulumi.get(self, "ratio")
+
+    @ratio.setter
+    def ratio(self, value: pulumi.Input[_builtins.float]):
+        pulumi.set(self, "ratio", value)
+
 
 @pulumi.type_token("constant:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -41,7 +74,10 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -73,7 +109,10 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -83,9 +122,18 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
+            if count is None and not opts.urn:
+                raise TypeError("Missing required property 'count'")
+            __props__.__dict__["count"] = 3
+            if flag is None and not opts.urn:
+                raise TypeError("Missing required property 'flag'")
+            __props__.__dict__["flag"] = True
             if kind is None and not opts.urn:
                 raise TypeError("Missing required property 'kind'")
             __props__.__dict__["kind"] = 'Constant'
+            if ratio is None and not opts.urn:
+                raise TypeError("Missing required property 'ratio'")
+            __props__.__dict__["ratio"] = 1.5
         super(Resource, __self__).__init__(
             'constant:index:Resource',
             resource_name,
@@ -108,11 +156,29 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
+        __props__.__dict__["count"] = None
+        __props__.__dict__["flag"] = None
         __props__.__dict__["kind"] = None
+        __props__.__dict__["ratio"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Output[Optional[Literal[3]]]:
+        return pulumi.get(self, "count")
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Output[Optional[Literal[True]]]:
+        return pulumi.get(self, "flag")
 
     @_builtins.property
     @pulumi.getter
     def kind(self) -> pulumi.Output[Optional[Literal['Constant']]]:
         return pulumi.get(self, "kind")
+
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Output[Optional[_builtins.float]]:
+        return pulumi.get(self, "ratio")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-resource-const/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-resource-const/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
 import pulumi_constant as constant
 
-first = constant.Resource("first", kind="Constant")
+first = constant.Resource("first",
+    kind="Constant",
+    flag=True,
+    count=3,
+    ratio=1.5)
 pulumi.export("kind", first.kind)
+pulumi.export("flag", first.flag)
+pulumi.export("count", first.count)
+pulumi.export("ratio", first.ratio)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/constant-43.0.0/pulumi_constant/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/constant-43.0.0/pulumi_constant/resource.py
@@ -19,11 +19,35 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 kind: pulumi.Input[Literal['Constant']]):
+                 count: pulumi.Input[Literal[3]],
+                 flag: pulumi.Input[Literal[True]],
+                 kind: pulumi.Input[Literal['Constant']],
+                 ratio: pulumi.Input[_builtins.float]):
         """
         The set of arguments for constructing a Resource resource.
         """
+        pulumi.set(__self__, "count", 3)
+        pulumi.set(__self__, "flag", True)
         pulumi.set(__self__, "kind", 'Constant')
+        pulumi.set(__self__, "ratio", 1.5)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Input[Literal[3]]:
+        return pulumi.get(self, "count")
+
+    @count.setter
+    def count(self, value: pulumi.Input[Literal[3]]):
+        pulumi.set(self, "count", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Input[Literal[True]]:
+        return pulumi.get(self, "flag")
+
+    @flag.setter
+    def flag(self, value: pulumi.Input[Literal[True]]):
+        pulumi.set(self, "flag", value)
 
     @_builtins.property
     @pulumi.getter
@@ -34,6 +58,15 @@ class ResourceArgs:
     def kind(self, value: pulumi.Input[Literal['Constant']]):
         pulumi.set(self, "kind", value)
 
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Input[_builtins.float]:
+        return pulumi.get(self, "ratio")
+
+    @ratio.setter
+    def ratio(self, value: pulumi.Input[_builtins.float]):
+        pulumi.set(self, "ratio", value)
+
 
 @pulumi.type_token("constant:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -41,7 +74,10 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -73,7 +109,10 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -83,9 +122,18 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
+            if count is None and not opts.urn:
+                raise TypeError("Missing required property 'count'")
+            __props__.__dict__["count"] = 3
+            if flag is None and not opts.urn:
+                raise TypeError("Missing required property 'flag'")
+            __props__.__dict__["flag"] = True
             if kind is None and not opts.urn:
                 raise TypeError("Missing required property 'kind'")
             __props__.__dict__["kind"] = 'Constant'
+            if ratio is None and not opts.urn:
+                raise TypeError("Missing required property 'ratio'")
+            __props__.__dict__["ratio"] = 1.5
         super(Resource, __self__).__init__(
             'constant:index:Resource',
             resource_name,
@@ -108,11 +156,29 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
+        __props__.__dict__["count"] = None
+        __props__.__dict__["flag"] = None
         __props__.__dict__["kind"] = None
+        __props__.__dict__["ratio"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Output[Optional[Literal[3]]]:
+        return pulumi.get(self, "count")
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Output[Optional[Literal[True]]]:
+        return pulumi.get(self, "flag")
 
     @_builtins.property
     @pulumi.getter
     def kind(self) -> pulumi.Output[Optional[Literal['Constant']]]:
         return pulumi.get(self, "kind")
+
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Output[Optional[_builtins.float]]:
+        return pulumi.get(self, "ratio")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-resource-const/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-resource-const/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
 import pulumi_constant as constant
 
-first = constant.Resource("first", kind="Constant")
+first = constant.Resource("first",
+    kind="Constant",
+    flag=True,
+    count=3,
+    ratio=1.5)
 pulumi.export("kind", first.kind)
+pulumi.export("flag", first.flag)
+pulumi.export("count", first.count)
+pulumi.export("ratio", first.ratio)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/constant-43.0.0/pulumi_constant/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/constant-43.0.0/pulumi_constant/resource.py
@@ -19,11 +19,35 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 kind: pulumi.Input[Literal['Constant']]):
+                 count: pulumi.Input[Literal[3]],
+                 flag: pulumi.Input[Literal[True]],
+                 kind: pulumi.Input[Literal['Constant']],
+                 ratio: pulumi.Input[_builtins.float]):
         """
         The set of arguments for constructing a Resource resource.
         """
+        pulumi.set(__self__, "count", 3)
+        pulumi.set(__self__, "flag", True)
         pulumi.set(__self__, "kind", 'Constant')
+        pulumi.set(__self__, "ratio", 1.5)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Input[Literal[3]]:
+        return pulumi.get(self, "count")
+
+    @count.setter
+    def count(self, value: pulumi.Input[Literal[3]]):
+        pulumi.set(self, "count", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Input[Literal[True]]:
+        return pulumi.get(self, "flag")
+
+    @flag.setter
+    def flag(self, value: pulumi.Input[Literal[True]]):
+        pulumi.set(self, "flag", value)
 
     @_builtins.property
     @pulumi.getter
@@ -34,6 +58,15 @@ class ResourceArgs:
     def kind(self, value: pulumi.Input[Literal['Constant']]):
         pulumi.set(self, "kind", value)
 
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Input[_builtins.float]:
+        return pulumi.get(self, "ratio")
+
+    @ratio.setter
+    def ratio(self, value: pulumi.Input[_builtins.float]):
+        pulumi.set(self, "ratio", value)
+
 
 @pulumi.type_token("constant:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -41,7 +74,10 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -73,7 +109,10 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -83,9 +122,18 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
+            if count is None and not opts.urn:
+                raise TypeError("Missing required property 'count'")
+            __props__.__dict__["count"] = 3
+            if flag is None and not opts.urn:
+                raise TypeError("Missing required property 'flag'")
+            __props__.__dict__["flag"] = True
             if kind is None and not opts.urn:
                 raise TypeError("Missing required property 'kind'")
             __props__.__dict__["kind"] = 'Constant'
+            if ratio is None and not opts.urn:
+                raise TypeError("Missing required property 'ratio'")
+            __props__.__dict__["ratio"] = 1.5
         super(Resource, __self__).__init__(
             'constant:index:Resource',
             resource_name,
@@ -108,11 +156,29 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
+        __props__.__dict__["count"] = None
+        __props__.__dict__["flag"] = None
         __props__.__dict__["kind"] = None
+        __props__.__dict__["ratio"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Output[Optional[Literal[3]]]:
+        return pulumi.get(self, "count")
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Output[Optional[Literal[True]]]:
+        return pulumi.get(self, "flag")
 
     @_builtins.property
     @pulumi.getter
     def kind(self) -> pulumi.Output[Optional[Literal['Constant']]]:
         return pulumi.get(self, "kind")
+
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Output[Optional[_builtins.float]]:
+        return pulumi.get(self, "ratio")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-resource-const/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-resource-const/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
 import pulumi_constant as constant
 
-first = constant.Resource("first", kind="Constant")
+first = constant.Resource("first",
+    kind="Constant",
+    flag=True,
+    count=3,
+    ratio=1.5)
 pulumi.export("kind", first.kind)
+pulumi.export("flag", first.flag)
+pulumi.export("count", first.count)
+pulumi.export("ratio", first.ratio)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/constant-43.0.0/pulumi_constant/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/constant-43.0.0/pulumi_constant/resource.py
@@ -19,11 +19,35 @@ __all__ = ['ResourceArgs', 'Resource']
 @pulumi.input_type
 class ResourceArgs:
     def __init__(__self__, *,
-                 kind: pulumi.Input[Literal['Constant']]):
+                 count: pulumi.Input[Literal[3]],
+                 flag: pulumi.Input[Literal[True]],
+                 kind: pulumi.Input[Literal['Constant']],
+                 ratio: pulumi.Input[_builtins.float]):
         """
         The set of arguments for constructing a Resource resource.
         """
+        pulumi.set(__self__, "count", 3)
+        pulumi.set(__self__, "flag", True)
         pulumi.set(__self__, "kind", 'Constant')
+        pulumi.set(__self__, "ratio", 1.5)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Input[Literal[3]]:
+        return pulumi.get(self, "count")
+
+    @count.setter
+    def count(self, value: pulumi.Input[Literal[3]]):
+        pulumi.set(self, "count", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Input[Literal[True]]:
+        return pulumi.get(self, "flag")
+
+    @flag.setter
+    def flag(self, value: pulumi.Input[Literal[True]]):
+        pulumi.set(self, "flag", value)
 
     @_builtins.property
     @pulumi.getter
@@ -34,6 +58,15 @@ class ResourceArgs:
     def kind(self, value: pulumi.Input[Literal['Constant']]):
         pulumi.set(self, "kind", value)
 
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Input[_builtins.float]:
+        return pulumi.get(self, "ratio")
+
+    @ratio.setter
+    def ratio(self, value: pulumi.Input[_builtins.float]):
+        pulumi.set(self, "ratio", value)
+
 
 @pulumi.type_token("constant:index:Resource")
 class Resource(pulumi.CustomResource):
@@ -41,7 +74,10 @@ class Resource(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
@@ -73,7 +109,10 @@ class Resource(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 count: pulumi.Input[Optional[Literal[3]]] = None,
+                 flag: pulumi.Input[Optional[Literal[True]]] = None,
                  kind: pulumi.Input[Optional[Literal['Constant']]] = None,
+                 ratio: pulumi.Input[Optional[_builtins.float]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -83,9 +122,18 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
+            if count is None and not opts.urn:
+                raise TypeError("Missing required property 'count'")
+            __props__.__dict__["count"] = 3
+            if flag is None and not opts.urn:
+                raise TypeError("Missing required property 'flag'")
+            __props__.__dict__["flag"] = True
             if kind is None and not opts.urn:
                 raise TypeError("Missing required property 'kind'")
             __props__.__dict__["kind"] = 'Constant'
+            if ratio is None and not opts.urn:
+                raise TypeError("Missing required property 'ratio'")
+            __props__.__dict__["ratio"] = 1.5
         super(Resource, __self__).__init__(
             'constant:index:Resource',
             resource_name,
@@ -108,11 +156,29 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
+        __props__.__dict__["count"] = None
+        __props__.__dict__["flag"] = None
         __props__.__dict__["kind"] = None
+        __props__.__dict__["ratio"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
+
+    @_builtins.property
+    @pulumi.getter
+    def count(self) -> pulumi.Output[Optional[Literal[3]]]:
+        return pulumi.get(self, "count")
+
+    @_builtins.property
+    @pulumi.getter
+    def flag(self) -> pulumi.Output[Optional[Literal[True]]]:
+        return pulumi.get(self, "flag")
 
     @_builtins.property
     @pulumi.getter
     def kind(self) -> pulumi.Output[Optional[Literal['Constant']]]:
         return pulumi.get(self, "kind")
+
+    @_builtins.property
+    @pulumi.getter
+    def ratio(self) -> pulumi.Output[Optional[_builtins.float]]:
+        return pulumi.get(self, "ratio")
 


### PR DESCRIPTION
The schema binder stores an integer property's constant value as an int32, but the PCL binder's constant handling only accepted bool, float64, and string, so binding any schema that declares an integer constant crashed with "unexpected constant type int32". Found by the importer round-trip test once the rapidschema generator learned to emit constant properties.

The l2-resource-const conformance test now covers a constant of every kind — string, boolean, integer, and number — and binding its program crashes without this fix.