### PR TITLE
redact secrets from URLs

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -66,6 +66,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
@@ -238,6 +239,8 @@ func newDIYBackend(
 	if opts.Env == nil {
 		opts.Env = env.Global()
 	}
+
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(originalURL), "[credential]")
 
 	if !IsDIYBackendURL(originalURL) {
 		return nil, fmt.Errorf("diy URL %s has an illegal prefix; expected one of: %s",

--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -27,6 +27,8 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -57,6 +59,7 @@ func NonInteractiveCurrentBackend(
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(url), "[credential]")
 	slog.InfoContext(ctx, "Current cloud URL", "url", url)
 
 	// Only set current if we don't currently have a cloud URL set.
@@ -71,6 +74,7 @@ func CurrentBackend(
 	if err != nil {
 		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(url), "[credential]")
 	slog.InfoContext(ctx, "Current cloud URL", "url", url)
 	insecure := pkgWorkspace.GetCloudInsecure(ws, url)
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/deckarep/golang-set/v2 v2.5.0
 	github.com/ebitengine/purego v0.10.2
 	github.com/git-pkgs/manifests v0.4.1
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -58,6 +58,8 @@ github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJzQ7y/sA=
+github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -150,6 +151,8 @@ func IsGitOriginURLGitHub(remoteURL string) bool {
 // and the type (kind) of VCS from it.
 func TryGetVCSInfo(remoteURL string) (_ *VCSInfo, err error) {
 	var project, vcsKind string
+
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(remoteURL), "[credential]")
 
 	defer func() {
 		if err != nil {

--- a/sdk/go/common/util/httputil/redact.go
+++ b/sdk/go/common/util/httputil/redact.go
@@ -17,20 +17,22 @@ package httputil
 import (
 	"net/url"
 	"strings"
+
+	mapset "github.com/deckarep/golang-set/v2"
 )
 
-var sensitiveQueryKeys = map[string]bool{
-	"sig":                  true, // Azure SAS signature
-	"signature":            true,
-	"x-amz-signature":      true,
-	"x-amz-credential":     true,
-	"x-amz-security-token": true,
-	"x-goog-signature":     true,
-	"x-goog-credential":    true,
-	"awsaccesskeyid":       true,
-	"token":                true,
-	"access_token":         true,
-}
+var sensitiveQueryKeys = mapset.NewSet(
+	"sig", // Azure SAS signature
+	"signature",
+	"x-amz-signature",
+	"x-amz-credential",
+	"x-amz-security-token",
+	"x-goog-signature",
+	"x-goog-credential",
+	"awsaccesskeyid",
+	"token",
+	"access_token",
+)
 
 func URLSecrets(raw string) []string {
 	u, err := url.Parse(raw)
@@ -44,7 +46,7 @@ func URLSecrets(raw string) []string {
 		}
 	}
 	for k, vs := range u.Query() {
-		if !sensitiveQueryKeys[strings.ToLower(k)] {
+		if !sensitiveQueryKeys.Contains(strings.ToLower(k)) {
 			continue
 		}
 		for _, v := range vs {
@@ -65,7 +67,7 @@ func RedactURL(raw string) string {
 		q := u.Query()
 		changed := false
 		for k := range q {
-			if sensitiveQueryKeys[strings.ToLower(k)] {
+			if sensitiveQueryKeys.Contains(strings.ToLower(k)) {
 				q[k] = []string{"redacted"}
 				changed = true
 			}

--- a/sdk/go/common/util/httputil/redact.go
+++ b/sdk/go/common/util/httputil/redact.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"net/url"
+	"strings"
+)
+
+var sensitiveQueryKeys = map[string]bool{
+	"sig":                  true, // Azure SAS signature
+	"signature":            true,
+	"x-amz-signature":      true,
+	"x-amz-credential":     true,
+	"x-amz-security-token": true,
+	"x-goog-signature":     true,
+	"x-goog-credential":    true,
+	"awsaccesskeyid":       true,
+	"token":                true,
+	"access_token":         true,
+}
+
+func URLSecrets(raw string) []string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	var secrets []string
+	if u.User != nil {
+		if pw, ok := u.User.Password(); ok && pw != "" {
+			secrets = append(secrets, pw)
+		}
+	}
+	for k, vs := range u.Query() {
+		if !sensitiveQueryKeys[strings.ToLower(k)] {
+			continue
+		}
+		for _, v := range vs {
+			if v != "" {
+				secrets = append(secrets, v)
+			}
+		}
+	}
+	return secrets
+}
+
+func RedactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "[redacted url]"
+	}
+	if u.RawQuery != "" {
+		q := u.Query()
+		changed := false
+		for k := range q {
+			if sensitiveQueryKeys[strings.ToLower(k)] {
+				q[k] = []string{"redacted"}
+				changed = true
+			}
+		}
+		if changed {
+			u.RawQuery = q.Encode()
+		}
+	}
+	return u.Redacted()
+}

--- a/sdk/go/common/util/httputil/redact_test.go
+++ b/sdk/go/common/util/httputil/redact_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "postgres dsn password",
+			in:   "postgres://user:hunter2@db.example.com:5432/pulumi",
+			want: "postgres://user:xxxxx@db.example.com:5432/pulumi",
+		},
+		{
+			name: "git pat in userinfo",
+			in:   "https://x-access-token:ghp_secret@github.com/pulumi/pulumi.git",
+			want: "https://x-access-token:xxxxx@github.com/pulumi/pulumi.git",
+		},
+		{
+			name: "presigned query values",
+			in:   "https://bucket.s3.amazonaws.com/p.tgz?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIA",
+			want: "https://bucket.s3.amazonaws.com/p.tgz?X-Amz-Credential=redacted&X-Amz-Signature=redacted",
+		},
+		{
+			name: "benign query preserved, sensitive redacted",
+			in:   "azblob://container?sv=2021&sig=abc123",
+			want: "azblob://container?sig=redacted&sv=2021",
+		},
+		{
+			name: "no credentials unchanged",
+			in:   "https://api.pulumi.com",
+			want: "https://api.pulumi.com",
+		},
+		{
+			name: "unparseable",
+			in:   "http://foo.com/%",
+			want: "[redacted url]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, RedactURL(tt.in))
+		})
+	}
+}
+
+func TestURLSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"password extracted", "postgres://user:hunter2@db/pulumi", []string{"hunter2"}},
+		{"git pat as password", "https://x-access-token:ghp_secret@github.com/x", []string{"ghp_secret"}},
+		{"azblob sas signature", "azblob://container?sv=2021&sp=r&sig=abc123def", []string{"abc123def"}},
+		{"benign query not extracted", "s3://bucket?region=us-west-2&profile=dev", nil},
+		{"no userinfo", "https://api.pulumi.com", nil},
+		{"username only, no password", "https://ghp_tok@github.com/x", nil},
+		{"unparseable", "http://foo.com/%", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.ElementsMatch(t, tt.want, URLSecrets(tt.in))
+		})
+	}
+}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1645,7 +1645,7 @@ func buildHTTPRequest(ctx context.Context, pluginEndpoint string, authorization 
 }
 
 func getHTTPResponse(req *http.Request) (io.ReadCloser, int64, error) {
-	logging.V(9).Infof("full plugin download url: %s", req.URL)
+	logging.V(9).Infof("full plugin download url: %s", httputil.RedactURL(req.URL.String()))
 	// This logs at level 11 because it could include authentication headers, we reserve log level 11 for
 	// detailed api logs that may include credentials.
 	logging.V(11).Infof("plugin install request headers: %v", req.Header)
@@ -1668,7 +1668,7 @@ func getHTTPResponse(req *http.Request) (io.ReadCloser, int64, error) {
 }
 
 func getHTTPResponseWithRetry(req *http.Request) (io.ReadCloser, int64, error) {
-	logging.V(9).Infof("full plugin download url: %s", req.URL)
+	logging.V(9).Infof("full plugin download url: %s", httputil.RedactURL(req.URL.String()))
 	// This logs at level 11 because it could include authentication headers, we reserve log level 11 for
 	// detailed api logs that may include credentials.
 	logging.V(11).Infof("plugin install request headers: %v", req.Header)

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/tests/integration/construct_component_provider_propagation/go/go.sum
+++ b/tests/integration/construct_component_provider_propagation/go/go.sum
@@ -50,6 +50,8 @@ github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJzQ7y/sA=
+github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/tests/integration/construct_component_resource_options/go/go.sum
+++ b/tests/integration/construct_component_resource_options/go/go.sum
@@ -50,6 +50,8 @@ github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJzQ7y/sA=
+github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/tests/integration/construct_nested_component/go/go.sum
+++ b/tests/integration/construct_nested_component/go/go.sum
@@ -50,6 +50,8 @@ github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJzQ7y/sA=
+github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=

--- a/tests/integration/run_plugin/go/go.mod
+++ b/tests/integration/run_plugin/go/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg/v2 v2.0.2 // indirect

--- a/tests/integration/run_plugin/go/go.sum
+++ b/tests/integration/run_plugin/go/go.sum
@@ -49,6 +49,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJzQ7y/sA=
+github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=


### PR DESCRIPTION
Currently we don't add secrets from URLs to the global secret filter. This inclueds e.g. postgres passwords in the postgres URL, and others. Add all secrets from URLs to the global secret filter, so they don't end up in logs.
