### PR TITLE
redact secrets in git URLs and plugin download URLs

### DIFF
--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -539,6 +539,7 @@ func resolveSymlinks(path string) string {
 
 // GitCloneAndCheckoutCommit clones the Git repository and checkouts the specified commit.
 func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.Hash, path string) error {
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(url), "[credential]")
 	logging.V(10).Infof("Attempting to clone from %s at commit %v and path %s", url, commit, path)
 
 	u, auth, err := getAuthForURL(url)
@@ -566,6 +567,7 @@ func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.
 
 // GitCloneAndCheckoutRevision clones a Git repository, resolves the revision and checks it out.
 func GitCloneAndCheckoutRevision(ctx context.Context, url string, revision plumbing.Revision, path string) error {
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(url), "[credential]")
 	logging.V(10).Infof("Attempting to clone from %s at commit %v and path %s", url, revision, path)
 
 	u, auth, err := getAuthForURL(url)
@@ -602,10 +604,11 @@ func GitCloneAndCheckoutRevision(ctx context.Context, url string, revision plumb
 func GitCloneOrPull(
 	ctx context.Context, rawurl string, referenceName plumbing.ReferenceName, path string, shallow bool,
 ) error {
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(rawurl), "[credential]")
 	tracer := otel.Tracer("pulumi-cli")
 	ctx, span := cmdutil.StartSpan(ctx, tracer, "git-clone-or-pull",
 		trace.WithAttributes(
-			attribute.String("url", rawurl),
+			attribute.String("url", httputil.RedactURL(rawurl)),
 			attribute.String("ref", referenceName.String()),
 		))
 	defer span.End()

--- a/sdk/go/common/util/gitutil/retrieve.go
+++ b/sdk/go/common/util/gitutil/retrieve.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
@@ -32,6 +33,7 @@ func RetrieveGitFolder(ctx context.Context, rawurl string, path string) (string,
 	if err != nil {
 		return "", err
 	}
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(url), "[credential]")
 
 	ref, commit, subDirectory, err := GetGitReferenceNameOrHashAndSubDirectory(url, urlPath)
 	if err != nil {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -756,7 +756,7 @@ func (source *httpSource) Download(
 ) (io.ReadCloser, int64, error) {
 	serverURL := interpolateURL(source.url, source.name, version, opSy, arch)
 	serverURL = strings.TrimSuffix(serverURL, "/")
-	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
+	logging.V(1).Infof("%s downloading from %s", source.name, httputil.RedactURL(serverURL))
 
 	endpoint := fmt.Sprintf("%s/%s",
 		serverURL,
@@ -832,7 +832,8 @@ func (source *fallbackSource) Download(
 	// which returns the GitHub URL, not the get.pulumi.com URL. When we actually fall back to
 	// get.pulumi.com here, we need to check if there's an override for that specific URL.
 	if overrideURL, ok := pluginDownloadURLOverridesParsed.get(pulumi.url()); ok {
-		logging.V(1).Infof("Applying URL override for %s: %s -> %s", source.name, pulumi.url(), overrideURL)
+		logging.V(1).Infof("Applying URL override for %s: %s -> %s",
+			source.name, pulumi.url(), httputil.RedactURL(overrideURL))
 		overrideSource, err := newPluginSource(source.name, source.kind, overrideURL)
 		if err != nil {
 			return nil, 0, fmt.Errorf("unable to construct override for %q: %w", source.name, err)
@@ -1720,7 +1721,7 @@ func newDownloadError(statusCode int, url *url.URL, header http.Header) error {
 	}
 	return &downloadError{
 		code:   statusCode,
-		msg:    fmt.Sprintf("%d HTTP error fetching plugin from %s", statusCode, url),
+		msg:    fmt.Sprintf("%d HTTP error fetching plugin from %s", statusCode, httputil.RedactURL(url.String())),
 		header: header,
 	}
 }
@@ -2194,7 +2195,7 @@ func getPluginInfoAndPath(
 		if path, err := exec.LookPath(filename); err == nil {
 			ambientPath = path
 			logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): found on $PATH %s",
-				spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL, path)
+				spec.Kind, spec.Name, spec.Version, httputil.RedactURL(spec.PluginDownloadURL), path)
 		}
 	}
 
@@ -2218,7 +2219,7 @@ func getPluginInfoAndPath(
 					if stat, err := os.Stat(candidate); err == nil &&
 						(stat.Mode()&0o100 != 0 || runtime.GOOS == windowsGOOS) {
 						logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): found next to current executable %s",
-							spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL, candidate)
+							spec.Kind, spec.Name, spec.Version, httputil.RedactURL(spec.PluginDownloadURL), candidate)
 						bundledPath = candidate
 						break
 					}
@@ -2271,15 +2272,15 @@ func getPluginInfoAndPath(
 		isPreReleaseVersion(*spec.Version) {
 		// We're looking for a plugin matching an exact hash, so we can't use the semver range logic.
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): enabling prerelease plugin behaviour",
-			spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL)
+			spec.Kind, spec.Name, spec.Version, httputil.RedactURL(spec.PluginDownloadURL))
 		match = SelectPrereleasePlugin(plugins, spec)
 	} else if !enableLegacyPluginBehavior && spec.Version != nil {
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): enabling new plugin behavior",
-			spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL)
+			spec.Kind, spec.Name, spec.Version, httputil.RedactURL(spec.PluginDownloadURL))
 		match = SelectCompatiblePlugin(plugins, spec)
 	} else {
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): using legacy plugin behavior",
-			spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL)
+			spec.Kind, spec.Name, spec.Version, httputil.RedactURL(spec.PluginDownloadURL))
 		match = LegacySelectCompatiblePlugin(plugins, spec)
 	}
 
@@ -2296,7 +2297,7 @@ func getPluginInfoAndPath(
 		}
 		matchPath := getPluginPath(match)
 		logging.V(6).Infof("GetPluginPath(%s, %s, %v, %s): found in cache at %s",
-			spec.Kind, spec.Name, spec.Version, spec.PluginDownloadURL, matchPath)
+			spec.Kind, spec.Name, spec.Version, httputil.RedactURL(spec.PluginDownloadURL), matchPath)
 		return match, matchPath, nil
 	}
 


### PR DESCRIPTION
URLs can encode secrets (and often do in case of git URLs, as they carry the token).  Filter the secrets out of URLs where we can.
