### PR TITLE
avoid hanging when policy pack start fails

### DIFF
--- a/changelog/pending/cli-policy-fix-20260828-142638.yaml
+++ b/changelog/pending/cli-policy-fix-20260828-142638.yaml
@@ -1,0 +1,4 @@
+component: cli/policy
+kind: fix
+body: Avoid hanging when policy pack fails to start up
+time: 2026-08-28T14:26:38.200306694+02:00

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1606,7 +1606,7 @@ func startDebugging(
 
 func (host *nodeLanguageHost) RunPlugin(
 	req *pulumirpc.RunPluginRequest, server pulumirpc.LanguageRuntime_RunPluginServer,
-) error {
+) (err error) {
 	logging.V(5).Infof("Attempting to run nodejs plugin in %s", req.Info.ProgramDirectory)
 	ctx := server.Context()
 
@@ -1713,6 +1713,11 @@ func (host *nodeLanguageHost) RunPlugin(
 		if err != nil {
 			return fmt.Errorf("could not start policy pack proxy: %w", err)
 		}
+		defer func() {
+			if err != nil {
+				policyPackServer.Abort(err)
+			}
+		}()
 
 		config, err := policyPackServer.AwaitConfiguration(ctx)
 		if err != nil {

--- a/sdk/policy_proxy.go
+++ b/sdk/policy_proxy.go
@@ -169,6 +169,10 @@ func (p *PolicyProxy) Attach(ctx context.Context, cmd *exec.Cmd) error {
 	return err
 }
 
+func (p *PolicyProxy) Abort(err error) {
+	p.client.Reject(fmt.Errorf("policy pack failed to start: %w", err))
+}
+
 func (p *PolicyProxy) ConfigureStack(
 	ctx context.Context,
 	req *pulumirpc.AnalyzerStackConfigureRequest,

--- a/sdk/policy_proxy_test.go
+++ b/sdk/policy_proxy_test.go
@@ -17,6 +17,7 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -198,6 +199,39 @@ func TestPolicyProxy_Attach_NewPolicyPackWithConfigureStack(t *testing.T) {
 
 	cmd.Process.Kill() //nolint:errcheck
 	<-attachDone
+}
+
+// TestPolicyProxy_Abort_UnblocksAwaitClient verifies that when the policy pack process fails to
+// start after the proxy handshake with the engine has completed (so Attach is never called), Abort
+// rejects the client promise and pending analyzer calls return an error instead of blocking forever.
+func TestPolicyProxy_Abort_UnblocksAwaitClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	proxy, _, err := NewPolicyProxy(ctx, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	infoDone := make(chan error, 1)
+	go func() {
+		_, err := proxy.GetAnalyzerInfo(ctx, &emptypb.Empty{})
+		infoDone <- err
+	}()
+
+	proxy.Abort(errors.New("fork/exec .venv/bin/python: no such file or directory"))
+
+	select {
+	case infoErr := <-infoDone:
+		require.ErrorContains(t, infoErr, "policy pack failed to start")
+		require.ErrorContains(t, infoErr, "no such file or directory")
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetAnalyzerInfo did not return after Abort")
+	}
+
+	// A second Abort is a no-op and later calls still see the original error.
+	proxy.Abort(errors.New("second abort"))
+	_, pluginErr := proxy.GetPluginInfo(ctx, &emptypb.Empty{})
+	require.ErrorContains(t, pluginErr, "no such file or directory")
+	require.NotContains(t, pluginErr.Error(), "second abort")
 }
 
 // TestPolicyProxy_Attach_ConfigureStackError verifies that when ConfigureStack fails with a

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1525,7 +1525,7 @@ func (host *pythonLanguageHost) GetProgramDependencies(
 //     entrypoint.
 func (host *pythonLanguageHost) RunPlugin(
 	req *pulumirpc.RunPluginRequest, server pulumirpc.LanguageRuntime_RunPluginServer,
-) error {
+) (err error) {
 	logging.V(5).Infof("Attempting to run python plugin in %s with args %v", req.Info.ProgramDirectory, req.Args)
 	ctx := server.Context()
 
@@ -1648,6 +1648,11 @@ func (host *pythonLanguageHost) RunPlugin(
 		if err != nil {
 			return fmt.Errorf("could not start policy pack proxy: %w", err)
 		}
+		defer func() {
+			if err != nil {
+				policyPackServer.Abort(err)
+			}
+		}()
 
 		config, err := policyPackServer.AwaitConfiguration(ctx)
 		if err != nil {


### PR DESCRIPTION
With the new policy pack proxy, we introduced a potential hang when the policy pack startup in `RunPlugin` fails.

In the startup sequence, the policy pack proxy prints out its port, making the engine attach to it.  However, the policy pack only starts after that handshake, because we need to pass the stack configuration to the policy pack via env variable for legacy policy packs.

When the startup fails, we error out, but the engine only sees that as the plugins output stream ending. It considers the analyzer up because the handshake with the proxy succeeded.  The next analyzer call blocks forever inside the proxy, waiting for the policy pack client that will never be attached.

Instead, we need to also abort the proxy explicitly when this happens. Rejecting the client promise means in-flight and future analyzer calls return the startup error, so the engine can error out instead of waiting forever.

Something the clanker noticed while looking into https://github.com/pulumi/pulumi-policy/issues/351.