### PR TITLE
cli/config: [PoC] read and write stack config through a mainEnvironment ESC environment

### DIFF
--- a/changelog/pending/20260828--cli-config--main-environment.yaml
+++ b/changelog/pending/20260828--cli-config--main-environment.yaml
@@ -1,0 +1,6 @@
+component: cli/config
+kind: feat
+body: Add an experimental `mainEnvironment` stack setting that reads stack configuration
+    from a named ESC environment and makes `pulumi config set` and `pulumi config rm`
+    write to it
+time: 2026-08-28T00:00:00Z

--- a/changelog/pending/20260828--cli-new--esc-config.yaml
+++ b/changelog/pending/20260828--cli-new--esc-config.yaml
@@ -1,0 +1,5 @@
+component: cli/new
+kind: feat
+body: Add an experimental `--esc-config` flag to `pulumi new` and `pulumi stack init`
+    that creates the new stack's ESC environments and records them as its `mainEnvironment`
+time: 2026-08-28T00:00:00Z

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -316,6 +316,54 @@ type EnvironmentsBackend interface {
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
 }
 
+// ErrEnvironmentConflict is returned by EnvironmentDefinitionsBackend.UpdateEnvironmentDefinition when the
+// environment was modified between the read that produced the etag and the write that carried it.
+var ErrEnvironmentConflict = errors.New("the environment was modified since it was read")
+
+// ErrEnvironmentNotFound is returned by EnvironmentDefinitionsBackend.GetEnvironmentDefinition when the named
+// environment does not exist.
+var ErrEnvironmentNotFound = errors.New("environment not found")
+
+// EnvironmentDefinitionsBackend is an interface defining an additional capability of a Backend, specifically the
+// ability to read and update the definition of a *named* environment with optimistic concurrency. This isn't a
+// requirement for all backends and should be checked for dynamically.
+//
+// EnvironmentsBackend covers anonymous environments (check/open a literal YAML document); this interface covers
+// the named environments that back a stack's `mainEnvironment`.
+type EnvironmentDefinitionsBackend interface {
+	// GetEnvironmentDefinition returns the YAML definition of an environment along with the etag that must be
+	// passed to a subsequent UpdateEnvironmentDefinition, and the revision the definition was read at. An empty
+	// version means "latest". Secrets are returned in their encrypted form.
+	GetEnvironmentDefinition(
+		ctx context.Context,
+		org string,
+		envProject string,
+		envName string,
+		version string,
+	) (yaml []byte, etag string, revision int, err error)
+
+	// UpdateEnvironmentDefinition writes a new definition for an environment, returning the revision it created.
+	// The etag must be the one returned by the immediately preceding GetEnvironmentDefinition; if the environment
+	// changed in the meantime the update fails with ErrEnvironmentConflict rather than overwriting it.
+	UpdateEnvironmentDefinition(
+		ctx context.Context,
+		org string,
+		envProject string,
+		envName string,
+		yaml []byte,
+		etag string,
+	) (apitype.EnvironmentDiagnostics, int, error)
+
+	// GetEnvironmentRevision resolves a version (a revision number, a tag, or "" for latest) to a revision number.
+	GetEnvironmentRevision(
+		ctx context.Context,
+		org string,
+		envProject string,
+		envName string,
+		version string,
+	) (int, error)
+}
+
 // SpecificDeploymentExporter is an interface defining an additional capability of a Backend, specifically the
 // ability to export a specific versions of a stack's deployment. This isn't a requirement for all backends and
 // should be checked for dynamically.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -324,6 +324,11 @@ var ErrEnvironmentConflict = errors.New("the environment was modified since it w
 // environment does not exist.
 var ErrEnvironmentNotFound = errors.New("environment not found")
 
+// ErrEnvironmentCreatedInvalid is returned by EnvironmentsBackend.CreateEnvironment when the environment
+// itself was created but the definition it was created with could not be stored. The environment exists
+// and is unusable, so a caller must not report it as "not created" or silently reuse it.
+var ErrEnvironmentCreatedInvalid = errors.New("the environment was created, but its definition was not stored")
+
 // EnvironmentDefinitionsBackend is an interface defining an additional capability of a Backend, specifically the
 // ability to read and update the definition of a *named* environment with optimistic concurrency. This isn't a
 // requirement for all backends and should be checked for dynamically.

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -50,13 +50,21 @@ func (b *cloudBackend) CreateEnvironment(
 	envName string,
 	yaml []byte,
 ) (apitype.EnvironmentDiagnostics, error) {
-	// Classify the errors so that callers creating an environment that already exists see
+	// Classify the create error so that callers creating an environment that already exists see
 	// backend.ErrEnvironmentConflict and can reuse it rather than failing.
 	if err := b.escClient.CreateEnvironment(ctx, org, projectName, envName); err != nil {
 		return nil, classifyEnvironmentError(err)
 	}
+	// The environment now exists; writing its definition is a separate call. Its error is deliberately
+	// *not* classified: a conflict here means the write failed, not that the environment was already
+	// there, and a caller that treats ErrEnvironmentConflict as "reuse" would otherwise adopt the empty
+	// environment this call just made.
 	diags, _, err := b.escClient.UpdateEnvironment(ctx, org, projectName, envName, yaml, "")
-	return convertESCDiags(diags), classifyEnvironmentError(err)
+	if err != nil {
+		return convertESCDiags(diags), fmt.Errorf("%w: %s/%s: %w",
+			backend.ErrEnvironmentCreatedInvalid, projectName, envName, err)
+	}
+	return convertESCDiags(diags), nil
 }
 
 func (b *cloudBackend) CheckYAMLEnvironment(

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -16,6 +16,8 @@ package httpstate
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -78,4 +80,73 @@ func (b *cloudBackend) OpenYAMLEnvironment(
 	}
 	env, err := b.escClient.GetAnonymousOpenEnvironment(ctx, org, id)
 	return env, nil, err
+}
+
+var _ = backend.EnvironmentDefinitionsBackend((*cloudBackend)(nil))
+
+// classifyEnvironmentError maps the HTTP status codes the ESC API uses for optimistic-concurrency and
+// missing-environment failures onto the sentinel errors the command layer matches on.
+func classifyEnvironmentError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var code int
+	switch e := err.(type) { //nolint:errorlint // the client returns these error values directly
+	case *apitype.ErrorResponse:
+		code = e.Code
+	case *client.EnvironmentErrorResponse:
+		code = e.Code
+	}
+	switch code {
+	case http.StatusPreconditionFailed, http.StatusConflict:
+		return fmt.Errorf("%w: %w", backend.ErrEnvironmentConflict, err)
+	case http.StatusNotFound:
+		return fmt.Errorf("%w: %w", backend.ErrEnvironmentNotFound, err)
+	}
+	return err
+}
+
+func (b *cloudBackend) GetEnvironmentDefinition(
+	ctx context.Context,
+	org string,
+	envProject string,
+	envName string,
+	version string,
+) ([]byte, string, int, error) {
+	// decrypt is false: existing secrets round-trip through read-modify-write as opaque ciphertext, so
+	// no other value's plaintext ever enters this process's memory.
+	yaml, etag, revision, err := b.escClient.GetEnvironment(ctx, org, envProject, envName, version, false)
+	if err != nil {
+		return nil, "", 0, classifyEnvironmentError(err)
+	}
+	return yaml, etag, revision, nil
+}
+
+func (b *cloudBackend) UpdateEnvironmentDefinition(
+	ctx context.Context,
+	org string,
+	envProject string,
+	envName string,
+	yaml []byte,
+	etag string,
+) (apitype.EnvironmentDiagnostics, int, error) {
+	diags, revision, err := b.escClient.UpdateEnvironment(ctx, org, envProject, envName, yaml, etag)
+	if err != nil {
+		return nil, 0, classifyEnvironmentError(err)
+	}
+	return convertESCDiags(diags), revision, nil
+}
+
+func (b *cloudBackend) GetEnvironmentRevision(
+	ctx context.Context,
+	org string,
+	envProject string,
+	envName string,
+	version string,
+) (int, error) {
+	revision, err := b.escClient.GetRevisionNumber(ctx, org, envProject, envName, version)
+	if err != nil {
+		return 0, classifyEnvironmentError(err)
+	}
+	return revision, nil
 }

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -50,11 +50,13 @@ func (b *cloudBackend) CreateEnvironment(
 	envName string,
 	yaml []byte,
 ) (apitype.EnvironmentDiagnostics, error) {
+	// Classify the errors so that callers creating an environment that already exists see
+	// backend.ErrEnvironmentConflict and can reuse it rather than failing.
 	if err := b.escClient.CreateEnvironment(ctx, org, projectName, envName); err != nil {
-		return nil, err
+		return nil, classifyEnvironmentError(err)
 	}
 	diags, _, err := b.escClient.UpdateEnvironment(ctx, org, projectName, envName, yaml, "")
-	return convertESCDiags(diags), err
+	return convertESCDiags(diags), classifyEnvironmentError(err)
 }
 
 func (b *cloudBackend) CheckYAMLEnvironment(

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -497,7 +497,10 @@ func (be *MockBackend) GetReadOnlyCloudRegistry() registry.Registry {
 	panic("not implemented")
 }
 
-var _ = EnvironmentsBackend((*MockEnvironmentsBackend)(nil))
+var (
+	_ = EnvironmentsBackend((*MockEnvironmentsBackend)(nil))
+	_ = EnvironmentDefinitionsBackend((*MockEnvironmentsBackend)(nil))
+)
 
 type MockEnvironmentsBackend struct {
 	MockBackend
@@ -523,6 +526,31 @@ type MockEnvironmentsBackend struct {
 		duration time.Duration,
 		environmentOverrides map[string]string,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
+
+	GetEnvironmentDefinitionF func(
+		ctx context.Context,
+		org string,
+		envProject string,
+		envName string,
+		version string,
+	) ([]byte, string, int, error)
+
+	UpdateEnvironmentDefinitionF func(
+		ctx context.Context,
+		org string,
+		envProject string,
+		envName string,
+		yaml []byte,
+		etag string,
+	) (apitype.EnvironmentDiagnostics, int, error)
+
+	GetEnvironmentRevisionF func(
+		ctx context.Context,
+		org string,
+		envProject string,
+		envName string,
+		version string,
+	) (int, error)
 }
 
 func (be *MockEnvironmentsBackend) CreateEnvironment(
@@ -558,6 +586,46 @@ func (be *MockEnvironmentsBackend) OpenYAMLEnvironment(
 ) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 	if be.OpenYAMLEnvironmentF != nil {
 		return be.OpenYAMLEnvironmentF(ctx, org, yaml, duration, environmentOverrides)
+	}
+	panic("not implemented")
+}
+
+func (be *MockEnvironmentsBackend) GetEnvironmentDefinition(
+	ctx context.Context,
+	org string,
+	envProject string,
+	envName string,
+	version string,
+) ([]byte, string, int, error) {
+	if be.GetEnvironmentDefinitionF != nil {
+		return be.GetEnvironmentDefinitionF(ctx, org, envProject, envName, version)
+	}
+	panic("not implemented")
+}
+
+func (be *MockEnvironmentsBackend) UpdateEnvironmentDefinition(
+	ctx context.Context,
+	org string,
+	envProject string,
+	envName string,
+	yaml []byte,
+	etag string,
+) (apitype.EnvironmentDiagnostics, int, error) {
+	if be.UpdateEnvironmentDefinitionF != nil {
+		return be.UpdateEnvironmentDefinitionF(ctx, org, envProject, envName, yaml, etag)
+	}
+	panic("not implemented")
+}
+
+func (be *MockEnvironmentsBackend) GetEnvironmentRevision(
+	ctx context.Context,
+	org string,
+	envProject string,
+	envName string,
+	version string,
+) (int, error) {
+	if be.GetEnvironmentRevisionF != nil {
+		return be.GetEnvironmentRevisionF(ctx, org, envProject, envName, version)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -167,13 +167,15 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 	cmd.AddCommand(newConfigSetAllCmd(ws, &stack, cmdBackend.DefaultLoginManager, &ssml, &configFile))
 	cmd.AddCommand(newConfigRefreshCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
-	cmd.AddCommand(newConfigCopyCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigCopyCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
 	cmd.AddCommand(newConfigEnvCmd(ws, &stack, &configFile))
 
 	return cmd
 }
 
-func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
+func newConfigCopyCmd(
+	ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager, configFile *string,
+) *cobra.Command {
 	var path bool
 	var destinationStackName string
 
@@ -204,7 +206,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				cmdBackend.DefaultLoginManager,
+				lm,
 				*stack,
 				cmdStack.SetCurrent,
 				opts,
@@ -221,12 +223,19 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				return err
 			}
 
+			// Refuse before reading anything: a main environment's values do not live in the source
+			// stack's `config:` block, so copying it would silently produce an empty (or stale)
+			// destination rather than the configuration the source actually resolves.
+			if mainEnv := activeMainEnvironment(cmd.ErrOrStderr(), currentStack, currentProjectStack); mainEnv != nil {
+				return errMainEnvUnsupported("copy", mainEnv)
+			}
+
 			// Get the destination stack
 			destinationStack, err := cmdStack.RequireStack(
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				cmdBackend.DefaultLoginManager,
+				lm,
 				destinationStackName,
 				cmdStack.LoadOnly,
 				opts,
@@ -242,6 +251,8 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				return err
 			}
 
+			mainEnv := activeMainEnvironment(cmd.ErrOrStderr(), destinationStack, destinationProjectStack)
+
 			if configLocation := destinationStack.ConfigLocation(); configLocation.IsRemote {
 				err := errors.New("config copy destination not supported for remote stack config")
 				if configLocation.EscEnv != nil {
@@ -251,7 +262,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				return err
 			}
 
-			if mainEnv := activeMainEnvironment(destinationStack, destinationProjectStack); mainEnv != nil {
+			if mainEnv != nil {
 				return errMainEnvUnsupported("copy", mainEnv)
 			}
 
@@ -447,6 +458,8 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 				return err
 			}
 
+			mainEnv := activeMainEnvironment(cmd.ErrOrStderr(), stack, ps)
+
 			if configLocation := stack.ConfigLocation(); configLocation.IsRemote {
 				err := errors.New("config rm not supported for remote stack config")
 				if configLocation.EscEnv != nil {
@@ -456,8 +469,8 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 				return err
 			}
 
-			if mainEnv := activeMainEnvironment(stack, ps); mainEnv != nil {
-				return removeFromMainEnvironment(ctx, cmd.OutOrStdout(), stack, mainEnv, key, path)
+			if mainEnv != nil {
+				return removeFromMainEnvironment(ctx, cmd.OutOrStdout(), stack, ps, mainEnv, key, path)
 			}
 
 			err = ps.Config.Remove(key, path)
@@ -531,6 +544,8 @@ func newConfigRemoveAllCmd(ws pkgWorkspace.Context, stack *string, configFile *s
 				return err
 			}
 
+			mainEnv := activeMainEnvironment(cmd.ErrOrStderr(), stack, ps)
+
 			if configLocation := stack.ConfigLocation(); configLocation.IsRemote {
 				err := errors.New("config rm-all not supported for remote stack config")
 				if configLocation.EscEnv != nil {
@@ -540,7 +555,7 @@ func newConfigRemoveAllCmd(ws pkgWorkspace.Context, stack *string, configFile *s
 				return err
 			}
 
-			if mainEnv := activeMainEnvironment(stack, ps); mainEnv != nil {
+			if mainEnv != nil {
 				return errMainEnvUnsupported("rm-all", mainEnv)
 			}
 
@@ -638,7 +653,7 @@ func newConfigRefreshCmd(
 				return err
 			}
 
-			if mainEnv := activeMainEnvironment(s, ps); mainEnv != nil {
+			if mainEnv := activeMainEnvironment(cmd.ErrOrStderr(), s, ps); mainEnv != nil {
 				return errMainEnvUnsupported("refresh", mainEnv)
 			}
 
@@ -726,6 +741,7 @@ func newConfigRefreshCmd(
 type configSetCmd struct {
 	Stdin            *os.File
 	Stdout           io.Writer
+	Stderr           io.Writer
 	LoadProjectStack func(
 		context.Context, diag.Sink, *workspace.Project, backend.Stack, string,
 	) (*workspace.ProjectStack, error)
@@ -735,6 +751,20 @@ type configSetCmd struct {
 	Path      bool
 	Raw       bool
 	Type      string
+}
+
+func (c *configSetCmd) stdout() io.Writer {
+	if c.Stdout == nil {
+		return os.Stdout //nolint:forbidigo // this is a command's default output stream
+	}
+	return c.Stdout
+}
+
+func (c *configSetCmd) stderr() io.Writer {
+	if c.Stderr == nil {
+		return os.Stderr //nolint:forbidigo // this is a command's default error stream
+	}
+	return c.Stderr
 }
 
 func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
@@ -793,6 +823,7 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 			}
 
 			configSetCmd.Stdout = cmd.OutOrStdout()
+			configSetCmd.Stderr = cmd.ErrOrStderr()
 			return configSetCmd.Run(ctx, ws, args, project, s, *configFile)
 		},
 	}
@@ -881,8 +912,8 @@ func (c *configSetCmd) Run(
 	// A stack with a main environment writes straight to that environment. This happens before the stack's
 	// secrets manager is ever consulted: secrets on this path are encrypted by ESC, not by the stack's
 	// passphrase or KMS key, and the stack file is not touched at all.
-	if mainEnv := activeMainEnvironment(s, ps); mainEnv != nil {
-		return c.setInMainEnvironment(ctx, key, value, s, mainEnv)
+	if mainEnv := activeMainEnvironment(c.stderr(), s, ps); mainEnv != nil {
+		return c.setInMainEnvironment(ctx, key, value, s, ps, mainEnv)
 	}
 
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
@@ -954,6 +985,7 @@ func removeFromMainEnvironment(
 	ctx context.Context,
 	out io.Writer,
 	s backend.Stack,
+	ps *workspace.ProjectStack,
 	mainEnv *workspace.MainEnvironment,
 	key config.Key,
 	path bool,
@@ -972,10 +1004,26 @@ func removeFromMainEnvironment(
 	}
 	if !removed {
 		fmt.Fprintf(out, "Configuration key '%s' is not set in %v\n", PrettyKey(key), mainEnv.Ref())
-		return nil
+	} else {
+		fmt.Fprintf(out, "Updated %v@%d\n", mainEnv.Ref(), revision)
 	}
-	fmt.Fprintf(out, "Updated %v@%d\n", mainEnv.Ref(), revision)
+	// An unmigrated value in the stack file wins over the environment, so removing the environment's copy
+	// alone would leave `pulumi config` still reporting the key.
+	if hasLocalConfigValue(ps, key) {
+		fmt.Fprintf(out, "warning: '%s' is still set in Pulumi.%s.yaml, which takes precedence over %v; "+
+			"migrate it with 'pulumi config env init --main'\n",
+			PrettyKey(key), s.Ref().Name(), mainEnv.Ref())
+	}
 	return nil
+}
+
+// hasLocalConfigValue reports whether a key is still set in the stack file's `config:` block.
+func hasLocalConfigValue(ps *workspace.ProjectStack, key config.Key) bool {
+	if ps == nil {
+		return false
+	}
+	_, ok, err := ps.Config.Get(key, false /*path*/)
+	return err == nil && ok
 }
 
 // setInMainEnvironment writes a single value into the stack's main environment and reports the revision the
@@ -985,12 +1033,10 @@ func (c *configSetCmd) setInMainEnvironment(
 	key config.Key,
 	value string,
 	s backend.Stack,
+	ps *workspace.ProjectStack,
 	mainEnv *workspace.MainEnvironment,
 ) error {
-	out := c.Stdout
-	if out == nil {
-		out = os.Stdout //nolint:forbidigo // this is a command's default output stream
-	}
+	out := c.stdout()
 
 	if c.Path {
 		return errMainEnvUnsupported("set --path", mainEnv)
@@ -1016,6 +1062,13 @@ func (c *configSetCmd) setInMainEnvironment(
 	}
 
 	fmt.Fprintf(out, "Updated %s@%d\n", mainEnv.Ref(), revision)
+	// An unmigrated value in the stack file wins over the environment, so the value just written would not
+	// be the one `pulumi config get` reports.
+	if hasLocalConfigValue(ps, key) {
+		fmt.Fprintf(out, "warning: '%s' is also set in Pulumi.%s.yaml, which shadows the value just "+
+			"written; migrate it with 'pulumi config env init --main'\n",
+			PrettyKey(key), s.Ref().Name())
+	}
 	return nil
 }
 
@@ -1087,7 +1140,7 @@ func newConfigSetAllCmd(
 				return err
 			}
 
-			if mainEnv := activeMainEnvironment(stack, ps); mainEnv != nil {
+			if mainEnv := activeMainEnvironment(cmd.ErrOrStderr(), stack, ps); mainEnv != nil {
 				return errMainEnvUnsupported("set-all", mainEnv)
 			}
 
@@ -1548,10 +1601,19 @@ func getConfig(
 			return fmt.Errorf("could not decrypt configuration value: %w", err)
 		}
 
+		var sources *sourceIndex
+		if showSourceFlag {
+			sources = buildSourceIndex(
+				ctx, stack, mainEnv, project.Name, stack.Ref().Name().String(), pulumiEnv, ps.Config)
+		}
+
 		if jsonOut {
 			value := configValueJSON{
 				Value:  &raw,
 				Secret: v.Secure(),
+				// Attribution goes in the JSON object rather than alongside it, so that
+				// `--json --show-source` stays parseable.
+				Source: sources.get(key),
 			}
 
 			if v.Object() {
@@ -1569,12 +1631,9 @@ func getConfig(
 			fmt.Fprintln(out, string(marshaled))
 		} else {
 			fmt.Fprintf(out, "%v\n", raw)
-		}
-
-		if showSourceFlag {
-			sources := buildSourceIndex(
-				ctx, stack, mainEnv, project.Name, stack.Ref().Name().String(), pulumiEnv, ps.Config)
-			showSource(out, sources, mainEnv, key, pulumiEnv)
+			if showSourceFlag {
+				showSource(out, sources, mainEnv, key, pulumiEnv)
+			}
 		}
 
 		if len(diags) != 0 {

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -1047,7 +1047,7 @@ func (c *configSetCmd) setInMainEnvironment(
 			key)
 	}
 
-	node, err := configValueNode(value, c.Type, c.Secret)
+	node, err := ConfigValueNode(value, c.Type, c.Secret)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -70,7 +70,10 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 		Short: "Manage configuration",
 		Long: "Lists all configuration values for a specific stack. To add a new configuration value, run\n" +
 			"`pulumi config set`. To remove an existing value run `pulumi config rm`. To get the value of\n" +
-			"for a specific configuration key, use `pulumi config get <key-name>`.",
+			"for a specific configuration key, use `pulumi config get <key-name>`.\n\n" +
+			"[EXPERIMENTAL] If the stack sets `mainEnvironment: <project>/<env>` then its configuration is\n" +
+			"read from that ESC environment, and a SOURCE column attributes each value to the environment\n" +
+			"revision that defined it.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			opts := display.Options{
@@ -248,6 +251,10 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				return err
 			}
 
+			if mainEnv := activeMainEnvironment(destinationStack, destinationProjectStack); mainEnv != nil {
+				return errMainEnvUnsupported("copy", mainEnv)
+			}
+
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 			// Do we need to copy a single value or the entire map
@@ -314,11 +321,14 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 	var jsonOut bool
 	var open bool
 	var path bool
+	var showSource bool
 
 	getCmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get a single configuration value",
 		Long: "Get a single configuration value.\n\n" +
+			"[EXPERIMENTAL] On a stack that sets `mainEnvironment`, `--show-source` additionally prints the\n" +
+			"environment revision that defined the value and any definitions it overrode.\n\n" +
 			"The `--path` flag can be used to get a value inside a map or list:\n\n" +
 			"  - `pulumi config get --path outer.inner` will get the value of the `inner` key, " +
 			"if the value of `outer` is a map `inner: value`.\n" +
@@ -350,7 +360,8 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 			}
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-			return getConfig(ctx, cmd.OutOrStdout(), cmdutil.Diag(), ssml, ws, s, key, path, jsonOut, open, *configFile)
+			return getConfig(
+				ctx, cmd.OutOrStdout(), cmdutil.Diag(), ssml, ws, s, key, path, jsonOut, open, showSource, *configFile)
 		},
 	}
 	constrictor.AttachArguments(getCmd, &constrictor.Arguments{
@@ -372,6 +383,11 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 		&path, "path", false,
 		"The key contains a path to a property in a map or list to get",
 	)
+	getCmd.Flags().BoolVar(
+		&showSource, "show-source", false,
+		"Show the environment revision that defined the value, and any definitions it overrode. "+
+			"Requires the stack to set `mainEnvironment`",
+	)
 
 	return getCmd
 }
@@ -384,6 +400,8 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 		Aliases: []string{"rm", "delete"},
 		Short:   "Remove configuration value",
 		Long: "Remove configuration value.\n\n" +
+			"[EXPERIMENTAL] On a stack that sets `mainEnvironment`, the value is removed from that ESC\n" +
+			"environment and the new environment revision is printed, instead of editing the stack file.\n\n" +
 			"The `--path` flag can be used to remove a value inside a map or list:\n\n" +
 			"  - `pulumi config rm --path outer.inner` will remove the `inner` key, " +
 			"if the value of `outer` is a map `inner: value`.\n" +
@@ -436,6 +454,10 @@ func newConfigRemoveCmd(ws pkgWorkspace.Context, stack *string, configFile *stri
 						err, *configLocation.EscEnv, key.String())
 				}
 				return err
+			}
+
+			if mainEnv := activeMainEnvironment(stack, ps); mainEnv != nil {
+				return removeFromMainEnvironment(ctx, cmd.OutOrStdout(), stack, mainEnv, key, path)
 			}
 
 			err = ps.Config.Remove(key, path)
@@ -516,6 +538,10 @@ func newConfigRemoveAllCmd(ws pkgWorkspace.Context, stack *string, configFile *s
 						err, *configLocation.EscEnv)
 				}
 				return err
+			}
+
+			if mainEnv := activeMainEnvironment(stack, ps); mainEnv != nil {
+				return errMainEnvUnsupported("rm-all", mainEnv)
 			}
 
 			for _, arg := range args {
@@ -612,6 +638,10 @@ func newConfigRefreshCmd(
 				return err
 			}
 
+			if mainEnv := activeMainEnvironment(s, ps); mainEnv != nil {
+				return errMainEnvUnsupported("refresh", mainEnv)
+			}
+
 			ps.Config = latest.Config
 
 			// If the backend is returning envs, then we want to use them.
@@ -695,6 +725,7 @@ func newConfigRefreshCmd(
 
 type configSetCmd struct {
 	Stdin            *os.File
+	Stdout           io.Writer
 	LoadProjectStack func(
 		context.Context, diag.Sink, *workspace.Project, backend.Stack, string,
 	) (*workspace.ProjectStack, error)
@@ -716,6 +747,10 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 			"If a value is not present on the command line, pulumi will prompt for the value. Multi-line values\n" +
 			"may be set by piping a file to standard in. Note that in that case, trailing newlines are stripped,\n" +
 			"unless `--raw` is passed.\n\n" +
+			"[EXPERIMENTAL] On a stack that sets `mainEnvironment`, the value is written to that ESC\n" +
+			"environment and the new environment revision is printed, instead of editing the stack file.\n" +
+			"Values set with `--secret` are encrypted by ESC as `fn::secret` values; the stack's own secrets\n" +
+			"provider is not involved.\n\n" +
 			"The `--path` flag can be used to set a value inside a map or list:\n\n" +
 			"  - `pulumi config set --path 'names[0]' a` " +
 			"will set the value to a list with the first item `a`.\n" +
@@ -757,6 +792,7 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 				return err
 			}
 
+			configSetCmd.Stdout = cmd.OutOrStdout()
 			return configSetCmd.Run(ctx, ws, args, project, s, *configFile)
 		},
 	}
@@ -842,6 +878,13 @@ func (c *configSetCmd) Run(
 		return err
 	}
 
+	// A stack with a main environment writes straight to that environment. This happens before the stack's
+	// secrets manager is ever consulted: secrets on this path are encrypted by ESC, not by the stack's
+	// passphrase or KMS key, and the stack file is not touched at all.
+	if mainEnv := activeMainEnvironment(s, ps); mainEnv != nil {
+		return c.setInMainEnvironment(ctx, key, value, s, mainEnv)
+	}
+
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 
 	// Encrypt the config value if needed.
@@ -903,6 +946,77 @@ func (c *configSetCmd) Run(
 	}
 
 	return cmdStack.SaveProjectStack(ctx, s, ps, configFile)
+}
+
+// removeFromMainEnvironment removes a single value from the stack's main environment and reports the
+// revision the removal produced. The local stack file is never modified on this path.
+func removeFromMainEnvironment(
+	ctx context.Context,
+	out io.Writer,
+	s backend.Stack,
+	mainEnv *workspace.MainEnvironment,
+	key config.Key,
+	path bool,
+) error {
+	if path {
+		return errMainEnvUnsupported("rm --path", mainEnv)
+	}
+
+	w, err := newMainEnvWriter(s, mainEnv)
+	if err != nil {
+		return err
+	}
+	revision, removed, err := w.removeKey(ctx, out, key)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		fmt.Fprintf(out, "Configuration key '%s' is not set in %v\n", PrettyKey(key), mainEnv.Ref())
+		return nil
+	}
+	fmt.Fprintf(out, "Updated %v@%d\n", mainEnv.Ref(), revision)
+	return nil
+}
+
+// setInMainEnvironment writes a single value into the stack's main environment and reports the revision the
+// write produced. The local stack file is never modified on this path.
+func (c *configSetCmd) setInMainEnvironment(
+	ctx context.Context,
+	key config.Key,
+	value string,
+	s backend.Stack,
+	mainEnv *workspace.MainEnvironment,
+) error {
+	out := c.Stdout
+	if out == nil {
+		out = os.Stdout //nolint:forbidigo // this is a command's default output stream
+	}
+
+	if c.Path {
+		return errMainEnvUnsupported("set --path", mainEnv)
+	}
+	if !c.Secret && !c.Plaintext && looksLikeSecret(key, value) {
+		return fmt.Errorf("config value for '%s' looks like a secret; "+
+			"rerun with --secret to encrypt it, or --plaintext if you meant to store in plaintext",
+			key)
+	}
+
+	node, err := configValueNode(value, c.Type, c.Secret)
+	if err != nil {
+		return err
+	}
+
+	w, err := newMainEnvWriter(s, mainEnv)
+	if err != nil {
+		return err
+	}
+	revision, err := w.setKey(ctx, out, key, node)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Updated %s@%d\n", mainEnv.Ref(), revision)
+	return nil
 }
 
 func newConfigSetAllCmd(
@@ -971,6 +1085,10 @@ func newConfigSetAllCmd(
 			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
 			if err != nil {
 				return err
+			}
+
+			if mainEnv := activeMainEnvironment(stack, ps); mainEnv != nil {
+				return errMainEnvUnsupported("set-all", mainEnv)
 			}
 
 			for _, ptArg := range plaintextArgs {
@@ -1114,6 +1232,9 @@ type configValueJSON struct {
 	Value       *string `json:"value,omitempty"`
 	ObjectValue any     `json:"objectValue,omitempty"`
 	Secret      bool    `json:"secret"`
+	// Source attributes the value to the environment revision that defined it. It is only ever populated
+	// for stacks that set `mainEnvironment`, so the output shape of every other stack is unchanged.
+	Source string `json:"source,omitempty"`
 }
 
 func listConfig(
@@ -1128,6 +1249,11 @@ func listConfig(
 	openEnvironment bool,
 	configFile string,
 ) error {
+	_, mainEnv, warnings := effectiveStackEnv(stack, ps)
+	if !jsonOut {
+		printConfigWarnings(stdout, warnings)
+	}
+
 	var env *esc.Environment
 	var diags []apitype.EnvironmentDiagnostic
 	var err error
@@ -1163,6 +1289,13 @@ func listConfig(
 	}
 
 	stackName := stack.Ref().Name().String()
+
+	// Attribute each value back to the environment revision that defined it. Only stacks with a main
+	// environment get this; every other stack's output is untouched.
+	var sources *sourceIndex
+	if mainEnv != nil {
+		sources = buildSourceIndex(ctx, stack, mainEnv, project.Name, stackName, pulumiEnv, ps.Config)
+	}
 
 	cfg, err := ps.Config.Copy(config.NopDecrypter, config.NopEncrypter)
 	if err != nil {
@@ -1212,6 +1345,7 @@ func listConfig(
 		for _, key := range keys {
 			entry := configValueJSON{
 				Secret: cfg[key].Secure(),
+				Source: sources.get(key),
 			}
 
 			decrypted := decryptedCfg[key]
@@ -1240,16 +1374,31 @@ func listConfig(
 			return err
 		}
 	} else {
+		headers := []string{"KEY", "VALUE"}
+		if sources != nil {
+			headers = append(headers, "SOURCE")
+		}
 		rows := []cmdutil.TableRow{}
 		for _, key := range keys {
 			decrypted := decryptedCfg[key]
-			rows = append(rows, cmdutil.TableRow{Columns: []string{PrettyKey(key), decrypted}})
+			columns := []string{PrettyKey(key), decrypted}
+			if sources != nil {
+				columns = append(columns, sources.get(key))
+			}
+			rows = append(rows, cmdutil.TableRow{Columns: columns})
 		}
 
 		ui.FprintTable(stdout, cmdutil.Table{
-			Headers: []string{"KEY", "VALUE"},
+			Headers: headers,
 			Rows:    rows,
 		}, nil)
+
+		if sources != nil && len(sources.unmigrated) != 0 {
+			fmt.Fprintf(stdout,
+				"\nwarning: %d configuration value(s) still set in Pulumi.%s.yaml override %v; "+
+					"run 'pulumi config env init --main' to migrate them\n",
+				len(sources.unmigrated), stackName, mainEnv.Ref())
+		}
 
 		if env != nil {
 			_, environ, _, _, err := cli.PrepareEnvironment(env, &cli.PrepareOptions{
@@ -1301,6 +1450,7 @@ func getConfig(
 	key config.Key,
 	path, jsonOut,
 	openEnvironment bool,
+	showSourceFlag bool,
 	configFile string,
 ) error {
 	cwd, err := os.Getwd()
@@ -1315,6 +1465,14 @@ func getConfig(
 	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
 	if err != nil {
 		return err
+	}
+
+	_, mainEnv, warnings := effectiveStackEnv(stack, ps)
+	if showSourceFlag && mainEnv == nil {
+		return errors.New("--show-source requires the stack to set 'mainEnvironment'")
+	}
+	if !jsonOut {
+		printConfigWarnings(out, warnings)
 	}
 
 	var env *esc.Environment
@@ -1413,6 +1571,12 @@ func getConfig(
 			fmt.Fprintf(out, "%v\n", raw)
 		}
 
+		if showSourceFlag {
+			sources := buildSourceIndex(
+				ctx, stack, mainEnv, project.Name, stack.Ref().Name().String(), pulumiEnv, ps.Config)
+			showSource(out, sources, mainEnv, key, pulumiEnv)
+		}
+
 		if len(diags) != 0 {
 			fmt.Fprintln(out)
 			fmt.Fprintln(out, "Environment diagnostics:")
@@ -1464,7 +1628,8 @@ func checkStackEnv(
 	stack backend.Stack,
 	workspaceStack *workspace.ProjectStack,
 ) (*esc.Environment, []apitype.EnvironmentDiagnostic, error) {
-	yaml := workspaceStack.EnvironmentBytes()
+	envDef, _, _ := effectiveStackEnv(stack, workspaceStack)
+	yaml := envDef.Definition()
 	if len(yaml) == 0 {
 		return nil, nil, nil
 	}

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -60,7 +60,9 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 		Use:   "env",
 		Short: "Manage ESC environments for a stack",
 		Long: "Manages the ESC environment associated with a specific stack. To create a new environment\n" +
-			"from a stack's configuration, use `pulumi config env init`.",
+			"from a stack's configuration, use `pulumi config env init`.\n\n" +
+			"[EXPERIMENTAL] A stack that sets `mainEnvironment` has exactly one environment, which supersedes\n" +
+			"the `environment:` list: `pulumi config env ls` reports it, and `add`/`rm` are not supported.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			impl.stdout = cmd.OutOrStdout()
 		},
@@ -165,17 +167,23 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 }
 
 func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, render stackEnvironmentsRenderFunc) error {
-	projectStack, _, _, err := cmd.loadEnvPreamble(ctx)
+	projectStack, _, stack, err := cmd.loadEnvPreamble(ctx)
 	if err != nil {
 		return err
 	}
 	imports := projectStack.Environment.Imports()
+	// A main environment is the stack's only environment, and it deliberately supersedes `environment:`,
+	// so listing the `environment:` imports here would report environments the stack does not resolve.
+	if mainEnv := activeMainEnvironment(cmd.stdout, *stack, projectStack); mainEnv != nil {
+		imports = []string{mainEnv.String()}
+	}
 
 	return render(cmd.stdout, imports)
 }
 
 func (cmd *configEnvCmd) editStackEnvironment(
 	ctx context.Context,
+	name string,
 	showSecrets bool,
 	yes bool,
 	edit func(stack *workspace.ProjectStack) error,
@@ -187,6 +195,12 @@ func (cmd *configEnvCmd) editStackEnvironment(
 	projectStack, project, stack, err := cmd.loadEnvPreamble(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Editing `environment:` on a stack with a main environment would silently have no effect, since the
+	// main environment supersedes that list.
+	if mainEnv := activeMainEnvironment(cmd.stdout, *stack, projectStack); mainEnv != nil {
+		return errMainEnvUnsupported("env "+name, mainEnv)
 	}
 
 	if err := edit(projectStack); err != nil {

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -39,9 +39,11 @@ import (
 
 // errBackendNoEnvironments indicates that the given backend does not support ESC environments and
 // points the user at the Pulumi Cloud backend, which does.
+//
+// The message lives in the `stack` package so that `pulumi stack init` can refuse a backend without
+// environment support before it creates anything; `config` cannot be imported from there.
 func errBackendNoEnvironments(b backend.Backend) error {
-	return fmt.Errorf("backend %v does not support environments; Pulumi ESC environments require the "+
-		"Pulumi Cloud backend, use `pulumi login` without arguments to log into the Pulumi Cloud backend", b.Name())
+	return cmdStack.ErrBackendNoEnvironments(b)
 }
 
 func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *string) *cobra.Command {

--- a/pkg/cmd/pulumi/config/config_env_add.go
+++ b/pkg/cmd/pulumi/config/config_env_add.go
@@ -64,7 +64,7 @@ type configEnvAddCmd struct {
 
 func (cmd *configEnvAddCmd) run(ctx context.Context, args []string) error {
 	return cmd.parent.editStackEnvironment(
-		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
+		ctx, "add", cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
 			stack.Environment = stack.Environment.Append(args...)
 			return nil
 		})

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -54,7 +55,9 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 		Short: "Creates an environment for a stack",
 		Long: "Creates an environment for a specific stack based on the stack's configuration values,\n" +
 			"then replaces the stack's configuration values with a reference to that environment.\n" +
-			"The environment will be created in the same organization as the stack.",
+			"The environment will be created in the same organization as the stack.\n\n" +
+			"[EXPERIMENTAL] Pass --main to record the environment as the stack's `mainEnvironment`, which\n" +
+			"also makes it the target of `pulumi config set` and `pulumi config rm`.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parent.initArgs()
 			return impl.run(cmd.Context(), args)
@@ -74,6 +77,11 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 	cmd.Flags().BoolVar(
 		&impl.keepConfig, "keep-config", false,
 		"Do not remove configuration values from the stack after creating the environment",
+	)
+	cmd.Flags().BoolVar(
+		&impl.main, "main", false,
+		"Bind the environment to the stack as its `mainEnvironment`, so that `pulumi config set` and "+
+			"`pulumi config rm` write to it, instead of appending it to the stack's `environment` list",
 	)
 	cmd.Flags().BoolVarP(
 		&impl.yes, "yes", "y", false,
@@ -100,6 +108,7 @@ type configEnvInitCmd struct {
 	envName     string
 	showSecrets bool
 	keepConfig  bool
+	main        bool
 	yes         bool
 }
 
@@ -160,6 +169,10 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	if cmd.main {
+		// Migrating must not silently retype values, so undo the engine's scalar coercion.
+		config = preserveScalarStringTypes(projectStack.Config, config)
+	}
 
 	crypter, err := cmd.newCrypter()
 	if err != nil {
@@ -202,14 +215,70 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 	}
 
 	fullName := fmt.Sprintf("%s/%s", envProject, envName)
-	projectStack.Environment = projectStack.Environment.Append(fullName)
+	if cmd.main {
+		// Bind the environment as the stack's single source of configuration and target of config writes.
+		// The stack's `environment` list is deliberately left alone.
+		projectStack.MainEnvironment = &workspace.MainEnvironment{Project: envProject, Name: envName}
+	} else {
+		projectStack.Environment = projectStack.Environment.Append(fullName)
+	}
 	if !cmd.keepConfig {
 		projectStack.Config = nil
 	}
 	if err = cmd.parent.saveProjectStack(ctx, stack, projectStack, *cmd.parent.configFile); err != nil {
 		return fmt.Errorf("saving stack config: %w", err)
 	}
+	if cmd.main {
+		cmd.printMigrationSummary(fullName, config)
+	}
 	return nil
+}
+
+// preserveScalarStringTypes restores the string-ness of untyped scalar configuration values.
+//
+// config.Map.AsDecryptedPropertyMap coerces an untyped "6" into the number 6, which is what the engine
+// hands to a program. A migration must not retype the stack's data, so a value that the stack file held
+// as a plain string is written to the environment as a string.
+func preserveScalarStringTypes(cfg config.Map, m property.Map) property.Map {
+	values := m.AsMap()
+	for k, v := range cfg {
+		if v.Secure() || v.Object() {
+			continue
+		}
+		raw, err := v.ToObject()
+		if err != nil {
+			continue
+		}
+		if s, ok := raw.(string); ok {
+			values[k.String()] = property.New(s)
+		}
+	}
+	return property.NewMap(values)
+}
+
+// printMigrationSummary reports which configuration values moved into the environment. The PoC does not
+// verify that the migrated environment resolves to values equivalent to the original config block, so
+// saying exactly what moved is how a user checks the migration themselves.
+func (cmd *configEnvInitCmd) printMigrationSummary(fullName string, config property.Map) {
+	keys := make([]string, 0, config.Len())
+	secrets := 0
+	for k, v := range config.All {
+		keys = append(keys, k)
+		if v.Secret() {
+			secrets++
+		}
+	}
+	sort.Strings(keys)
+
+	fmt.Fprintf(cmd.parent.stdout, "Moved %d configuration value(s) (%d secret) to %v:\n",
+		len(keys), secrets, fullName)
+	for _, k := range keys {
+		fmt.Fprintf(cmd.parent.stdout, "  %v\n", k)
+	}
+	if cmd.keepConfig {
+		fmt.Fprintf(cmd.parent.stdout,
+			"The stack's 'config' block was kept and still overrides %v.\n", fullName)
+	}
 }
 
 func (cmd *configEnvInitCmd) getStackConfig(

--- a/pkg/cmd/pulumi/config/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config/config_env_init_test.go
@@ -287,3 +287,44 @@ runtime: yaml`
 		assert.Equal(t, expectedYAML, newStackYAML)
 	})
 }
+
+// TestConfigEnvInitMain covers the migration path: `--main` moves the stack's `config:` block into the
+// environment and rewrites the stack file to `mainEnvironment:`.
+func TestConfigEnvInitMain(t *testing.T) {
+	t.Parallel()
+
+	projectYAML := `name: test
+runtime: yaml`
+
+	cfg := map[config.Key]config.Value{
+		config.MustMakeKey("aws", "region"):        config.NewValue("us-west-2"),
+		config.MustMakeKey("app", "instanceCount"): config.NewValue("6"),
+		config.MustMakeKey("app", "password"):      config.NewSecureValue("aHVudGVyMg==" /*base64 of hunter2*/),
+	}
+
+	stackYAML, err := encoding.YAML.Marshal(workspace.ProjectStack{Config: cfg})
+	require.NoError(t, err)
+
+	var newStackYAML string
+	stdin := strings.NewReader("y")
+	var stdout bytes.Buffer
+	parent := newConfigEnvCmdForInitTest(stdin, &stdout, projectYAML, string(stackYAML), &newStackYAML, envDefMap{})
+	init := &configEnvInitCmd{
+		parent: parent, newCrypter: newBase64EvalCrypter, showSecrets: true, main: true, yes: true,
+	}
+	require.NoError(t, init.run(t.Context(), nil))
+
+	out := cleanStdout(stdout.String())
+	// Value types are preserved: the string "6" stays a string, and the stack secret becomes an ESC secret.
+	assert.Contains(t, out, "    app:instanceCount: \"6\"\n")
+	assert.Contains(t, out, "    app:password:\n      fn::secret: hunter2\n")
+	// The command reports what moved, since it does not verify value-equivalence itself.
+	assert.Contains(t, out, "Moved 3 configuration value(s) (1 secret) to test/stack:\n"+
+		"  app:instanceCount\n"+
+		"  app:password\n"+
+		"  aws:region\n")
+
+	// The stack file now binds the environment as its main environment, with no `environment:` list and
+	// no leftover `config:` block.
+	assert.Equal(t, "mainEnvironment: test/stack\n", newStackYAML)
+}

--- a/pkg/cmd/pulumi/config/config_env_remove.go
+++ b/pkg/cmd/pulumi/config/config_env_remove.go
@@ -62,7 +62,7 @@ type configEnvRmCmd struct {
 
 func (cmd *configEnvRmCmd) run(ctx context.Context, args []string) error {
 	return cmd.parent.editStackEnvironment(
-		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
+		ctx, "rm", cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
 			stack.Environment = stack.Environment.Remove(args[0])
 			return nil
 		})

--- a/pkg/cmd/pulumi/config/config_main_env.go
+++ b/pkg/cmd/pulumi/config/config_main_env.go
@@ -1,0 +1,452 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/syntax/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// effectiveStackEnv decides which environment definition a stack resolves its configuration through.
+//
+// A stack that sets `mainEnvironment:` resolves a synthesized environment that imports exactly that one
+// named environment, which keeps every downstream behaviour (imports, environment variables, secret
+// handling, `pulumiConfig` merging) identical to an `environment:` stack. It returns the environment
+// definition to resolve, the main environment when one is active, and any warnings the caller should
+// surface to the user.
+func effectiveStackEnv(
+	s backend.Stack, ps *workspace.ProjectStack,
+) (*workspace.Environment, *workspace.MainEnvironment, []string) {
+	if ps == nil {
+		return nil, nil, nil
+	}
+	if ps.MainEnvironment == nil {
+		return ps.Environment, nil, nil
+	}
+
+	// Remote stack configuration is a separate, service-side mechanism that already owns the stack's
+	// config. Leave it in charge and say so rather than silently resolving two sources.
+	if s != nil && s.ConfigLocation().IsRemote {
+		return ps.Environment, nil, []string{
+			"'mainEnvironment' is ignored because this stack's configuration is stored remotely",
+		}
+	}
+
+	var warnings []string
+	if ps.Environment != nil {
+		warnings = append(warnings,
+			"'environment' is ignored because this stack sets 'mainEnvironment'")
+	}
+	return workspace.NewEnvironment([]string{ps.MainEnvironment.String()}), ps.MainEnvironment, warnings
+}
+
+// activeMainEnvironment returns the stack's main environment, or nil if it does not have one in effect.
+func activeMainEnvironment(s backend.Stack, ps *workspace.ProjectStack) *workspace.MainEnvironment {
+	_, mainEnv, _ := effectiveStackEnv(s, ps)
+	return mainEnv
+}
+
+func printConfigWarnings(out io.Writer, warnings []string) {
+	color := cmdutil.GetGlobalColorization()
+	for _, w := range warnings {
+		fmt.Fprintln(out, color.Colorize(colors.SpecWarning+"warning: "+w+colors.Reset))
+	}
+}
+
+// errMainEnvUnsupported reports that a config subcommand has not been taught to write through a main
+// environment. Refusing is deliberate: silently writing the local `config:` block would shadow the
+// environment's values instead of updating them.
+func errMainEnvUnsupported(command string, mainEnv *workspace.MainEnvironment) error {
+	return fmt.Errorf(
+		"'pulumi config %s' is not supported yet on a stack that sets 'mainEnvironment: %s'; "+
+			"use 'pulumi config set'/'pulumi config rm', or edit the environment directly with 'pulumi env'",
+		command, mainEnv)
+}
+
+// mainEnvWriter performs read-modify-write updates of a stack's main environment.
+//
+// Every write carries the etag returned by the read that immediately preceded it, so a violation of the
+// single-writer assumption surfaces as a hard error instead of clobbering someone else's change.
+type mainEnvWriter struct {
+	envs    backend.EnvironmentDefinitionsBackend
+	org     string
+	mainEnv *workspace.MainEnvironment
+}
+
+func newMainEnvWriter(s backend.Stack, mainEnv *workspace.MainEnvironment) (*mainEnvWriter, error) {
+	// Writing to a pinned stack would create a revision the stack itself would never read, so the very
+	// next `pulumi config` would not show the value that was just set. Refuse instead.
+	if mainEnv.Version != "" {
+		return nil, fmt.Errorf(
+			"cannot modify environment %v: this stack pins it to version %q; "+
+				"remove the '@%s' pin from 'mainEnvironment' to write to it, "+
+				"or edit the environment directly with 'pulumi env set'",
+			mainEnv.Ref(), mainEnv.Version, mainEnv.Version)
+	}
+
+	envs, ok := s.Backend().(backend.EnvironmentDefinitionsBackend)
+	if !ok {
+		return nil, errBackendNoEnvironments(s.Backend())
+	}
+	orgNamer, ok := s.(interface{ OrgName() string })
+	if !ok {
+		return nil, fmt.Errorf("cannot determine organization for stack %v", s.Ref())
+	}
+	return &mainEnvWriter{envs: envs, org: orgNamer.OrgName(), mainEnv: mainEnv}, nil
+}
+
+// read fetches the environment's definition along with the etag a subsequent write must carry.
+func (w *mainEnvWriter) read(ctx context.Context) (*yaml.Node, string, error) {
+	def, etag, _, err := w.envs.GetEnvironmentDefinition(ctx, w.org, w.mainEnv.Project, w.mainEnv.Name, "")
+	if err != nil {
+		if errors.Is(err, backend.ErrEnvironmentNotFound) {
+			return nil, "", fmt.Errorf(
+				"environment %v does not exist; create it with 'pulumi env init %v', "+
+					"or migrate this stack's configuration with 'pulumi config env init --main'",
+				w.mainEnv.Ref(), w.mainEnv.Ref())
+		}
+		return nil, "", fmt.Errorf("getting environment definition: %w", err)
+	}
+
+	docNode := &yaml.Node{}
+	if err := yaml.Unmarshal(def, docNode); err != nil {
+		return nil, "", fmt.Errorf("unmarshaling environment definition: %w", err)
+	}
+	if docNode.Kind != yaml.DocumentNode {
+		docNode = &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{}}}
+	}
+	return docNode, etag, nil
+}
+
+// write sends the edited definition back with the etag from the preceding read and returns the revision
+// the update created.
+func (w *mainEnvWriter) write(ctx context.Context, out io.Writer, docNode *yaml.Node, etag string) (int, error) {
+	newYAML, err := yaml.Marshal(docNode.Content[0])
+	if err != nil {
+		return 0, fmt.Errorf("marshaling environment definition: %w", err)
+	}
+
+	diags, revision, err := w.envs.UpdateEnvironmentDefinition(
+		ctx, w.org, w.mainEnv.Project, w.mainEnv.Name, newYAML, etag)
+	if err != nil {
+		if errors.Is(err, backend.ErrEnvironmentConflict) {
+			return 0, fmt.Errorf(
+				"environment %v changed since it was read, so the update was rejected rather than "+
+					"overwriting it; re-run the command", w.mainEnv.Ref())
+		}
+		return 0, fmt.Errorf("updating environment: %w", err)
+	}
+	if len(diags) != 0 {
+		printESCDiagnostics(out, diags)
+		return 0, fmt.Errorf("updating environment %v: too many errors", w.mainEnv.Ref())
+	}
+	return revision, nil
+}
+
+// configValuePath is the location of a stack configuration key within an environment definition. The key
+// is used verbatim as a single path element so that its `<namespace>:<name>` form is never parsed as a
+// path expression.
+func configValuePath(key config.Key) resource.PropertyPath {
+	return resource.PropertyPath{"pulumiConfig", key.String()}
+}
+
+// setKey writes a single configuration value into the environment's `values.pulumiConfig` and returns the
+// revision the write created.
+func (w *mainEnvWriter) setKey(
+	ctx context.Context, out io.Writer, key config.Key, value yaml.Node,
+) (int, error) {
+	docNode, etag, err := w.read(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	valuesNode, ok := encoding.YAMLSyntax{Node: docNode}.Get(resource.PropertyPath{"values"})
+	if !ok {
+		valuesNode, err = encoding.YAMLSyntax{Node: docNode}.Set(
+			nil, resource.PropertyPath{"values"}, yaml.Node{Kind: yaml.MappingNode})
+		if err != nil {
+			return 0, fmt.Errorf("internal error: %w", err)
+		}
+	}
+	if _, err = (encoding.YAMLSyntax{Node: valuesNode}).Set(nil, configValuePath(key), value); err != nil {
+		return 0, err
+	}
+
+	return w.write(ctx, out, docNode, etag)
+}
+
+// removeKey deletes a single configuration value from the environment's `values.pulumiConfig`. It reports
+// false if the key was not present, in which case no revision was created.
+func (w *mainEnvWriter) removeKey(ctx context.Context, out io.Writer, key config.Key) (int, bool, error) {
+	docNode, etag, err := w.read(ctx)
+	if err != nil {
+		return 0, false, err
+	}
+
+	valuesNode, ok := encoding.YAMLSyntax{Node: docNode}.Get(resource.PropertyPath{"values"})
+	if !ok {
+		return 0, false, nil
+	}
+	before, err := yaml.Marshal(docNode.Content[0])
+	if err != nil {
+		return 0, false, fmt.Errorf("marshaling environment definition: %w", err)
+	}
+	if err = (encoding.YAMLSyntax{Node: valuesNode}).Delete(nil, configValuePath(key)); err != nil {
+		return 0, false, err
+	}
+	after, err := yaml.Marshal(docNode.Content[0])
+	if err != nil {
+		return 0, false, fmt.Errorf("marshaling environment definition: %w", err)
+	}
+	if bytes.Equal(before, after) {
+		return 0, false, nil
+	}
+
+	revision, err := w.write(ctx, out, docNode, etag)
+	return revision, true, err
+}
+
+// configValueNode renders a `pulumi config set` value as the YAML node to store in the environment.
+//
+// Plain values follow `pulumi config set`'s own typing rules, so an untyped "6" stays the string "6".
+// Secrets are wrapped in `fn::secret` and encrypted by ESC: the stack's secrets manager is never involved
+// on this path, and the plaintext exists only in this in-memory node.
+func configValueNode(value string, typ string, secret bool) (yaml.Node, error) {
+	var node yaml.Node
+	if secret {
+		node.SetString(value)
+		wrapped, err := yaml.Marshal(map[string]yaml.Node{"fn::secret": node})
+		if err != nil {
+			return yaml.Node{}, fmt.Errorf("internal error: marshaling secret: %w", err)
+		}
+		var doc yaml.Node
+		if err := yaml.Unmarshal(wrapped, &doc); err != nil {
+			return yaml.Node{}, fmt.Errorf("internal error: marshaling secret: %w", err)
+		}
+		return *doc.Content[0], nil
+	}
+
+	switch typ {
+	case "", "string":
+		node.SetString(value)
+	case "int":
+		if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+			return yaml.Node{}, fmt.Errorf("invalid int value %q", value)
+		}
+		node = yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: value}
+	case "float":
+		if _, err := strconv.ParseFloat(value, 64); err != nil {
+			return yaml.Node{}, fmt.Errorf("invalid float value %q", value)
+		}
+		node = yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: value}
+	case "bool":
+		if _, err := strconv.ParseBool(value); err != nil {
+			return yaml.Node{}, fmt.Errorf("invalid bool value %q", value)
+		}
+		node = yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: value}
+	default:
+		return yaml.Node{}, fmt.Errorf("invalid type %q; must be one of string, int, bool, or float", typ)
+	}
+	return node, nil
+}
+
+//
+// Attribution.
+//
+
+// unmigratedSource is the SOURCE shown for values that still live in the stack file even though the stack
+// has a main environment. Those values win over the environment, so making them visible is the point.
+func unmigratedSource(stackName string) string {
+	return fmt.Sprintf("Pulumi.%s.yaml (unmigrated)", stackName)
+}
+
+// sourceIndex attributes each configuration key to the environment revision that defined it.
+type sourceIndex struct {
+	sources    map[config.Key]string
+	unmigrated []config.Key
+}
+
+func (i *sourceIndex) get(key config.Key) string {
+	if i == nil {
+		return ""
+	}
+	return i.sources[key]
+}
+
+// revisionResolver resolves environment references to revision numbers, caching one lookup per distinct
+// environment. Under the single-writer assumption a latest-revision lookup is race-free.
+type revisionResolver struct {
+	ctx   context.Context
+	envs  backend.EnvironmentDefinitionsBackend
+	org   string
+	cache map[string]int
+}
+
+// describe renders `<project>/<env>@<revision>`, degrading to `<project>/<env>` when the revision cannot
+// be resolved (for instance when an environment reference cannot be split into a project and a name).
+func (r *revisionResolver) describe(ref string, version string) string {
+	if r == nil || r.envs == nil {
+		return ref
+	}
+	if rev, ok := r.cache[ref+"@"+version]; ok {
+		if rev == 0 {
+			return ref
+		}
+		return fmt.Sprintf("%s@%d", ref, rev)
+	}
+
+	rev := 0
+	if envProject, envName, ok := strings.Cut(ref, "/"); ok && envProject != "" && envName != "" {
+		if n, err := r.envs.GetEnvironmentRevision(r.ctx, r.org, envProject, envName, version); err == nil {
+			rev = n
+		}
+	}
+	if r.cache == nil {
+		r.cache = map[string]int{}
+	}
+	r.cache[ref+"@"+version] = rev
+
+	if rev == 0 {
+		return ref
+	}
+	return fmt.Sprintf("%s@%d", ref, rev)
+}
+
+// traceEnvironment returns the reference of the environment that defined a value, normalized against the
+// main environment. ESC reports the defining environment's name, which may or may not be qualified with
+// its project.
+func traceEnvironment(v esc.Value, mainEnv *workspace.MainEnvironment) string {
+	name, _, _ := strings.Cut(v.Trace.Def.Environment, "@")
+	switch name {
+	case "", "yaml", mainEnv.Name, mainEnv.Ref():
+		// An empty or synthesized environment name means the value came from the stack's own main
+		// environment rather than one of its imports.
+		return mainEnv.Ref()
+	}
+	return name
+}
+
+// buildSourceIndex attributes every configuration value visible to the stack to the environment revision
+// (or the stack file) that defined it.
+func buildSourceIndex(
+	ctx context.Context,
+	s backend.Stack,
+	mainEnv *workspace.MainEnvironment,
+	projectName tokens.PackageName,
+	stackName string,
+	pulumiEnv esc.Value,
+	localCfg config.Map,
+) *sourceIndex {
+	index := &sourceIndex{sources: map[config.Key]string{}}
+
+	resolver := &revisionResolver{ctx: ctx, org: "", cache: map[string]int{}}
+	if envs, ok := s.Backend().(backend.EnvironmentDefinitionsBackend); ok {
+		if orgNamer, ok := s.(interface{ OrgName() string }); ok {
+			resolver.envs, resolver.org = envs, orgNamer.OrgName()
+		}
+	}
+	mainSource := resolver.describe(mainEnv.Ref(), mainEnv.Version)
+
+	if envMap, ok := pulumiEnv.Value.(map[string]esc.Value); ok {
+		for rawKey, value := range envMap {
+			key, err := ParseConfigKeyForProject(projectName, rawKey, false /*path*/)
+			if err != nil {
+				continue
+			}
+			if ref := traceEnvironment(value, mainEnv); ref != mainEnv.Ref() {
+				index.sources[key] = resolver.describe(ref, "") + " (imported)"
+			} else {
+				index.sources[key] = mainSource
+			}
+		}
+	}
+
+	for key := range localCfg {
+		index.sources[key] = unmigratedSource(stackName)
+		index.unmigrated = append(index.unmigrated, key)
+	}
+	sort.Sort(config.KeyArray(index.unmigrated))
+
+	return index
+}
+
+// showSource prints where a single configuration value came from and what it overrode.
+func showSource(
+	out io.Writer,
+	index *sourceIndex,
+	mainEnv *workspace.MainEnvironment,
+	key config.Key,
+	pulumiEnv esc.Value,
+) {
+	source := index.get(key)
+	if source == "" {
+		return
+	}
+	fmt.Fprintf(out, "Source: %s\n", source)
+
+	var value *esc.Value
+	if envMap, ok := pulumiEnv.Value.(map[string]esc.Value); ok {
+		if v, ok := envMap[key.String()]; ok {
+			value = &v
+		} else if v, ok := envMap[key.Name()]; ok {
+			value = &v
+		}
+	}
+	if value == nil {
+		return
+	}
+
+	// A value still in the stack file wins over the environment's definition of the same key.
+	if strings.HasSuffix(source, "(unmigrated)") {
+		fmt.Fprintf(out, "  overrides %s\n", traceEnvironment(*value, mainEnv))
+	}
+	if def := value.Trace.Def; def.Begin.Line != 0 {
+		fmt.Fprintf(out, "  defined at %s:%d:%d\n", traceEnvironment(*value, mainEnv), def.Begin.Line, def.Begin.Column)
+	}
+	for base := value.Trace.Base; base != nil; base = base.Trace.Base {
+		fmt.Fprintf(out, "  overrides %s\n", traceEnvironment(*base, mainEnv))
+	}
+}
+
+// printConfigSource reports the environment revision a command resolved its configuration against.
+func printConfigSource(
+	ctx context.Context, out io.Writer, s backend.Stack, mainEnv *workspace.MainEnvironment,
+) {
+	resolver := &revisionResolver{ctx: ctx}
+	if envs, ok := s.Backend().(backend.EnvironmentDefinitionsBackend); ok {
+		if orgNamer, ok := s.(interface{ OrgName() string }); ok {
+			resolver.envs, resolver.org = envs, orgNamer.OrgName()
+		}
+	}
+	fmt.Fprintf(out, "Config source: %s\n", resolver.describe(mainEnv.Ref(), mainEnv.Version))
+}

--- a/pkg/cmd/pulumi/config/config_main_env.go
+++ b/pkg/cmd/pulumi/config/config_main_env.go
@@ -238,12 +238,12 @@ func (w *mainEnvWriter) removeKey(ctx context.Context, out io.Writer, key config
 	return revision, true, err
 }
 
-// configValueNode renders a `pulumi config set` value as the YAML node to store in the environment.
+// ConfigValueNode renders a `pulumi config set` value as the YAML node to store in the environment.
 //
 // Plain values follow `pulumi config set`'s own typing rules, so an untyped "6" stays the string "6".
 // Secrets are wrapped in `fn::secret` and encrypted by ESC: the stack's secrets manager is never involved
 // on this path, and the plaintext exists only in this in-memory node.
-func configValueNode(value string, typ string, secret bool) (yaml.Node, error) {
+func ConfigValueNode(value string, typ string, secret bool) (yaml.Node, error) {
 	var node yaml.Node
 	if secret {
 		node.SetString(value)

--- a/pkg/cmd/pulumi/config/config_main_env.go
+++ b/pkg/cmd/pulumi/config/config_main_env.go
@@ -70,9 +70,11 @@ func effectiveStackEnv(
 	return workspace.NewEnvironment([]string{ps.MainEnvironment.String()}), ps.MainEnvironment, warnings
 }
 
-// activeMainEnvironment returns the stack's main environment, or nil if it does not have one in effect.
-func activeMainEnvironment(s backend.Stack, ps *workspace.ProjectStack) *workspace.MainEnvironment {
-	_, mainEnv, _ := effectiveStackEnv(s, ps)
+// activeMainEnvironment returns the stack's main environment, or nil if it does not have one in effect,
+// printing any warning that explains why a configured 'mainEnvironment' is not in effect.
+func activeMainEnvironment(out io.Writer, s backend.Stack, ps *workspace.ProjectStack) *workspace.MainEnvironment {
+	_, mainEnv, warnings := effectiveStackEnv(s, ps)
+	printConfigWarnings(out, warnings)
 	return mainEnv
 }
 
@@ -343,17 +345,17 @@ func (r *revisionResolver) describe(ref string, version string) string {
 }
 
 // traceEnvironment returns the reference of the environment that defined a value, normalized against the
-// main environment. ESC reports the defining environment's name, which may or may not be qualified with
-// its project.
-func traceEnvironment(v esc.Value, mainEnv *workspace.MainEnvironment) string {
-	name, _, _ := strings.Cut(v.Trace.Def.Environment, "@")
+// main environment, along with the version it was pinned to (empty when unpinned). ESC reports the defining
+// environment's name, which may or may not be qualified with its project or pinned to a version.
+func traceEnvironment(v esc.Value, mainEnv *workspace.MainEnvironment) (string, string) {
+	name, version, _ := strings.Cut(v.Trace.Def.Environment, "@")
 	switch name {
 	case "", "yaml", mainEnv.Name, mainEnv.Ref():
 		// An empty or synthesized environment name means the value came from the stack's own main
 		// environment rather than one of its imports.
-		return mainEnv.Ref()
+		return mainEnv.Ref(), mainEnv.Version
 	}
-	return name
+	return name, version
 }
 
 // buildSourceIndex attributes every configuration value visible to the stack to the environment revision
@@ -383,8 +385,10 @@ func buildSourceIndex(
 			if err != nil {
 				continue
 			}
-			if ref := traceEnvironment(value, mainEnv); ref != mainEnv.Ref() {
-				index.sources[key] = resolver.describe(ref, "") + " (imported)"
+			// An import pinned to a version defined the value at that version, not at the
+			// environment's latest revision, so the pin has to survive into the lookup.
+			if ref, version := traceEnvironment(value, mainEnv); ref != mainEnv.Ref() {
+				index.sources[key] = resolver.describe(ref, version) + " (imported)"
 			} else {
 				index.sources[key] = mainSource
 			}
@@ -427,14 +431,16 @@ func showSource(
 	}
 
 	// A value still in the stack file wins over the environment's definition of the same key.
+	envRef, _ := traceEnvironment(*value, mainEnv)
 	if strings.HasSuffix(source, "(unmigrated)") {
-		fmt.Fprintf(out, "  overrides %s\n", traceEnvironment(*value, mainEnv))
+		fmt.Fprintf(out, "  overrides %s\n", envRef)
 	}
 	if def := value.Trace.Def; def.Begin.Line != 0 {
-		fmt.Fprintf(out, "  defined at %s:%d:%d\n", traceEnvironment(*value, mainEnv), def.Begin.Line, def.Begin.Column)
+		fmt.Fprintf(out, "  defined at %s:%d:%d\n", envRef, def.Begin.Line, def.Begin.Column)
 	}
 	for base := value.Trace.Base; base != nil; base = base.Trace.Base {
-		fmt.Fprintf(out, "  overrides %s\n", traceEnvironment(*base, mainEnv))
+		baseRef, _ := traceEnvironment(*base, mainEnv)
+		fmt.Fprintf(out, "  overrides %s\n", baseRef)
 	}
 }
 

--- a/pkg/cmd/pulumi/config/config_main_env_test.go
+++ b/pkg/cmd/pulumi/config/config_main_env_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -1151,4 +1153,147 @@ func TestMainEnvironmentConfigEnvSubcommands(t *testing.T) {
 			t.Context(), "rm", false, true, func(*workspace.ProjectStack) error { return nil })
 		require.ErrorContains(t, err, "'pulumi config env rm' is not supported yet")
 	})
+}
+
+//
+// Stack birth, end to end on the mock backend (DoD 10).
+//
+
+// birthEnvUniverse is an in-memory organization's worth of named environments: it can create them,
+// read them back, update them with an etag, and resolve one into the values ESC would return.
+type birthEnvUniverse struct {
+	t         *testing.T
+	defs      map[string]string
+	etags     map[string]string
+	revisions map[string]int
+}
+
+func newBirthEnvUniverse(t *testing.T) *birthEnvUniverse {
+	return &birthEnvUniverse{
+		t:         t,
+		defs:      map[string]string{},
+		etags:     map[string]string{},
+		revisions: map[string]int{},
+	}
+}
+
+// resolve flattens an environment and the environments it imports into the values ESC would hand back,
+// attributing each value to the environment that defines it.
+func (u *birthEnvUniverse) resolve(ref string) map[string]esc.Value {
+	var doc struct {
+		Imports []string `yaml:"imports"`
+		Values  struct {
+			PulumiConfig map[string]string `yaml:"pulumiConfig"`
+		} `yaml:"values"`
+	}
+	require.NoError(u.t, yaml.Unmarshal([]byte(u.defs[ref]), &doc))
+
+	values := map[string]esc.Value{}
+	for _, imported := range doc.Imports {
+		maps.Copy(values, u.resolve(imported))
+	}
+	for k, v := range doc.Values.PulumiConfig {
+		values[k] = esc.Value{Value: v, Trace: esc.Trace{Def: esc.Range{Environment: ref}}}
+	}
+	return values
+}
+
+func (u *birthEnvUniverse) backend() *backend.MockEnvironmentsBackend {
+	return &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{NameF: func() string { return "test" }},
+		CreateEnvironmentF: func(
+			_ context.Context, _, envProject, envName string, yaml []byte,
+		) (apitype.EnvironmentDiagnostics, error) {
+			ref := envProject + "/" + envName
+			u.defs[ref], u.etags[ref], u.revisions[ref] = string(yaml), "etag-1", 1
+			return nil, nil
+		},
+		GetEnvironmentDefinitionF: func(
+			_ context.Context, _, envProject, envName, _ string,
+		) ([]byte, string, int, error) {
+			ref := envProject + "/" + envName
+			def, ok := u.defs[ref]
+			if !ok {
+				return nil, "", 0, fmt.Errorf("%w: %v", backend.ErrEnvironmentNotFound, ref)
+			}
+			return []byte(def), u.etags[ref], u.revisions[ref], nil
+		},
+		UpdateEnvironmentDefinitionF: func(
+			_ context.Context, _, envProject, envName string, yaml []byte, etag string,
+		) (apitype.EnvironmentDiagnostics, int, error) {
+			ref := envProject + "/" + envName
+			if etag != u.etags[ref] {
+				return nil, 0, fmt.Errorf("%w: %v", backend.ErrEnvironmentConflict, ref)
+			}
+			u.revisions[ref]++
+			u.defs[ref] = string(yaml)
+			u.etags[ref] = fmt.Sprintf("etag-%d", u.revisions[ref])
+			return nil, u.revisions[ref], nil
+		},
+		GetEnvironmentRevisionF: func(_ context.Context, _, envProject, envName, _ string) (int, error) {
+			return u.revisions[envProject+"/"+envName], nil
+		},
+		OpenYAMLEnvironmentF: func(
+			context.Context, string, []byte, time.Duration, map[string]string,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			return &esc.Environment{Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(u.resolve("testProject/testStack")),
+			}}, nil, nil
+		},
+	}
+}
+
+// TestStackBirthEndToEnd walks the whole loop the PoC demos: the environments a stack is born with feed
+// `pulumi config`'s SOURCE column, and `pulumi config set` produces the next revision, with no manual
+// environment setup in between.
+func TestStackBirthEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	u := newBirthEnvUniverse(t)
+	be := u.backend()
+	s := mainEnvStack(be)
+
+	regionNode, err := ConfigValueNode("us-west-2", "", false)
+	require.NoError(t, err)
+
+	// 1. Birth: `pulumi stack init --esc-config` creates both environments and records the main one.
+	var birthOut bytes.Buffer
+	mainEnv, err := cmdStack.CreateStackEnvironments(t.Context(), s, cmdStack.StackEnvironmentOptions{
+		EnvProject: "testProject",
+		EnvName:    "testStack",
+		Values:     map[string]yaml.Node{"aws:region": regionNode},
+		Stdout:     &birthOut,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "testProject/testStack", mainEnv.String())
+	assert.Contains(t, birthOut.String(), "Creating environment 'test-org/testProject/base'...")
+	assert.Contains(t, birthOut.String(),
+		"Creating environment 'test-org/testProject/testStack'... (imports testProject/base)")
+
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: "+mainEnv.String()+"\n")
+
+	secretsManager, _, _, _, _ := getCountingBase64SecretsManager(t.Context(), t, false)
+	s.SnapshotF = func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		return &deploy.Snapshot{SecretsManager: stack.NewBatchingCachingSecretsManager(secretsManager)}, nil
+	}
+	ssml := cmdStack.SecretsManagerLoader{FallbackToState: true}
+
+	// 2. `pulumi config` attributes the value to the freshly created environment at revision 1.
+	var listOut bytes.Buffer
+	require.NoError(t, listConfig(t.Context(), ssml, &listOut, project, s, ps, false, false, true, ""))
+	assert.Contains(t, listOut.String(), "aws:region  us-west-2  testProject/testStack@1")
+
+	// 3. `pulumi config set` on the newborn stack produces the next revision, with no manual setup.
+	var setOut bytes.Buffer
+	setCmd := newMainEnvSetCmd(ps, &setOut)
+	require.NoError(t, setCmd.Run(
+		t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:instanceCount", "6"},
+		project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml")))
+	assert.Equal(t, "Updated testProject/testStack@2\n", setOut.String())
+
+	listOut.Reset()
+	require.NoError(t, listConfig(t.Context(), ssml, &listOut, project, s, ps, false, false, true, ""))
+	assert.Contains(t, listOut.String(), "aws:region                 us-west-2  testProject/testStack@2")
+	assert.Contains(t, listOut.String(), "testProject:instanceCount  6          testProject/testStack@2")
 }

--- a/pkg/cmd/pulumi/config/config_main_env_test.go
+++ b/pkg/cmd/pulumi/config/config_main_env_test.go
@@ -1258,13 +1258,15 @@ func TestStackBirthEndToEnd(t *testing.T) {
 
 	// 1. Birth: `pulumi stack init --esc-config` creates both environments and records the main one.
 	var birthOut bytes.Buffer
-	mainEnv, err := cmdStack.CreateStackEnvironments(t.Context(), s, cmdStack.StackEnvironmentOptions{
+	env, err := cmdStack.CreateStackEnvironments(t.Context(), s, cmdStack.StackEnvironmentOptions{
 		EnvProject: "testProject",
 		EnvName:    "testStack",
 		Values:     map[string]yaml.Node{"aws:region": regionNode},
 		Stdout:     &birthOut,
 	})
 	require.NoError(t, err)
+	require.False(t, env.StackEnvironmentReused)
+	mainEnv := env.MainEnvironment
 	assert.Equal(t, "testProject/testStack", mainEnv.String())
 	assert.Contains(t, birthOut.String(), "Creating environment 'test-org/testProject/base'...")
 	assert.Contains(t, birthOut.String(),

--- a/pkg/cmd/pulumi/config/config_main_env_test.go
+++ b/pkg/cmd/pulumi/config/config_main_env_test.go
@@ -17,8 +17,10 @@ package config
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,6 +135,22 @@ func mainEnvStack(be backend.Backend) *backend.MockStack {
 		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
 		OrgNameF:        func() string { return "test-org" },
 		BackendF:        func() backend.Backend { return be },
+	}
+}
+
+func mainEnvLoginManager(be backend.Backend) cmdBackend.LoginManager {
+	return &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool,
+			colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
 	}
 }
 
@@ -478,7 +496,7 @@ func TestMainEnvironmentConfigRemove(t *testing.T) {
 	project := &workspace.Project{Name: "testProject"}
 	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
 
-	mainEnv := activeMainEnvironment(s, ps)
+	mainEnv := activeMainEnvironment(io.Discard, s, ps)
 	require.NotNil(t, mainEnv)
 	w, err := newMainEnvWriter(s, mainEnv)
 	require.NoError(t, err)
@@ -507,25 +525,25 @@ func TestMainEnvironmentConfigRemoveCommandPath(t *testing.T) {
 	s := mainEnvStack(store.backend())
 	project := &workspace.Project{Name: "testProject"}
 	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
-	mainEnv := activeMainEnvironment(s, ps)
+	mainEnv := activeMainEnvironment(io.Discard, s, ps)
 	require.NotNil(t, mainEnv)
 
 	var out bytes.Buffer
 	require.NoError(t, removeFromMainEnvironment(
-		t.Context(), &out, s, mainEnv, config.MustMakeKey("testProject", "a"), false))
+		t.Context(), &out, s, ps, mainEnv, config.MustMakeKey("testProject", "a"), false))
 	assert.Equal(t, "Updated payments/dev@2\n", out.String())
 	assert.NotContains(t, store.yaml, "testProject:a")
 
 	// Removing a key that is not set reports so and creates no revision.
 	out.Reset()
 	require.NoError(t, removeFromMainEnvironment(
-		t.Context(), &out, s, mainEnv, config.MustMakeKey("testProject", "missing"), false))
+		t.Context(), &out, s, ps, mainEnv, config.MustMakeKey("testProject", "missing"), false))
 	assert.Equal(t, "Configuration key 'testProject:missing' is not set in payments/dev\n", out.String())
 	assert.Equal(t, 2, store.revision)
 
 	// `--path` removals are not supported yet.
 	err := removeFromMainEnvironment(
-		t.Context(), &out, s, mainEnv, config.MustMakeKey("testProject", "b.c"), true)
+		t.Context(), &out, s, ps, mainEnv, config.MustMakeKey("testProject", "b.c"), true)
 	require.ErrorContains(t, err, "'pulumi config rm --path' is not supported yet")
 	assert.Equal(t, 2, store.revision)
 }
@@ -813,21 +831,6 @@ func TestMainEnvironmentUnsupportedSubcommands(t *testing.T) {
 
 	const stackFile = "mainEnvironment: payments/dev\n"
 
-	newLoginManager := func(be backend.Backend) cmdBackend.LoginManager {
-		return &cmdBackend.MockLoginManager{
-			CurrentF: func(
-				context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool,
-			) (backend.Backend, error) {
-				return be, nil
-			},
-			LoginF: func(
-				context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool,
-				colors.Colorization,
-			) (backend.Backend, error) {
-				return be, nil
-			},
-		}
-	}
 	ws := &pkgWorkspace.MockContext{
 		ReadProjectF: func(string) (*workspace.Project, string, error) {
 			return &workspace.Project{Name: "testProject"}, "", nil
@@ -848,7 +851,7 @@ func TestMainEnvironmentUnsupportedSubcommands(t *testing.T) {
 
 		configPath := writeStackFile(t, stackFile)
 		stackName := "testStack"
-		cmd := newConfigSetAllCmd(ws, &stackName, newLoginManager(be), &mockEncrypterFactory{}, &configPath)
+		cmd := newConfigSetAllCmd(ws, &stackName, mainEnvLoginManager(be), &mockEncrypterFactory{}, &configPath)
 		cmd.SetContext(t.Context())
 		require.NoError(t, cmd.PersistentFlags().Set("plaintext", "testProject:key=value"))
 
@@ -887,7 +890,7 @@ func TestMainEnvironmentUnsupportedSubcommands(t *testing.T) {
 
 		configPath := writeStackFile(t, stackFile)
 		stackName := "testStack"
-		cmd := newConfigRefreshCmd(ws, &stackName, newLoginManager(be), &configPath)
+		cmd := newConfigRefreshCmd(ws, &stackName, mainEnvLoginManager(be), &configPath)
 		cmd.SetContext(t.Context())
 		require.NoError(t, cmd.PersistentFlags().Set("force", "true"))
 
@@ -898,5 +901,254 @@ func TestMainEnvironmentUnsupportedSubcommands(t *testing.T) {
 		data, readErr := os.ReadFile(configPath)
 		require.NoError(t, readErr)
 		assert.Equal(t, stackFile, string(data))
+	})
+}
+
+// TestMainEnvironmentCopySourceRefused covers the half of DoD 12 that `config copy` reaches through its
+// *source* stack: a migrated stack's values live in ESC, not in its `config:` block, so copying from one
+// would quietly write an empty (or stale) destination.
+func TestMainEnvironmentCopySourceRefused(t *testing.T) { //nolint:paralleltest // t.Chdir forbids t.Parallel
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "Pulumi.yaml"), []byte("name: testProject\nruntime: nodejs\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "Pulumi.source.yaml"), []byte("mainEnvironment: payments/dev\n"), 0o600))
+	const destFile = "config:\n  testProject:existing: keep\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.dest.yaml"), []byte(destFile), 0o600))
+
+	store := newFakeEnvStore(t, "values:\n  pulumiConfig:\n    testProject:a: one\n")
+	source := mainEnvStack(store.backend())
+	source.RefF = func() backend.StackReference {
+		return &backend.MockStackReference{
+			NameV:               tokens.MustParseStackName("source"),
+			FullyQualifiedNameV: "test-org/testProject/source",
+		}
+	}
+	dest := mainEnvStack(store.backend())
+	dest.RefF = func() backend.StackReference {
+		return &backend.MockStackReference{
+			NameV:               tokens.MustParseStackName("dest"),
+			FullyQualifiedNameV: "test-org/testProject/dest",
+		}
+	}
+
+	be := &backend.MockBackend{
+		GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
+			if ref.Name().String() == "dest" {
+				return dest, nil
+			}
+			return source, nil
+		},
+		ParseStackReferenceF: func(name string) (backend.StackReference, error) {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName(name),
+				FullyQualifiedNameV: tokens.QName("test-org/testProject/" + name),
+			}, nil
+		},
+	}
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "testProject"}, filepath.Join(dir, "Pulumi.yaml"), nil
+		},
+		GetStoredCredentialsF: func() (workspace.Credentials, error) {
+			return workspace.Credentials{Current: "https://api.pulumi.com"}, nil
+		},
+	}
+
+	stackName, configFile := "source", ""
+	cmd := newConfigCopyCmd(ws, &stackName, mainEnvLoginManager(be), &configFile)
+	cmd.SetContext(t.Context())
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	require.NoError(t, cmd.PersistentFlags().Set("dest", "dest"))
+
+	err := cmd.RunE(cmd, []string{})
+	require.ErrorContains(t, err, "'pulumi config copy' is not supported yet")
+
+	// The destination stack file was not touched.
+	data, readErr := os.ReadFile(filepath.Join(dir, "Pulumi.dest.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, destFile, string(data))
+}
+
+// TestGetConfigShowSourceJSON asserts `--json --show-source` stays parseable: attribution goes inside the
+// JSON object rather than being printed alongside it.
+func TestGetConfigShowSourceJSON(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	store.revision = 8
+	s, project, _, ssml := prepareMainEnvListConfig(
+		t, "mainEnvironment: payments/dev\n", mainEnvAttributionEnvironment(), store)
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) { return project, "", nil },
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, getConfig(
+		t.Context(), &out, cmdutil.Diag(), ssml, ws, s,
+		config.MustMakeKey("testProject", "instanceCount"), false, true, true, true,
+		writeStackFile(t, "mainEnvironment: payments/dev\n")))
+
+	var value configValueJSON
+	require.NoError(t, json.Unmarshal(out.Bytes(), &value))
+	require.NotNil(t, value.Value)
+	assert.Equal(t, "6", *value.Value)
+	assert.Equal(t, "payments/dev@8", value.Source)
+}
+
+// TestMainEnvironmentAttributionPinnedImport asserts a value inherited from a pinned import is attributed to
+// the pinned version rather than to the import's latest revision.
+func TestMainEnvironmentAttributionPinnedImport(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	store.revision = 8
+	env := &esc.Environment{Properties: map[string]esc.Value{
+		"pulumiConfig": esc.NewValue(map[string]esc.Value{
+			"testProject:logLevel": {
+				Value: "info",
+				Trace: esc.Trace{Def: esc.Range{Environment: "payments/base@4"}},
+			},
+		}),
+	}}
+	s, project, ps, ssml := prepareMainEnvListConfig(t, "mainEnvironment: payments/dev\n", env, store)
+
+	var requestedVersion string
+	be := s.Backend().(*backend.MockEnvironmentsBackend)
+	inner := be.GetEnvironmentRevisionF
+	be.GetEnvironmentRevisionF = func(
+		ctx context.Context, org, envProject, envName, version string,
+	) (int, error) {
+		if envProject+"/"+envName == "payments/base" {
+			requestedVersion = version
+			return 4, nil
+		}
+		return inner(ctx, org, envProject, envName, version)
+	}
+
+	var stdout bytes.Buffer
+	require.NoError(t, listConfig(
+		t.Context(), ssml, &stdout, project, s, ps, false, false, true, ""))
+
+	assert.Equal(t, "4", requestedVersion)
+	assert.Contains(t, stdout.String(), "payments/base@4 (imported)")
+}
+
+// TestMainEnvironmentWriteWarnsAboutShadowingLocalValue covers the transitional state where a key is set
+// both in the stack file and in the environment: the stack file wins on reads, so a write that did not say
+// so would report a value the very next read would not return.
+func TestMainEnvironmentWriteWarnsAboutShadowingLocalValue(t *testing.T) {
+	t.Parallel()
+
+	const stackFile = "mainEnvironment: payments/dev\nconfig:\n  testProject:a: local\n"
+	project := &workspace.Project{Name: "testProject"}
+
+	t.Run("set", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+		s := mainEnvStack(store.backend())
+		ps := loadStackFile(t, project, stackFile)
+
+		var stdout bytes.Buffer
+		c := newMainEnvSetCmd(ps, &stdout)
+		require.NoError(t, c.Run(
+			t.Context(), nil, []string{"testProject:a", "env"}, project, s, writeStackFile(t, stackFile)))
+
+		assert.Contains(t, stdout.String(), "Updated payments/dev@2")
+		assert.Contains(t, stdout.String(),
+			"warning: 'testProject:a' is also set in Pulumi.testStack.yaml, which shadows the value just written")
+	})
+
+	t.Run("rm", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "values:\n  pulumiConfig:\n    testProject:a: env\n")
+		s := mainEnvStack(store.backend())
+		ps := loadStackFile(t, project, stackFile)
+		mainEnv := activeMainEnvironment(io.Discard, s, ps)
+		require.NotNil(t, mainEnv)
+
+		var out bytes.Buffer
+		require.NoError(t, removeFromMainEnvironment(
+			t.Context(), &out, s, ps, mainEnv, config.MustMakeKey("testProject", "a"), false))
+		assert.Contains(t, out.String(), "Updated payments/dev@2")
+		assert.Contains(t, out.String(),
+			"warning: 'testProject:a' is still set in Pulumi.testStack.yaml, which takes precedence over payments/dev")
+	})
+}
+
+// TestMainEnvironmentRemoteConfigWarnsOnWritePath asserts that a stack configured both ways is told its
+// `mainEnvironment` is ignored, instead of hitting the pre-existing remote-config refusal with no
+// explanation.
+func TestMainEnvironmentRemoteConfigWarnsOnWritePath(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+	s := mainEnvStack(store.backend())
+	escEnv := "payments/remote"
+	s.ConfigLocationF = func() backend.StackConfigLocation {
+		return backend.StackConfigLocation{IsRemote: true, EscEnv: &escEnv}
+	}
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	var stdout, stderr bytes.Buffer
+	c := newMainEnvSetCmd(ps, &stdout)
+	c.Stderr = &stderr
+	err := c.Run(t.Context(), nil, []string{"testProject:a", "b"}, project, s, "")
+
+	require.ErrorContains(t, err, "config set not supported for remote stack config")
+	assert.Contains(t, stderr.String(),
+		"'mainEnvironment' is ignored because this stack's configuration is stored remotely")
+	assert.Equal(t, 0, store.updates)
+}
+
+// TestMainEnvironmentConfigEnvSubcommands asserts `pulumi config env ls/add/rm` do not silently operate on
+// the `environment:` list that a main environment supersedes.
+func TestMainEnvironmentConfigEnvSubcommands(t *testing.T) {
+	t.Parallel()
+
+	const stackYAML = "mainEnvironment: payments/dev\nenvironment:\n  - payments/legacy\n"
+	env := &esc.Environment{Properties: map[string]esc.Value{
+		"pulumiConfig": esc.NewValue(map[string]esc.Value{}),
+	}}
+
+	newCmd := func(stdout io.Writer) *configEnvCmd {
+		return newConfigEnvCmdForTest(
+			strings.NewReader(""), stdout, "name: test\nruntime: yaml", stackYAML, env, nil, nil)
+	}
+
+	t.Run("ls", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout bytes.Buffer
+		var listed []string
+		require.NoError(t, newCmd(&stdout).listStackEnvironments(
+			t.Context(), func(_ io.Writer, imports []string) error {
+				listed = imports
+				return nil
+			}))
+		assert.Equal(t, []string{"payments/dev"}, listed)
+	})
+
+	t.Run("add", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout bytes.Buffer
+		err := newCmd(&stdout).editStackEnvironment(
+			t.Context(), "add", false, true, func(*workspace.ProjectStack) error { return nil })
+		require.ErrorContains(t, err, "'pulumi config env add' is not supported yet")
+	})
+
+	t.Run("rm", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout bytes.Buffer
+		err := newCmd(&stdout).editStackEnvironment(
+			t.Context(), "rm", false, true, func(*workspace.ProjectStack) error { return nil })
+		require.ErrorContains(t, err, "'pulumi config env rm' is not supported yet")
 	})
 }

--- a/pkg/cmd/pulumi/config/config_main_env_test.go
+++ b/pkg/cmd/pulumi/config/config_main_env_test.go
@@ -1,0 +1,902 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// fakeEnvStore is an in-memory stand-in for a single named ESC environment. It bumps the revision and
+// rotates the etag on every accepted update, and rejects an update that does not carry the etag from the
+// most recent read, exactly as the service does.
+type fakeEnvStore struct {
+	t *testing.T
+
+	yaml     string
+	etag     string
+	revision int
+
+	// exists reports whether the environment has been created.
+	exists bool
+
+	gets          int
+	updates       int
+	lastEtagSent  string
+	revisionCalls map[string]int
+}
+
+func newFakeEnvStore(t *testing.T, yaml string) *fakeEnvStore {
+	return &fakeEnvStore{
+		t:             t,
+		yaml:          yaml,
+		etag:          "etag-1",
+		revision:      1,
+		exists:        true,
+		revisionCalls: map[string]int{},
+	}
+}
+
+func (s *fakeEnvStore) backend() *backend.MockEnvironmentsBackend {
+	return &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{
+			NameF: func() string { return "test" },
+		},
+		GetEnvironmentDefinitionF: func(
+			_ context.Context, org, envProject, envName, version string,
+		) ([]byte, string, int, error) {
+			assert.Equal(s.t, "test-org", org)
+			assert.Equal(s.t, "payments", envProject)
+			assert.Equal(s.t, "dev", envName)
+			if !s.exists {
+				return nil, "", 0, fmt.Errorf("%w: payments/dev", backend.ErrEnvironmentNotFound)
+			}
+			s.gets++
+			return []byte(s.yaml), s.etag, s.revision, nil
+		},
+		UpdateEnvironmentDefinitionF: func(
+			_ context.Context, org, envProject, envName string, yaml []byte, etag string,
+		) (apitype.EnvironmentDiagnostics, int, error) {
+			s.updates++
+			s.lastEtagSent = etag
+			if etag != s.etag {
+				return nil, 0, fmt.Errorf("%w: payments/dev", backend.ErrEnvironmentConflict)
+			}
+			s.yaml = string(yaml)
+			s.revision++
+			s.etag = fmt.Sprintf("etag-%d", s.revision)
+			return nil, s.revision, nil
+		},
+		GetEnvironmentRevisionF: func(
+			_ context.Context, org, envProject, envName, version string,
+		) (int, error) {
+			ref := envProject + "/" + envName
+			s.revisionCalls[ref]++
+			switch ref {
+			case "payments/dev":
+				return s.revision, nil
+			case "payments/base":
+				return 2, nil
+			}
+			return 0, fmt.Errorf("no such environment %v", ref)
+		},
+	}
+}
+
+func mainEnvStack(be backend.Backend) *backend.MockStack {
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "test-org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		OrgNameF:        func() string { return "test-org" },
+		BackendF:        func() backend.Backend { return be },
+	}
+}
+
+func loadStackFile(t *testing.T, project *workspace.Project, text string) *workspace.ProjectStack {
+	t.Helper()
+	ps, err := workspace.LoadProjectStackBytes(
+		cmdutil.Diag(), project, []byte(text), "Pulumi.testStack.yaml", encoding.YAML)
+	require.NoError(t, err)
+	return ps
+}
+
+func newMainEnvSetCmd(ps *workspace.ProjectStack, stdout *bytes.Buffer) *configSetCmd {
+	return &configSetCmd{
+		Stdout: stdout,
+		LoadProjectStack: func(
+			context.Context, diag.Sink, *workspace.Project, backend.Stack, string,
+		) (*workspace.ProjectStack, error) {
+			return ps, nil
+		},
+	}
+}
+
+//
+// Precedence (DoD 3).
+//
+
+func TestEffectiveStackEnv(t *testing.T) {
+	t.Parallel()
+
+	project := &workspace.Project{Name: "testProject"}
+	localStack := mainEnvStack(nil)
+
+	t.Run("neither field", func(t *testing.T) {
+		t.Parallel()
+
+		ps := loadStackFile(t, project, "config:\n  testProject:foo: bar\n")
+		envDef, mainEnv, warnings := effectiveStackEnv(localStack, ps)
+		assert.Nil(t, envDef)
+		assert.Nil(t, mainEnv)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("environment only", func(t *testing.T) {
+		t.Parallel()
+
+		ps := loadStackFile(t, project, "environment:\n  - payments/base\n")
+		envDef, mainEnv, warnings := effectiveStackEnv(localStack, ps)
+		assert.Equal(t, ps.Environment, envDef)
+		assert.Nil(t, mainEnv)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("mainEnvironment only", func(t *testing.T) {
+		t.Parallel()
+
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+		envDef, mainEnv, warnings := effectiveStackEnv(localStack, ps)
+		require.NotNil(t, mainEnv)
+		assert.Equal(t, "payments/dev", mainEnv.String())
+		assert.JSONEq(t, `{"imports":["payments/dev"]}`, string(envDef.Definition()))
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("mainEnvironment pinned", func(t *testing.T) {
+		t.Parallel()
+
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev@4\n")
+		envDef, mainEnv, _ := effectiveStackEnv(localStack, ps)
+		require.NotNil(t, mainEnv)
+		assert.JSONEq(t, `{"imports":["payments/dev@4"]}`, string(envDef.Definition()))
+	})
+
+	t.Run("mainEnvironment wins over environment", func(t *testing.T) {
+		t.Parallel()
+
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev\nenvironment:\n  - other/env\n")
+		envDef, mainEnv, warnings := effectiveStackEnv(localStack, ps)
+		require.NotNil(t, mainEnv)
+		assert.JSONEq(t, `{"imports":["payments/dev"]}`, string(envDef.Definition()))
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "'environment' is ignored")
+	})
+
+	t.Run("remote stack config wins over mainEnvironment", func(t *testing.T) {
+		t.Parallel()
+
+		remote := mainEnvStack(nil)
+		remote.ConfigLocationF = func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true}
+		}
+
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+		envDef, mainEnv, warnings := effectiveStackEnv(remote, ps)
+		assert.Nil(t, envDef)
+		assert.Nil(t, mainEnv)
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "'mainEnvironment' is ignored")
+	})
+}
+
+//
+// Reads (DoD 2 and DoD 8).
+//
+
+func TestMainEnvironmentReadResolvesThroughEnvironment(t *testing.T) {
+	t.Parallel()
+
+	var openedYAML string
+	be := &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{NameF: func() string { return "test" }},
+		OpenYAMLEnvironmentF: func(
+			_ context.Context, org string, yaml []byte, _ time.Duration, _ map[string]string,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			assert.Equal(t, "test-org", org)
+			openedYAML = string(yaml)
+			return &esc.Environment{Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(map[string]esc.Value{
+					// Defined by the main environment itself.
+					"testProject:instanceCount": {
+						Value: "6",
+						Trace: esc.Trace{Def: esc.Range{Environment: "payments/dev"}},
+					},
+					// Inherited through the main environment's own `imports:`.
+					"testProject:logLevel": {
+						Value: "info",
+						Trace: esc.Trace{Def: esc.Range{Environment: "payments/base"}},
+					},
+				}),
+			}}, nil, nil
+		},
+		GetEnvironmentRevisionF: func(_ context.Context, _, envProject, envName, _ string) (int, error) {
+			if envProject+"/"+envName == "payments/dev" {
+				return 8, nil
+			}
+			return 0, errors.New("unexpected environment")
+		},
+	}
+	s := mainEnvStack(be)
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	var stderr bytes.Buffer
+	cfg, err := getStackConfigurationFromProjectStackWithWriter(
+		t.Context(), &stderr, s, project, nil, ps, nil)
+	require.NoError(t, err)
+
+	// The main environment is resolved as a single import, so ESC resolves its own imports server-side.
+	assert.JSONEq(t, `{"imports":["payments/dev"]}`, openedYAML)
+	assert.Equal(t, []string{"payments/dev"}, cfg.EnvironmentImports)
+
+	values, ok := cfg.Environment.Value.(map[string]esc.Value)
+	require.True(t, ok)
+	assert.Contains(t, values, "testProject:instanceCount")
+	assert.Contains(t, values, "testProject:logLevel")
+
+	// DoD 8: the revision the run resolved against is reported.
+	assert.Contains(t, stderr.String(), "Config source: payments/dev@8")
+}
+
+func TestNonMainEnvironmentReadPrintsNoConfigSource(t *testing.T) {
+	t.Parallel()
+
+	be := &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{NameF: func() string { return "test" }},
+		OpenYAMLEnvironmentF: func(
+			_ context.Context, _ string, _ []byte, _ time.Duration, _ map[string]string,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			return &esc.Environment{Properties: map[string]esc.Value{
+				"pulumiConfig": esc.NewValue(map[string]esc.Value{"testProject:a": esc.NewValue("b")}),
+			}}, nil, nil
+		},
+	}
+	s := mainEnvStack(be)
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "environment:\n  - payments/base\n")
+
+	var stderr bytes.Buffer
+	_, err := getStackConfigurationFromProjectStackWithWriter(t.Context(), &stderr, s, project, nil, ps, nil)
+	require.NoError(t, err)
+	assert.NotContains(t, stderr.String(), "Config source:")
+}
+
+//
+// Writes (DoD 4, 5, 6).
+//
+
+func TestMainEnvironmentConfigSet(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "values:\n  pulumiConfig:\n    testProject:existing: keep\n")
+	s := mainEnvStack(store.backend())
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	tmpdir := t.TempDir()
+	configFile := filepath.Join(tmpdir, "Pulumi.testStack.yaml")
+
+	var stdout bytes.Buffer
+	cmd := newMainEnvSetCmd(ps, &stdout)
+	ws := &pkgWorkspace.MockContext{}
+
+	require.NoError(t, cmd.Run(t.Context(), ws, []string{"testProject:instanceCount", "6"}, project, s, configFile))
+	require.NoError(t, cmd.Run(t.Context(), ws, []string{"testProject:region", "us-west-2"}, project, s, configFile))
+
+	// DoD 4: successive writes produce successive revisions.
+	assert.Equal(t, "Updated payments/dev@2\nUpdated payments/dev@3\n", stdout.String())
+	assert.Equal(t, 3, store.revision)
+
+	// Untyped values keep `pulumi config set` semantics: "6" stays a string.
+	assert.Contains(t, store.yaml, `testProject:instanceCount: "6"`)
+	assert.Contains(t, store.yaml, "testProject:region: us-west-2")
+	// Existing values are preserved by the read-modify-write.
+	assert.Contains(t, store.yaml, "testProject:existing: keep")
+
+	// The local stack file is never written on this path.
+	_, err := os.Stat(configFile)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestMainEnvironmentConfigSetTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		typ      string
+		value    string
+		expected string
+	}{
+		{"", "6", `testProject:test: "6"`},
+		{"string", "6", `testProject:test: "6"`},
+		{"int", "6", "testProject:test: 6"},
+		{"bool", "true", "testProject:test: true"},
+		{"float", "1.5", "testProject:test: 1.5"},
+	}
+	for _, c := range cases {
+		t.Run(c.typ, func(t *testing.T) {
+			t.Parallel()
+
+			store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+			s := mainEnvStack(store.backend())
+			project := &workspace.Project{Name: "testProject"}
+			ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+			var stdout bytes.Buffer
+			cmd := newMainEnvSetCmd(ps, &stdout)
+			cmd.Type = c.typ
+			require.NoError(t, cmd.Run(
+				t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:test", c.value},
+				project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml")))
+
+			assert.Contains(t, store.yaml, c.expected)
+		})
+	}
+}
+
+func TestMainEnvironmentConfigSetSecret(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+	s := mainEnvStack(store.backend())
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	tmpdir := t.TempDir()
+	configFile := filepath.Join(tmpdir, "Pulumi.testStack.yaml")
+
+	var stdout bytes.Buffer
+	cmd := newMainEnvSetCmd(ps, &stdout)
+	cmd.Secret = true
+	require.NoError(t, cmd.Run(
+		t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:token", "hunter2"},
+		project, s, configFile))
+
+	// DoD 5: the value is an ESC secret, not a stack-secrets-manager ciphertext.
+	assert.Contains(t, store.yaml, "fn::secret")
+	assert.Contains(t, store.yaml, "hunter2")
+	// No secrets provider was ever configured for the stack, and nothing was written to disk...
+	assert.Empty(t, ps.SecretsProvider)
+	assert.Empty(t, ps.EncryptionSalt)
+	assert.Empty(t, ps.EncryptedKey)
+	_, err := os.Stat(configFile)
+	assert.True(t, os.IsNotExist(err))
+	// ...and the plaintext never reaches the command's output.
+	assert.NotContains(t, stdout.String(), "hunter2")
+	assert.Equal(t, "Updated payments/dev@2\n", stdout.String())
+}
+
+func TestMainEnvironmentConfigSetSendsEtagFromRead(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+	s := mainEnvStack(store.backend())
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	var stdout bytes.Buffer
+	cmd := newMainEnvSetCmd(ps, &stdout)
+	require.NoError(t, cmd.Run(
+		t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:a", "b"},
+		project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml")))
+
+	// DoD 6: the write carried exactly the etag the read returned.
+	assert.Equal(t, "etag-1", store.lastEtagSent)
+	assert.Equal(t, 1, store.gets)
+	assert.Equal(t, 1, store.updates)
+}
+
+func TestMainEnvironmentConfigSetStaleEtag(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+	be := store.backend()
+	// Simulate a concurrent writer: the environment moves on between the read and the write.
+	get := be.GetEnvironmentDefinitionF
+	be.GetEnvironmentDefinitionF = func(
+		ctx context.Context, org, envProject, envName, version string,
+	) ([]byte, string, int, error) {
+		yaml, _, revision, err := get(ctx, org, envProject, envName, version)
+		return yaml, "stale-etag", revision, err
+	}
+
+	s := mainEnvStack(be)
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	before := store.yaml
+	var stdout bytes.Buffer
+	cmd := newMainEnvSetCmd(ps, &stdout)
+	err := cmd.Run(
+		t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:a", "b"},
+		project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml"))
+
+	require.ErrorContains(t, err, "environment payments/dev changed since it was read")
+	assert.Equal(t, before, store.yaml, "the environment must not be overwritten")
+	assert.Equal(t, 1, store.revision)
+}
+
+func TestMainEnvironmentConfigRemove(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t,
+		"values:\n  pulumiConfig:\n    testProject:a: one\n    testProject:b: two\n")
+	s := mainEnvStack(store.backend())
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+	mainEnv := activeMainEnvironment(s, ps)
+	require.NotNil(t, mainEnv)
+	w, err := newMainEnvWriter(s, mainEnv)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	revision, removed, err := w.removeKey(t.Context(), &stdout, config.MustMakeKey("testProject", "a"))
+	require.NoError(t, err)
+	assert.True(t, removed)
+	assert.Equal(t, 2, revision)
+	assert.NotContains(t, store.yaml, "testProject:a")
+	assert.Contains(t, store.yaml, "testProject:b: two")
+
+	// Removing a key that isn't there creates no revision.
+	revision, removed, err = w.removeKey(t.Context(), &stdout, config.MustMakeKey("testProject", "missing"))
+	require.NoError(t, err)
+	assert.False(t, removed)
+	assert.Zero(t, revision)
+	assert.Equal(t, 2, store.revision)
+}
+
+func TestMainEnvironmentConfigRemoveCommandPath(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t,
+		"values:\n  pulumiConfig:\n    testProject:a: one\n    testProject:b: two\n")
+	s := mainEnvStack(store.backend())
+	project := &workspace.Project{Name: "testProject"}
+	ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+	mainEnv := activeMainEnvironment(s, ps)
+	require.NotNil(t, mainEnv)
+
+	var out bytes.Buffer
+	require.NoError(t, removeFromMainEnvironment(
+		t.Context(), &out, s, mainEnv, config.MustMakeKey("testProject", "a"), false))
+	assert.Equal(t, "Updated payments/dev@2\n", out.String())
+	assert.NotContains(t, store.yaml, "testProject:a")
+
+	// Removing a key that is not set reports so and creates no revision.
+	out.Reset()
+	require.NoError(t, removeFromMainEnvironment(
+		t.Context(), &out, s, mainEnv, config.MustMakeKey("testProject", "missing"), false))
+	assert.Equal(t, "Configuration key 'testProject:missing' is not set in payments/dev\n", out.String())
+	assert.Equal(t, 2, store.revision)
+
+	// `--path` removals are not supported yet.
+	err := removeFromMainEnvironment(
+		t.Context(), &out, s, mainEnv, config.MustMakeKey("testProject", "b.c"), true)
+	require.ErrorContains(t, err, "'pulumi config rm --path' is not supported yet")
+	assert.Equal(t, 2, store.revision)
+}
+
+func TestMainEnvironmentWriteRefusals(t *testing.T) {
+	t.Parallel()
+
+	project := &workspace.Project{Name: "testProject"}
+
+	t.Run("pinned version", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+		s := mainEnvStack(store.backend())
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev@4\n")
+
+		var stdout bytes.Buffer
+		cmd := newMainEnvSetCmd(ps, &stdout)
+		err := cmd.Run(
+			t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:a", "b"},
+			project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml"))
+		require.ErrorContains(t, err, "pins it to version \"4\"")
+		assert.Equal(t, 0, store.updates)
+	})
+
+	t.Run("missing environment", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "")
+		store.exists = false
+		s := mainEnvStack(store.backend())
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+		var stdout bytes.Buffer
+		cmd := newMainEnvSetCmd(ps, &stdout)
+		err := cmd.Run(
+			t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:a", "b"},
+			project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml"))
+		require.ErrorContains(t, err, "environment payments/dev does not exist")
+		assert.Equal(t, 0, store.updates)
+	})
+
+	t.Run("--path", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+		s := mainEnvStack(store.backend())
+		ps := loadStackFile(t, project, "mainEnvironment: payments/dev\n")
+
+		var stdout bytes.Buffer
+		cmd := newMainEnvSetCmd(ps, &stdout)
+		cmd.Path = true
+		err := cmd.Run(
+			t.Context(), &pkgWorkspace.MockContext{}, []string{"testProject:a.b", "c"},
+			project, s, filepath.Join(t.TempDir(), "Pulumi.testStack.yaml"))
+		require.ErrorContains(t, err, "'pulumi config set --path' is not supported yet")
+		assert.Equal(t, 0, store.updates)
+	})
+
+	t.Run("unsupported subcommands", func(t *testing.T) {
+		t.Parallel()
+
+		mainEnv := &workspace.MainEnvironment{Project: "payments", Name: "dev"}
+		for _, name := range []string{"copy", "set-all", "rm-all", "refresh"} {
+			err := errMainEnvUnsupported(name, mainEnv)
+			assert.ErrorContains(t, err, "'pulumi config "+name+"' is not supported yet")
+			assert.ErrorContains(t, err, "mainEnvironment: payments/dev")
+		}
+	})
+}
+
+//
+// Attribution (DoD 7).
+//
+
+func prepareMainEnvListConfig(
+	t *testing.T,
+	stackFile string,
+	env *esc.Environment,
+	store *fakeEnvStore,
+) (backend.Stack, *workspace.Project, *workspace.ProjectStack, cmdStack.SecretsManagerLoader) {
+	t.Helper()
+
+	secretsManager, _, _, _, _ := getCountingBase64SecretsManager(t.Context(), t, false)
+	snapshot := &deploy.Snapshot{SecretsManager: stack.NewBatchingCachingSecretsManager(secretsManager)}
+
+	be := store.backend()
+	be.CheckYAMLEnvironmentF = func(
+		context.Context, string, []byte,
+	) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+		return env, apitype.EnvironmentDiagnostics{}, nil
+	}
+	be.OpenYAMLEnvironmentF = func(
+		context.Context, string, []byte, time.Duration, map[string]string,
+	) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+		return env, apitype.EnvironmentDiagnostics{}, nil
+	}
+
+	s := mainEnvStack(be)
+	s.SnapshotF = func(context.Context, secrets.Provider) (*deploy.Snapshot, error) { return snapshot, nil }
+
+	project := &workspace.Project{Name: "testProject"}
+	return s, project, loadStackFile(t, project, stackFile), cmdStack.SecretsManagerLoader{FallbackToState: true}
+}
+
+func mainEnvAttributionEnvironment() *esc.Environment {
+	return &esc.Environment{Properties: map[string]esc.Value{
+		"pulumiConfig": esc.NewValue(map[string]esc.Value{
+			"testProject:instanceCount": {
+				Value: "6",
+				Trace: esc.Trace{Def: esc.Range{Environment: "payments/dev", Begin: esc.Pos{Line: 4, Column: 7}}},
+			},
+			"testProject:logLevel": {
+				Value: "info",
+				Trace: esc.Trace{Def: esc.Range{Environment: "payments/base"}},
+			},
+		}),
+	}}
+}
+
+func TestMainEnvironmentListConfigSourceColumn(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	store.revision = 8
+	s, project, ps, ssml := prepareMainEnvListConfig(
+		t, "mainEnvironment: payments/dev\n", mainEnvAttributionEnvironment(), store)
+
+	var stdout bytes.Buffer
+	require.NoError(t, listConfig(
+		t.Context(), ssml, &stdout, project, s, ps, false, false, true, ""))
+
+	expected := strings.TrimSpace(`
+KEY                        VALUE  SOURCE
+testProject:instanceCount  6      payments/dev@8
+testProject:logLevel       info   payments/base@2 (imported)
+`)
+	assert.Equal(t, expected, strings.TrimSpace(stdout.String()))
+
+	// One revision lookup per distinct environment, not one per value.
+	assert.Equal(t, 1, store.revisionCalls["payments/dev"])
+	assert.Equal(t, 1, store.revisionCalls["payments/base"])
+}
+
+func TestMainEnvironmentListConfigUnmigratedValues(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	store.revision = 8
+	s, project, ps, ssml := prepareMainEnvListConfig(
+		t,
+		"mainEnvironment: payments/dev\nconfig:\n  testProject:instanceCount: \"9\"\n",
+		mainEnvAttributionEnvironment(),
+		store)
+
+	var stdout bytes.Buffer
+	require.NoError(t, listConfig(
+		t.Context(), ssml, &stdout, project, s, ps, false, false, true, ""))
+
+	out := stdout.String()
+	// The stack file's value wins, and is attributed as unmigrated.
+	assert.Contains(t, out, "testProject:instanceCount  9      Pulumi.testStack.yaml (unmigrated)")
+	assert.Contains(t, out, "1 configuration value(s) still set in Pulumi.testStack.yaml override payments/dev")
+}
+
+func TestMainEnvironmentListConfigJSON(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	store.revision = 8
+	s, project, ps, ssml := prepareMainEnvListConfig(
+		t, "mainEnvironment: payments/dev\n", mainEnvAttributionEnvironment(), store)
+
+	var stdout bytes.Buffer
+	require.NoError(t, listConfig(
+		t.Context(), ssml, &stdout, project, s, ps, false, true, true, ""))
+	assert.Contains(t, stdout.String(), `"source": "payments/dev@8"`)
+	assert.Contains(t, stdout.String(), `"source": "payments/base@2 (imported)"`)
+}
+
+// TestEnvironmentStackListConfigUnchanged is the explicit regression test for DoD 11: an
+// `environment:`-only stack gains neither a SOURCE column nor a `source` JSON field.
+func TestEnvironmentStackListConfigUnchanged(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	s, project, ps, ssml := prepareMainEnvListConfig(
+		t, "environment:\n  - payments/dev\n", mainEnvAttributionEnvironment(), store)
+
+	var stdout bytes.Buffer
+	require.NoError(t, listConfig(
+		t.Context(), ssml, &stdout, project, s, ps, false, false, true, ""))
+	expected := strings.TrimSpace(`
+KEY                        VALUE
+testProject:instanceCount  6
+testProject:logLevel       info
+`)
+	assert.Equal(t, expected, strings.TrimSpace(stdout.String()))
+	assert.NotContains(t, stdout.String(), "Config source:")
+
+	stdout.Reset()
+	require.NoError(t, listConfig(
+		t.Context(), ssml, &stdout, project, s, ps, false, true, true, ""))
+	assert.NotContains(t, stdout.String(), `"source"`)
+	assert.Empty(t, store.revisionCalls)
+}
+
+func TestShowSource(t *testing.T) {
+	t.Parallel()
+
+	mainEnv := &workspace.MainEnvironment{Project: "payments", Name: "dev"}
+	base := esc.Value{
+		Value: "debug",
+		Trace: esc.Trace{Def: esc.Range{Environment: "payments/base"}},
+	}
+	pulumiEnv := esc.NewValue(map[string]esc.Value{
+		"testProject:logLevel": {
+			Value: "info",
+			Trace: esc.Trace{
+				Def:  esc.Range{Environment: "payments/dev", Begin: esc.Pos{Line: 4, Column: 7}},
+				Base: &base,
+			},
+		},
+	})
+	key := config.MustMakeKey("testProject", "logLevel")
+	index := &sourceIndex{sources: map[config.Key]string{key: "payments/dev@8"}}
+
+	var out bytes.Buffer
+	showSource(&out, index, mainEnv, key, pulumiEnv)
+	assert.Equal(t, "Source: payments/dev@8\n"+
+		"  defined at payments/dev:4:7\n"+
+		"  overrides payments/base\n", out.String())
+}
+
+// writeStackFile writes a stack file to a temporary directory and returns its path.
+func writeStackFile(t *testing.T, text string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "Pulumi.testStack.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(text), 0o600))
+	return path
+}
+
+func TestGetConfigShowSource(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	store.revision = 8
+	s, project, _, ssml := prepareMainEnvListConfig(
+		t, "mainEnvironment: payments/dev\n", mainEnvAttributionEnvironment(), store)
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) { return project, "", nil },
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, getConfig(
+		t.Context(), &out, cmdutil.Diag(), ssml, ws, s,
+		config.MustMakeKey("testProject", "logLevel"), false, false, true, true,
+		writeStackFile(t, "mainEnvironment: payments/dev\n")))
+
+	assert.Equal(t, "info\nSource: payments/base@2 (imported)\n", out.String())
+}
+
+func TestShowSourceRequiresMainEnvironment(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeEnvStore(t, "")
+	s, project, _, ssml := prepareMainEnvListConfig(
+		t, "environment:\n  - payments/dev\n", mainEnvAttributionEnvironment(), store)
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) { return project, "", nil },
+	}
+
+	var out bytes.Buffer
+	err := getConfig(
+		t.Context(), &out, cmdutil.Diag(), ssml, ws, s,
+		config.MustMakeKey("testProject", "logLevel"), false, false, true, true,
+		writeStackFile(t, "environment:\n  - payments/dev\n"))
+	require.ErrorContains(t, err, "--show-source requires the stack to set 'mainEnvironment'")
+}
+
+// TestMainEnvironmentUnsupportedSubcommands is the command-level half of DoD 12: subcommands that have no
+// environment write path refuse rather than silently writing the local `config:` block.
+func TestMainEnvironmentUnsupportedSubcommands(t *testing.T) {
+	t.Parallel()
+
+	const stackFile = "mainEnvironment: payments/dev\n"
+
+	newLoginManager := func(be backend.Backend) cmdBackend.LoginManager {
+		return &cmdBackend.MockLoginManager{
+			CurrentF: func(
+				context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool,
+			) (backend.Backend, error) {
+				return be, nil
+			},
+			LoginF: func(
+				context.Context, pkgWorkspace.Context, diag.Sink, string, *workspace.Project, bool, bool,
+				colors.Colorization,
+			) (backend.Backend, error) {
+				return be, nil
+			},
+		}
+	}
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(string) (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "testProject"}, "", nil
+		},
+		GetStoredCredentialsF: func() (workspace.Credentials, error) {
+			return workspace.Credentials{Current: "https://api.pulumi.com"}, nil
+		},
+	}
+
+	t.Run("set-all", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+		s := mainEnvStack(store.backend())
+		be := &backend.MockBackend{
+			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) { return s, nil },
+		}
+
+		configPath := writeStackFile(t, stackFile)
+		stackName := "testStack"
+		cmd := newConfigSetAllCmd(ws, &stackName, newLoginManager(be), &mockEncrypterFactory{}, &configPath)
+		cmd.SetContext(t.Context())
+		require.NoError(t, cmd.PersistentFlags().Set("plaintext", "testProject:key=value"))
+
+		err := cmd.RunE(cmd, []string{})
+		require.ErrorContains(t, err, "'pulumi config set-all' is not supported yet")
+
+		// Neither the environment nor the stack file was written.
+		assert.Equal(t, 0, store.updates)
+		data, readErr := os.ReadFile(configPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, stackFile, string(data))
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		t.Parallel()
+
+		store := newFakeEnvStore(t, "values:\n  pulumiConfig: {}\n")
+		envBackend := store.backend()
+		envBackend.GetLatestConfigurationF = func(
+			context.Context, backend.Stack,
+		) (backend.LatestConfiguration, error) {
+			return backend.LatestConfiguration{
+				Config: config.Map{config.MustMakeKey("testProject", "key1"): config.NewValue("value1")},
+			}, nil
+		}
+		s := mainEnvStack(envBackend)
+		be := &backend.MockBackend{
+			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) { return s, nil },
+			ParseStackReferenceF: func(name string) (backend.StackReference, error) {
+				return &backend.MockStackReference{
+					NameV:               tokens.MustParseStackName(name),
+					FullyQualifiedNameV: tokens.QName("test-org/testProject/" + name),
+				}, nil
+			},
+		}
+
+		configPath := writeStackFile(t, stackFile)
+		stackName := "testStack"
+		cmd := newConfigRefreshCmd(ws, &stackName, newLoginManager(be), &configPath)
+		cmd.SetContext(t.Context())
+		require.NoError(t, cmd.PersistentFlags().Set("force", "true"))
+
+		err := cmd.RunE(cmd, []string{})
+		require.ErrorContains(t, err, "'pulumi config refresh' is not supported yet")
+
+		assert.Equal(t, 0, store.updates)
+		data, readErr := os.ReadFile(configPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, stackFile, string(data))
+	})
+}

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -135,15 +136,36 @@ func getStackConfigurationFromProjectStack(
 	workspaceStack *workspace.ProjectStack,
 	envOverrides []string,
 ) (backend.StackConfiguration, error) {
+	// This is a non-command helper; we don't have a *cobra.Command writer to thread through here, so
+	// informational output goes to stderr to keep any command's stdout (including --json) untouched.
+	return getStackConfigurationFromProjectStackWithWriter(
+		ctx, os.Stderr, stack, project, sm, workspaceStack, envOverrides) //nolint:forbidigo
+}
+
+func getStackConfigurationFromProjectStackWithWriter(
+	ctx context.Context,
+	stderr io.Writer,
+	stack backend.Stack,
+	project *workspace.Project,
+	sm secrets.Manager,
+	workspaceStack *workspace.ProjectStack,
+	envOverrides []string,
+) (backend.StackConfiguration, error) {
+	envDef, mainEnv, warnings := effectiveStackEnv(stack, workspaceStack)
+	printConfigWarnings(stderr, warnings)
+
 	env, diags, err := openStackEnv(ctx, stack, workspaceStack, envOverrides)
 	if err != nil {
 		return backend.StackConfiguration{}, fmt.Errorf("opening environment: %w", err)
 	}
 	if len(diags) != 0 {
-		// This is a non-command helper; we don't have a *cobra.Command writer
-		// to thread through here. Writes go to the process streams directly.
-		printESCDiagnostics(os.Stderr, diags) //nolint:forbidigo
+		printESCDiagnostics(stderr, diags)
 		return backend.StackConfiguration{}, errors.New("opening environment: too many errors")
+	}
+
+	// Tell the user which revision of the main environment this run resolved its configuration against.
+	if mainEnv != nil {
+		printConfigSource(ctx, stderr, stack, mainEnv)
 	}
 
 	var pulumiEnv esc.Value
@@ -174,7 +196,7 @@ func getStackConfigurationFromProjectStack(
 	// the correct decrypter for the diy backend would involve prompting for a passphrase)
 	if !needsCrypter(workspaceStack.Config, pulumiEnv) {
 		return backend.StackConfiguration{
-			EnvironmentImports: workspaceStack.Environment.Imports(),
+			EnvironmentImports: envDef.Imports(),
 			Environment:        pulumiEnv,
 			Config:             workspaceStack.Config,
 			Decrypter:          config.NewPanicCrypter(),
@@ -184,7 +206,7 @@ func getStackConfigurationFromProjectStack(
 	crypter := sm.Decrypter()
 
 	return backend.StackConfiguration{
-		EnvironmentImports: workspaceStack.Environment.Imports(),
+		EnvironmentImports: envDef.Imports(),
 		Environment:        pulumiEnv,
 		Config:             workspaceStack.Config,
 		Decrypter:          crypter,
@@ -241,7 +263,8 @@ func openStackEnv(
 	workspaceStack *workspace.ProjectStack,
 	envOverrides []string,
 ) (*esc.Environment, []apitype.EnvironmentDiagnostic, error) {
-	yaml := workspaceStack.EnvironmentBytes()
+	envDef, _, _ := effectiveStackEnv(stack, workspaceStack)
+	yaml := envDef.Definition()
 	if len(yaml) == 0 {
 		return nil, nil, nil
 	}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -452,6 +452,7 @@ func NewUpCmd() *cobra.Command {
 			path,
 			opts.Display,
 			configFile,
+			false, /* escConfig */
 		); err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -55,7 +55,27 @@ func HandleConfig(
 	path bool,
 	opts display.Options,
 	configFile string,
+	escConfig bool,
 ) error {
+	if escConfig {
+		// A stack being born has no previous deployment, so there is nothing for the
+		// isPreconfiguredEmptyStack shortcut below to reuse — and reading it would need the stack
+		// decrypter this path deliberately never touches.
+		commandLineConfig, err := ParseConfigForProject(project.Name, configArray, path)
+		if err != nil {
+			return err
+		}
+		values, err := resolveTemplateConfig(project.Name, template.Config, commandLineConfig, nil, nil)
+		if err != nil {
+			return err
+		}
+		if err := askTemplateConfig(values, prompt, yes, askAll, opts); err != nil {
+			return err
+		}
+		return saveTemplateConfigToEnvironment(
+			ctx, sink, opts.Stdout, project, s, values, commandLineConfig, configFile)
+	}
+
 	// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
 	latest, err := backend.GetLatestConfiguration(ctx, s)
 	if err != nil && err != backenderr.ErrNoPreviousDeployment {

--- a/pkg/cmd/pulumi/project/newcmd/config_env.go
+++ b/pkg/cmd/pulumi/project/newcmd/config_env.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -50,7 +52,7 @@ func saveTemplateConfigToEnvironment(
 		return err
 	}
 
-	mainEnv, err := cmdStack.CreateStackEnvironments(ctx, s, cmdStack.StackEnvironmentOptions{
+	env, err := cmdStack.CreateStackEnvironments(ctx, s, cmdStack.StackEnvironmentOptions{
 		EnvProject: project.Name.String(),
 		EnvName:    s.Ref().Name().String(),
 		Values:     envValues,
@@ -64,16 +66,46 @@ func saveTemplateConfigToEnvironment(
 	if err != nil {
 		return err
 	}
-	ps.MainEnvironment = mainEnv
+	ps.MainEnvironment = env.MainEnvironment
 	if err := cmdStack.SaveProjectStack(ctx, s, ps, configFile); err != nil {
 		return err
 	}
 
-	if len(envValues) > 0 {
-		fmt.Fprintf(out, "Saved config to %s\n", mainEnv.Ref())
-		fmt.Fprintln(out)
+	if len(envValues) == 0 {
+		return nil
 	}
+	if env.StackEnvironmentReused {
+		// The environment already existed, and an existing environment is never overwritten, so
+		// nothing the wizard gathered was stored. One of those values may have been typed at a
+		// `--secret` prompt, so this must not be reported as a save. Name the keys — never the
+		// values — and say where to put them.
+		warnConfigNotSaved(sink, out, env.MainEnvironment.Ref(), envValues)
+		return nil
+	}
+
+	fmt.Fprintf(out, "Saved config to %s\n", env.MainEnvironment.Ref())
+	fmt.Fprintln(out)
 	return nil
+}
+
+// warnConfigNotSaved reports the config keys that were gathered but not written, because the stack's
+// environment already existed. Only the keys are named: a value may be a secret.
+func warnConfigNotSaved(sink diag.Sink, out io.Writer, envRef string, values map[string]yaml.Node) {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	msg := fmt.Sprintf("environment %s already exists and is never overwritten, so the configuration "+
+		"gathered here was not saved: %s\n"+
+		"    Set the values you need with 'pulumi config set [--secret] <key> <value>' after checking "+
+		"what the environment already provides.", envRef, strings.Join(keys, ", "))
+	if sink != nil {
+		sink.Warningf(diag.Message("", "%s"), msg)
+		return
+	}
+	fmt.Fprintf(out, "warning: %s\n", msg)
 }
 
 // templateConfigNodes renders the gathered config as the `values.pulumiConfig` entries of an environment

--- a/pkg/cmd/pulumi/project/newcmd/config_env.go
+++ b/pkg/cmd/pulumi/project/newcmd/config_env.go
@@ -1,0 +1,128 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// saveTemplateConfigToEnvironment is the `--esc-config` counterpart of saveTemplateConfig: the config the
+// wizard gathered becomes the initial contents of the stack's own ESC environment instead of the stack
+// file's `config:` block.
+//
+// The stack's secrets manager is never involved. A prompted secret is wrapped in `fn::secret` and
+// encrypted by ESC, so its plaintext exists only in the in-memory YAML node this builds, never on disk
+// and never in a log.
+func saveTemplateConfigToEnvironment(
+	ctx context.Context, sink diag.Sink, out io.Writer,
+	project *workspace.Project, s backend.Stack,
+	values []templateConfigValue, commandLineConfig config.Map, configFile string,
+) error {
+	if out == nil {
+		out = io.Discard
+	}
+
+	envValues, err := templateConfigNodes(values, commandLineConfig)
+	if err != nil {
+		return err
+	}
+
+	mainEnv, err := cmdStack.CreateStackEnvironments(ctx, s, cmdStack.StackEnvironmentOptions{
+		EnvProject: project.Name.String(),
+		EnvName:    s.Ref().Name().String(),
+		Values:     envValues,
+		Stdout:     out,
+	})
+	if err != nil {
+		return err
+	}
+
+	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, s, configFile)
+	if err != nil {
+		return err
+	}
+	ps.MainEnvironment = mainEnv
+	if err := cmdStack.SaveProjectStack(ctx, s, ps, configFile); err != nil {
+		return err
+	}
+
+	if len(envValues) > 0 {
+		fmt.Fprintf(out, "Saved config to %s\n", mainEnv.Ref())
+		fmt.Fprintln(out)
+	}
+	return nil
+}
+
+// templateConfigNodes renders the gathered config as the `values.pulumiConfig` entries of an environment
+// definition. `--config` values win over prompted ones, matching encryptTemplateConfig.
+func templateConfigNodes(
+	values []templateConfigValue, commandLineConfig config.Map,
+) (map[string]yaml.Node, error) {
+	nodes := make(map[string]yaml.Node, len(values)+len(commandLineConfig))
+
+	for key, val := range commandLineConfig {
+		// Command-line values come from ParseConfig, which never produces a secure value, so no
+		// decrypter is needed to read them back.
+		if val.Object() {
+			obj, err := val.ToObject()
+			if err != nil {
+				return nil, err
+			}
+			var node yaml.Node
+			if err := node.Encode(obj); err != nil {
+				return nil, fmt.Errorf("rendering config value %v: %w", key, err)
+			}
+			nodes[key.String()] = node
+			continue
+		}
+		plain, err := val.Value(config.NopDecrypter)
+		if err != nil {
+			return nil, err
+		}
+		node, err := cmdConfig.ConfigValueNode(plain, "" /*typ*/, false /*secret*/)
+		if err != nil {
+			return nil, err
+		}
+		nodes[key.String()] = node
+	}
+
+	for _, v := range values {
+		if _, ok := nodes[v.key.String()]; ok {
+			continue
+		}
+		if v.value == "" {
+			// Don't add empty values to the config.
+			continue
+		}
+		node, err := cmdConfig.ConfigValueNode(v.value, "" /*typ*/, v.secret)
+		if err != nil {
+			return nil, err
+		}
+		nodes[v.key.String()] = node
+	}
+
+	return nodes, nil
+}

--- a/pkg/cmd/pulumi/project/newcmd/config_env_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/config_env_test.go
@@ -183,9 +183,25 @@ func TestSaveTemplateConfigToEnvironmentReusesExistingEnvironment(t *testing.T) 
 	require.NoError(t, saveTemplateConfigToEnvironment(
 		t.Context(), diag.DefaultSink(&out, &out, diag.FormatOptions{Color: colors.Never}), &out,
 		f.project, f.stack,
-		[]templateConfigValue{{key: config.MustMakeKey("aws", "region"), value: "us-west-2"}},
+		[]templateConfigValue{
+			{key: config.MustMakeKey("aws", "region"), value: "us-west-2"},
+			{key: config.MustMakeKey("payments", "dbPassword"), value: "hunter2", secret: true},
+		},
 		nil, ""))
 
 	assert.Empty(t, f.created)
 	assert.Contains(t, out.String(), "Environment 'acme/payments/dev' already exists — reusing.")
+
+	// The values were not written anywhere, so this must not be reported as a save. The user is told
+	// which keys were dropped, by name only — one of them was typed at a secret prompt.
+	assert.NotContains(t, out.String(), "Saved config to")
+	assert.Contains(t, out.String(), "environment payments/dev already exists and is never overwritten")
+	assert.Contains(t, out.String(), "aws:region, payments:dbPassword")
+	assert.Contains(t, out.String(), "pulumi config set")
+	assert.NotContains(t, out.String(), "hunter2")
+
+	stackFile, err := os.ReadFile(filepath.Join(f.dir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(stackFile), "hunter2")
+	assert.NotContains(t, string(stackFile), "us-west-2")
 }

--- a/pkg/cmd/pulumi/project/newcmd/config_env_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/config_env_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// escStackFixture is a project directory plus a backend that records the environments created for it.
+type escStackFixture struct {
+	dir      string
+	created  map[string]string
+	stack    backend.Stack
+	project  *workspace.Project
+	existing map[string]bool
+}
+
+func newESCStackFixture(t *testing.T) *escStackFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "Pulumi.yaml"), []byte("name: payments\nruntime: yaml\n"), 0o600))
+	t.Chdir(dir)
+
+	f := &escStackFixture{
+		dir:      dir,
+		created:  map[string]string{},
+		existing: map[string]bool{},
+		project:  &workspace.Project{Name: "payments"},
+	}
+
+	be := &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{NameF: func() string { return "test" }},
+		GetEnvironmentDefinitionF: func(
+			_ context.Context, org, envProject, envName, version string,
+		) ([]byte, string, int, error) {
+			ref := envProject + "/" + envName
+			if !f.existing[ref] {
+				return nil, "", 0, fmt.Errorf("%w: %v", backend.ErrEnvironmentNotFound, ref)
+			}
+			return []byte("values: {}\n"), "etag-1", 1, nil
+		},
+		CreateEnvironmentF: func(
+			_ context.Context, org, envProject, envName string, yaml []byte,
+		) (apitype.EnvironmentDiagnostics, error) {
+			f.created[envProject+"/"+envName] = string(yaml)
+			f.existing[envProject+"/"+envName] = true
+			return nil, nil
+		},
+	}
+	f.stack = &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				StringV:             "dev",
+				NameV:               tokens.MustParseStackName("dev"),
+				FullyQualifiedNameV: "acme/payments/dev",
+			}
+		},
+		OrgNameF: func() string { return "acme" },
+		BackendF: func() backend.Backend { return be },
+	}
+	return f
+}
+
+// The wizard's config lands in the stack environment, with prompted secrets as `fn::secret`. The stack's
+// secrets manager is never involved: no loader is passed at all, and no plaintext reaches the disk.
+//
+//nolint:paralleltest // changes directory for the process
+func TestSaveTemplateConfigToEnvironment(t *testing.T) {
+	f := newESCStackFixture(t)
+
+	values := []templateConfigValue{
+		{key: config.MustMakeKey("aws", "region"), value: "us-west-2"},
+		{key: config.MustMakeKey("payments", "dbPassword"), value: "hunter2", secret: true},
+		{key: config.MustMakeKey("payments", "unset"), value: ""},
+	}
+	commandLineConfig := config.Map{
+		config.MustMakeKey("payments", "instanceCount"): config.NewValue("6"),
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, saveTemplateConfigToEnvironment(
+		t.Context(), diag.DefaultSink(&out, &out, diag.FormatOptions{Color: colors.Never}), &out,
+		f.project, f.stack, values, commandLineConfig, ""))
+
+	assert.Equal(t, "values: {}\n", f.created["payments/base"])
+	assert.Equal(t,
+		"imports:\n  - payments/base\n"+
+			"values:\n  pulumiConfig:\n"+
+			"    aws:region: us-west-2\n"+
+			"    payments:dbPassword:\n      fn::secret: hunter2\n"+
+			"    payments:instanceCount: \"6\"\n",
+		f.created["payments/dev"])
+
+	stackFile, err := os.ReadFile(filepath.Join(f.dir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(stackFile), "mainEnvironment: payments/dev")
+	assert.NotContains(t, string(stackFile), "config:")
+	// Neither the secret nor its ciphertext is ever written to the stack file or the log.
+	assert.NotContains(t, string(stackFile), "hunter2")
+	assert.NotContains(t, string(stackFile), "encryptionsalt")
+	assert.NotContains(t, out.String(), "hunter2")
+}
+
+// A --config value wins over a prompted one for the same key, exactly as it does today.
+//
+//nolint:paralleltest // changes directory for the process
+func TestSaveTemplateConfigToEnvironmentPrefersCommandLineConfig(t *testing.T) {
+	f := newESCStackFixture(t)
+
+	values := []templateConfigValue{
+		{key: config.MustMakeKey("aws", "region"), value: "us-west-2"},
+	}
+	commandLineConfig := config.Map{
+		config.MustMakeKey("aws", "region"): config.NewValue("eu-west-1"),
+	}
+
+	require.NoError(t, saveTemplateConfigToEnvironment(
+		t.Context(), diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{Color: colors.Never}), &bytes.Buffer{},
+		f.project, f.stack, values, commandLineConfig, ""))
+
+	assert.Contains(t, f.created["payments/dev"], "aws:region: eu-west-1")
+	assert.NotContains(t, f.created["payments/dev"], "us-west-2")
+}
+
+// A run with no config at all still gives the stack its environments and its `mainEnvironment`.
+//
+//nolint:paralleltest // changes directory for the process
+func TestSaveTemplateConfigToEnvironmentWithoutConfig(t *testing.T) {
+	f := newESCStackFixture(t)
+
+	var out bytes.Buffer
+	require.NoError(t, saveTemplateConfigToEnvironment(
+		t.Context(), diag.DefaultSink(&out, &out, diag.FormatOptions{Color: colors.Never}), &out,
+		f.project, f.stack, nil, nil, ""))
+
+	assert.Equal(t, "imports:\n  - payments/base\nvalues: {}\n", f.created["payments/dev"])
+	assert.NotContains(t, out.String(), "Saved config to")
+
+	stackFile, err := os.ReadFile(filepath.Join(f.dir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(stackFile), "mainEnvironment: payments/dev")
+}
+
+// An existing stack environment is reused, never overwritten by the values the wizard gathered.
+//
+//nolint:paralleltest // changes directory for the process
+func TestSaveTemplateConfigToEnvironmentReusesExistingEnvironment(t *testing.T) {
+	f := newESCStackFixture(t)
+	f.existing["payments/base"] = true
+	f.existing["payments/dev"] = true
+
+	var out bytes.Buffer
+	require.NoError(t, saveTemplateConfigToEnvironment(
+		t.Context(), diag.DefaultSink(&out, &out, diag.FormatOptions{Color: colors.Never}), &out,
+		f.project, f.stack,
+		[]templateConfigValue{{key: config.MustMakeKey("aws", "region"), value: "us-west-2"}},
+		nil, ""))
+
+	assert.Empty(t, f.created)
+	assert.Contains(t, out.String(), "Environment 'acme/payments/dev' already exists — reusing.")
+}

--- a/pkg/cmd/pulumi/project/newcmd/confirm.go
+++ b/pkg/cmd/pulumi/project/newcmd/confirm.go
@@ -93,10 +93,15 @@ func (c *confirmedNew) saveConfig(
 	args newArgs, opts display.Options,
 ) error {
 	if c.createsStack() {
+		if args.escConfig {
+			return saveTemplateConfigToEnvironment(
+				ctx, sink, args.stdout, proj, s, c.config, c.commandLineConfig, "")
+		}
 		return saveTemplateConfig(ctx, sink, ssml, ws, proj, s, c.config, c.commandLineConfig, "")
 	}
 	return HandleConfig(ctx, sink, ssml, ws, args.prompt, proj, s,
-		args.templateNameOrURL, template, args.configArray, args.yes, args.configPath, opts, "")
+		args.templateNameOrURL, template, args.configArray, args.yes, args.configPath, opts, "",
+		args.escConfig)
 }
 
 func printPreamble(w io.Writer, opts display.Options) {

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -274,6 +274,13 @@ func runNew(ctx context.Context, args newArgs) error {
 			return err
 		}
 		if existingStack != nil {
+			if args.escConfig {
+				// --esc-config gives a *new* stack its environments. Adopting an existing stack would
+				// point it at an environment while its `config:` block quietly stops being effective.
+				return fmt.Errorf("--esc-config cannot be used with the existing stack %s: "+
+					"it configures a stack as it is created. Move that stack's configuration into an "+
+					"environment with 'pulumi config env init --main' instead", args.stack)
+			}
 			s = existingStack
 			if args.description == "" {
 				args.description = existingDesc

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -95,6 +95,7 @@ type newArgs struct {
 	templateMode         bool
 	runtimeOptions       []string
 	remoteStackConfig    bool
+	escConfig            bool
 	stdout               io.Writer
 	stderr               io.Writer
 }
@@ -176,6 +177,14 @@ func runNew(ctx context.Context, args newArgs) error {
 		// Check project name and stack reference project name are the same, we skip this check if
 		// --generate-only is set because we're not going to actually use the --stack argument given.
 		if err := compareStackProjectName(b, args.stack, args.name); err != nil {
+			return err
+		}
+	}
+
+	// Everything --esc-config needs must be checked before a template is downloaded, a stack is
+	// created, or a file is written, so that a refusal leaves nothing behind.
+	if args.escConfig {
+		if err := validateESCConfig(b, args); err != nil {
 			return err
 		}
 	}
@@ -659,7 +668,27 @@ func NewNewCmd() *cobra.Command {
 	)
 	_ = cmd.PersistentFlags().MarkHidden("remote-stack-config")
 
+	cmd.PersistentFlags().BoolVar(
+		&args.escConfig, "esc-config", false,
+		"[EXPERIMENTAL] Store this stack's configuration in a new ESC environment "+
+			"'<project>/<stack>' that imports '<project>/base', recorded as the stack's 'mainEnvironment'. "+
+			"--secrets-provider still applies to any stack-local secrets",
+	)
+
 	return cmd
+}
+
+// validateESCConfig rejects the flag combinations --esc-config cannot honour. Each of these would
+// otherwise produce a stack whose 'mainEnvironment' is wrong or inert.
+func validateESCConfig(b backend.Backend, args newArgs) error {
+	if args.generateOnly {
+		return errors.New("--esc-config cannot be combined with --generate-only: no stack is created")
+	}
+	if args.remoteStackConfig {
+		return errors.New("--esc-config cannot be combined with --remote-stack-config: " +
+			"a stack whose configuration is stored remotely does not read its 'mainEnvironment'")
+	}
+	return cmdStack.CheckEnvironmentSupport(b)
 }
 
 func validateProjectName(ctx context.Context, b backend.Backend,

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1550,3 +1550,51 @@ func TestNewCmdYesDoesNotOverwriteExistingPulumiYAML(t *testing.T) {
 	require.NoError(t, readErr)
 	assert.Equal(t, "name: existing\n", string(contents))
 }
+
+// A backend that cannot host environments is refused before the project files are written.
+//
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestNewESCConfigRefusesBackendWithoutEnvironments(t *testing.T) {
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	mockCurrentBackend(t, &backend.MockBackend{
+		NameF: func() string { return "file://~" },
+	})
+
+	args := newArgs{
+		interactive:       false,
+		yes:               true,
+		escConfig:         true,
+		name:              projectName,
+		prompt:            ui.PromptForValue,
+		secretsProvider:   "default",
+		templateNameOrURL: localTemplate(t),
+		languageTemplate:  languageTemplateMock,
+	}
+
+	err := runNew(t.Context(), args)
+	assert.ErrorContains(t, err, "backend file://~ does not support environments")
+	assert.NoFileExists(t, filepath.Join(tempdir, "Pulumi.yaml"))
+}
+
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestNewESCConfigRefusesGenerateOnly(t *testing.T) {
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	args := newArgs{
+		generateOnly:      true,
+		interactive:       false,
+		yes:               true,
+		escConfig:         true,
+		name:              projectName,
+		prompt:            ui.PromptForValue,
+		secretsProvider:   "default",
+		templateNameOrURL: localTemplate(t),
+		languageTemplate:  languageTemplateMock,
+	}
+
+	err := runNew(t.Context(), args)
+	assert.ErrorContains(t, err, "--esc-config cannot be combined with --generate-only")
+}

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1578,6 +1578,53 @@ func TestNewESCConfigRefusesBackendWithoutEnvironments(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(tempdir, "Pulumi.yaml"))
 }
 
+// --esc-config gives a *new* stack its environments. Adopting a stack that already exists would point
+// it at an environment and quietly stop its existing `config:` block from being effective.
+//
+//nolint:paralleltest // changes directory for process, mocks login manager
+func TestNewESCConfigRefusesExistingStack(t *testing.T) {
+	tempdir := tempProjectDir(t)
+	t.Chdir(tempdir)
+
+	existing := &backend.MockStack{
+		RefF:  func() backend.StackReference { return &backend.MockStackReference{} },
+		TagsF: func() map[apitype.StackTagName]string { return nil },
+	}
+	mockCurrentBackend(t, &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{
+			NameF: func() string { return "test" },
+			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+				parts := strings.Split(s, "/")
+				return &backend.MockStackReference{
+					ProjectV: tokens.Name(parts[1]),
+					NameV:    tokens.MustParseStackName(parts[2]),
+				}, nil
+			},
+			GetStackF: func(context.Context, backend.StackReference) (backend.Stack, error) {
+				return existing, nil
+			},
+			DoesProjectExistF: func(context.Context, string, string) (bool, error) { return false, nil },
+		},
+	})
+
+	args := newArgs{
+		interactive:       false,
+		yes:               true,
+		escConfig:         true,
+		stack:             "acme/" + projectName + "/dev",
+		name:              projectName,
+		prompt:            ui.PromptForValue,
+		secretsProvider:   "default",
+		templateNameOrURL: localTemplate(t),
+		languageTemplate:  languageTemplateMock,
+	}
+
+	err := runNew(t.Context(), args)
+	assert.ErrorContains(t, err, "--esc-config cannot be used with the existing stack acme/"+projectName+"/dev")
+	assert.ErrorContains(t, err, "pulumi config env init --main")
+	assert.NoFileExists(t, filepath.Join(tempdir, "Pulumi.yaml"))
+}
+
 //nolint:paralleltest // changes directory for process, mocks login manager
 func TestNewESCConfigRefusesGenerateOnly(t *testing.T) {
 	tempdir := tempProjectDir(t)

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -472,6 +472,18 @@ func CopyEntireConfigMap(
 	destinationStack backend.Stack,
 	destinationProjectStack *workspace.ProjectStack,
 ) (bool, error) {
+	// A source stack whose configuration lives in an ESC environment has nothing in its `config:` block
+	// to copy, so copying would silently produce a stack with no configuration at all. Carrying the
+	// pointer across instead would alias two stacks onto one environment, which the one-stack-one-main-
+	// environment model does not allow; refuse and name the two ways forward.
+	if currentProjectStack.MainEnvironment != nil {
+		return false, fmt.Errorf(
+			"copying configuration from stack %s is not supported yet: it sets 'mainEnvironment: %s'.\n"+
+				"Create the new stack with 'pulumi stack init <name> --esc-config', or add\n"+
+				"'mainEnvironment: %s' to the new stack's file to point it at the same environment",
+			currentStack.Ref(), currentProjectStack.MainEnvironment, currentProjectStack.MainEnvironment)
+	}
+
 	var decrypter config.Decrypter
 	currentConfig := currentProjectStack.Config
 	currentEnvironments := currentProjectStack.Environment

--- a/pkg/cmd/pulumi/stack/io_test.go
+++ b/pkg/cmd/pulumi/stack/io_test.go
@@ -168,3 +168,29 @@ func TestCreateStackQuiet(t *testing.T) {
 		})
 	}
 }
+
+// A source stack whose configuration lives in an ESC environment has nothing in its `config:` block, so
+// copying it must refuse rather than silently produce a stack with no configuration source at all.
+func TestCopyEntireConfigMapRefusesMainEnvironmentSource(t *testing.T) {
+	t.Parallel()
+
+	sourceStack := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{StringV: "acme/payments/dev"}
+		},
+	}
+	sourceProjectStack := &workspace.ProjectStack{
+		MainEnvironment: &workspace.MainEnvironment{Project: "payments", Name: "dev"},
+	}
+
+	// A nil loader proves nothing beyond the guard runs: any decrypter or encrypter lookup would panic.
+	requiresSaving, err := CopyEntireConfigMap(
+		t.Context(), SecretsManagerLoader{}, sourceStack, sourceProjectStack,
+		&backend.MockStack{}, &workspace.ProjectStack{},
+	)
+	assert.False(t, requiresSaving)
+	assert.ErrorContains(t, err,
+		"copying configuration from stack acme/payments/dev is not supported yet: "+
+			"it sets 'mainEnvironment: payments/dev'")
+	assert.ErrorContains(t, err, "--esc-config")
+}

--- a/pkg/cmd/pulumi/stack/stack_env.go
+++ b/pkg/cmd/pulumi/stack/stack_env.go
@@ -74,7 +74,11 @@ type EnvironmentBirthError struct {
 	Created []string
 	// Failed is the fully qualified reference of the environment that could not be created.
 	Failed string
-	Err    error
+	// FailedExists reports that Failed does exist on the service, but with a definition that could
+	// not be written or is not valid. Re-running would reuse that unusable environment, so the user
+	// has to fix or delete it rather than simply try again.
+	FailedExists bool
+	Err          error
 }
 
 func (e *EnvironmentBirthError) Error() string {
@@ -82,7 +86,13 @@ func (e *EnvironmentBirthError) Error() string {
 	if len(e.Created) > 0 {
 		fmt.Fprintf(&b, "created environment(s) %s, but ", strings.Join(e.Created, ", "))
 	}
-	fmt.Fprintf(&b, "could not create environment %s: %v\n", e.Failed, e.Err)
+	if e.FailedExists {
+		fmt.Fprintf(&b, "environment %s was created with an unusable definition: %v\n", e.Failed, e.Err)
+		b.WriteString("that environment exists and would be reused as-is, so fix or delete it before " +
+			"re-running. ")
+	} else {
+		fmt.Fprintf(&b, "could not create environment %s: %v\n", e.Failed, e.Err)
+	}
 	b.WriteString("the stack was created without 'mainEnvironment', so it works as an ordinary stack; " +
 		"re-run with --esc-config once the problem is fixed, " +
 		"or migrate later with 'pulumi config env init --main'")
@@ -90,6 +100,17 @@ func (e *EnvironmentBirthError) Error() string {
 }
 
 func (e *EnvironmentBirthError) Unwrap() error { return e.Err }
+
+// StackEnvironmentResult reports what CreateStackEnvironments did, so that a caller which passed
+// Values can tell whether they were actually written.
+type StackEnvironmentResult struct {
+	// MainEnvironment is the environment to record as the stack's `mainEnvironment`.
+	MainEnvironment *workspace.MainEnvironment
+	// StackEnvironmentReused reports that `<EnvProject>/<EnvName>` already existed and was left
+	// exactly as it was found. Because reuse is never a write, any Values the caller passed were
+	// *not* stored, and the caller has to say so rather than report success.
+	StackEnvironmentReused bool
+}
 
 // CreateStackEnvironments gives a newly created stack the environments its configuration lives in:
 // `<EnvProject>/base`, shared by every stack in the project, and `<EnvProject>/<EnvName>`, which
@@ -100,7 +121,7 @@ func (e *EnvironmentBirthError) Unwrap() error { return e.Err }
 // configuration that is already there.
 func CreateStackEnvironments(
 	ctx context.Context, s backend.Stack, opts StackEnvironmentOptions,
-) (*workspace.MainEnvironment, error) {
+) (StackEnvironmentResult, error) {
 	out := opts.Stdout
 	if out == nil {
 		out = io.Discard
@@ -108,28 +129,30 @@ func CreateStackEnvironments(
 
 	b := s.Backend()
 	if err := CheckEnvironmentSupport(b); err != nil {
-		return nil, err
+		return StackEnvironmentResult{}, err
 	}
 	creator := b.(backend.EnvironmentsBackend)
 	definitions := b.(backend.EnvironmentDefinitionsBackend)
 
 	orgNamer, ok := s.(interface{ OrgName() string })
 	if !ok {
-		return nil, fmt.Errorf("cannot determine organization for stack %v", s.Ref())
+		return StackEnvironmentResult{}, fmt.Errorf("cannot determine organization for stack %v", s.Ref())
 	}
 	org := orgNamer.OrgName()
 
 	var created []string
-	ensure := func(envName string, definition []byte, creating string) error {
+	// ensure creates envName with the given definition, or reports that it already exists. It returns
+	// whether the environment was reused, i.e. whether the definition was *not* written.
+	ensure := func(envName string, definition []byte, creating string) (bool, error) {
 		fullName := fmt.Sprintf("%s/%s/%s", org, opts.EnvProject, envName)
 
 		_, _, _, err := definitions.GetEnvironmentDefinition(ctx, org, opts.EnvProject, envName, "")
 		switch {
 		case err == nil:
 			fmt.Fprintf(out, "Environment '%s' already exists — reusing.\n", fullName)
-			return nil
+			return true, nil
 		case !errors.Is(err, backend.ErrEnvironmentNotFound):
-			return &EnvironmentBirthError{Created: created, Failed: fullName, Err: err}
+			return false, &EnvironmentBirthError{Created: created, Failed: fullName, Err: err}
 		}
 
 		fmt.Fprintf(out, "Creating environment '%s'...%s\n", fullName, creating)
@@ -138,41 +161,59 @@ func CreateStackEnvironments(
 			// Someone created it in the window between the probe and the create. Reuse it, exactly as
 			// the probe would have.
 			fmt.Fprintf(out, "Environment '%s' already exists — reusing.\n", fullName)
-			return nil
+			return true, nil
 		}
 		if err != nil {
-			return &EnvironmentBirthError{Created: created, Failed: fullName, Err: err}
+			// The backend creates the environment before storing its definition, so a failure to store
+			// leaves the environment behind: say so rather than "could not create".
+			exists := errors.Is(err, backend.ErrEnvironmentCreatedInvalid)
+			return false, &EnvironmentBirthError{
+				Created: created, Failed: fullName, FailedExists: exists, Err: err,
+			}
 		}
 		if len(diags) != 0 {
-			return &EnvironmentBirthError{Created: created, Failed: fullName, Err: diags}
+			// The environment itself was created — the backend writes its definition as a second step —
+			// so it exists with a definition the service rejected. Say that, rather than claiming it
+			// was not created: a rerun would silently reuse this broken environment.
+			return false, &EnvironmentBirthError{
+				Created: created, Failed: fullName, FailedExists: true, Err: diags,
+			}
 		}
 		created = append(created, fullName)
-		return nil
+		return false, nil
 	}
 
 	base, err := renderStackEnvironment(nil /*imports*/, nil /*values*/)
 	if err != nil {
-		return nil, err
+		return StackEnvironmentResult{}, err
 	}
-	if err := ensure(BaseEnvironmentName, base, ""); err != nil {
-		return nil, err
+	baseReused, err := ensure(BaseEnvironmentName, base, "")
+	if err != nil {
+		return StackEnvironmentResult{}, err
 	}
 
 	// A stack literally named `base` is its own base environment; importing itself would be a cycle.
 	if opts.EnvName == BaseEnvironmentName {
-		return &workspace.MainEnvironment{Project: opts.EnvProject, Name: BaseEnvironmentName}, nil
+		return StackEnvironmentResult{
+			MainEnvironment:        &workspace.MainEnvironment{Project: opts.EnvProject, Name: BaseEnvironmentName},
+			StackEnvironmentReused: baseReused,
+		}, nil
 	}
 
 	baseRef := opts.EnvProject + "/" + BaseEnvironmentName
 	definition, err := renderStackEnvironment([]string{baseRef}, opts.Values)
 	if err != nil {
-		return nil, err
+		return StackEnvironmentResult{}, err
 	}
-	if err := ensure(opts.EnvName, definition, fmt.Sprintf(" (imports %s)", baseRef)); err != nil {
-		return nil, err
+	reused, err := ensure(opts.EnvName, definition, fmt.Sprintf(" (imports %s)", baseRef))
+	if err != nil {
+		return StackEnvironmentResult{}, err
 	}
 
-	return &workspace.MainEnvironment{Project: opts.EnvProject, Name: opts.EnvName}, nil
+	return StackEnvironmentResult{
+		MainEnvironment:        &workspace.MainEnvironment{Project: opts.EnvProject, Name: opts.EnvName},
+		StackEnvironmentReused: reused,
+	}, nil
 }
 
 // renderStackEnvironment renders the definition a stack environment is created with.

--- a/pkg/cmd/pulumi/stack/stack_env.go
+++ b/pkg/cmd/pulumi/stack/stack_env.go
@@ -183,7 +183,15 @@ func CreateStackEnvironments(
 		return false, nil
 	}
 
-	base, err := renderStackEnvironment(nil /*imports*/, nil /*values*/)
+	// A stack literally named `base` is its own base environment; importing itself would be a cycle, so
+	// it gets a single environment which carries the stack's values directly.
+	stackIsBase := opts.EnvName == BaseEnvironmentName
+
+	var baseValues map[string]yaml.Node
+	if stackIsBase {
+		baseValues = opts.Values
+	}
+	base, err := renderStackEnvironment(nil /*imports*/, baseValues)
 	if err != nil {
 		return StackEnvironmentResult{}, err
 	}
@@ -192,8 +200,7 @@ func CreateStackEnvironments(
 		return StackEnvironmentResult{}, err
 	}
 
-	// A stack literally named `base` is its own base environment; importing itself would be a cycle.
-	if opts.EnvName == BaseEnvironmentName {
+	if stackIsBase {
 		return StackEnvironmentResult{
 			MainEnvironment:        &workspace.MainEnvironment{Project: opts.EnvProject, Name: BaseEnvironmentName},
 			StackEnvironmentReused: baseReused,

--- a/pkg/cmd/pulumi/stack/stack_env.go
+++ b/pkg/cmd/pulumi/stack/stack_env.go
@@ -1,0 +1,225 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// BaseEnvironmentName is the environment every stack environment in a project imports. It gives a
+// project one place to put configuration shared by all of its stacks.
+const BaseEnvironmentName = "base"
+
+// ErrBackendNoEnvironments indicates that the given backend does not support ESC environments and
+// points the user at the Pulumi Cloud backend, which does.
+func ErrBackendNoEnvironments(b backend.Backend) error {
+	return fmt.Errorf("backend %v does not support environments; Pulumi ESC environments require the "+
+		"Pulumi Cloud backend, use `pulumi login` without arguments to log into the Pulumi Cloud backend", b.Name())
+}
+
+// CheckEnvironmentSupport reports whether a backend can host the environments a stack is born with.
+//
+// Callers check this *before* creating a stack or writing any file, so that an unsupported backend
+// fails without leaving anything half-built behind.
+func CheckEnvironmentSupport(b backend.Backend) error {
+	if _, ok := b.(backend.EnvironmentsBackend); !ok {
+		return ErrBackendNoEnvironments(b)
+	}
+	if _, ok := b.(backend.EnvironmentDefinitionsBackend); !ok {
+		return ErrBackendNoEnvironments(b)
+	}
+	return nil
+}
+
+// StackEnvironmentOptions describes the environments to create for a newly born stack.
+type StackEnvironmentOptions struct {
+	// EnvProject is the ESC project the environments live in; it is the Pulumi project's name.
+	EnvProject string
+	// EnvName is the environment that backs the stack; it is the stack's name.
+	EnvName string
+	// Values are the `values.pulumiConfig` entries the stack environment starts life with. Secrets are
+	// already wrapped in `fn::secret` by the caller, so no plaintext secret is ever written elsewhere.
+	Values map[string]yaml.Node
+	// Stdout receives the progress messages. A nil writer discards them.
+	Stdout io.Writer
+}
+
+// EnvironmentBirthError reports that creating a stack's environments failed, naming the environments
+// that were created before the failure so the user knows exactly what state they are in.
+type EnvironmentBirthError struct {
+	// Created holds the fully qualified references of the environments that were created.
+	Created []string
+	// Failed is the fully qualified reference of the environment that could not be created.
+	Failed string
+	Err    error
+}
+
+func (e *EnvironmentBirthError) Error() string {
+	var b strings.Builder
+	if len(e.Created) > 0 {
+		fmt.Fprintf(&b, "created environment(s) %s, but ", strings.Join(e.Created, ", "))
+	}
+	fmt.Fprintf(&b, "could not create environment %s: %v\n", e.Failed, e.Err)
+	b.WriteString("the stack was created without 'mainEnvironment', so it works as an ordinary stack; " +
+		"re-run with --esc-config once the problem is fixed, " +
+		"or migrate later with 'pulumi config env init --main'")
+	return b.String()
+}
+
+func (e *EnvironmentBirthError) Unwrap() error { return e.Err }
+
+// CreateStackEnvironments gives a newly created stack the environments its configuration lives in:
+// `<EnvProject>/base`, shared by every stack in the project, and `<EnvProject>/<EnvName>`, which
+// imports it and holds the stack's own values.
+//
+// Creation is additive only: an environment that already exists is reused with a message and is never
+// modified, so re-running the command — or creating a second stack in a project — cannot clobber
+// configuration that is already there.
+func CreateStackEnvironments(
+	ctx context.Context, s backend.Stack, opts StackEnvironmentOptions,
+) (*workspace.MainEnvironment, error) {
+	out := opts.Stdout
+	if out == nil {
+		out = io.Discard
+	}
+
+	b := s.Backend()
+	if err := CheckEnvironmentSupport(b); err != nil {
+		return nil, err
+	}
+	creator := b.(backend.EnvironmentsBackend)
+	definitions := b.(backend.EnvironmentDefinitionsBackend)
+
+	orgNamer, ok := s.(interface{ OrgName() string })
+	if !ok {
+		return nil, fmt.Errorf("cannot determine organization for stack %v", s.Ref())
+	}
+	org := orgNamer.OrgName()
+
+	var created []string
+	ensure := func(envName string, definition []byte, creating string) error {
+		fullName := fmt.Sprintf("%s/%s/%s", org, opts.EnvProject, envName)
+
+		_, _, _, err := definitions.GetEnvironmentDefinition(ctx, org, opts.EnvProject, envName, "")
+		switch {
+		case err == nil:
+			fmt.Fprintf(out, "Environment '%s' already exists — reusing.\n", fullName)
+			return nil
+		case !errors.Is(err, backend.ErrEnvironmentNotFound):
+			return &EnvironmentBirthError{Created: created, Failed: fullName, Err: err}
+		}
+
+		fmt.Fprintf(out, "Creating environment '%s'...%s\n", fullName, creating)
+		diags, err := creator.CreateEnvironment(ctx, org, opts.EnvProject, envName, definition)
+		if errors.Is(err, backend.ErrEnvironmentConflict) {
+			// Someone created it in the window between the probe and the create. Reuse it, exactly as
+			// the probe would have.
+			fmt.Fprintf(out, "Environment '%s' already exists — reusing.\n", fullName)
+			return nil
+		}
+		if err != nil {
+			return &EnvironmentBirthError{Created: created, Failed: fullName, Err: err}
+		}
+		if len(diags) != 0 {
+			return &EnvironmentBirthError{Created: created, Failed: fullName, Err: diags}
+		}
+		created = append(created, fullName)
+		return nil
+	}
+
+	base, err := renderStackEnvironment(nil /*imports*/, nil /*values*/)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensure(BaseEnvironmentName, base, ""); err != nil {
+		return nil, err
+	}
+
+	// A stack literally named `base` is its own base environment; importing itself would be a cycle.
+	if opts.EnvName == BaseEnvironmentName {
+		return &workspace.MainEnvironment{Project: opts.EnvProject, Name: BaseEnvironmentName}, nil
+	}
+
+	baseRef := opts.EnvProject + "/" + BaseEnvironmentName
+	definition, err := renderStackEnvironment([]string{baseRef}, opts.Values)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensure(opts.EnvName, definition, fmt.Sprintf(" (imports %s)", baseRef)); err != nil {
+		return nil, err
+	}
+
+	return &workspace.MainEnvironment{Project: opts.EnvProject, Name: opts.EnvName}, nil
+}
+
+// renderStackEnvironment renders the definition a stack environment is created with.
+//
+// `values:` is always present, even when empty, so that the document a later `pulumi config set`
+// reads back already has the mapping its writes extend.
+func renderStackEnvironment(imports []string, values map[string]yaml.Node) ([]byte, error) {
+	scalar := func(s string) *yaml.Node {
+		n := &yaml.Node{}
+		n.SetString(s)
+		return n
+	}
+
+	root := &yaml.Node{Kind: yaml.MappingNode}
+	if len(imports) > 0 {
+		seq := &yaml.Node{Kind: yaml.SequenceNode}
+		for _, i := range imports {
+			seq.Content = append(seq.Content, scalar(i))
+		}
+		root.Content = append(root.Content, scalar("imports"), seq)
+	}
+
+	valuesNode := &yaml.Node{Kind: yaml.MappingNode}
+	if len(values) > 0 {
+		keys := make([]string, 0, len(values))
+		for k := range values {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		pulumiConfig := &yaml.Node{Kind: yaml.MappingNode}
+		for _, k := range keys {
+			value := values[k]
+			pulumiConfig.Content = append(pulumiConfig.Content, scalar(k), &value)
+		}
+		valuesNode.Content = append(valuesNode.Content, scalar("pulumiConfig"), pulumiConfig)
+	}
+	root.Content = append(root.Content, scalar("values"), valuesNode)
+
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return nil, fmt.Errorf("rendering environment definition: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("rendering environment definition: %w", err)
+	}
+	return b.Bytes(), nil
+}

--- a/pkg/cmd/pulumi/stack/stack_env_test.go
+++ b/pkg/cmd/pulumi/stack/stack_env_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// fakeEnvUniverse is an in-memory stand-in for an organization's named ESC environments. It records
+// every created definition so a test can assert both what was written and what was left alone.
+type fakeEnvUniverse struct {
+	t *testing.T
+
+	// definitions maps "<project>/<name>" to the environment's YAML.
+	definitions map[string]string
+	// created lists "<project>/<name>" in creation order.
+	created []string
+	// createErrs fails the creation of the named environments.
+	createErrs map[string]error
+}
+
+func newFakeEnvUniverse(t *testing.T, existing ...string) *fakeEnvUniverse {
+	u := &fakeEnvUniverse{
+		t:           t,
+		definitions: map[string]string{},
+		createErrs:  map[string]error{},
+	}
+	for _, e := range existing {
+		u.definitions[e] = "values: {}\n"
+	}
+	return u
+}
+
+// backend returns a mock backend that leaves UpdateEnvironmentDefinitionF unset: creating a stack's
+// environments must never update one, and the mock panics if it does.
+func (u *fakeEnvUniverse) backend() *backend.MockEnvironmentsBackend {
+	return &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{
+			NameF: func() string { return "test" },
+		},
+		GetEnvironmentDefinitionF: func(
+			_ context.Context, org, envProject, envName, version string,
+		) ([]byte, string, int, error) {
+			assert.Equal(u.t, "acme", org)
+			ref := envProject + "/" + envName
+			def, ok := u.definitions[ref]
+			if !ok {
+				return nil, "", 0, fmt.Errorf("%w: %v", backend.ErrEnvironmentNotFound, ref)
+			}
+			return []byte(def), "etag-1", 1, nil
+		},
+		CreateEnvironmentF: func(
+			_ context.Context, org, envProject, envName string, yaml []byte,
+		) (apitype.EnvironmentDiagnostics, error) {
+			assert.Equal(u.t, "acme", org)
+			ref := envProject + "/" + envName
+			if err, ok := u.createErrs[ref]; ok {
+				return nil, err
+			}
+			u.definitions[ref] = string(yaml)
+			u.created = append(u.created, ref)
+			return nil, nil
+		},
+	}
+}
+
+func (u *fakeEnvUniverse) stack() *backend.MockStack {
+	be := u.backend()
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("dev"),
+				FullyQualifiedNameV: "acme/payments/dev",
+			}
+		},
+		OrgNameF: func() string { return "acme" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+func TestCreateStackEnvironmentsCreatesBaseAndStackEnvironment(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t)
+	var out bytes.Buffer
+
+	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+		Stdout:     &out,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mainEnv)
+	assert.Equal(t, "payments/dev", mainEnv.String())
+
+	assert.Equal(t, []string{"payments/base", "payments/dev"}, u.created)
+	assert.Equal(t, "values: {}\n", u.definitions["payments/base"])
+	assert.Equal(t, "imports:\n  - payments/base\nvalues: {}\n", u.definitions["payments/dev"])
+
+	assert.Contains(t, out.String(), "Creating environment 'acme/payments/base'...\n")
+	assert.Contains(t, out.String(), "Creating environment 'acme/payments/dev'... (imports payments/base)\n")
+}
+
+func TestCreateStackEnvironmentsReusesExistingBase(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t, "payments/base")
+	u.definitions["payments/base"] = "values:\n  pulumiConfig:\n    payments:logLevel: info\n"
+	var out bytes.Buffer
+
+	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+		Stdout:     &out,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "payments/dev", mainEnv.String())
+
+	// The pre-existing base is neither recreated nor edited.
+	assert.Equal(t, []string{"payments/dev"}, u.created)
+	assert.Equal(t, "values:\n  pulumiConfig:\n    payments:logLevel: info\n", u.definitions["payments/base"])
+	assert.Contains(t, out.String(), "Environment 'acme/payments/base' already exists — reusing.\n")
+}
+
+func TestCreateStackEnvironmentsReusesExistingStackEnvironment(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t, "payments/base", "payments/dev")
+	u.definitions["payments/dev"] = "values:\n  pulumiConfig:\n    aws:region: eu-west-1\n"
+	var out bytes.Buffer
+
+	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+		Values:     map[string]yaml.Node{"aws:region": mustScalar(t, "us-west-2")},
+		Stdout:     &out,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "payments/dev", mainEnv.String())
+
+	assert.Empty(t, u.created)
+	assert.Equal(t, "values:\n  pulumiConfig:\n    aws:region: eu-west-1\n", u.definitions["payments/dev"])
+	assert.Contains(t, out.String(), "Environment 'acme/payments/dev' already exists — reusing.\n")
+}
+
+func TestCreateStackEnvironmentsWritesValues(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t)
+	secret := yaml.Node{}
+	require.NoError(t, secret.Encode(map[string]string{"fn::secret": "hunter2"}))
+
+	_, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+		Values: map[string]yaml.Node{
+			"aws:region":          mustScalar(t, "us-west-2"),
+			"payments:dbPassword": secret,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "imports:\n  - payments/base\n"+
+		"values:\n  pulumiConfig:\n    aws:region: us-west-2\n"+
+		"    payments:dbPassword:\n      fn::secret: hunter2\n",
+		u.definitions["payments/dev"])
+}
+
+func TestCreateStackEnvironmentsConflictOnCreateIsReuse(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t)
+	// The base appears between the probe and the create, exactly as a racing writer would produce.
+	u.createErrs["payments/base"] = fmt.Errorf("%w: payments/base", backend.ErrEnvironmentConflict)
+	var out bytes.Buffer
+
+	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+		Stdout:     &out,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "payments/dev", mainEnv.String())
+	assert.Equal(t, []string{"payments/dev"}, u.created)
+	assert.Contains(t, out.String(), "Environment 'acme/payments/base' already exists — reusing.\n")
+}
+
+func TestCreateStackEnvironmentsStackNamedBase(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t)
+
+	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "base",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "payments/base", mainEnv.String())
+	// Exactly one environment, with no self-import.
+	assert.Equal(t, []string{"payments/base"}, u.created)
+	assert.Equal(t, "values: {}\n", u.definitions["payments/base"])
+}
+
+func TestCreateStackEnvironmentsFailureNamesWhatWasCreated(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t)
+	u.createErrs["payments/dev"] = errors.New("boom")
+
+	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+	})
+	// No main environment is returned, so the caller never records one and the stack stays ordinary.
+	assert.Nil(t, mainEnv)
+
+	var birthErr *EnvironmentBirthError
+	require.ErrorAs(t, err, &birthErr)
+	assert.Equal(t, []string{"acme/payments/base"}, birthErr.Created)
+	assert.Equal(t, "acme/payments/dev", birthErr.Failed)
+	assert.Contains(t, err.Error(), "created environment(s) acme/payments/base")
+	assert.Contains(t, err.Error(), "could not create environment acme/payments/dev: boom")
+	assert.Contains(t, err.Error(), "the stack was created without 'mainEnvironment'")
+}
+
+func TestCreateStackEnvironmentsRefusesBackendWithoutEnvironments(t *testing.T) {
+	t.Parallel()
+
+	b := &backend.MockBackend{NameF: func() string { return "file://~" }}
+	s := &backend.MockStack{
+		RefF:     func() backend.StackReference { return &backend.MockStackReference{} },
+		BackendF: func() backend.Backend { return b },
+	}
+
+	_, err := CreateStackEnvironments(t.Context(), s, StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+	})
+	assert.ErrorContains(t, err, "backend file://~ does not support environments")
+}
+
+func mustScalar(t *testing.T, value string) yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	n.SetString(value)
+	return n
+}

--- a/pkg/cmd/pulumi/stack/stack_env_test.go
+++ b/pkg/cmd/pulumi/stack/stack_env_test.go
@@ -41,6 +41,9 @@ type fakeEnvUniverse struct {
 	created []string
 	// createErrs fails the creation of the named environments.
 	createErrs map[string]error
+	// createDiags makes creation of the named environments succeed on the service but report
+	// diagnostics, i.e. the environment exists with a definition the service rejected.
+	createDiags map[string]apitype.EnvironmentDiagnostics
 }
 
 func newFakeEnvUniverse(t *testing.T, existing ...string) *fakeEnvUniverse {
@@ -48,6 +51,7 @@ func newFakeEnvUniverse(t *testing.T, existing ...string) *fakeEnvUniverse {
 		t:           t,
 		definitions: map[string]string{},
 		createErrs:  map[string]error{},
+		createDiags: map[string]apitype.EnvironmentDiagnostics{},
 	}
 	for _, e := range existing {
 		u.definitions[e] = "values: {}\n"
@@ -81,6 +85,11 @@ func (u *fakeEnvUniverse) backend() *backend.MockEnvironmentsBackend {
 			if err, ok := u.createErrs[ref]; ok {
 				return nil, err
 			}
+			if diags, ok := u.createDiags[ref]; ok {
+				// The service created the environment, then rejected its definition.
+				u.definitions[ref] = string(yaml)
+				return diags, nil
+			}
 			u.definitions[ref] = string(yaml)
 			u.created = append(u.created, ref)
 			return nil, nil
@@ -108,14 +117,15 @@ func TestCreateStackEnvironmentsCreatesBaseAndStackEnvironment(t *testing.T) {
 	u := newFakeEnvUniverse(t)
 	var out bytes.Buffer
 
-	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "dev",
 		Stdout:     &out,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, mainEnv)
-	assert.Equal(t, "payments/dev", mainEnv.String())
+	require.NotNil(t, env.MainEnvironment)
+	assert.Equal(t, "payments/dev", env.MainEnvironment.String())
+	assert.False(t, env.StackEnvironmentReused)
 
 	assert.Equal(t, []string{"payments/base", "payments/dev"}, u.created)
 	assert.Equal(t, "values: {}\n", u.definitions["payments/base"])
@@ -132,18 +142,20 @@ func TestCreateStackEnvironmentsReusesExistingBase(t *testing.T) {
 	u.definitions["payments/base"] = "values:\n  pulumiConfig:\n    payments:logLevel: info\n"
 	var out bytes.Buffer
 
-	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "dev",
 		Stdout:     &out,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "payments/dev", mainEnv.String())
+	assert.Equal(t, "payments/dev", env.MainEnvironment.String())
 
 	// The pre-existing base is neither recreated nor edited.
 	assert.Equal(t, []string{"payments/dev"}, u.created)
 	assert.Equal(t, "values:\n  pulumiConfig:\n    payments:logLevel: info\n", u.definitions["payments/base"])
 	assert.Contains(t, out.String(), "Environment 'acme/payments/base' already exists — reusing.\n")
+	// Only the base was reused; the stack's own environment was created, so its values were written.
+	assert.False(t, env.StackEnvironmentReused)
 }
 
 func TestCreateStackEnvironmentsReusesExistingStackEnvironment(t *testing.T) {
@@ -153,18 +165,20 @@ func TestCreateStackEnvironmentsReusesExistingStackEnvironment(t *testing.T) {
 	u.definitions["payments/dev"] = "values:\n  pulumiConfig:\n    aws:region: eu-west-1\n"
 	var out bytes.Buffer
 
-	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "dev",
 		Values:     map[string]yaml.Node{"aws:region": mustScalar(t, "us-west-2")},
 		Stdout:     &out,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "payments/dev", mainEnv.String())
+	assert.Equal(t, "payments/dev", env.MainEnvironment.String())
 
 	assert.Empty(t, u.created)
 	assert.Equal(t, "values:\n  pulumiConfig:\n    aws:region: eu-west-1\n", u.definitions["payments/dev"])
 	assert.Contains(t, out.String(), "Environment 'acme/payments/dev' already exists — reusing.\n")
+	// The caller has to know the values it passed were not written.
+	assert.True(t, env.StackEnvironmentReused)
 }
 
 func TestCreateStackEnvironmentsWritesValues(t *testing.T) {
@@ -198,13 +212,13 @@ func TestCreateStackEnvironmentsConflictOnCreateIsReuse(t *testing.T) {
 	u.createErrs["payments/base"] = fmt.Errorf("%w: payments/base", backend.ErrEnvironmentConflict)
 	var out bytes.Buffer
 
-	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "dev",
 		Stdout:     &out,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "payments/dev", mainEnv.String())
+	assert.Equal(t, "payments/dev", env.MainEnvironment.String())
 	assert.Equal(t, []string{"payments/dev"}, u.created)
 	assert.Contains(t, out.String(), "Environment 'acme/payments/base' already exists — reusing.\n")
 }
@@ -214,12 +228,12 @@ func TestCreateStackEnvironmentsStackNamedBase(t *testing.T) {
 
 	u := newFakeEnvUniverse(t)
 
-	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "base",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "payments/base", mainEnv.String())
+	assert.Equal(t, "payments/base", env.MainEnvironment.String())
 	// Exactly one environment, with no self-import.
 	assert.Equal(t, []string{"payments/base"}, u.created)
 	assert.Equal(t, "values: {}\n", u.definitions["payments/base"])
@@ -231,12 +245,12 @@ func TestCreateStackEnvironmentsFailureNamesWhatWasCreated(t *testing.T) {
 	u := newFakeEnvUniverse(t)
 	u.createErrs["payments/dev"] = errors.New("boom")
 
-	mainEnv, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "dev",
 	})
 	// No main environment is returned, so the caller never records one and the stack stays ordinary.
-	assert.Nil(t, mainEnv)
+	assert.Nil(t, env.MainEnvironment)
 
 	var birthErr *EnvironmentBirthError
 	require.ErrorAs(t, err, &birthErr)
@@ -245,6 +259,30 @@ func TestCreateStackEnvironmentsFailureNamesWhatWasCreated(t *testing.T) {
 	assert.Contains(t, err.Error(), "created environment(s) acme/payments/base")
 	assert.Contains(t, err.Error(), "could not create environment acme/payments/dev: boom")
 	assert.Contains(t, err.Error(), "the stack was created without 'mainEnvironment'")
+}
+
+// The service creates an environment before writing its definition, so a rejected definition leaves an
+// environment behind. The error has to say that, or a rerun silently reuses the broken environment.
+func TestCreateStackEnvironmentsInvalidDefinitionReportsEnvironmentExists(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t)
+	u.createDiags["payments/dev"] = apitype.EnvironmentDiagnostics{{Summary: "bad value"}}
+
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "dev",
+	})
+	assert.Nil(t, env.MainEnvironment)
+
+	var birthErr *EnvironmentBirthError
+	require.ErrorAs(t, err, &birthErr)
+	assert.Equal(t, []string{"acme/payments/base"}, birthErr.Created)
+	assert.Equal(t, "acme/payments/dev", birthErr.Failed)
+	assert.True(t, birthErr.FailedExists)
+	assert.Contains(t, err.Error(), "environment acme/payments/dev was created with an unusable definition")
+	assert.Contains(t, err.Error(), "fix or delete it before re-running")
+	assert.NotContains(t, err.Error(), "could not create environment acme/payments/dev")
 }
 
 func TestCreateStackEnvironmentsRefusesBackendWithoutEnvironments(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_env_test.go
+++ b/pkg/cmd/pulumi/stack/stack_env_test.go
@@ -227,16 +227,49 @@ func TestCreateStackEnvironmentsStackNamedBase(t *testing.T) {
 	t.Parallel()
 
 	u := newFakeEnvUniverse(t)
+	secret := yaml.Node{}
+	require.NoError(t, secret.Encode(map[string]string{"fn::secret": "hunter2"}))
 
 	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
 		EnvProject: "payments",
 		EnvName:    "base",
+		Values: map[string]yaml.Node{
+			"aws:region":          mustScalar(t, "us-west-2"),
+			"payments:dbPassword": secret,
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "payments/base", env.MainEnvironment.String())
-	// Exactly one environment, with no self-import.
+	assert.False(t, env.StackEnvironmentReused)
+	// Exactly one environment, with no self-import, carrying the stack's own values.
 	assert.Equal(t, []string{"payments/base"}, u.created)
-	assert.Equal(t, "values: {}\n", u.definitions["payments/base"])
+	assert.Equal(t, "values:\n  pulumiConfig:\n    aws:region: us-west-2\n"+
+		"    payments:dbPassword:\n      fn::secret: hunter2\n",
+		u.definitions["payments/base"])
+}
+
+// A stack named `base` in a project that already has a base environment reuses it untouched, and has to
+// report that so the caller does not claim the wizard's config was saved.
+func TestCreateStackEnvironmentsStackNamedBaseReusesExisting(t *testing.T) {
+	t.Parallel()
+
+	u := newFakeEnvUniverse(t, "payments/base")
+	u.definitions["payments/base"] = "values:\n  pulumiConfig:\n    aws:region: eu-west-1\n"
+	var out bytes.Buffer
+
+	env, err := CreateStackEnvironments(t.Context(), u.stack(), StackEnvironmentOptions{
+		EnvProject: "payments",
+		EnvName:    "base",
+		Values:     map[string]yaml.Node{"aws:region": mustScalar(t, "us-west-2")},
+		Stdout:     &out,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "payments/base", env.MainEnvironment.String())
+	assert.True(t, env.StackEnvironmentReused)
+
+	assert.Empty(t, u.created)
+	assert.Equal(t, "values:\n  pulumiConfig:\n    aws:region: eu-west-1\n", u.definitions["payments/base"])
+	assert.Contains(t, out.String(), "Environment 'acme/payments/base' already exists — reusing.\n")
 }
 
 func TestCreateStackEnvironmentsFailureNamesWhatWasCreated(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -232,7 +232,7 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	if cmd.escConfig {
-		mainEnv, err := CreateStackEnvironments(ctx, newStack, StackEnvironmentOptions{
+		env, err := CreateStackEnvironments(ctx, newStack, StackEnvironmentOptions{
 			EnvProject: proj.Name.String(),
 			EnvName:    stackRef.Name().String(),
 			Stdout:     cmd.stdout,
@@ -245,7 +245,7 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		ps.MainEnvironment = mainEnv
+		ps.MainEnvironment = env.MainEnvironment
 		if err := SaveProjectStack(ctx, newStack, ps, ""); err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -102,6 +102,11 @@ func newStackNewCmd() *cobra.Command {
 		&sicmd.remoteConfig, "remote-config", false, "Store stack configuration remotely",
 	)
 	_ = cmd.PersistentFlags().MarkHidden("remote-config")
+	cmd.PersistentFlags().BoolVar(
+		&sicmd.escConfig, "esc-config", false,
+		"[EXPERIMENTAL] Store this stack's configuration in a new ESC environment "+
+			"'<project>/<stack>' that imports '<project>/base', recorded as the stack's 'mainEnvironment'. "+
+			"--secrets-provider still applies to any stack-local secrets")
 	cmd.PersistentFlags().BoolVarP(
 		&sicmd.yes, "yes", "y", false,
 		"Skip interactive prompts; fail if required information is missing")
@@ -116,6 +121,7 @@ type stackNewCmd struct {
 	noSelect        bool
 	teams           []string
 	remoteConfig    bool
+	escConfig       bool
 	yes             bool
 	stdout          io.Writer
 
@@ -203,6 +209,14 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 		return projectErr
 	}
 
+	// Everything --esc-config needs must be checked before the stack exists, so that a refusal leaves
+	// nothing created and no file written.
+	if cmd.escConfig {
+		if err := cmd.validateESCConfig(b, projectErr); err != nil {
+			return err
+		}
+	}
+
 	newStack, err := CreateStack(ctx, cmdutil.Diag(), ws, b, stackRef, root, CreateStackOptions{
 		Teams:           sanitizeTeams(cmd.teams),
 		SetCurrent:      !cmd.noSelect,
@@ -215,6 +229,26 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 				"%s does not support --teams", cmd.stackName, b.Name(), b.Name())
 		}
 		return err
+	}
+
+	if cmd.escConfig {
+		mainEnv, err := CreateStackEnvironments(ctx, newStack, StackEnvironmentOptions{
+			EnvProject: proj.Name.String(),
+			EnvName:    stackRef.Name().String(),
+			Stdout:     cmd.stdout,
+		})
+		if err != nil {
+			return err
+		}
+
+		ps, err := LoadProjectStack(ctx, cmdutil.Diag(), proj, newStack, "")
+		if err != nil {
+			return err
+		}
+		ps.MainEnvironment = mainEnv
+		if err := SaveProjectStack(ctx, newStack, ps, ""); err != nil {
+			return err
+		}
 	}
 
 	if cmd.stackToCopy != "" {
@@ -271,6 +305,24 @@ func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	return nil
+}
+
+// validateESCConfig rejects the flag combinations --esc-config cannot honour, before anything is
+// created. Each of these would otherwise produce a stack whose 'mainEnvironment' is wrong or inert.
+func (cmd *stackNewCmd) validateESCConfig(b backend.Backend, projectErr error) error {
+	if cmd.stackToCopy != "" {
+		return errors.New("--esc-config cannot be combined with --copy-config-from: " +
+			"the new stack's configuration would come from its environment, not from the copied stack")
+	}
+	if cmd.remoteConfig {
+		return errors.New("--esc-config cannot be combined with --remote-config: " +
+			"a stack whose configuration is stored remotely does not read its 'mainEnvironment'")
+	}
+	if err := CheckEnvironmentSupport(b); err != nil {
+		return err
+	}
+	// The ESC project the environments live in is the Pulumi project's name.
+	return projectErr
 }
 
 // newCreateStackOptions constructs a backend.CreateStackOptions object

--- a/pkg/cmd/pulumi/stack/stack_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_new_test.go
@@ -15,7 +15,12 @@
 package stack
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -24,8 +29,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // When a backend doesn't support the --teams flag,
@@ -118,5 +125,201 @@ func TestNewCreateStackOptsFiltersWhitespace(t *testing.T) {
 			got := sanitizeTeams(tt.giveTeams)
 			assert.ElementsMatch(t, tt.wantTeams, got)
 		})
+	}
+}
+
+// escConfigBackend extends a fake environment universe with just enough backend to create a stack.
+func (u *fakeEnvUniverse) escConfigBackend(t *testing.T) *backend.MockEnvironmentsBackend {
+	be := u.backend()
+	be.ValidateStackNameF = func(string) error { return nil }
+	be.ParseStackReferenceF = func(ref string) (backend.StackReference, error) {
+		return &backend.MockStackReference{
+			StringV:             ref,
+			NameV:               tokens.MustParseStackName(ref),
+			FullyQualifiedNameV: tokens.QName("acme/payments/" + ref),
+		}, nil
+	}
+	be.DefaultSecretManagerF = func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
+		return nil, nil
+	}
+	// The stack does not exist until CreateStack makes it.
+	be.GetStackF = func(context.Context, backend.StackReference) (backend.Stack, error) {
+		return nil, nil
+	}
+	be.CreateStackF = func(
+		_ context.Context, ref backend.StackReference, _ string,
+		_ *apitype.UntypedDeployment, _ *backend.CreateStackOptions,
+	) (backend.Stack, error) {
+		return &backend.MockStack{
+			RefF:     func() backend.StackReference { return ref },
+			OrgNameF: func() string { return "acme" },
+			BackendF: func() backend.Backend { return be },
+		}, nil
+	}
+	return be
+}
+
+func escConfigProjectDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "Pulumi.yaml"), []byte("name: payments\nruntime: nodejs\n"), 0o600))
+	return dir
+}
+
+// A backend that cannot host environments must be refused before anything is created.
+//
+//nolint:paralleltest // changes directory for the process
+func TestStackInitESCConfigRefusesBackendWithoutEnvironments(t *testing.T) {
+	t.Chdir(escConfigProjectDir(t))
+
+	mockBackend := &backend.MockBackend{
+		NameF:              func() string { return "file://~" },
+		ValidateStackNameF: func(string) error { return nil },
+		ParseStackReferenceF: func(ref string) (backend.StackReference, error) {
+			return &backend.MockStackReference{StringV: ref}, nil
+		},
+		CreateStackF: func(
+			context.Context, backend.StackReference, string,
+			*apitype.UntypedDeployment, *backend.CreateStackOptions,
+		) (backend.Stack, error) {
+			t.Fatal("the stack must not be created when the backend cannot host environments")
+			return nil, nil
+		},
+	}
+	cmd := &stackNewCmd{
+		stackName: "dev",
+		escConfig: true,
+		noSelect:  true,
+		stdout:    io.Discard,
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	}
+
+	err := cmd.Run(t.Context(), nil /* args */)
+	assert.ErrorContains(t, err, "backend file://~ does not support environments")
+	assert.NoFileExists(t, "Pulumi.dev.yaml")
+}
+
+//nolint:paralleltest // changes directory for the process
+func TestStackInitESCConfigRefusesCopyConfigFrom(t *testing.T) {
+	t.Chdir(escConfigProjectDir(t))
+
+	u := newFakeEnvUniverse(t)
+	be := u.escConfigBackend(t)
+	be.CreateStackF = func(
+		context.Context, backend.StackReference, string,
+		*apitype.UntypedDeployment, *backend.CreateStackOptions,
+	) (backend.Stack, error) {
+		t.Fatal("the stack must not be created when the flags are refused")
+		return nil, nil
+	}
+	cmd := &stackNewCmd{
+		stackName:   "dev",
+		escConfig:   true,
+		stackToCopy: "prod",
+		noSelect:    true,
+		stdout:      io.Discard,
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	err := cmd.Run(t.Context(), nil /* args */)
+	assert.ErrorContains(t, err, "--esc-config cannot be combined with --copy-config-from")
+}
+
+// With the flag, the stack file points at the new environment and holds no config of its own.
+//
+//nolint:paralleltest // changes directory for the process
+func TestStackInitESCConfigWritesMainEnvironment(t *testing.T) {
+	dir := escConfigProjectDir(t)
+	t.Chdir(dir)
+
+	u := newFakeEnvUniverse(t)
+	var out bytes.Buffer
+	cmd := &stackNewCmd{
+		stackName: "dev",
+		escConfig: true,
+		noSelect:  true,
+		stdout:    &out,
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
+			return u.escConfigBackend(t), nil
+		},
+	}
+
+	require.NoError(t, cmd.Run(t.Context(), nil /* args */))
+
+	assert.Equal(t, []string{"payments/base", "payments/dev"}, u.created)
+	assert.Contains(t, out.String(), "Creating environment 'acme/payments/base'...\n")
+	assert.Contains(t, out.String(), "Creating environment 'acme/payments/dev'... (imports payments/base)\n")
+
+	contents, err := os.ReadFile(filepath.Join(dir, "Pulumi.dev.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), "mainEnvironment: payments/dev")
+	assert.NotContains(t, string(contents), "config:")
+}
+
+// Without the flag nothing about the command changes: the mock's environment functions are never
+// reached, and touching them would panic.
+//
+//nolint:paralleltest // changes directory for the process
+func TestStackInitWithoutESCConfigTouchesNoEnvironment(t *testing.T) {
+	dir := escConfigProjectDir(t)
+	t.Chdir(dir)
+
+	be := (&fakeEnvUniverse{t: t}).escConfigBackend(t)
+	be.GetEnvironmentDefinitionF = nil
+	be.CreateEnvironmentF = nil
+	cmd := &stackNewCmd{
+		stackName: "dev",
+		noSelect:  true,
+		stdout:    io.Discard,
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	require.NoError(t, cmd.Run(t.Context(), nil /* args */))
+	assert.NoFileExists(t, filepath.Join(dir, "Pulumi.dev.yaml"))
+}
+
+// A failure after the stack exists leaves an ordinary, working stack: no 'mainEnvironment' is recorded.
+//
+//nolint:paralleltest // changes directory for the process
+func TestStackInitESCConfigFailureLeavesOrdinaryStack(t *testing.T) {
+	dir := escConfigProjectDir(t)
+	t.Chdir(dir)
+
+	u := newFakeEnvUniverse(t)
+	u.createErrs["payments/dev"] = errors.New("boom")
+	cmd := &stackNewCmd{
+		stackName: "dev",
+		escConfig: true,
+		noSelect:  true,
+		stdout:    io.Discard,
+		currentBackend: func(
+			context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
+		) (backend.Backend, error) {
+			return u.escConfigBackend(t), nil
+		},
+	}
+
+	err := cmd.Run(t.Context(), nil /* args */)
+	assert.ErrorContains(t, err, "created environment(s) acme/payments/base")
+	assert.ErrorContains(t, err, "could not create environment acme/payments/dev: boom")
+	assert.ErrorContains(t, err, "the stack was created without 'mainEnvironment'")
+
+	if contents, readErr := os.ReadFile(filepath.Join(dir, "Pulumi.dev.yaml")); readErr == nil {
+		assert.NotContains(t, string(contents), "mainEnvironment")
 	}
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -1225,6 +1225,95 @@ func (e *Environment) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
+// MainEnvironment references the single ESC environment that is both the source of a stack's
+// configuration and the target of `pulumi config set` and `pulumi config rm`.
+//
+// It is serialized as a scalar string of the form `<project>/<env>`, with an optional
+// `@<version-or-tag>` suffix that pins reads to a specific revision, e.g. `payments/dev@8`.
+// Unlike `environment:`, it never holds a list or an inline environment definition: exactly one
+// named environment is bound to the stack.
+type MainEnvironment struct {
+	// Project is the ESC project that contains the environment.
+	Project string
+	// Name is the name of the environment within the project.
+	Name string
+	// Version is an optional revision number or tag. An empty version means "latest".
+	Version string
+}
+
+// mainEnvironmentSyntax describes the accepted syntax; it is reused by the errors below so that the
+// hint a user sees is the same regardless of how the value was malformed.
+const mainEnvironmentSyntax = "<project>/<env>[@<version-or-tag>]"
+
+// ParseMainEnvironment parses a `mainEnvironment` reference.
+func ParseMainEnvironment(s string) (*MainEnvironment, error) {
+	ref, version, hasVersion := strings.Cut(s, "@")
+	if hasVersion && version == "" {
+		return nil, fmt.Errorf("invalid mainEnvironment %q: expected %s", s, mainEnvironmentSyntax)
+	}
+	if strings.Contains(version, "@") || strings.Contains(version, "/") {
+		return nil, fmt.Errorf("invalid mainEnvironment %q: expected %s", s, mainEnvironmentSyntax)
+	}
+
+	project, name, hasSlash := strings.Cut(ref, "/")
+	if !hasSlash || project == "" || name == "" || strings.Contains(name, "/") {
+		return nil, fmt.Errorf("invalid mainEnvironment %q: expected %s", s, mainEnvironmentSyntax)
+	}
+
+	return &MainEnvironment{Project: project, Name: name, Version: version}, nil
+}
+
+// Ref returns the `<project>/<env>` reference, without any version pin.
+func (m MainEnvironment) Ref() string {
+	return m.Project + "/" + m.Name
+}
+
+// String returns the reference as it appears in the stack file, including any version pin.
+func (m MainEnvironment) String() string {
+	if m.Version == "" {
+		return m.Ref()
+	}
+	return m.Ref() + "@" + m.Version
+}
+
+func (m MainEnvironment) MarshalYAML() (any, error) {
+	return m.String(), nil
+}
+
+func (m *MainEnvironment) UnmarshalYAML(n *yaml.Node) error {
+	var s string
+	if err := n.Decode(&s); err != nil {
+		return fmt.Errorf(
+			"mainEnvironment must be a single environment reference of the form %s; "+
+				"use 'environment:' for lists or inline environment definitions", mainEnvironmentSyntax)
+	}
+	parsed, err := ParseMainEnvironment(s)
+	if err != nil {
+		return err
+	}
+	*m = *parsed
+	return nil
+}
+
+func (m MainEnvironment) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.String())
+}
+
+func (m *MainEnvironment) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf(
+			"mainEnvironment must be a single environment reference of the form %s; "+
+				"use 'environment:' for lists or inline environment definitions", mainEnvironmentSyntax)
+	}
+	parsed, err := ParseMainEnvironment(s)
+	if err != nil {
+		return err
+	}
+	*m = *parsed
+	return nil
+}
+
 // ProjectStack holds stack specific information about a project.
 type ProjectStack struct {
 	// SecretsProvider is this stack's secrets provider.
@@ -1239,6 +1328,9 @@ type ProjectStack struct {
 	Config config.Map `json:"config,omitempty" yaml:"config,omitempty"`
 	// Environment is an optional environment definition or list of environments.
 	Environment *Environment `json:"environment,omitempty" yaml:"environment,omitempty"`
+	// MainEnvironment optionally names the single ESC environment that provides this stack's
+	// configuration and that receives `pulumi config set` and `pulumi config rm` writes.
+	MainEnvironment *MainEnvironment `json:"mainEnvironment,omitempty" yaml:"mainEnvironment,omitempty"`
 
 	// The original byte representation of the file, used to attempt trivia-preserving edits
 	raw []byte

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -1866,3 +1866,152 @@ func TestAddPackage(t *testing.T) {
 		requireTextualRepresentationIsSpec(t, proj.Packages["string-package"])
 	})
 }
+
+func TestParseMainEnvironment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			text     string
+			expected MainEnvironment
+		}{
+			{"payments/dev", MainEnvironment{Project: "payments", Name: "dev"}},
+			{"payments/dev@4", MainEnvironment{Project: "payments", Name: "dev", Version: "4"}},
+			{"payments/dev@stable", MainEnvironment{Project: "payments", Name: "dev", Version: "stable"}},
+		}
+		for _, c := range cases {
+			actual, err := ParseMainEnvironment(c.text)
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, *actual)
+			// The reference must round-trip through String.
+			assert.Equal(t, c.text, actual.String())
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []string{
+			"",
+			"dev",
+			"payments/",
+			"/dev",
+			"payments/dev/extra",
+			"payments/dev@",
+			"payments/dev@1@2",
+		}
+		for _, c := range cases {
+			_, err := ParseMainEnvironment(c)
+			assert.ErrorContains(t, err, "expected <project>/<env>[@<version-or-tag>]", "input %q", c)
+		}
+	})
+}
+
+func TestProjectStackMainEnvironment(t *testing.T) {
+	t.Parallel()
+
+	projectYaml := `name: test
+runtime: yaml`
+
+	loadStack := func(t *testing.T, text string) (*ProjectStack, error) {
+		project, err := loadProjectFromText(t, projectYaml)
+		require.NoError(t, err)
+		var stdout, stderr bytes.Buffer
+		sink := diagtest.MockSink(&stdout, &stderr)
+		return loadProjectStackFromText(t, sink, project, text)
+	}
+
+	t.Run("unpinned", func(t *testing.T) {
+		t.Parallel()
+
+		stack, err := loadStack(t, "mainEnvironment: payments/dev\n")
+		require.NoError(t, err)
+		require.NotNil(t, stack.MainEnvironment)
+		assert.Equal(t, MainEnvironment{Project: "payments", Name: "dev"}, *stack.MainEnvironment)
+	})
+
+	t.Run("pinned", func(t *testing.T) {
+		t.Parallel()
+
+		stack, err := loadStack(t, "mainEnvironment: payments/dev@4\n")
+		require.NoError(t, err)
+		require.NotNil(t, stack.MainEnvironment)
+		assert.Equal(t, MainEnvironment{Project: "payments", Name: "dev", Version: "4"}, *stack.MainEnvironment)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+
+		stack, err := loadStack(t, "config:\n  test:foo: bar\n")
+		require.NoError(t, err)
+		assert.Nil(t, stack.MainEnvironment)
+	})
+
+	t.Run("rejects lists", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loadStack(t, "mainEnvironment:\n  - payments/dev\n")
+		assert.ErrorContains(t, err, "mainEnvironment must be a single environment reference")
+	})
+
+	t.Run("rejects inline definitions", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loadStack(t, "mainEnvironment:\n  values:\n    pulumiConfig:\n      aws:region: us-west-2\n")
+		assert.ErrorContains(t, err, "mainEnvironment must be a single environment reference")
+	})
+
+	t.Run("rejects malformed references", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loadStack(t, "mainEnvironment: dev\n")
+		assert.ErrorContains(t, err, "expected <project>/<env>[@<version-or-tag>]")
+	})
+
+	t.Run("round-trips losslessly", func(t *testing.T) {
+		t.Parallel()
+
+		text := `# a comment about this stack
+mainEnvironment: payments/dev@4
+config:
+  test:foo: bar
+`
+		stack, err := loadStack(t, text)
+		require.NoError(t, err)
+
+		marshaled, err := encoding.YAML.Marshal(stack)
+		require.NoError(t, err)
+		assert.Equal(t, text, string(marshaled))
+	})
+
+	t.Run("round-trips through JSON", func(t *testing.T) {
+		t.Parallel()
+
+		project, err := loadProjectFromText(t, projectYaml)
+		require.NoError(t, err)
+		var stdout, stderr bytes.Buffer
+		sink := diagtest.MockSink(&stdout, &stderr)
+		stack, err := loadProjectStackFromJSONText(t, sink, project, `{"mainEnvironment": "payments/dev@4"}`)
+		require.NoError(t, err)
+		require.NotNil(t, stack.MainEnvironment)
+
+		marshaled, err := encoding.JSON.Marshal(stack)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"mainEnvironment": "payments/dev@4"}`, string(marshaled))
+	})
+
+	t.Run("adding the field preserves trivia", func(t *testing.T) {
+		t.Parallel()
+
+		stack, err := loadStack(t, "# a comment\nconfig:\n  test:foo: bar\n")
+		require.NoError(t, err)
+
+		stack.MainEnvironment = &MainEnvironment{Project: "payments", Name: "dev"}
+		marshaled, err := encoding.YAML.Marshal(stack)
+		require.NoError(t, err)
+		assert.Contains(t, string(marshaled), "# a comment")
+		assert.Contains(t, string(marshaled), "mainEnvironment: payments/dev")
+	})
+}


### PR DESCRIPTION
Refs: IaC ↔ ESC Integration design proposal (https://app.notion.com/p/IaC-ESC-Integration-3c9fdbdf1cce819ca876e94aa93b236c)

No originating GitHub issue: this work was specified in a local design doc rather than an issue, so there is no `Closes #<n>` line to give.

## This is a proof of concept, not production-ready

It exists to make one loop demonstrable end to end — bind a stack to an ESC environment, read config through it, write config back to it, and see every value attributed to an environment revision. It is deliberately a small slice of the full proposal.

**The whole thing rests on one simplifying assumption:**

> The ESC environment bound to a stack is never mutated outside this program. The only way to change it is `pulumi config set` / `pulumi config rm`.

That assumption is what makes the design this small. Drafts exist to make concurrent edits safe; with a single writer there is no race, so a write can go straight to the environment and produce a new revision immediately.

### Deliberately not built

None of this is missing by oversight — each item is dead under the single-writer assumption or explicitly out of scope:

- **Drafts** — no `draft:` pointer, no draft-local reads, no draft-scoped writes
- **The based-on-latest merge precondition** and `pulumi config rebase` / `config revert`
- **Merge-before-deploy** in `pulumi up`, and `--no-merge`
- **Approvals / change requests** and `pulumi config promote`
- **Any pulumi-service change.** Everything here runs on the existing vendored ESC client.

If a reviewer finds a code path reaching for a draft, that is a bug — it means the design left scope.

## What this adds

### 1. `mainEnvironment` in the stack file

```yaml
# Pulumi.dev.yaml
mainEnvironment: payments/dev      # or payments/dev@8, or payments/dev@stable
```

A new optional `MainEnvironment` field on `ProjectStack`, serialized as a scalar `<project>/<env>[@<version-or-tag>]`. Lists and inline definitions are rejected with a message pointing at `environment:`, which is what those are for. The field is additive and rides the existing trivia-preserving save path, so it round-trips losslessly alongside comments.

### 2. Reads resolve through the environment

`effectiveStackEnv` synthesizes a one-import environment (`{"imports": ["payments/dev"]}`) and hands it to the *unchanged* open/check pipeline. That is the load-bearing design decision: imports, environment variables, secret filtering, the check-vs-open split, and the `pulumiConfig` merge all behave byte-for-byte as they do for an `environment:` stack, and `preview`/`up` inherit the behaviour without either command being touched.

Precedence:

| Stack file | Behaviour |
| --- | --- |
| `mainEnvironment:` only | It is the config source |
| `mainEnvironment:` + `environment:` | `mainEnvironment` wins; warns that `environment:` is ignored |
| `mainEnvironment:` + `config:` | `config:` entries still win, reported as unmigrated |
| neither | Completely unchanged |

`pulumi up` / `preview` print `Config source: payments/dev@8` (to stderr, so `--json` output is untouched).

### 3. Writes go straight to the environment

```
$ pulumi config set payments:instanceCount 6
Updated payments/dev@8
```

`config set`, `config set --secret` and `config rm` read the environment YAML plus its etag, edit `values.pulumiConfig.<key>`, and write it back **with that etag**. The stack file is not touched on this path.

- **Secrets** become ESC `fn::secret` values. The stack's secrets manager is never consulted — no passphrase prompt, no KMS key, nothing written to disk, nothing logged. Plaintext lives only in the in-memory YAML node and the TLS request body, the same posture as `pulumi env set --secret`.
- **Etags** make a violated single-writer assumption fail loudly (`environment payments/dev changed since it was read...`) rather than silently clobbering. A 412 from the API becomes `backend.ErrEnvironmentConflict`.
- Untyped values keep `pulumi config set` semantics: `"6"` stays a string.

### 4. Attribution — the demo payoff

```
$ pulumi config
KEY                     VALUE       SOURCE
aws:region              us-west-2   payments/dev@8
payments:instanceCount  6           payments/dev@8
payments:logLevel       info        payments/base@2 (imported)
```

Derived from `esc.Value.Trace`, with one revision lookup per distinct environment (cached — race-free under the single-writer assumption). `pulumi config get <key> --show-source` prints the winning definition and anything it overrode. Values still sitting in the stack file show as `Pulumi.<stack>.yaml (unmigrated)` with a one-line nudge to migrate.

### 5. Migration

`pulumi config env init --main` reuses the existing pipeline (decrypt with the stack secrets manager, re-render as `fn::secret`, create the environment) and only changes the final rewrite: `mainEnvironment:` instead of appending to `environment:`. A flag, not a default change, so the existing command is untouched.

### 6. A stack is born with its environments — `--esc-config`

`pulumi new` and `pulumi stack init` gain an opt-in `--esc-config` flag. Without it, both commands behave byte-for-byte as they do today; their existing test suites pass unmodified and are the guard.

```
$ pulumi stack init acme/payments/prod --esc-config
Created stack 'acme/payments/prod'
Creating environment 'acme/payments/base'...
Creating environment 'acme/payments/prod'... (imports payments/base)

$ pulumi stack init acme/payments/dev --esc-config
Created stack 'acme/payments/dev'
Environment 'acme/payments/base' already exists — reusing.
Creating environment 'acme/payments/dev'... (imports payments/base)
```

The stack file is written with `mainEnvironment: <project>/<stack>` and **no `config:` block**, so the loop above works on the new stack with no manual setup: `pulumi config` attributes values to `<project>/<stack>@1`, and the next `pulumi config set` produces `@2`.

**Creation is additive only.** Existence is probed with `GetEnvironmentDefinition`; an environment that is already there is reused with a message and never modified, so a rerun or a second stack in the project cannot clobber configuration that already exists. (An already-exists conflict from the create itself — the racy window — is treated as reuse too.)

Because reuse is never a write, `pulumi new` says so rather than claiming a save when the stack's environment was already there and the wizard gathered values:

```
Environment 'acme/payments/dev' already exists — reusing.
warning: environment payments/dev already exists and is never overwritten, so the configuration
gathered here was not saved: aws:region, payments:dbPassword
    Set the values you need with 'pulumi config set [--secret] <key> <value>' after checking
    what the environment already provides.
```

Only the keys are named — one of them may have been typed at a secret prompt.

**`pulumi new`'s wizard config goes into the environment**, not the stack file. Prompted values and `--config` values alike land in `values.pulumiConfig`, and prompted secrets become `fn::secret`: the stack's secrets manager is never consulted on this path, so no passphrase prompt, no KMS key, no plaintext on disk, nothing logged.

Two decisions worth a deliberate opinion:

- **Config shape: direct `values.pulumiConfig` entries**, not the proposal's `values.aws.region` + `${aws.region}` interpolation. Both writers already on this branch produce the direct shape, so the indirection would mean the very first `pulumi config set` after `pulumi new` writes a *second*, shadowing entry into the same file. Direct also reuses `ConfigValueNode` verbatim rather than adding a third YAML writer.
- **`stack init --copy-config-from <mainEnvironment stack>` is refused**, which also fixes the open review finding from the first round: `CopyEntireConfigMap` copied `Config` and `Environment` but not `MainEnvironment`, so copying from a migrated stack silently produced a stack with an empty `config:` block and no configuration source. Carrying the pointer across would alias two stacks onto one environment, contradicting the one-stack-one-environment model the whole PoC demos; a faithful copy would mean creating a new environment and duplicating values, which is scope creep. The guard lives in `CopyEntireConfigMap`, so `pulumi config cp` is covered by the same line.

Everything `--esc-config` cannot honour is refused **before anything is created** — no stack, no file, no environment:

| Combination | Why refused |
| --- | --- |
| Backend without environment support | `errBackendNoEnvironments`, checked up front rather than after the stack exists |
| `--copy-config-from` (`stack init`) | Same aliasing question as above |
| `--remote-config` / `--remote-stack-config` | A remote-config stack ignores `mainEnvironment`, so the pointer would be inert forever |
| `--generate-only` (`new`) | No stack is created |
| A stack that already exists (`new --stack org/proj/prod`) | `--esc-config` configures a stack as it is born; pointing an existing stack at an environment would silently stop its `config:` block being effective. `pulumi config env init --main` is the migration path |
| No local project (`stack init`) | The ESC project name is the Pulumi project's name |

If environment creation fails *after* the stack was created, `mainEnvironment` is never written, so what is left behind is an ordinary, working stack — and the error names exactly which environments exist and which do not:

```
created environment(s) acme/payments/base, but could not create environment acme/payments/dev: <err>
the stack was created without 'mainEnvironment', so it works as an ordinary stack;
re-run with --esc-config once the problem is fixed, or migrate later with 'pulumi config env init --main'
```

No new backend surface was needed: `CreateEnvironment` already existed on `EnvironmentsBackend`, and creating with content is a single call.

### 7. Backend capability

`EnvironmentDefinitionsBackend` is a **new optional capability** following the `SpecificDeploymentExporter` pattern, not an addition to `EnvironmentsBackend` — so DIY backends keep failing with the existing `errBackendNoEnvironments` message rather than gaining unimplemented methods. Three thin wrappers over the vendored client (`GetEnvironment`, `UpdateEnvironment`, `GetRevisionNumber`), plus matching `...F` fields on the mock backend.

## What is refused rather than approximated

Each of these is a deliberate refusal, because the alternative would either lose data or quadruple the write-path surface for no demo value:

| Situation | Behaviour |
| --- | --- |
| `mainEnvironment: payments/dev@4` (pinned) + a write | Refused. The write would create revision 5 while the stack keeps reading 4, so the very next `pulumi config` would not show what was just set. |
| Environment does not exist | Refused, with a hint at `pulumi env init` / `pulumi config env init --main`. No auto-creation — a typo'd env name must not silently spawn an environment. |
| `config set --path` / `config rm --path` | Not supported yet. |
| `config copy`, `set-all`, `rm-all`, `refresh` | Not supported yet. They would otherwise silently write the local `config:` block and shadow the environment. `copy` refuses on either end: a migrated stack's values are not in its `config:` block, so copying *from* one would write an empty destination. |
| `config env add` / `config env rm` | Not supported yet. A main environment supersedes the `environment:` list, so editing that list would have no effect. `config env ls` reports the main environment. |
| Stack has both remote stack config and `mainEnvironment:` | Existing remote-config behaviour wins, with a warning that `mainEnvironment` is ignored. The `escConfigEnv` mechanism is service-coupled and out of this PR's zero-service-change mandate. |
| `--show-source` on a non-`mainEnvironment` stack | Errors. |

## Known gaps

- No value-equivalence verification in the migration. It prints exactly what moved instead; verifying it is on the user.
- Import revisions degrade gracefully: if an environment reference from `esc.Value.Trace` cannot be split into a project and a name, the SOURCE column shows `payments/base (imported)` without `@N`. The main environment's own revision always resolves. A pinned import (`imports: [payments/base@4]`) is attributed at its pin, not at the import's latest revision.
- A key set in both the stack file and the environment is a transitional state the PoC supports rather than resolves: the stack file wins on reads, and `config set` / `config rm` warn at write time that the local entry shadows what was just written. There is no command that removes an unmigrated key from the environment side; `pulumi config env init --main` is the way out.
- `Config source:` also prints for `refresh`, `watch` and `logs` on `mainEnvironment` stacks — accurate, harmless, and invisible everywhere else.
- Command-level guard tests cover `copy`, `set-all` and `refresh`; `rm-all` constructs its login manager internally and is not unit-testable today, so its guard is covered at the helper level.
- An older CLI reading a `mainEnvironment:` stack file ignores the unknown key and behaves as an env-less stack. Acceptable for a PoC, worth knowing.
- `--esc-config` skips the `isPreconfiguredEmptyStack` shortcut in `pulumi new`, whose input is a previous deployment's config that a stack being born does not have (and reading it would need the stack decrypter this path deliberately never touches). A console-preconfigured stack's existing config is not carried into the environment; `pulumi config env init --main` covers that case.
- `cloudBackend.CreateEnvironment` is create-then-update internally. If the update leg fails, or the service rejects the definition, an environment is left behind with no imports and no values, and a rerun would reuse it rather than repair it. The error says exactly that — `environment acme/payments/dev was created with an unusable definition: ... fix or delete it before re-running` — rather than claiming the environment was not created. The update leg's errors are deliberately *not* classified onto `ErrEnvironmentConflict`, so a conflict there can never be mistaken for "it already existed, reusing".
- `--esc-config` creates the environments in the org the stack lands in, taken from the fully qualified stack reference. There is no separately configurable org.

## Testing

All unit tests against the mock backend — no live service required. `go build ./...` and the following pass:

```
$ cd sdk && go test ./go/common/workspace/...
ok      github.com/pulumi/pulumi/sdk/v3/go/common/workspace     1.624s

$ cd pkg && go test ./cmd/pulumi/... 
(all ok)

$ cd pkg && go test ./backend/... ./workspace/...
ok      github.com/pulumi/pulumi/pkg/v3/backend                 0.584s
ok      github.com/pulumi/pulumi/pkg/v3/backend/httpstate       11.581s
ok      github.com/pulumi/pulumi/pkg/v3/workspace               11.528s
(and the rest)

$ mise exec -- make format && mise exec -- make lint
0 issues.
```

New coverage: parse/round-trip for the stack-file field (valid, pinned, tagged, malformed, list, inline); precedence across all four combinations; two consecutive sets producing successive revisions; `--secret` landing as `fn::secret` with the stack file untouched and no secrets provider configured; the exact etag from the read reaching the write, and a simulated mismatch failing without overwriting; the SOURCE column including the `(imported)` marker and unmigrated attribution, with a call-count assertion proving revision lookups are cached; `--show-source` output and its refusal off `mainEnvironment`; `Config source:` present for main-env stacks and absent otherwise; every refusal above; and the `--main` migration preserving a string `"6"` and re-encrypting a stack secret.

Stack-birth coverage: base created and base reused (asserting the pre-existing base is never rewritten — the mock's `UpdateEnvironmentDefinition` is left unset, so any call panics); the stack environment created with `imports: [<project>/base]` and reused rather than overwritten when it already exists; a create-time conflict treated as reuse; a stack literally named `base` getting one environment with no self-import; the failure path naming what was and was not created; every refusal in the table above, asserting no stack file is written; `pulumi new`'s config landing in `values.pulumiConfig` with a prompted secret as `fn::secret` and no plaintext or `encryptionsalt` reaching the stack file; `--config` winning over a prompted value; the `--copy-config-from` refusal; and a full birth-to-`config set` walk on the mock backend asserting `@1` then `@2`.

Guards for "nothing changed for anyone else": the existing test suite passes unmodified, plus an explicit regression test asserting an `environment:`-only stack produces no SOURCE column, no `source` JSON field, no `Config source:` line, and makes zero revision lookups; and a `stack init` run without `--esc-config` against a backend whose environment functions would panic if touched.

## For the reviewer

Two things are externally visible surface and worth a deliberate opinion:

1. **The `mainEnvironment` stack-file key name.** `Pulumi.<stack>.yaml` is widely parsed; this name is what we would be committing to.
2. **The `EnvironmentDefinitionsBackend` shape** — three methods, or fewer/more?

Also worth a look: the concurrency window between the revision lookup used for display and the environment open used for values. It is benign under the single-writer assumption and I did not close it.




