### PR TITLE
verify tls certificate for foreign template downloads

### DIFF
--- a/changelog/pending/20260830--cli--template-download-tls-verification.yaml
+++ b/changelog/pending/20260830--cli--template-download-tls-verification.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Verify TLS certificates when downloading a template from a URL outside the configured service
+time: 2026-08-30T00:00:00Z

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -3305,7 +3305,7 @@ func (pc *Client) DownloadTemplate(ctx context.Context, downloadURL string) (io.
 	} else {
 		// Set pc to the new client. This only sets the local variable. It is very
 		// different from *pc = *NewClient().
-		pc = NewClient(downloadURL, "", true, pc.diag)
+		pc = NewClient(downloadURL, "", pc.insecure, pc.diag)
 		downloadURL = ""
 	}
 

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -2167,9 +2167,8 @@ func TestClientInsecure(t *testing.T) {
 	assert.False(t, NewClient("https://api.example.com", "tok", false, nil).Insecure())
 }
 
+//nolint:paralleltest // overrides the package-level newClient hook
 func TestDownloadTemplateForeignURLInheritsInsecure(t *testing.T) {
-	t.Parallel()
-
 	// A template download URL that isn't the configured api endpoint makes DownloadTemplate
 	// build a fresh client for that host. That client has to carry the caller's TLS setting,
 	// otherwise `pulumi new <template>` accepts any certificate for the foreign host even when
@@ -2192,7 +2191,7 @@ func TestDownloadTemplateForeignURLInheritsInsecure(t *testing.T) {
 		return origNewClient(apiURL, apiToken, insecure, d)
 	}
 
-	body, err := pc.DownloadTemplate(context.Background(), server.URL+"/template.tar")
+	body, err := pc.DownloadTemplate(t.Context(), server.URL+"/template.tar")
 	require.NoError(t, err)
 	if body != nil {
 		require.NoError(t, body.Close())

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
@@ -2164,4 +2165,39 @@ func TestClientInsecure(t *testing.T) {
 	// later rebuild a client from it, so the flag must survive construction.
 	assert.True(t, NewClient("https://api.example.com", "tok", true, nil).Insecure())
 	assert.False(t, NewClient("https://api.example.com", "tok", false, nil).Insecure())
+}
+
+func TestDownloadTemplateForeignURLInheritsInsecure(t *testing.T) {
+	t.Parallel()
+
+	// A template download URL that isn't the configured api endpoint makes DownloadTemplate
+	// build a fresh client for that host. That client has to carry the caller's TLS setting,
+	// otherwise `pulumi new <template>` accepts any certificate for the foreign host even when
+	// the user never opted into insecure transport.
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// A secure caller (insecure == false).
+	pc := NewClient("https://api.example.com", "tok", false, nil)
+
+	// Capture the insecure flag the fresh client is constructed with. Installed after pc is built
+	// so it only observes the client made inside DownloadTemplate.
+	origNewClient := newClient
+	defer func() { newClient = origNewClient }()
+	var captured, capturedInsecure bool
+	newClient = func(apiURL, apiToken string, insecure bool, d diag.Sink) *Client {
+		captured, capturedInsecure = true, insecure
+		return origNewClient(apiURL, apiToken, insecure, d)
+	}
+
+	body, err := pc.DownloadTemplate(context.Background(), server.URL+"/template.tar")
+	require.NoError(t, err)
+	if body != nil {
+		require.NoError(t, body.Close())
+	}
+
+	require.True(t, captured, "a foreign template URL should build a fresh client")
+	assert.False(t, capturedInsecure, "the fresh client must inherit the caller's TLS verification setting")
 }


### PR DESCRIPTION
## Summary
DownloadTemplate splits on whether the template URL points at the configured service or somewhere else. For a URL that isn't the service (a github, gitlab, or other registry-hosted template that `pulumi new` fetches) it builds a fresh client for that host, and it was passing `insecure=true` to `NewClient`, which sets `InsecureSkipVerify` on the transport. That disables certificate verification for the download regardless of what the user configured, so an on-path attacker can present any certificate and swap in template content that then gets written to disk and, for most templates, installed and run. The user never opted into that; every other `NewClient` call site threads the real insecure setting, and this is the only place that hardcodes it. I noticed it while reading the call sites for the insecure flag. Passing `pc.insecure` makes the foreign download inherit the caller's TLS setting like the rest of the code, and behavior is unchanged for the normal case where the certificate is valid.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestDownloadTemplateForeignURLInheritsInsecure` captures the flag the fresh client is built with for a non-service URL; it fails before this change (client built with verification off) and passes after.

## Validation
- [ ] `make lint` — clean
- [x] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Ran `go test ./backend/httpstate/client/` (pass) and `gofmt`/`go vet` on the touched files. `make lint` uses a custom plugin I couldn't build in isolation.

## Changelog
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
Extraction/download only. Downloads over https with a valid certificate are unchanged. The only behavior change is for a user who did not opt into insecure transport but relied on the accidental skip for a self-signed foreign template host; they now pass the insecure flag like every other client path. No public API change.
