### PR TITLE
Shorten GCP KMS test-key destroy schedule to 24h

### DIFF
--- a/changelog/pending/20260828--pkg--kms-test-key-destroy-schedule.yaml
+++ b/changelog/pending/20260828--pkg--kms-test-key-destroy-schedule.yaml
@@ -1,4 +1,0 @@
-component: pkg
-kind: chore
-body: Clean up test GCP KMS keys sooner
-time: 2026-08-28T00:00:00Z

--- a/changelog/pending/20260828--pkg--kms-test-key-destroy-schedule.yaml
+++ b/changelog/pending/20260828--pkg--kms-test-key-destroy-schedule.yaml
@@ -1,0 +1,4 @@
+component: pkg
+kind: chore
+body: Clean up test GCP KMS keys sooner
+time: 2026-08-28T00:00:00Z

--- a/pkg/secrets/cloud/gcp_test.go
+++ b/pkg/secrets/cloud/gcp_test.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func createGCPKey(ctx context.Context, t *testing.T) string {
@@ -42,6 +44,8 @@ func createGCPKey(ctx context.Context, t *testing.T) string {
 			VersionTemplate: &kmspb.CryptoKeyVersionTemplate{
 				Algorithm: kmspb.CryptoKeyVersion_GOOGLE_SYMMETRIC_ENCRYPTION,
 			},
+			// Minimum allowed by KMS; keeps abandoned test keys from lingering 30 days.
+			DestroyScheduledDuration: durationpb.New(24 * time.Hour),
 		},
 	}
 


### PR DESCRIPTION
These test keys are currently retained (and billed) for 30 days after cleanup; let's instead only keep them around for the minimum 24h.