### PR TITLE
Fix ProgramTest for double-digit major versions

### DIFF
--- a/changelog/pending/pkg-testing-fix-20260828-141458.yaml
+++ b/changelog/pending/pkg-testing-fix-20260828-141458.yaml
@@ -1,0 +1,4 @@
+component: pkg/testing
+kind: fix
+body: Fix ProgramTest for providers whose Go module or NuGet package has a double-digit major version
+time: 2026-08-28T14:14:58.697087893Z

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2886,15 +2886,14 @@ func getVirtualenvBinPath(cwd, bin string, pt *ProgramTester) (string, error) {
 	return virtualenvBinPath, nil
 }
 
-// getSanitizedPkg strips the version string from a go dep
+// moduleMajorVersionSuffix matches the trailing major version element of a Go
+// module path, for example the "/v10" of "github.com/pulumi/pulumi-gcp/sdk/v10".
+var moduleMajorVersionSuffix = regexp.MustCompile(`/v[0-9]+$`)
+
+// getSanitizedModulePath strips the major version element from a go dep
 // Note: most of the pulumi modules don't use major version subdirectories for modules
 func getSanitizedModulePath(pkg string) string {
-	re := regexp.MustCompile(`v\d`)
-	v := re.FindString(pkg)
-	if v != "" {
-		return strings.TrimSuffix(strings.ReplaceAll(pkg, v, ""), "/")
-	}
-	return pkg
+	return moduleMajorVersionSuffix.ReplaceAllString(pkg, "")
 }
 
 func getRewritePath(pkg string, gopath string, depRoot string) string {
@@ -3106,7 +3105,7 @@ func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 
 	for _, dep := range pt.opts.Dependencies {
 		// dotnet add package requires a specific version in case of a pre-release, so we have to look it up.
-		globPattern := filepath.Join(localNuget, dep+".?.*.nupkg")
+		globPattern := filepath.Join(localNuget, dep+".[0-9]*.nupkg")
 		matches, err := filepath.Glob(globPattern)
 		if err != nil {
 			return fmt.Errorf("failed to find a local Pulumi NuGet package: %w", err)

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -69,8 +69,19 @@ func TestSanitizedPkg(t *testing.T) {
 	v3 := getSanitizedModulePath("github.com/pulumi/pulumi-aws/sdk/v3")
 	assert.Equal(t, "github.com/pulumi/pulumi-aws/sdk", v3)
 
+	v10 := getSanitizedModulePath("github.com/pulumi/pulumi-gcp/sdk/v10")
+	assert.Equal(t, "github.com/pulumi/pulumi-gcp/sdk", v10)
+
+	v123 := getSanitizedModulePath("github.com/pulumi/pulumi-gcp/sdk/v123")
+	assert.Equal(t, "github.com/pulumi/pulumi-gcp/sdk", v123)
+
 	nonVersion := getSanitizedModulePath("github.com/pulumi/pulumi-auth/sdk")
 	assert.Equal(t, "github.com/pulumi/pulumi-auth/sdk", nonVersion)
+
+	// Only a trailing major version element is stripped, never a lookalike
+	// element in the middle of the path.
+	embedded := getSanitizedModulePath("github.com/pulumi/v2fly/sdk")
+	assert.Equal(t, "github.com/pulumi/v2fly/sdk", embedded)
 }
 
 func TestDepRootCalc(t *testing.T) {
@@ -95,6 +106,12 @@ func TestDepRootCalc(t *testing.T) {
 
 	dep = getRewritePath("github.com/pulumi/pulumi-auth0/sdk", "gopath", "/my-go-src")
 	assert.Equal(t, "/my-go-src/pulumi-auth0/sdk", filepath.ToSlash(dep))
+
+	dep = getRewritePath("github.com/pulumi/pulumi-gcp/sdk/v10", "/gopath", "/my-go-src")
+	assert.Equal(t, "/my-go-src/pulumi-gcp/sdk", filepath.ToSlash(dep))
+
+	dep = getRewritePath("github.com/pulumi/pulumi-gcp/sdk/v10", "/gopath", "")
+	assert.Equal(t, "/gopath/src/github.com/pulumi/pulumi-gcp/sdk", filepath.ToSlash(dep))
 }
 
 func TestGoModEdits(t *testing.T) {


### PR DESCRIPTION
## Summary

`pkg/testing/integration` assumed a single-digit major version in two places, which broke `ProgramTest` for the Go and .NET SDKs of any provider at v10 or above.

`getSanitizedModulePath` matched `v\d` anywhere in the module path and stripped that substring. For `github.com/pulumi/pulumi-gcp/sdk/v10` it found the `v1` inside `v10` and rewrote the path to `github.com/pulumi/pulumi-gcp/sdk/0`, so every Go program test resolved its replace directive to a directory that does not exist. It also mangled unrelated paths that happen to contain a `vN` substring. It now strips a trailing `/vN` element and nothing else.

The local NuGet lookup used the glob `dep+".?.*.nupkg"`, where `?` matches exactly one character. `Pulumi.Gcp.9.0.0.nupkg` matched but `Pulumi.Gcp.10.0.0.nupkg` did not, so the lookup failed with `yielded 0 results`. The pattern is now `dep+".[0-9]*.nupkg"`, which accepts any digit count while still refusing to match a longer package name sharing the same prefix.

Part of #24497

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestSanitizedPkg` and `TestDepRootCalc` gain cases for major versions of an arbitrary number of digits (`v10`, `v123`) plus a path with an embedded `vN` substring. Both fail against the previous implementation, which reproduces the symptoms directly: `.../sdk/v10` becoming `.../sdk/0`, `.../sdk/v123` becoming `.../sdk/23`, and `github.com/pulumi/v2fly/sdk` becoming `github.com/pulumi/fly/sdk`. The NuGet glob is now a single inlined expression at its only call site and carries no unit test of its own.

## Validation

- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

One caveat on `test_fast`: it reports 15 failures across `cmd/pulumi/convert` and `cmd/pulumi/project/newcmd`. Every one of them reproduces identically on an unmodified `master` on this machine, so they are pre-existing and environmental rather than anything this branch introduces. `pkg/testing/integration`, the package actually changed here, passes in full. No go.mod or proto changes, so tidy and check_proto are no-ops.

## Changelog

- [x] Changelog entry added.

## Risk

Low and confined to the test harness; nothing here ships in the CLI or the SDKs. The behaviour change for existing single-digit callers is that a `vN` substring is only stripped when it is the trailing path element, which is what a Go module major version always is. Every existing case in `TestSanitizedPkg` and `TestDepRootCalc` is unchanged.

