### PR TITLE
[sdk/python] Reduce a union to its member by wire-shape matching

### DIFF
--- a/changelog/pending/20260827--sdk-python--wire-shape-union-reduction.yaml
+++ b/changelog/pending/20260827--sdk-python--wire-shape-union-reduction.yaml
@@ -1,0 +1,6 @@
+component: sdk/python
+kind: improvement
+body: Resolve a union value to its member by matching the value's wire shape, so
+    unions whose members carry no constant properties serialize and translate with
+    the right member's property names
+time: 2026-08-27T00:00:00+00:00

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -219,6 +219,8 @@ func GenGitAttributesFile() []byte {
 //     finite, so co-matchability is a least fixpoint: recursion through cyclic object graphs reports false on
 //     revisits, which makes required-recursive object pairs — types with no finite values at all — vacuously
 //     disjoint.
+//
+// Must match sdk/python/lib/pulumi/_types.py's _wire_matches.
 func IsWireDiscriminatableUnionType(u *schema.UnionType) bool {
 	members, nullable, ok := flattenWireMembers(u)
 	if !ok || nullable > 1 {

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -267,6 +267,7 @@
 
 import builtins
 import collections.abc
+import enum
 import functools
 import inspect
 import sys
@@ -747,66 +748,68 @@ def _is_optional_type(tp):
     return False
 
 
-# A property a union member pins to a constant: its Pulumi name and the pinned value.
-_Constant = tuple[str, Any]
-
-# A union member and the constants it pins.
-_ConstrainedMember = tuple[type, tuple[_Constant, ...]]
+# The sentinel the engine uses for values that are unknown during preview. It mirrors
+# runtime.rpc.UNKNOWN, which cannot be imported here without an import cycle.
+_UNKNOWN = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
 
 
-def _literal_constants(cls: type) -> tuple[_Constant, ...]:
+def _is_plumbing_arg(arg: Any) -> bool:
     """
-    Returns the properties of `cls` that codegen typed as a single-value `Literal`, which is how a
-    schema constant is rendered, keyed by their Pulumi name.
+    Reports whether a union arg is runtime plumbing rather than a member of its own: the
+    `Awaitable` and `Output` wrappers an `Input` carries, and the `TypedDict` alternatives, which
+    duplicate a sibling member.
     """
-    types_of = input_type_types if is_input_type(cls) else output_type_types
-    constants: list[_Constant] = []
-    for name, tp in types_of(cls).items():
-        if get_origin(tp) is not Literal:
-            continue
-        args = typing.get_args(tp)
-        # A schema constant is a bool, an integer or a string. Numbers are excluded because
-        # `typing.Literal` does not admit floats, so codegen leaves them as their primitive type.
-        if len(args) == 1 and isinstance(args[0], (bool, int, str)):
-            constants.append((name, args[0]))
-    return tuple(constants)
+    from . import Output
+
+    if arg is Output or get_origin(arg) is Output:
+        return True
+    if isinstance(arg, typing.ForwardRef):
+        # `Input` quotes its "Output[T]" arg; in a union built outside a class body the reference
+        # is never resolved.
+        return arg.__forward_arg__.startswith("Output[")
+    if get_origin(arg) in (abc.Awaitable, abc.Coroutine):
+        return True
+    return typing.is_typeddict(arg)
+
+
+def _wire_matchable(arg: Any) -> bool:
+    """
+    Reports whether the wire shape of `arg` is known well enough to test a value against it.
+    `Any` and unrecognized annotations are not: a value might always belong to them.
+    """
+    if arg is Any:
+        return False
+    if origin := get_origin(arg):
+        return origin in (list, abc.Sequence, dict, abc.Mapping, Literal)
+    return inspect.isclass(arg)
 
 
 @functools.cache
-def _constrained_union_members(typ: Any) -> Optional[tuple[_ConstrainedMember, ...]]:
+def _wire_union_members(typ: Any) -> Optional[tuple[Any, ...]]:
     """
-    Returns each member of the union paired with the constants it pins, or None if `typ` is not a
-    union whose members can all be told apart this way. Args that carry no metadata of their own,
-    such as `None`, `Awaitable`, `Output` and the `TypedDict` alternative, are ignored.
+    Returns the members of the union `typ` a wire value could belong to, or None if `typ` is not
+    a union with at least two of them. `None` and plumbing args are dropped; a union carrying a
+    member whose shape cannot be tested is rejected outright.
     """
     if not _is_union_type(typ):
         return None
-
-    members = [
-        arg
-        for arg in typing.get_args(typ)
-        if isinstance(arg, type) and (is_input_type(arg) or is_output_type(arg))
-    ]
+    members = []
+    for arg in typing.get_args(typ):
+        if arg is type(None) or _is_plumbing_arg(arg):
+            continue
+        if not _wire_matchable(arg):
+            return None
+        members.append(arg)
     if len(members) < 2:
         return None
-
-    constrained = tuple(
-        (member, constants)
-        for member in members
-        if (constants := _literal_constants(member))
-    )
-    # A union is only discriminated when every member is tagged. If one is not, a value of that
-    # member could satisfy another member's constants and be mistyped, so do not guess.
-    if len(constrained) != len(members):
-        return None
-    return constrained
+    return tuple(members)
 
 
 def is_discriminated_union(typ: Any) -> bool:
     """
     Reports whether a value of `typ` can be reduced to one of its members.
     """
-    return _constrained_union_members(typ) is not None
+    return _wire_union_members(typ) is not None
 
 
 def _py_name_for(cls: type, pulumi_name: str) -> Optional[str]:
@@ -835,46 +838,134 @@ def _same_constant(expected: Any, actual: Any) -> bool:
     return expected == actual
 
 
-def _member_matches(
-    member: type,
-    constants: tuple[_Constant, ...],
-    value: abc.Mapping,
-    name_for: Callable[[type, str], Optional[str]],
+def _wire_matches(
+    value: Any, typ: Any, name_for: Callable[[type, str], Optional[str]]
 ) -> bool:
     """
-    Reports whether `value` satisfies `constants`: at least one is present and agrees, and none
-    disagree. A constant absent from `value` neither confirms nor rules out its member, so a value
-    mentioning none of them matches nothing.
+    Reports whether `value` can belong to `typ` on the wire. Values that cannot be examined —
+    outputs, awaitables, and the engine's unknown sentinel — match every type, so an unknown
+    never rules out the member a value actually belongs to; at worst it leaves the reduction
+    ambiguous. Must match pkg/codegen/utilities.go's IsWireDiscriminatableUnionType.
     """
-    confirmed = False
-    for name, expected in constants:
-        lookup_name = name_for(member, name)
-        if lookup_name is None:
-            continue
-        actual = _lookup(value, lookup_name)
-        if actual is MISSING:
-            continue
-        if not _same_constant(expected, actual):
+    from . import Output
+
+    if isinstance(value, Output) or inspect.isawaitable(value):
+        return True
+    if isinstance(value, str) and value == _UNKNOWN:
+        return True
+
+    if typ is Any:
+        return True
+    if typ is type(None):
+        return value is None
+    if _is_union_type(typ):
+        return any(
+            _wire_matches(value, arg, name_for)
+            for arg in typing.get_args(typ)
+            if not _is_plumbing_arg(arg)
+        )
+
+    origin = get_origin(typ)
+    if origin is Literal:
+        return any(_same_constant(arg, value) for arg in typing.get_args(typ))
+    if typ is list or origin in (list, abc.Sequence):
+        if not isinstance(value, abc.Sequence) or isinstance(value, (str, bytes)):
             return False
-        confirmed = True
-    return confirmed
+        args = typing.get_args(typ)
+        return not args or all(_wire_matches(v, args[0], name_for) for v in value)
+    if typ is dict or origin in (dict, abc.Mapping):
+        if not isinstance(value, abc.Mapping):
+            return False
+        args = typing.get_args(typ)
+        return len(args) != 2 or all(
+            _wire_matches(v, args[1], name_for) for v in value.values()
+        )
+
+    if not inspect.isclass(typ):
+        # An annotation we do not understand cannot rule anything out.
+        return True
+    if typ is bool:
+        return isinstance(value, bool)
+    if typ in (int, float):
+        # All wire numbers arrive as floats, so int and float are one shape; `True == 1` in
+        # Python, so booleans are excluded.
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if is_input_type(typ) or is_output_type(typ):
+        return _object_wire_matches(value, typ, name_for)
+    if issubclass(typ, enum.Enum):
+        return isinstance(value, typ) or any(
+            _same_constant(member.value, value) for member in typ
+        )
+    if typing.is_typeddict(typ):
+        # TypedDict classes do not support isinstance checks.
+        return isinstance(value, abc.Mapping)
+    return isinstance(value, typ)
+
+
+def _object_wire_matches(
+    value: Any, cls: type, name_for: Callable[[type, str], Optional[str]]
+) -> bool:
+    """
+    Reports whether `value` can be a `cls` under the closed reading: every key names a declared
+    property, required properties are present, and every present value matches its property's
+    annotation. Properties are looked up under the names `name_for` maps them to.
+    """
+    if isinstance(value, cls):
+        return True
+    if not isinstance(value, abc.Mapping):
+        return False
+
+    lookup_names = {
+        pulumi_name: name_for(cls, pulumi_name)
+        for _, pulumi_name, _prop in _py_properties(cls)
+    }
+    declared = {name for name in lookup_names.values() if name is not None}
+    if any(key not in declared for key in value):
+        return False
+
+    property_types = (
+        input_type_types(cls) if is_input_type(cls) else output_type_types(cls)
+    )
+    required = _required_property_names(cls)
+    for pulumi_name, lookup_name in lookup_names.items():
+        v = _lookup(value, lookup_name) if lookup_name is not None else MISSING
+        if v is MISSING or v is None:
+            if pulumi_name in required:
+                return False
+            continue
+        annotation = property_types.get(pulumi_name)
+        if annotation is not None and not _wire_matches(v, annotation, name_for):
+            return False
+    return True
+
+
+@functools.cache
+def _required_property_names(cls: type) -> frozenset[str]:
+    """
+    Returns the Pulumi names of the properties of `cls` whose declared annotation does not admit
+    None.
+    """
+    return frozenset(
+        name
+        for name, hint in _raw_return_hints(cls).items()
+        if not _is_optional_type(hint)
+    )
 
 
 def reduce_discriminated_union(
     typ: Any, value: abc.Mapping, name_for: Callable[[type, str], Optional[str]]
-) -> Optional[type]:
+) -> Optional[Any]:
     """
-    Returns the single member of the union `typ` whose constants `value` satisfies, or None if no
-    single member matches. `name_for` maps a member and a constant's Pulumi name to the name to
-    look up in `value`: pass `_py_name_for` for Python-keyed values, or the identity for
-    Pulumi-keyed values as the engine sends them.
+    Returns the single member of the union `typ` that `value` can belong to on the wire, or None
+    when no member — or more than one — matches. `name_for` maps a member and a property's
+    Pulumi name to the name to look up in `value`: pass `_py_name_for` for Python-keyed values,
+    or the identity for Pulumi-keyed values as the engine sends them.
     """
-    members = _constrained_union_members(typ)
+    members = _wire_union_members(typ)
     if members is None:
         return None
-
     candidates = [
-        m for m, constants in members if _member_matches(m, constants, value, name_for)
+        member for member in members if _wire_matches(value, member, name_for)
     ]
     if len(candidates) != 1:
         return None
@@ -897,15 +988,13 @@ def _globals_for_cls(cls: type) -> Optional[dict[str, Any]]:
 
 
 @functools.cache
-def _types_from_py_properties(cls: type) -> dict[str, type]:
+def _raw_return_hints(cls: type) -> dict[str, Any]:
     """
-    Returns a dict of Pulumi names to types for a type.
+    Returns a dict of Pulumi names to each property getter's resolved return type annotation,
+    before any Output/Optional unwrapping.
     """
     from . import Output
 
-    # We use get_type_hints() below on each Python property to resolve the getter function's
-    # return type annotation, resolving forward references.
-    #
     # We pass the cls's globals to get_type_hints() to ensure any other referenced
     # output types (which may exist in other modules of the cls, like `.outputs` or
     # `...meta.v1.outputs`) can be resolved. If we didn't pass the cls's globals,
@@ -923,24 +1012,34 @@ def _types_from_py_properties(cls: type) -> dict[str, type]:
     # and it doesn't matter what the value is for our purposes.
     localns = {"Output": Output, "T": type(None)}  # type: ignore
 
-    # Build-up a dictionary of Pulumi property names to types by looping through all the
-    # Python properties on the class that have a getter marked as a Pulumi property getter,
-    # and looking at the getter function's return type annotation.
-    # Types that are Output[T] and Optional[T] are unwrapped to just T.
-    result: dict[str, type] = {}
+    hints: dict[str, Any] = {}
     for _, pulumi_name, prop in _py_properties(cls):
-        cls_hints = get_type_hints(prop.fget, globalns=globalns, localns=localns)
-        # Get the function's return type hint.
-        return_hint = cls_hints.get("return")
+        return_hint = get_type_hints(prop.fget, globalns=globalns, localns=localns).get(
+            "return"
+        )
         if return_hint is not None:
-            typ = unwrap_type(return_hint)
-            # If typ is Output, it was specified non-generically (as Output rather than Output[T]),
-            # because unwrap_type would have returned the T in Output[T] if it was specified
-            # generically. To avoid raising a type mismatch error when the deserialized output type
-            # doesn't match Output, we exclude it from the results.
-            if typ is Output:
-                continue
-            result[pulumi_name] = typ
+            hints[pulumi_name] = return_hint
+    return hints
+
+
+@functools.cache
+def _types_from_py_properties(cls: type) -> dict[str, type]:
+    """
+    Returns a dict of Pulumi names to types for a type. Types that are Output[T] and Optional[T]
+    are unwrapped to just T.
+    """
+    from . import Output
+
+    result: dict[str, type] = {}
+    for pulumi_name, return_hint in _raw_return_hints(cls).items():
+        typ = unwrap_type(return_hint)
+        # If typ is Output, it was specified non-generically (as Output rather than Output[T]),
+        # because unwrap_type would have returned the T in Output[T] if it was specified
+        # generically. To avoid raising a type mismatch error when the deserialized output type
+        # doesn't match Output, we exclude it from the results.
+        if typ is Output:
+            continue
+        result[pulumi_name] = typ
     return result
 
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -725,7 +725,7 @@ async def serialize_property(
         # any passed-in input_transformer.
         if typ is not None:
             # A union carries no metadata of its own, so reduce it to the member the value's
-            # constants select and translate using that member's names.
+            # wire shape selects and translate using that member's names.
             case = _types.reduce_discriminated_union(typ, value, _types._py_name_for)
             if case is not None:
                 typ = case

--- a/sdk/python/lib/test/test_types_discriminated_union.py
+++ b/sdk/python/lib/test/test_types_discriminated_union.py
@@ -14,7 +14,9 @@
 
 import asyncio
 import unittest
-from typing import Literal, Optional, Union
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any, Literal, Optional, Union
 
 import pulumi
 from pulumi import _types
@@ -138,6 +140,106 @@ class Untagged(dict):
     name: str = pulumi.property("name")
 
 
+# Members with no constants at all, told apart by their required properties.
+@pulumi.output_type
+class Circle(dict):
+    radius: float = pulumi.property("radius")
+
+
+@pulumi.output_type
+class Square(dict):
+    side_length: float = pulumi.property("sideLength")
+
+
+@pulumi.input_type
+class CircleArgs:
+    radius: pulumi.Input[float] = pulumi.property("radius")
+
+
+@pulumi.input_type
+class SquareArgs:
+    side_length: pulumi.Input[float] = pulumi.property("sideLength")
+
+
+# The deciding property is required on one side and optional, with another type, on the other.
+@pulumi.output_type
+class RequiredFizz(dict):
+    fizz: int = pulumi.property("fizz")
+
+
+@pulumi.output_type
+class OptionalFizz(dict):
+    fizz: Optional[bool] = pulumi.property("fizz")
+
+
+# Members whose shapes only differ one level down.
+@pulumi.output_type
+class IntInner(dict):
+    fizz: int = pulumi.property("fizz")
+
+
+@pulumi.output_type
+class BoolInner(dict):
+    fizz: bool = pulumi.property("fizz")
+
+
+@pulumi.output_type
+class IntHolder(dict):
+    foo: "IntInner" = pulumi.property("foo")
+
+
+@pulumi.output_type
+class BoolHolder(dict):
+    foo: "BoolInner" = pulumi.property("foo")
+
+
+# Members told apart only by a union one level down: Wide.inner admits both Left and Right,
+# Narrow.inner admits Right alone.
+@pulumi.output_type
+class Left(dict):
+    a: int = pulumi.property("a")
+
+
+@pulumi.output_type
+class Right(dict):
+    b: str = pulumi.property("b")
+
+
+@pulumi.output_type
+class Wide(dict):
+    inner: Union["Left", "Right"] = pulumi.property("inner")
+
+
+@pulumi.output_type
+class Narrow(dict):
+    inner: "Right" = pulumi.property("inner")
+
+
+class Color(str, Enum):
+    RED = "red"
+    GREEN = "green"
+
+
+class Shade(str, Enum):
+    LIGHT = "light"
+    DARK = "dark"
+
+
+@pulumi.output_type
+class HasColor(dict):
+    tag: "Color" = pulumi.property("tag")
+
+
+@pulumi.output_type
+class HasShade(dict):
+    tag: "Shade" = pulumi.property("tag")
+
+
+class _NeverResolves:
+    def __await__(self):
+        yield
+
+
 InputUnion = pulumi.Input[Optional[Union[CatArgs, DogArgs]]]
 OutputUnion = Optional[Union[Cat, Dog]]
 
@@ -237,8 +339,13 @@ class ReduceTests(unittest.TestCase):
             reduce_pulumi(Union[SameConstantA, SameConstantB], {"kind": "same"})
         )
 
-    def test_member_without_constants_is_not_a_union(self):
-        self.assertIsNone(reduce_pulumi(Union[Cat, Untagged], {"kind": "cat"}))
+    def test_shape_reaches_members_without_constants(self):
+        union = Union[Cat, Untagged]
+        # `kind` alone satisfies neither member: Cat requires `livesLeft` and Untagged does not
+        # declare `kind` at all.
+        self.assertIsNone(reduce_pulumi(union, {"kind": "cat"}))
+        self.assertIs(reduce_pulumi(union, {"kind": "cat", "livesLeft": 9}), Cat)
+        self.assertIs(reduce_pulumi(union, {"name": "n"}), Untagged)
 
     def test_non_union_and_single_member(self):
         self.assertIsNone(reduce_pulumi(Cat, {"kind": "cat"}))
@@ -265,15 +372,70 @@ class DirectionTests(unittest.TestCase):
 
 
 class IsDiscriminatedUnionTests(unittest.TestCase):
-    def test_recognises_constrained_unions(self):
+    def test_recognises_reducible_unions(self):
         self.assertTrue(_types.is_discriminated_union(InputUnion))
         self.assertTrue(_types.is_discriminated_union(OutputUnion))
         self.assertTrue(_types.is_discriminated_union(Union[ConfigMap, Secret]))
+        self.assertTrue(_types.is_discriminated_union(Union[Cat, Untagged]))
+        self.assertTrue(_types.is_discriminated_union(Union[str, int]))
 
     def test_rejects_everything_else(self):
-        self.assertFalse(_types.is_discriminated_union(Union[Cat, Untagged]))
         self.assertFalse(_types.is_discriminated_union(Cat))
         self.assertFalse(_types.is_discriminated_union(Optional[Cat]))
+        # A value might always belong to an `Any` member, so nothing can be attributed.
+        self.assertFalse(_types.is_discriminated_union(Union[Cat, Any]))
+
+
+class ShapeReduceTests(unittest.TestCase):
+    def test_required_properties_tell_members_apart(self):
+        union = Union[Circle, Square]
+        self.assertIs(reduce_pulumi(union, {"radius": 1.0}), Circle)
+        self.assertIs(reduce_pulumi(union, {"sideLength": 1.0}), Square)
+        self.assertIs(reduce_python(union, {"side_length": 1.0}), Square)
+
+    def test_property_required_on_one_side(self):
+        union = Union[RequiredFizz, OptionalFizz]
+        self.assertIs(reduce_pulumi(union, {"fizz": 3}), RequiredFizz)
+        self.assertIs(reduce_pulumi(union, {"fizz": True}), OptionalFizz)
+        self.assertIs(reduce_pulumi(union, {}), OptionalFizz)
+
+    def test_nested_required_objects(self):
+        union = Union[IntHolder, BoolHolder]
+        self.assertIs(reduce_pulumi(union, {"foo": {"fizz": 1}}), IntHolder)
+        self.assertIs(reduce_pulumi(union, {"foo": {"fizz": True}}), BoolHolder)
+
+    def test_nested_union_property(self):
+        union = Union[Wide, Narrow]
+        self.assertIs(reduce_pulumi(union, {"inner": {"a": 1}}), Wide)
+        self.assertIsNone(reduce_pulumi(union, {"inner": {"b": "s"}}))
+        self.assertIsNone(reduce_pulumi(union, {"inner": {"c": 1}}))
+
+    def test_enum_typed_property_decides(self):
+        union = Union[HasColor, HasShade]
+        self.assertIs(reduce_pulumi(union, {"tag": "red"}), HasColor)
+        self.assertIs(reduce_pulumi(union, {"tag": "dark"}), HasShade)
+        self.assertIsNone(reduce_pulumi(union, {"tag": "mauve"}))
+
+    def test_object_against_map_member(self):
+        union = Union[Cat, Mapping[str, str]]
+        self.assertIs(reduce_pulumi(union, {"kind": "cat", "livesLeft": 9}), Cat)
+        self.assertEqual(reduce_pulumi(union, {"a": "b"}), Mapping[str, str])
+
+    def test_unknown_value_never_rules_a_member_out(self):
+        # An unknown at the deciding position leaves identical shapes ambiguous...
+        self.assertIsNone(
+            reduce_pulumi(Union[Metric, Imperial], {"kind": rpc.UNKNOWN, "amount": 1.0})
+        )
+        # ...but does not stop the rest of the shape from deciding.
+        self.assertIs(
+            reduce_pulumi(OutputUnion, {"kind": rpc.UNKNOWN, "livesLeft": 9}), Cat
+        )
+
+    def test_awaitable_value_never_rules_a_member_out(self):
+        self.assertIs(
+            reduce_pulumi(InputUnion, {"kind": "cat", "livesLeft": _NeverResolves()}),
+            CatArgs,
+        )
 
 
 class SerializeInputTests(unittest.TestCase):
@@ -305,6 +467,15 @@ class SerializeInputTests(unittest.TestCase):
     def test_unknown_constant_is_left_alone(self):
         value = {"kind": "fish", "lives_left": 1}
         self.assertEqual(serialize(value, InputUnion), value)
+
+    def test_shape_selected_member_translates_names(self):
+        # The member is selected by its required property alone; no constants anywhere.
+        self.assertEqual(
+            serialize(
+                {"side_length": 2.0}, pulumi.Input[Union[CircleArgs, SquareArgs]]
+            ),
+            {"sideLength": 2.0},
+        )
 
 
 class TranslateOutputTests(unittest.TestCase):
@@ -340,6 +511,20 @@ class TranslateOutputTests(unittest.TestCase):
     def test_unknown_constant_leaves_the_value_untyped(self):
         result = translate({"kind": "fish", "fins": 2}, OutputUnion)
         self.assertEqual(result, {"kind": "fish", "fins": 2})
+
+    def test_shape_selected_member_is_instantiated(self):
+        result = translate({"sideLength": 2.0}, Optional[Union[Circle, Square]])
+        self.assertIsInstance(result, Square)
+        self.assertEqual(result.side_length, 2.0)
+
+    def test_nested_union_member_is_instantiated(self):
+        for output, inner in (
+            ({"inner": {"a": 1}}, Left),
+            ({"inner": {"b": "s"}}, Right),
+        ):
+            result = translate(output, Optional[Union[Wide, Untagged]])
+            self.assertIsInstance(result, Wide)
+            self.assertIsInstance(result.inner, inner)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`reduce_discriminated_union` previously discriminated only by Literal constants: every member had to pin at least one constant, and a value needed a present-and-agreeing constant to select a member. Codegen is about to emit precise output types for every wire-discriminatable union. This PR enables the runtime to handle complex union types.