### PR TITLE
Add IsWireDiscriminatableUnionType

### DIFF
--- a/pkg/codegen/testing/utils/rapidresource/rapidresource.go
+++ b/pkg/codegen/testing/utils/rapidresource/rapidresource.go
@@ -56,6 +56,13 @@ func ResourceState(r *schema.Resource) *rapid.Generator[*property.Map] {
 	return rapid.Map(inner, func(m property.Map) *property.Map { return &m })
 }
 
+// Value returns a generator for a property.Value conforming to typ.
+func Value(typ schema.Type) *rapid.Generator[property.Value] {
+	return rapid.Custom(func(t *rapid.T) property.Value {
+		return drawValue(t, typ, "value", maxValueDepth)
+	})
+}
+
 // maxValueDepth caps recursion through arrays, maps, and JSON-shaped values.
 // The schema generator forbids required-recursive object cycles, so the only
 // remaining unbounded recursion is through containers — which can still
@@ -313,23 +320,19 @@ func drawEnumValue(t *rapid.T, e *schema.EnumType, label string) property.Value 
 // liftGoValue lifts a bound schema constant (bool, int32, float64, or string)
 // into a property.Value, widening integers to float64.
 func liftGoValue(v any) property.Value {
-	pv, err := property.Any(toPropertyGoValue(v))
+	switch i := v.(type) {
+	case int:
+		v = float64(i)
+	case int32:
+		v = float64(i)
+	case int64:
+		v = float64(i)
+	}
+	pv, err := property.Any(v)
 	if err != nil {
 		panic(fmt.Sprintf("rapidresource: value %v (%[1]T): %v", v, err))
 	}
 	return pv
-}
-
-func toPropertyGoValue(v any) any {
-	switch v := v.(type) {
-	case int:
-		return float64(v)
-	case int32:
-		return float64(v)
-	case int64:
-		return float64(v)
-	}
-	return v
 }
 
 // drawResourceReferenceValue emits a reference to a resource of typ's type.

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -196,3 +196,298 @@ func PkgEquals(p1, p2 schema.PackageReference) bool {
 func GenGitAttributesFile() []byte {
 	return []byte("* linguist-generated\n")
 }
+
+// IsWireDiscriminatableUnionType checks whether u is wire discriminatable when known: given a fully-known protobuf
+// wire value and the union's type information, the member the value belongs to can always be determined.
+//
+// The union's members are flattened through optional, input, token, and nested union wrappers; the union is
+// discriminatable when at most one member admits null and no wire value is comatchable with two members: no value
+// belongs to both. Types are compared by their wire shape (bool, number, string, list, dict, asset, archive,
+// resource reference); asset, archive, and resource-reference values carry signature keys that separate them from
+// plain dicts, and resource references of different types are separated by the type embedded in their URNs. Within
+// a shape:
+//   - int and number share the number shape, since all wire numbers arrive as float64.
+//   - Enums reduce to their sets of literal values: two members of one primitive shape are disjoint only when both
+//     are literal-bounded with disjoint sets.
+//   - Lists never separate and neither do two maps: their empty values are indistinguishable. A map and an object
+//     are disjoint only when some required property of the object cannot co-match the map's element type.
+//   - Two objects share a value exactly when each one's required properties are all declared by the other and
+//     every property required by either side admits a common value — recursively by type, with a constant property
+//     narrowed to a single-valued enum so its bound distributes through unions and optionals. This assumes closed
+//     objects: a value carries only the properties its member declares.
+//     The union's declared Discriminator is not trusted; only this structural evidence counts. A common value is
+//     finite, so co-matchability is a least fixpoint: recursion through cyclic object graphs reports false on
+//     revisits, which makes required-recursive object pairs — types with no finite values at all — vacuously
+//     disjoint.
+func IsWireDiscriminatableUnionType(u *schema.UnionType) bool {
+	members, nullable, ok := flattenWireMembers(u)
+	if !ok || nullable > 1 {
+		return false
+	}
+	for i, a := range members {
+		for _, b := range members[i+1:] {
+			if comatchable(a, b, map[typePair]bool{}) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// flattenWireMembers resolves u's members to concrete types, counting how many admit null. ok is false when a
+// member admits values whose type cannot be determined from the wire (Any, JSON, an opaque token type).
+func flattenWireMembers(u *schema.UnionType) (members []schema.Type, nullable int, ok bool) {
+	var visit func(t schema.Type) bool
+	visit = func(t schema.Type) bool {
+		switch t := t.(type) {
+		case *schema.OptionalType:
+			nullable++
+			return visit(t.ElementType)
+		case *schema.InputType:
+			return visit(t.ElementType)
+		case *schema.TokenType:
+			if t.UnderlyingType == nil {
+				return false
+			}
+			return visit(t.UnderlyingType)
+		case *schema.UnionType:
+			for _, e := range t.ElementTypes {
+				if !visit(e) {
+					return false
+				}
+			}
+			return true
+		default:
+			if _, known := wireShapeOf(t); !known {
+				return false
+			}
+			members = append(members, t)
+			return true
+		}
+	}
+	for _, e := range u.ElementTypes {
+		if !visit(e) {
+			return nil, 0, false
+		}
+	}
+	return members, nullable, true
+}
+
+type wireShape int
+
+const (
+	wireBool wireShape = iota
+	wireNumber
+	wireString
+	wireList
+	wireDict
+	wireAsset
+	wireArchive
+	wireResource
+)
+
+// wireShapeOf classifies the wire form of a concrete (unwrapped) type; ok is false for types that admit values of
+// every shape (Any, JSON, an opaque token).
+func wireShapeOf(t schema.Type) (wireShape, bool) {
+	switch t {
+	case schema.BoolType:
+		return wireBool, true
+	case schema.IntType, schema.NumberType:
+		return wireNumber, true
+	case schema.StringType:
+		return wireString, true
+	case schema.AssetType:
+		return wireAsset, true
+	case schema.ArchiveType:
+		return wireArchive, true
+	}
+	switch t := t.(type) {
+	case *schema.EnumType:
+		return wireShapeOf(t.ElementType)
+	case *schema.ArrayType:
+		return wireList, true
+	case *schema.MapType, *schema.ObjectType:
+		return wireDict, true
+	case *schema.ResourceType:
+		return wireResource, true
+	}
+	return 0, false
+}
+
+// typePair keys the cycle guard for object-pair recursion.
+type typePair [2]schema.Type
+
+// comatchable reports whether some finite, fully-known wire value belongs to both a and b. seen holds the object
+// pairs on the current recursion stack: a common value is finite, so co-matchability that depends on itself has no
+// witness and revisits report false, computing a least fixpoint.
+func comatchable(a, b schema.Type, seen map[typePair]bool) bool {
+	switch t := a.(type) {
+	case *schema.InputType:
+		return comatchable(t.ElementType, b, seen)
+	case *schema.TokenType:
+		if t.UnderlyingType == nil {
+			return true // Opaque: assume it admits any value.
+		}
+		return comatchable(t.UnderlyingType, b, seen)
+	case *schema.UnionType:
+		for _, e := range t.ElementTypes {
+			if comatchable(e, b, seen) {
+				return true
+			}
+		}
+		return false
+	case *schema.OptionalType:
+		if _, optional := b.(*schema.OptionalType); optional {
+			return true // Null belongs to both.
+		}
+		return comatchable(t.ElementType, b, seen)
+	}
+	switch b.(type) {
+	case *schema.InputType, *schema.TokenType, *schema.UnionType, *schema.OptionalType:
+		return comatchable(b, a, seen)
+	}
+
+	shapeA, okA := wireShapeOf(a)
+	shapeB, okB := wireShapeOf(b)
+	if !okA || !okB {
+		return true // Any and friends admit values of every shape.
+	}
+	if shapeA != shapeB {
+		return false
+	}
+	switch shapeA {
+	case wireBool, wireNumber, wireString:
+		la, lb := literalSet(a), literalSet(b)
+		return la == nil || lb == nil || !setsDisjoint(la, lb)
+	case wireResource:
+		ra, _ := a.(*schema.ResourceType)
+		rb, _ := b.(*schema.ResourceType)
+		return ra.Token == rb.Token
+	case wireDict:
+		return dictsComatchable(a, b, seen)
+	case wireList, wireAsset, wireArchive:
+		return true // Empty lists — and blobs of one kind — are indistinguishable.
+	}
+	return true
+}
+
+// dictsComatchable resolves the dict wire shape: two maps always share the empty dict, a map and an object share a
+// value unless a required property of the object cannot co-match the map's element type, and two objects delegate
+// to objectsComatchable.
+func dictsComatchable(a, b schema.Type, seen map[typePair]bool) bool {
+	oa, aIsObject := a.(*schema.ObjectType)
+	ob, bIsObject := b.(*schema.ObjectType)
+	switch {
+	case aIsObject && bIsObject:
+		return objectsComatchable(oa, ob, seen)
+	case aIsObject:
+		return mapComatchable(b.(*schema.MapType), oa, seen)
+	case bIsObject:
+		return mapComatchable(a.(*schema.MapType), ob, seen)
+	default:
+		return true
+	}
+}
+
+// mapComatchable reports whether some dict of m's element values also matches o: every required property of o must
+// admit a value of the element type. Optional properties are omitted from the witness.
+func mapComatchable(m *schema.MapType, o *schema.ObjectType, seen map[typePair]bool) bool {
+	for _, p := range o.Properties {
+		if !p.IsRequired() {
+			continue
+		}
+		if !comatchable(effectivePropertyType(p), m.ElementType, seen) {
+			return false
+		}
+	}
+	return true
+}
+
+// objectsComatchable reports whether some finite wire value matches both a and b under the closed-object reading: a
+// value carries only the properties its member declares. Each side's required properties must all be declared by
+// the other, every property required by either side must admit a common value, and properties optional on both
+// sides are simply omitted from the witness.
+func objectsComatchable(a, b *schema.ObjectType, seen map[typePair]bool) bool {
+	pair := typePair{a, b}
+	if seen[pair] {
+		// Co-matchability that depends on itself has no finite witness.
+		return false
+	}
+	seen[pair] = true
+	defer delete(seen, pair)
+
+	for _, x := range [][2]*schema.ObjectType{{a, b}, {b, a}} {
+		for _, p := range x[0].Properties {
+			if !p.IsRequired() {
+				continue
+			}
+			if _, has := x[1].Property(p.Name); !has {
+				return false
+			}
+		}
+	}
+	for _, p := range a.Properties {
+		q, has := b.Property(p.Name)
+		if !has || (!p.IsRequired() && !q.IsRequired()) {
+			continue
+		}
+		if !comatchable(effectivePropertyType(p), effectivePropertyType(q), seen) {
+			return false
+		}
+	}
+	return true
+}
+
+// effectivePropertyType is the type whose values p admits: the declared type, with a constant property narrowed to
+// a single-valued enum so the bound distributes through unions and optionals during co-matching.
+func effectivePropertyType(p *schema.Property) schema.Type {
+	if p.ConstValue == nil {
+		return p.Type
+	}
+	var t schema.Type = &schema.EnumType{
+		ElementType: UnwrapType(p.Type),
+		Elements:    []*schema.Enum{{Value: p.ConstValue}},
+	}
+	if !p.IsRequired() {
+		t = &schema.OptionalType{ElementType: t}
+	}
+	return t
+}
+
+// literalSet is the set of wire values t admits when t is literal-bounded (a non-empty enum); nil means unbounded.
+func literalSet(t schema.Type) map[any]struct{} {
+	e, ok := t.(*schema.EnumType)
+	if !ok || len(e.Elements) == 0 {
+		return nil
+	}
+	set := make(map[any]struct{}, len(e.Elements))
+	for _, el := range e.Elements {
+		set[normalizeWireValue(el.Value)] = struct{}{}
+	}
+	return set
+}
+
+func setsDisjoint(a, b map[any]struct{}) bool {
+	for v := range a {
+		if _, shared := b[v]; shared {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeWireValue widens numeric literals to float64, the representation every number has on the wire.
+func normalizeWireValue(v any) any {
+	switch v := v.(type) {
+	case int:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case float32:
+		return float64(v)
+	default:
+		return v
+	}
+}

--- a/pkg/codegen/utilities_rapid_test.go
+++ b/pkg/codegen/utilities_rapid_test.go
@@ -1,0 +1,369 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen_test
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils/rapidresource"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils/rapidschema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWireDiscriminatableUnionsAttributeUniquely is the soundness property for
+// codegen.IsWireDiscriminatableUnionType: whenever the function reports a
+// union as wire discriminatable, a fully-known value drawn from any member is
+// matched by exactly that member. Unions are drawn from a deliberately tiny
+// alphabet so members frequently share wire shapes, literals, and property
+// names, making the discriminatable cases non-trivial. The result must also
+// be invariant under member order.
+func TestWireDiscriminatableUnionsAttributeUniquely(t *testing.T) {
+	t.Parallel()
+
+	discriminatable := 0
+	rapid.Check(t, func(t *rapid.T) {
+		u := drawCollisionUnion(t)
+
+		permuted := &schema.UnionType{
+			ElementTypes: rapid.Permutation(slices.Clone(u.ElementTypes)).Draw(t, "perm"),
+		}
+		require.Equal(t,
+			codegen.IsWireDiscriminatableUnionType(u),
+			codegen.IsWireDiscriminatableUnionType(permuted),
+			"member order changed the result for %v", u)
+
+		if !codegen.IsWireDiscriminatableUnionType(u) {
+			return
+		}
+		discriminatable++
+		requireUniqueAttribution(t, u)
+	})
+	require.Positive(t, discriminatable, "no discriminatable unions were generated; the property was vacuous")
+}
+
+// TestWireDiscriminatableUnionsFromRapidSchema runs the same soundness
+// property over every union appearing in packages drawn by
+// rapidschema.Package(), covering shapes the collision generator does not
+// produce: nested unions, builtin refs, and deep object graphs.
+func TestWireDiscriminatableUnionsFromRapidSchema(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		pkg := rapidschema.Package().Draw(t, "pkg")
+		var unions []*schema.UnionType
+		collect := func(typ schema.Type) {
+			if u, ok := typ.(*schema.UnionType); ok {
+				unions = append(unions, u)
+			}
+		}
+		for _, r := range pkg.Resources {
+			codegen.VisitTypeClosure(r.Properties, collect)
+			codegen.VisitTypeClosure(r.InputProperties, collect)
+			if r.StateInputs != nil {
+				codegen.VisitTypeClosure(r.StateInputs.Properties, collect)
+			}
+		}
+
+		for _, u := range unions {
+			if codegen.IsWireDiscriminatableUnionType(u) {
+				requireUniqueAttribution(t, u)
+			}
+		}
+	})
+}
+
+// requireUniqueAttribution draws a value from one member of u and asserts that
+// exactly that member matches it.
+func requireUniqueAttribution(t *rapid.T, u *schema.UnionType) {
+	idx := rapid.IntRange(0, len(u.ElementTypes)-1).Draw(t, "member")
+	member := u.ElementTypes[idx]
+	v := rapidresource.Value(member).Draw(t, "value")
+
+	require.True(t, wireMatches(v, member),
+		"value %v does not match the member %v it was drawn from", v, member)
+	matched := 0
+	for _, e := range u.ElementTypes {
+		if wireMatches(v, e) {
+			matched++
+		}
+	}
+	require.Equal(t, 1, matched, "value %v of member %v matched %d members of %v", v, member, matched, u)
+}
+
+// wireMatches reports whether the fully-known wire value v belongs to typ. It
+// is the ground-truth definition IsWireDiscriminatableUnionType is checked
+// against, under the same closed-object reading: a value of an object type
+// carries only that object's declared properties.
+func wireMatches(v property.Value, typ schema.Type) bool {
+	switch typ {
+	case schema.BoolType:
+		return v.IsBool()
+	case schema.IntType, schema.NumberType:
+		return v.IsNumber()
+	case schema.StringType:
+		return v.IsString()
+	case schema.AssetType:
+		return v.IsAsset()
+	case schema.ArchiveType:
+		return v.IsArchive()
+	case schema.JSONType, schema.AnyType, schema.AnyResourceType:
+		return true
+	}
+
+	switch typ := typ.(type) {
+	case *schema.OptionalType:
+		return v.IsNull() || wireMatches(v, typ.ElementType)
+	case *schema.InputType:
+		return wireMatches(v, typ.ElementType)
+	case *schema.TokenType:
+		if typ.UnderlyingType != nil {
+			return wireMatches(v, typ.UnderlyingType)
+		}
+		return v.IsString()
+	case *schema.UnionType:
+		for _, e := range typ.ElementTypes {
+			if wireMatches(v, e) {
+				return true
+			}
+		}
+		return false
+	case *schema.EnumType:
+		if len(typ.Elements) == 0 {
+			return wireMatches(v, typ.ElementType)
+		}
+		for _, e := range typ.Elements {
+			if v.Equals(liftConstant(e.Value)) {
+				return true
+			}
+		}
+		return false
+	case *schema.ArrayType:
+		if !v.IsArray() {
+			return false
+		}
+		for _, e := range v.AsArray().AsSlice() {
+			if !wireMatches(e, typ.ElementType) {
+				return false
+			}
+		}
+		return true
+	case *schema.MapType:
+		if !v.IsMap() {
+			return false
+		}
+		ok := true
+		v.AsMap().All(func(_ string, e property.Value) bool {
+			ok = wireMatches(e, typ.ElementType)
+			return ok
+		})
+		return ok
+	case *schema.ObjectType:
+		return objectWireMatches(v, typ)
+	case *schema.ResourceType:
+		return v.IsResourceReference() && v.AsResourceReference().URN.Type() == tokens.Type(typ.Token)
+	}
+	return false
+}
+
+func objectWireMatches(v property.Value, typ *schema.ObjectType) bool {
+	if !v.IsMap() {
+		return false
+	}
+	m := v.AsMap()
+	ok := true
+	m.All(func(name string, e property.Value) bool {
+		p, declared := typ.Property(name)
+		switch {
+		case !declared:
+			ok = false
+		case p.ConstValue != nil:
+			// An optional constant property may also be explicitly null.
+			ok = e.Equals(liftConstant(p.ConstValue)) || (!p.IsRequired() && e.IsNull())
+		default:
+			ok = wireMatches(e, p.Type)
+		}
+		return ok
+	})
+	if !ok {
+		return false
+	}
+	for _, p := range typ.Properties {
+		if p.IsRequired() {
+			if _, has := m.GetOk(p.Name); !has {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// liftConstant lifts a bound schema constant or enum value into its wire
+// value: all numbers arrive as float64.
+func liftConstant(v any) property.Value {
+	switch v := v.(type) {
+	case bool:
+		return property.New(v)
+	case int:
+		return property.New(float64(v))
+	case int32:
+		return property.New(float64(v))
+	case int64:
+		return property.New(float64(v))
+	case float64:
+		return property.New(v)
+	case string:
+		return property.New(v)
+	}
+	panic(fmt.Sprintf("unexpected constant %v (%[1]T)", v))
+}
+
+// Tiny alphabets: three property names, three string literals, three integer
+// literals. Small domains make members collide often, so the discriminatable
+// unions the test exercises are the barely-discriminatable ones.
+var (
+	collisionPropertyNames = []string{"a", "b", "c"}
+	collisionStrings       = []string{"x", "y", "z"}
+	collisionInts          = []int32{1, 2, 3}
+)
+
+func drawCollisionUnion(t *rapid.T) *schema.UnionType {
+	n := rapid.IntRange(2, 4).Draw(t, "members")
+	members := make([]schema.Type, n)
+	for i := range n {
+		members[i] = drawCollisionMember(t, fmt.Sprintf("m%d", i))
+	}
+	return &schema.UnionType{ElementTypes: members}
+}
+
+var collisionMemberKinds = []string{
+	"bool", "int", "number", "string",
+	"stringEnum", "intEnum",
+	"optional", "array", "map",
+	"asset", "archive", "resource", "any",
+	// Objects are the interesting case; weight them heavily.
+	"object", "object", "object", "object", "object",
+}
+
+func drawCollisionMember(t *rapid.T, label string) schema.Type {
+	switch kind := rapid.SampledFrom(collisionMemberKinds).Draw(t, label+":kind"); kind {
+	case "bool":
+		return schema.BoolType
+	case "int":
+		return schema.IntType
+	case "number":
+		return schema.NumberType
+	case "string":
+		return schema.StringType
+	case "stringEnum":
+		return drawCollisionEnum(t, label, schema.StringType)
+	case "intEnum":
+		return drawCollisionEnum(t, label, schema.IntType)
+	case "optional":
+		return &schema.OptionalType{ElementType: drawCollisionPrimitive(t, label)}
+	case "array":
+		return &schema.ArrayType{ElementType: drawCollisionPrimitive(t, label)}
+	case "map":
+		return &schema.MapType{ElementType: drawCollisionPrimitive(t, label)}
+	case "asset":
+		return schema.AssetType
+	case "archive":
+		return schema.ArchiveType
+	case "resource":
+		return &schema.ResourceType{
+			Token: rapid.SampledFrom([]string{"pkg:index:A", "pkg:index:B"}).Draw(t, label+":token"),
+		}
+	case "any":
+		return schema.AnyType
+	case "object":
+		return drawCollisionObjectDepth(t, label, 1)
+	default:
+		panic("unknown member kind " + kind)
+	}
+}
+
+func drawCollisionPrimitive(t *rapid.T, label string) schema.Type {
+	return rapid.SampledFrom([]schema.Type{
+		schema.BoolType, schema.IntType, schema.NumberType, schema.StringType,
+	}).Draw(t, label+":prim")
+}
+
+func drawCollisionEnum(t *rapid.T, label string, element schema.Type) *schema.EnumType {
+	e := &schema.EnumType{ElementType: element}
+	n := rapid.IntRange(1, 2).Draw(t, label+":nvalues")
+	switch element {
+	case schema.StringType:
+		values := rapid.SliceOfNDistinct(rapid.SampledFrom(collisionStrings), n, n, rapid.ID[string]).
+			Draw(t, label+":strings")
+		for _, s := range values {
+			e.Elements = append(e.Elements, &schema.Enum{Value: s})
+		}
+	case schema.IntType:
+		values := rapid.SliceOfNDistinct(rapid.SampledFrom(collisionInts), n, n, rapid.ID[int32]).
+			Draw(t, label+":ints")
+		for _, i := range values {
+			e.Elements = append(e.Elements, &schema.Enum{Value: i})
+		}
+	}
+	return e
+}
+
+func drawCollisionObjectDepth(t *rapid.T, label string, depth int) *schema.ObjectType {
+	n := rapid.IntRange(1, 3).Draw(t, label+":nprops")
+	names := rapid.SliceOfNDistinct(rapid.SampledFrom(collisionPropertyNames), n, n, rapid.ID[string]).
+		Draw(t, label+":names")
+	kinds := []string{"string", "int", "stringConst", "intConst", "enum", "enumUnion"}
+	if depth > 0 {
+		kinds = append(kinds, "object")
+	}
+	props := make([]*schema.Property, n)
+	for i, name := range names {
+		p := &schema.Property{Name: name}
+		propLabel := label + ":" + name
+		switch rapid.SampledFrom(kinds).Draw(t, propLabel+":kind") {
+		case "string":
+			p.Type = schema.StringType
+		case "int":
+			p.Type = schema.IntType
+		case "stringConst":
+			p.Type = schema.StringType
+			p.ConstValue = rapid.SampledFrom(collisionStrings).Draw(t, propLabel+":const")
+		case "intConst":
+			p.Type = schema.IntType
+			p.ConstValue = rapid.SampledFrom(collisionInts).Draw(t, propLabel+":const")
+		case "enum":
+			p.Type = drawCollisionEnum(t, propLabel, schema.StringType)
+		case "enumUnion":
+			p.Type = &schema.UnionType{ElementTypes: []schema.Type{
+				drawCollisionEnum(t, propLabel+":u0", schema.StringType),
+				drawCollisionEnum(t, propLabel+":u1", schema.StringType),
+			}}
+		case "object":
+			p.Type = drawCollisionObjectDepth(t, propLabel, depth-1)
+		}
+		if rapid.Bool().Draw(t, propLabel+":optional") {
+			p.Type = &schema.OptionalType{ElementType: p.Type}
+		}
+		props[i] = p
+	}
+	return &schema.ObjectType{Token: "pkg:index:T", Properties: props}
+}

--- a/pkg/codegen/utilities_test.go
+++ b/pkg/codegen/utilities_test.go
@@ -59,6 +59,251 @@ func TestStringSetContains(t *testing.T) {
 	assert.True(t, set123.Contains(setEmpty))
 }
 
+func TestIsWireDiscriminatableUnionType(t *testing.T) {
+	t.Parallel()
+
+	stringEnum := func(values ...string) *schema.EnumType {
+		e := &schema.EnumType{ElementType: schema.StringType}
+		for _, v := range values {
+			e.Elements = append(e.Elements, &schema.Enum{Value: v})
+		}
+		return e
+	}
+	object := func(props ...*schema.Property) *schema.ObjectType {
+		return &schema.ObjectType{Properties: props}
+	}
+	constProp := func(name string, value any) *schema.Property {
+		return &schema.Property{Name: name, Type: schema.StringType, ConstValue: value}
+	}
+
+	// nested builds {foo: {fizz: <fizzType>}} with both foo and fizz required.
+	nested := func(fizzType schema.Type) *schema.ObjectType {
+		return object(&schema.Property{
+			Name: "foo",
+			Type: object(&schema.Property{Name: "fizz", Type: fizzType}),
+		})
+	}
+
+	recursiveA := &schema.ObjectType{}
+	recursiveB := &schema.ObjectType{}
+	recursiveA.Properties = []*schema.Property{{Name: "foo", Type: recursiveB}}
+	recursiveB.Properties = []*schema.Property{{Name: "foo", Type: recursiveA}}
+
+	cases := []struct {
+		name     string
+		union    *schema.UnionType
+		expected bool
+	}{
+		{
+			name:     "single member",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{schema.StringType}},
+			expected: true,
+		},
+		{
+			name:     "distinct primitive shapes",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{schema.StringType, schema.IntType, schema.BoolType}},
+			expected: true,
+		},
+		{
+			name:     "int and number share a wire shape",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{schema.IntType, schema.NumberType}},
+			expected: false,
+		},
+		{
+			name:     "literal and unbounded string",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{stringEnum("foo"), schema.StringType}},
+			expected: false,
+		},
+		{
+			name:     "disjoint string literals and int",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{stringEnum("foo"), stringEnum("bar"), schema.IntType}},
+			expected: true,
+		},
+		{
+			name:     "overlapping string literals",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{stringEnum("foo", "bar"), stringEnum("bar", "baz")}},
+			expected: false,
+		},
+		{
+			name: "int and float literals normalize to one wire number",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.EnumType{ElementType: schema.IntType, Elements: []*schema.Enum{{Value: 1}}},
+				&schema.EnumType{ElementType: schema.NumberType, Elements: []*schema.Enum{{Value: float64(1)}}},
+			}},
+			expected: false,
+		},
+		{
+			name: "objects with disjoint required constants",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(constProp("kind", "a"), &schema.Property{Name: "value", Type: schema.StringType}),
+				object(constProp("kind", "b"), &schema.Property{Name: "value", Type: schema.StringType}),
+			}},
+			expected: true,
+		},
+		{
+			name: "objects with a constant on only one side",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(constProp("kind", "a")),
+				object(&schema.Property{Name: "kind", Type: schema.StringType}),
+			}},
+			expected: false,
+		},
+		{
+			name: "constant disjoint from a union of enums",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(constProp("kind", "x")),
+				object(&schema.Property{Name: "kind", Type: &schema.UnionType{
+					ElementTypes: []schema.Type{stringEnum("y"), stringEnum("z")},
+				}}),
+			}},
+			expected: true,
+		},
+		{
+			name: "constant intersecting a union of enums",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(constProp("kind", "x")),
+				object(&schema.Property{Name: "kind", Type: &schema.UnionType{
+					ElementTypes: []schema.Type{stringEnum("x", "y"), stringEnum("z")},
+				}}),
+			}},
+			expected: false,
+		},
+		{
+			name: "objects with disjoint enum discriminators",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(&schema.Property{Name: "kind", Type: stringEnum("a", "b")}),
+				object(&schema.Property{Name: "kind", Type: stringEnum("c")}),
+			}},
+			expected: true,
+		},
+		{
+			name: "object requires a property the other lacks",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(&schema.Property{Name: "a", Type: schema.StringType}),
+				object(&schema.Property{Name: "b", Type: schema.StringType}),
+			}},
+			expected: true,
+		},
+		{
+			name:     "objects distinguished by nested required objects",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{nested(schema.IntType), nested(schema.BoolType)}},
+			expected: true,
+		},
+		{
+			name: "nested discriminating property is optional",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(&schema.Property{
+					Name: "foo",
+					Type: object(&schema.Property{Name: "fizz", Type: &schema.OptionalType{ElementType: schema.IntType}}),
+				}),
+				object(&schema.Property{
+					Name: "foo",
+					Type: object(&schema.Property{Name: "fizz", Type: &schema.OptionalType{ElementType: schema.BoolType}}),
+				}),
+			}},
+			expected: false,
+		},
+		{
+			name: "nested object is optional",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(&schema.Property{Name: "foo", Type: &schema.OptionalType{
+					ElementType: object(&schema.Property{Name: "fizz", Type: schema.IntType}),
+				}}),
+				object(&schema.Property{Name: "foo", Type: &schema.OptionalType{
+					ElementType: object(&schema.Property{Name: "fizz", Type: schema.BoolType}),
+				}}),
+			}},
+			expected: false,
+		},
+		{
+			// Required-recursive objects admit no finite value at all, so no value is ambiguous between them.
+			name:     "required-recursive objects are uninhabited and vacuously disjoint",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{recursiveA, recursiveB}},
+			expected: true,
+		},
+		{
+			name: "nested discriminating property required on one side",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				object(&schema.Property{Name: "fizz", Type: schema.IntType}),
+				object(&schema.Property{Name: "fizz", Type: &schema.OptionalType{ElementType: schema.BoolType}}),
+			}},
+			expected: true,
+		},
+		{
+			name: "map and object collide",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.MapType{ElementType: schema.StringType},
+				object(&schema.Property{Name: "a", Type: schema.StringType}),
+			}},
+			expected: false,
+		},
+		{
+			name: "map disjoint from object by required property type",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.MapType{ElementType: schema.StringType},
+				object(&schema.Property{Name: "a", Type: schema.IntType}),
+			}},
+			expected: true,
+		},
+		{
+			name: "two arrays collide",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.ArrayType{ElementType: schema.StringType},
+				&schema.ArrayType{ElementType: schema.IntType},
+			}},
+			expected: false,
+		},
+		{
+			name:     "asset and archive are distinct",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{schema.AssetType, schema.ArchiveType, schema.StringType}},
+			expected: true,
+		},
+		{
+			name: "resource references of distinct types",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.ResourceType{Token: "pkg:index:A"},
+				&schema.ResourceType{Token: "pkg:index:B"},
+			}},
+			expected: true,
+		},
+		{
+			name: "resource references of one type collide",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.ResourceType{Token: "pkg:index:A"},
+				&schema.ResourceType{Token: "pkg:index:A"},
+			}},
+			expected: false,
+		},
+		{
+			name:     "any admits every shape",
+			union:    &schema.UnionType{ElementTypes: []schema.Type{schema.AnyType, schema.StringType}},
+			expected: false,
+		},
+		{
+			name: "two optional members collide on null",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.OptionalType{ElementType: schema.StringType},
+				&schema.OptionalType{ElementType: schema.IntType},
+			}},
+			expected: false,
+		},
+		{
+			name: "one optional member",
+			union: &schema.UnionType{ElementTypes: []schema.Type{
+				&schema.OptionalType{ElementType: schema.StringType},
+				schema.IntType,
+			}},
+			expected: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.expected, IsWireDiscriminatableUnionType(c.union))
+		})
+	}
+}
+
 func TestStringSetSubtract(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add `codegen.IsWireDiscriminatableUnionType` to allow codegen to make decisions based on if a union type is wire distinguishable. This currently only introduces the helper function. https://github.com/pulumi/pulumi/pull/24485 takes advantage of it to produce tight unions in python codegen output.