### PR TITLE
[Python] Use `codegen.IsWireDiscriminatableUnionType` in outputs

### DIFF
--- a/changelog/pending/20260807--sdkgen--python-discriminated-union-outputs.yaml
+++ b/changelog/pending/20260807--sdkgen--python-discriminated-union-outputs.yaml
@@ -1,0 +1,6 @@
+component: sdkgen
+kind: improvement
+body: Generate precise Python output types for discriminated unions. An array of a
+    union was typed `Sequence[Any]` and a scalar union `Any`, while the matching
+    getters on the generated Args classes were already typed
+time: 2026-08-07T00:00:00+00:00

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2884,10 +2884,15 @@ func (mod *modContext) typeString(t schema.Type, opts typeStringOpts) string {
 					return mod.typeString(typ.ElementType, opts)
 				}
 			}
-			if t.DefaultType != nil {
-				return mod.typeString(t.DefaultType, opts)
+			// A discriminated union of object types keeps its members on the output side too: the
+			// runtime reduces a value to the member its constants select, so only an
+			// undiscriminatable union degrades to its default type or `Any`.
+			if !codegen.IsWireDiscriminatableUnionType(t) {
+				if t.DefaultType != nil {
+					return mod.typeString(t.DefaultType, opts)
+				}
+				return "Any"
 			}
-			return "Any"
 		}
 
 		elementTypeSet := mapset.NewSet[string]()

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
@@ -125,11 +125,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="arrayOfUnionOf")
-    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Any]]]:
+    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Union['outputs.VariantOne', 'outputs.VariantTwo']]]]:
         return pulumi.get(self, "array_of_union_of")
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.VariantOne', 'outputs.VariantTwo']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
@@ -109,6 +109,6 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3', 'outputs.Variant4', 'outputs.Variant5', 'outputs.Variant6', 'outputs.Variant7', 'outputs.Variant8', 'outputs.Variant9', 'outputs.Variant10']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
@@ -109,6 +109,6 @@ class SubsetExample(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
@@ -112,11 +112,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionIn")
-    def union_in(self) -> pulumi.Output[Any]:
+    def union_in(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_in")
 
     @_builtins.property
     @pulumi.getter(name="unionOut")
-    def union_out(self) -> pulumi.Output[Any]:
+    def union_out(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_out")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/pulumi_union/example.py
@@ -156,7 +156,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="mapMapUnionProperty")
-    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Any]]]]:
+    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Union[_builtins.str, Sequence[_builtins.str]]]]]]:
         return pulumi.get(self, "map_map_union_property")
 
     @_builtins.property
@@ -166,7 +166,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="stringOrIntegerProperty")
-    def string_or_integer_property(self) -> pulumi.Output[Optional[Any]]:
+    def string_or_integer_property(self) -> pulumi.Output[Optional[Union[_builtins.str, _builtins.int]]]:
         return pulumi.get(self, "string_or_integer_property")
 
     @_builtins.property

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
@@ -125,11 +125,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="arrayOfUnionOf")
-    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Any]]]:
+    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Union['outputs.VariantOne', 'outputs.VariantTwo']]]]:
         return pulumi.get(self, "array_of_union_of")
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.VariantOne', 'outputs.VariantTwo']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
@@ -109,6 +109,6 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3', 'outputs.Variant4', 'outputs.Variant5', 'outputs.Variant6', 'outputs.Variant7', 'outputs.Variant8', 'outputs.Variant9', 'outputs.Variant10']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
@@ -109,6 +109,6 @@ class SubsetExample(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
@@ -112,11 +112,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionIn")
-    def union_in(self) -> pulumi.Output[Any]:
+    def union_in(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_in")
 
     @_builtins.property
     @pulumi.getter(name="unionOut")
-    def union_out(self) -> pulumi.Output[Any]:
+    def union_out(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_out")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/pulumi_union/example.py
@@ -156,7 +156,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="mapMapUnionProperty")
-    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Any]]]]:
+    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Union[_builtins.str, Sequence[_builtins.str]]]]]]:
         return pulumi.get(self, "map_map_union_property")
 
     @_builtins.property
@@ -166,7 +166,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="stringOrIntegerProperty")
-    def string_or_integer_property(self) -> pulumi.Output[Optional[Any]]:
+    def string_or_integer_property(self) -> pulumi.Output[Optional[Union[_builtins.str, _builtins.int]]]:
         return pulumi.get(self, "string_or_integer_property")
 
     @_builtins.property

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
@@ -130,11 +130,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="arrayOfUnionOf")
-    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Any]]]:
+    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Union['outputs.VariantOne', 'outputs.VariantTwo']]]]:
         return pulumi.get(self, "array_of_union_of")
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.VariantOne', 'outputs.VariantTwo']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
@@ -114,6 +114,6 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3', 'outputs.Variant4', 'outputs.Variant5', 'outputs.Variant6', 'outputs.Variant7', 'outputs.Variant8', 'outputs.Variant9', 'outputs.Variant10']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
@@ -114,6 +114,6 @@ class SubsetExample(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
@@ -117,11 +117,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionIn")
-    def union_in(self) -> pulumi.Output[Any]:
+    def union_in(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_in")
 
     @_builtins.property
     @pulumi.getter(name="unionOut")
-    def union_out(self) -> pulumi.Output[Any]:
+    def union_out(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_out")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/pulumi_union/example.py
@@ -161,7 +161,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="mapMapUnionProperty")
-    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Any]]]]:
+    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Union[_builtins.str, Sequence[_builtins.str]]]]]]:
         return pulumi.get(self, "map_map_union_property")
 
     @_builtins.property
@@ -171,7 +171,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="stringOrIntegerProperty")
-    def string_or_integer_property(self) -> pulumi.Output[Optional[Any]]:
+    def string_or_integer_property(self) -> pulumi.Output[Optional[Union[_builtins.str, _builtins.int]]]:
         return pulumi.get(self, "string_or_integer_property")
 
     @_builtins.property

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
@@ -130,11 +130,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="arrayOfUnionOf")
-    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Any]]]:
+    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Union['outputs.VariantOne', 'outputs.VariantTwo']]]]:
         return pulumi.get(self, "array_of_union_of")
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.VariantOne', 'outputs.VariantTwo']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
@@ -114,6 +114,6 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3', 'outputs.Variant4', 'outputs.Variant5', 'outputs.Variant6', 'outputs.Variant7', 'outputs.Variant8', 'outputs.Variant9', 'outputs.Variant10']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
@@ -114,6 +114,6 @@ class SubsetExample(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
@@ -117,11 +117,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionIn")
-    def union_in(self) -> pulumi.Output[Any]:
+    def union_in(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_in")
 
     @_builtins.property
     @pulumi.getter(name="unionOut")
-    def union_out(self) -> pulumi.Output[Any]:
+    def union_out(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_out")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/pulumi_union/example.py
@@ -161,7 +161,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="mapMapUnionProperty")
-    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Any]]]]:
+    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Union[_builtins.str, Sequence[_builtins.str]]]]]]:
         return pulumi.get(self, "map_map_union_property")
 
     @_builtins.property
@@ -171,7 +171,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="stringOrIntegerProperty")
-    def string_or_integer_property(self) -> pulumi.Output[Optional[Any]]:
+    def string_or_integer_property(self) -> pulumi.Output[Optional[Union[_builtins.str, _builtins.int]]]:
         return pulumi.get(self, "string_or_integer_property")
 
     @_builtins.property

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
@@ -130,11 +130,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="arrayOfUnionOf")
-    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Any]]]:
+    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Union['outputs.VariantOne', 'outputs.VariantTwo']]]]:
         return pulumi.get(self, "array_of_union_of")
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.VariantOne', 'outputs.VariantTwo']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
@@ -114,6 +114,6 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3', 'outputs.Variant4', 'outputs.Variant5', 'outputs.Variant6', 'outputs.Variant7', 'outputs.Variant8', 'outputs.Variant9', 'outputs.Variant10']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
@@ -114,6 +114,6 @@ class SubsetExample(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
@@ -117,11 +117,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionIn")
-    def union_in(self) -> pulumi.Output[Any]:
+    def union_in(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_in")
 
     @_builtins.property
     @pulumi.getter(name="unionOut")
-    def union_out(self) -> pulumi.Output[Any]:
+    def union_out(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_out")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pulumi_union/example.py
@@ -161,7 +161,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="mapMapUnionProperty")
-    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Any]]]]:
+    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Union[_builtins.str, Sequence[_builtins.str]]]]]]:
         return pulumi.get(self, "map_map_union_property")
 
     @_builtins.property
@@ -171,7 +171,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="stringOrIntegerProperty")
-    def string_or_integer_property(self) -> pulumi.Output[Optional[Any]]:
+    def string_or_integer_property(self) -> pulumi.Output[Optional[Union[_builtins.str, _builtins.int]]]:
         return pulumi.get(self, "string_or_integer_property")
 
     @_builtins.property

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/example.py
@@ -130,11 +130,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="arrayOfUnionOf")
-    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Any]]]:
+    def array_of_union_of(self) -> pulumi.Output[Optional[Sequence[Union['outputs.VariantOne', 'outputs.VariantTwo']]]]:
         return pulumi.get(self, "array_of_union_of")
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.VariantOne', 'outputs.VariantTwo']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/example.py
@@ -114,6 +114,6 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3', 'outputs.Variant4', 'outputs.Variant5', 'outputs.Variant6', 'outputs.Variant7', 'outputs.Variant8', 'outputs.Variant9', 'outputs.Variant10']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/subset_example.py
@@ -114,6 +114,6 @@ class SubsetExample(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionOf")
-    def union_of(self) -> pulumi.Output[Optional[Any]]:
+    def union_of(self) -> pulumi.Output[Optional[Union['outputs.Variant1', 'outputs.Variant2', 'outputs.Variant3']]]:
         return pulumi.get(self, "union_of")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/example.py
@@ -117,11 +117,11 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="unionIn")
-    def union_in(self) -> pulumi.Output[Any]:
+    def union_in(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_in")
 
     @_builtins.property
     @pulumi.getter(name="unionOut")
-    def union_out(self) -> pulumi.Output[Any]:
+    def union_out(self) -> pulumi.Output[Union['outputs.VariantOne', 'outputs.VariantTwo']]:
         return pulumi.get(self, "union_out")
 

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pulumi_union/example.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pulumi_union/example.py
@@ -161,7 +161,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="mapMapUnionProperty")
-    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Any]]]]:
+    def map_map_union_property(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Union[_builtins.str, Sequence[_builtins.str]]]]]]:
         return pulumi.get(self, "map_map_union_property")
 
     @_builtins.property
@@ -171,7 +171,7 @@ class Example(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="stringOrIntegerProperty")
-    def string_or_integer_property(self) -> pulumi.Output[Optional[Any]]:
+    def string_or_integer_property(self) -> pulumi.Output[Optional[Union[_builtins.str, _builtins.int]]]:
         return pulumi.get(self, "string_or_integer_property")
 
     @_builtins.property

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/outputs.py
@@ -87,7 +87,7 @@ class BillingMeterDetailsResponse(dict):
     """
     def __init__(__self__, *,
                  frequency: _builtins.str,
-                 meter_details: Any,
+                 meter_details: Union['outputs.Pav2MeterDetailsResponse', 'outputs.PurchaseMeterDetailsResponse'],
                  metering_type: _builtins.str,
                  name: _builtins.str):
         """
@@ -113,7 +113,7 @@ class BillingMeterDetailsResponse(dict):
 
     @_builtins.property
     @pulumi.getter(name="meterDetails")
-    def meter_details(self) -> Any:
+    def meter_details(self) -> Union['outputs.Pav2MeterDetailsResponse', 'outputs.PurchaseMeterDetailsResponse']:
         """
         Represents MeterDetails
         """

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
@@ -45,7 +45,7 @@ class GetIntegrationRuntimeObjectMetadatumResult:
 
     @_builtins.property
     @pulumi.getter
-    def value(self) -> Optional[Sequence[Any]]:
+    def value(self) -> Optional[Sequence[Union['outputs.SsisEnvironmentResponse', 'outputs.SsisFolderResponse', 'outputs.SsisPackageResponse', 'outputs.SsisProjectResponse']]]:
         """
         List of SSIS object metadata.
         """

--- a/tests/testdata/codegen/types.json
+++ b/tests/testdata/codegen/types.json
@@ -557,8 +557,8 @@
                   "plain": "outputs.Object | any[] | undefined"
                 },
                 "python": {
-                  "input": "Optional[Any]",
-                  "plain": "Optional[Any]"
+                  "input": "pulumi.Input[Optional[Union['outputs.ObjectArgs', Sequence[Any]]]]",
+                  "plain": "Optional[Union['outputs.Object', Sequence[Any]]]"
                 }
               }
             }


### PR DESCRIPTION
Generate tightly typed union outputs. This fixes https://github.com/pulumi/pulumi/issues/21832 in the general case.

Closes https://github.com/pulumi/pulumi/pull/24238
Closes https://github.com/pulumi/pulumi/pull/21925