### PR TITLE
Re-validate agent claims marked unavailable

### DIFF
--- a/changelog/pending/20260828--cli--agent-claim-revalidate.yaml
+++ b/changelog/pending/20260828--cli--agent-claim-revalidate.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: fix
+body: Re-validate an agent account claim marked unavailable instead of trusting the
+    stale marker forever
+time: 2026-08-28T00:00:00Z

--- a/pkg/cmd/pulumi/agentauth/agentauth.go
+++ b/pkg/cmd/pulumi/agentauth/agentauth.go
@@ -106,7 +106,7 @@ func MaybePrintClaimWarning(ctx context.Context, stderr io.Writer) {
 // agents when an ephemeral agent account can no longer authenticate. If the
 // local token has already expired but the claim URL is still valid, it returns
 // the claim instruction instead of the auth-required instruction.
-func AuthRequiredMessage(now time.Time) string {
+func AuthRequiredMessage(ctx context.Context, now time.Time) string {
 	if agentdetect.Detect(os.Getenv) == "" {
 		return ""
 	}
@@ -120,13 +120,13 @@ func AuthRequiredMessage(now time.Time) string {
 		return ""
 	}
 	expiresAt, valid := workspace.AgentAccessTokenExpiresAt(account, now)
-	claim = revalidatedClaim(context.Background(), claim)
+	claim = revalidatedClaim(ctx, claim)
 	if claim.ClaimUnavailableAt != nil {
 		return workspace.FormatAgentLoginRequiredInstruction(
 			workspace.AgentLoginClaimUnavailable, expiresAt, now)
 	}
 	if claim.ClaimToken != "" {
-		claimable, err := validateAgentClaim(context.Background(), claim.CloudURL, claim.ClaimToken)
+		claimable, err := validateAgentClaim(ctx, claim.CloudURL, claim.ClaimToken)
 		if err != nil {
 			slog.Info("Could not validate agent claim token", "cloud-url", claim.CloudURL, "err", err)
 		} else if !claimable {

--- a/pkg/cmd/pulumi/agentauth/agentauth.go
+++ b/pkg/cmd/pulumi/agentauth/agentauth.go
@@ -32,6 +32,28 @@ var validateAgentClaim = func(ctx context.Context, cloudURL, claimToken string) 
 	return client.NewClient(cloudURL, "", false, nil).ValidateAgentClaim(ctx, claimToken)
 }
 
+// revalidatedClaim brings a persisted claim-unavailable marker up to date:
+// when one is present, the claim is re-checked with the service, and the
+// marker is cleared if the claim is usable again. The marker is kept while
+// the service still refuses the claim or cannot be reached.
+func revalidatedClaim(ctx context.Context, claim workspace.AgentClaim) workspace.AgentClaim {
+	if claim.ClaimUnavailableAt == nil || claim.ClaimToken == "" {
+		return claim
+	}
+	claimable, err := validateAgentClaim(ctx, claim.CloudURL, claim.ClaimToken)
+	if err != nil || !claimable {
+		if err != nil {
+			slog.InfoContext(ctx, "Could not re-validate agent claim token", "cloud-url", claim.CloudURL, "err", err)
+		}
+		return claim
+	}
+	if err := workspace.ClearAgentClaimUnavailable(); err != nil {
+		slog.InfoContext(ctx, "Could not clear agent claim unavailable marker", "cloud-url", claim.CloudURL, "err", err)
+	}
+	claim.ClaimUnavailableAt = nil
+	return claim
+}
+
 // MaybePrintClaimWarning reminds detected coding agents to tell the user about
 // a claim URL for shared agent credentials used by this CLI process.
 func MaybePrintClaimWarning(ctx context.Context, stderr io.Writer) {
@@ -70,6 +92,11 @@ func MaybePrintClaimWarning(ctx context.Context, stderr io.Writer) {
 		return
 	}
 
+	claim = revalidatedClaim(ctx, claim)
+	if claim.ClaimUnavailableAt != nil {
+		return
+	}
+
 	warning := workspace.FormatAgentClaimInstruction(claim.ClaimURL, accessTokenExpiresAt, claim.ValidUntil, now)
 	_, err = io.WriteString(stderr, warning)
 	contract.IgnoreError(err)
@@ -93,6 +120,7 @@ func AuthRequiredMessage(now time.Time) string {
 		return ""
 	}
 	expiresAt, valid := workspace.AgentAccessTokenExpiresAt(account, now)
+	claim = revalidatedClaim(context.Background(), claim)
 	if claim.ClaimUnavailableAt != nil {
 		return workspace.FormatAgentLoginRequiredInstruction(
 			workspace.AgentLoginClaimUnavailable, expiresAt, now)

--- a/pkg/cmd/pulumi/agentauth/agentauth_test.go
+++ b/pkg/cmd/pulumi/agentauth/agentauth_test.go
@@ -381,7 +381,7 @@ func TestAuthRequiredMessageOmitsClaimURLWhenClaimIsNotClaimable(t *testing.T) {
 	assert.True(t, claim.ClaimUnavailableAt.Equal(now))
 }
 
-func TestAuthRequiredMessageSkipsValidationWhenClaimMarkedUnavailable(t *testing.T) {
+func TestAuthRequiredMessageKeepsUnavailableWhenStillNotClaimable(t *testing.T) {
 	oldAgentCreds, err := workspace.GetAgentStoredCredentials()
 	require.NoError(t, err)
 	oldAgentClaim, err := workspace.GetAgentClaim()
@@ -415,7 +415,8 @@ func TestAuthRequiredMessageSkipsValidationWhenClaimMarkedUnavailable(t *testing
 	})
 	require.NoError(t, err)
 	setValidateAgentClaim(t, func(ctx context.Context, gotCloudURL, claimToken string) (bool, error) {
-		t.Fatal("validateAgentClaim should not be called for a cached unavailable claim")
+		assert.Equal(t, cloudURL, gotCloudURL)
+		assert.Equal(t, "cached-unavailable-claim", claimToken)
 		return false, nil
 	})
 
@@ -423,6 +424,152 @@ func TestAuthRequiredMessageSkipsValidationWhenClaimMarkedUnavailable(t *testing
 	assert.Contains(t, message, "PULUMI_EPHEMERAL_AGENT_ACCOUNT")
 	assert.NotContains(t, message, "CLAIM_URL=")
 	assert.Contains(t, message, "claim URL is no longer claimable")
+	claim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	require.NotNil(t, claim.ClaimUnavailableAt, "a still-unclaimable claim keeps its marker")
+}
+
+func TestAuthRequiredMessageClearsUnavailableWhenClaimableAgain(t *testing.T) {
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv("CODEX_SANDBOX", "1")
+
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	unavailableAt := now.Add(-time.Minute)
+	expiresAt := now.Add(time.Hour)
+	cloudURL := "https://api.recovered-claim.example.com"
+	err := workspace.StoreAgentAccount(cloudURL, workspace.Account{
+		AccessToken: "agent-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiresAt,
+		},
+	}, true)
+	require.NoError(t, err)
+	err = workspace.StoreAgentClaim(workspace.AgentClaim{
+		ClaimURL:           "https://app.pulumi.com/claim/recovered-claim",
+		ClaimToken:         "recovered-claim",
+		CloudURL:           cloudURL,
+		ValidUntil:         now.Add(time.Hour),
+		ClaimUnavailableAt: &unavailableAt,
+	})
+	require.NoError(t, err)
+	setValidateAgentClaim(t, func(ctx context.Context, gotCloudURL, claimToken string) (bool, error) {
+		assert.Equal(t, cloudURL, gotCloudURL)
+		assert.Equal(t, "recovered-claim", claimToken)
+		return true, nil
+	})
+
+	message := AuthRequiredMessage(now)
+	assert.Contains(t, message, "CLAIM_URL=https://app.pulumi.com/claim/recovered-claim")
+	assert.NotContains(t, message, "no longer claimable")
+	claim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	assert.Nil(t, claim.ClaimUnavailableAt, "a claimable claim clears its stale marker")
+}
+
+func TestAuthRequiredMessageKeepsUnavailableWhenRevalidationFails(t *testing.T) {
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv("CODEX_SANDBOX", "1")
+
+	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	unavailableAt := now.Add(-time.Minute)
+	expiresAt := now.Add(time.Hour)
+	cloudURL := "https://api.revalidation-error.example.com"
+	err := workspace.StoreAgentAccount(cloudURL, workspace.Account{
+		AccessToken: "agent-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiresAt,
+		},
+	}, true)
+	require.NoError(t, err)
+	err = workspace.StoreAgentClaim(workspace.AgentClaim{
+		ClaimURL:           "https://app.pulumi.com/claim/revalidation-error",
+		ClaimToken:         "revalidation-error",
+		CloudURL:           cloudURL,
+		ValidUntil:         now.Add(time.Hour),
+		ClaimUnavailableAt: &unavailableAt,
+	})
+	require.NoError(t, err)
+	setValidateAgentClaim(t, func(ctx context.Context, gotCloudURL, claimToken string) (bool, error) {
+		return false, errors.New("temporary validation failure")
+	})
+
+	message := AuthRequiredMessage(now)
+	assert.Contains(t, message, "claim URL is no longer claimable")
+	assert.NotContains(t, message, "CLAIM_URL=")
+	claim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	require.NotNil(t, claim.ClaimUnavailableAt, "an unreachable service keeps the last-known marker")
+}
+
+func TestMaybePrintClaimWarningSkipsStillUnclaimableClaim(t *testing.T) {
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv("CODEX_SANDBOX", "1")
+
+	unavailableAt := time.Now().Add(-time.Minute)
+	expiresAt := time.Now().Add(time.Hour)
+	cloudURL := "https://api.unclaimable-warning.example.com"
+	err := workspace.StoreAgentAccount(cloudURL, workspace.Account{
+		AccessToken: "agent-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiresAt,
+		},
+	}, true)
+	require.NoError(t, err)
+	err = workspace.StoreAgentClaim(workspace.AgentClaim{
+		ClaimURL:           "https://app.pulumi.com/claim/unclaimable-warning",
+		ClaimToken:         "unclaimable-warning",
+		CloudURL:           cloudURL,
+		ValidUntil:         time.Now().Add(time.Hour),
+		ClaimUnavailableAt: &unavailableAt,
+	})
+	require.NoError(t, err)
+	setValidateAgentClaim(t, func(ctx context.Context, gotCloudURL, claimToken string) (bool, error) {
+		return false, nil
+	})
+
+	ctx := httpstate.ContextWithAgentCredentialUse(t.Context())
+	httpstate.MarkAgentCredentialsUsed(ctx, cloudURL)
+
+	var output bytes.Buffer
+	MaybePrintClaimWarning(ctx, &output)
+	assert.Empty(t, output.String(), "no claim block for a claim the service refuses")
+}
+
+func TestMaybePrintClaimWarningClearsRecoveredClaim(t *testing.T) {
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv("CODEX_SANDBOX", "1")
+
+	unavailableAt := time.Now().Add(-time.Minute)
+	expiresAt := time.Now().Add(time.Hour)
+	cloudURL := "https://api.recovered-warning.example.com"
+	err := workspace.StoreAgentAccount(cloudURL, workspace.Account{
+		AccessToken: "agent-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiresAt,
+		},
+	}, true)
+	require.NoError(t, err)
+	err = workspace.StoreAgentClaim(workspace.AgentClaim{
+		ClaimURL:           "https://app.pulumi.com/claim/recovered-warning",
+		ClaimToken:         "recovered-warning",
+		CloudURL:           cloudURL,
+		ValidUntil:         time.Now().Add(time.Hour),
+		ClaimUnavailableAt: &unavailableAt,
+	})
+	require.NoError(t, err)
+	setValidateAgentClaim(t, func(ctx context.Context, gotCloudURL, claimToken string) (bool, error) {
+		return true, nil
+	})
+
+	ctx := httpstate.ContextWithAgentCredentialUse(t.Context())
+	httpstate.MarkAgentCredentialsUsed(ctx, cloudURL)
+
+	var output bytes.Buffer
+	MaybePrintClaimWarning(ctx, &output)
+	assert.Contains(t, output.String(), "CLAIM_URL=https://app.pulumi.com/claim/recovered-warning")
+	claim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	assert.Nil(t, claim.ClaimUnavailableAt, "a claimable claim clears its stale marker")
 }
 
 func TestAuthRequiredMessageFallsBackToLocalClaimWhenValidationFails(t *testing.T) {

--- a/pkg/cmd/pulumi/agentauth/agentauth_test.go
+++ b/pkg/cmd/pulumi/agentauth/agentauth_test.go
@@ -46,7 +46,7 @@ func TestMaybePrintClaimWarningSkipsOutsideAgentMode(t *testing.T) {
 func TestAuthRequiredMessageSkipsOutsideAgentMode(t *testing.T) {
 	clearAgentEnv(t)
 
-	assert.Empty(t, AuthRequiredMessage(time.Now()))
+	assert.Empty(t, AuthRequiredMessage(t.Context(), time.Now()))
 }
 
 func TestMaybePrintClaimWarningSkipsMissingClaim(t *testing.T) {
@@ -62,7 +62,7 @@ func TestAuthRequiredMessageSkipsMissingClaim(t *testing.T) {
 	t.Setenv("CODEX_SANDBOX", "1")
 	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
 
-	assert.Empty(t, AuthRequiredMessage(time.Now()))
+	assert.Empty(t, AuthRequiredMessage(t.Context(), time.Now()))
 }
 
 func TestMaybePrintClaimWarningSkipsDeletedExpiredAgentCredentials(t *testing.T) {
@@ -225,7 +225,7 @@ func TestAuthRequiredMessagePrintsClaimInstructionWhenTokenExpiredButClaimValid(
 		return true, nil
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "PULUMI_EPHEMERAL_AGENT_ACCOUNT")
 	assert.Contains(t, message, "CLAIM_URL=https://app.pulumi.com/claim/expired-token-valid-claim")
 	assert.Contains(t, message, "CLAIM_URL_VALID_FOR=1h")
@@ -269,7 +269,7 @@ func TestAuthRequiredMessageChecksClaimWhenTokenLocallyValidButRejected(t *testi
 		return true, nil
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "PULUMI_EPHEMERAL_AGENT_ACCOUNT")
 	assert.Contains(t, message, "CLAIM_URL=https://app.pulumi.com/claim/locally-valid-token")
 	assert.Contains(t, message, "EPHEMERAL_ACCOUNT_ACCESS_EXPIRES_IN=1h")
@@ -303,7 +303,7 @@ func TestAuthRequiredMessageUsesDefaultClaimValidator(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "ACTION_REQUIRED=Tell the user to run pulumi login.")
 	assert.NotContains(t, message, "CLAIM_URL=")
 }
@@ -328,7 +328,7 @@ func TestAuthRequiredMessageWithoutClaimTokenUsesLocalTokenState(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "ACTION_REQUIRED=Tell the user to run pulumi login.")
 	assert.NotContains(t, message, "CLAIM_URL=")
 }
@@ -370,7 +370,7 @@ func TestAuthRequiredMessageOmitsClaimURLWhenClaimIsNotClaimable(t *testing.T) {
 		return false, nil
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "PULUMI_EPHEMERAL_AGENT_ACCOUNT")
 	assert.Contains(t, message, "ACTION_REQUIRED=Tell the user to run pulumi login.")
 	assert.NotContains(t, message, "CLAIM_URL=")
@@ -420,7 +420,7 @@ func TestAuthRequiredMessageKeepsUnavailableWhenStillNotClaimable(t *testing.T) 
 		return false, nil
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "PULUMI_EPHEMERAL_AGENT_ACCOUNT")
 	assert.NotContains(t, message, "CLAIM_URL=")
 	assert.Contains(t, message, "claim URL is no longer claimable")
@@ -458,7 +458,7 @@ func TestAuthRequiredMessageClearsUnavailableWhenClaimableAgain(t *testing.T) {
 		return true, nil
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "CLAIM_URL=https://app.pulumi.com/claim/recovered-claim")
 	assert.NotContains(t, message, "no longer claimable")
 	claim, err := workspace.GetAgentClaim()
@@ -493,7 +493,7 @@ func TestAuthRequiredMessageKeepsUnavailableWhenRevalidationFails(t *testing.T) 
 		return false, errors.New("temporary validation failure")
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "claim URL is no longer claimable")
 	assert.NotContains(t, message, "CLAIM_URL=")
 	claim, err := workspace.GetAgentClaim()
@@ -609,7 +609,7 @@ func TestAuthRequiredMessageFallsBackToLocalClaimWhenValidationFails(t *testing.
 		return false, errors.New("temporary validation failure")
 	})
 
-	message := AuthRequiredMessage(now)
+	message := AuthRequiredMessage(t.Context(), now)
 	assert.Contains(t, message, "PULUMI_EPHEMERAL_AGENT_ACCOUNT")
 	assert.Contains(t, message, "CLAIM_URL=https://app.pulumi.com/claim/validation-error")
 	assert.Contains(t, message, "CLAIM_URL_VALID_FOR=1h")

--- a/pkg/cmd/pulumi/cmd/cmd.go
+++ b/pkg/cmd/pulumi/cmd/cmd.go
@@ -81,7 +81,7 @@ func processCmdErrors(ctx context.Context, err error, stderr io.Writer) error {
 	}
 
 	if isAuthRequiredError(err) {
-		if message := agentauth.AuthRequiredMessage(time.Now()); message != "" {
+		if message := agentauth.AuthRequiredMessage(ctx, time.Now()); message != "" {
 			_, printErr := fmt.Fprint(stderr, message)
 			contract.IgnoreError(printErr)
 			return result.BailError(err)

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -1052,6 +1052,20 @@ func MarkAgentClaimUnavailable(unavailableAt time.Time) error {
 	return StoreAgentClaim(claim)
 }
 
+// ClearAgentClaimUnavailable removes a persisted claim-unavailable marker,
+// e.g. after the service reports the claim usable again.
+func ClearAgentClaimUnavailable() error {
+	claim, err := GetAgentClaim()
+	if err != nil {
+		return err
+	}
+	if claim.ClaimURL == "" || claim.ClaimUnavailableAt == nil {
+		return nil
+	}
+	claim.ClaimUnavailableAt = nil
+	return StoreAgentClaim(claim)
+}
+
 // DeleteExpiredAgentCredentials removes shared temporary agent credentials when
 // both the claim URL and access token have expired. It returns true when
 // credentials were removed.

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -299,6 +299,14 @@ func TestMarkAgentClaimUnavailable(t *testing.T) {
 	assert.True(t, claim.ValidUntil.Equal(validUntil))
 	require.NotNil(t, claim.ClaimUnavailableAt)
 	assert.True(t, claim.ClaimUnavailableAt.Equal(unavailableAt))
+
+	require.NoError(t, ClearAgentClaimUnavailable())
+	claim, err = GetAgentClaim()
+	require.NoError(t, err)
+	assert.Nil(t, claim.ClaimUnavailableAt)
+	assert.Equal(t, "abc123", claim.ClaimToken, "clearing the marker keeps the rest of the claim")
+
+	require.NoError(t, ClearAgentClaimUnavailable(), "clearing an unset marker is a no-op")
 }
 
 //nolint:paralleltest // mutates package global


### PR DESCRIPTION
## Summary

Fixes https://linear.app/pulumi/issue/GRO-589/cli-permanently-stores-claim-failed-instead-of-re-validating

Once `ValidateAgentClaim` reported an agent account's claim as not claimable, the CLI persisted a `claimUnavailableAt` marker in the shared agent store and trusted it forever — every later command printed "can no longer authenticate, and its claim URL is no longer claimable", even after the claim became usable again. A single transient wrong answer from the service permanently poisoned the local state (the confusing state hit while testing the agent onboarding flow; Linear GRO-589).

The marker is now a last-known state instead of a permanent verdict:

- Whenever a marked claim would influence output — the auth-required instruction and the post-command claim block — the CLI re-validates it against the service first.
- Service says claimable → the marker is cleared and the claim URL is surfaced again.
- Service still refuses → the message stays "no longer claimable" (and the marker is kept).
- Service unreachable → the last-known marker wins, so behavior is unchanged offline.

New `workspace.ClearAgentClaimUnavailable` complements the existing `MarkAgentClaimUnavailable`. The post-command claim block now also skips printing for a claim the service currently refuses, instead of advertising a claim URL that won't work — consistent with the permalink suppression from #24476.

The re-validation only fires when a marker is present, so the common paths gain no network calls.

## Test 
Tested locally by having a conflict, fixing it and being able to claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)