### PR TITLE
remaining potential secret leakage in logs

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -53,6 +53,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -381,6 +382,7 @@ func (pc *Client) ValidateAgentClaim(ctx context.Context, claimToken string) (bo
 	if strings.TrimSpace(claimToken) == "" {
 		return false, nil
 	}
+	logging.AddGlobalSecretFilter([]string{claimToken, url.PathEscape(claimToken)}, "[credential]")
 	err := pc.restCall(ctx, http.MethodGet, "/api/agents/signup/validate/"+url.PathEscape(claimToken), nil, nil, nil)
 	if err == nil {
 		return true, nil

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -146,6 +147,12 @@ type (
 		ParameterizationArgs []string
 	}
 )
+
+func redactPackageSpec(spec workspace.PackageSpec) workspace.PackageSpec {
+	spec.Source = httputil.RedactURL(spec.Source)
+	spec.PluginDownloadURL = httputil.RedactURL(spec.PluginDownloadURL)
+	return spec
+}
 
 // parameterizeArgs returns the arguments used to parameterize a package on install.
 func parameterizeArgs(spec workspace.PackageSpec) []string {
@@ -296,7 +303,7 @@ func Resolve(
 	spec workspace.PackageSpec,
 	options Options,
 ) (Resolution, error) {
-	slog.InfoContext(ctx, "Resolving package", "spec", spec)
+	slog.InfoContext(ctx, "Resolving package", "spec", redactPackageSpec(spec))
 	if plugin.IsLocalPluginPath(ctx, spec.Source) {
 		return PathResolution{
 			Path:                 spec.Source,
@@ -326,7 +333,7 @@ func Resolve(
 
 	remoteResolution := func() (Resolution, error) {
 		slog.InfoContext(ctx, "Resolved package to an external source",
-			"spec", spec, "descriptor", naivePackageDescriptor)
+			"spec", redactPackageSpec(spec), "descriptor", naivePackageDescriptor)
 		installed, atVersion, err := IsPluginInstalled(ctx, naivePackageDescriptor.PluginDescriptor, ws, options)
 		if err != nil {
 			return nil, err
@@ -428,11 +435,11 @@ func Resolve(
 	}
 
 	if registryQueryErr != nil {
-		slog.InfoContext(ctx, "Failed to resolve package", "spec", spec)
+		slog.InfoContext(ctx, "Failed to resolve package", "spec", redactPackageSpec(spec))
 		return nil, registryQueryErr
 	}
 
-	slog.InfoContext(ctx, "Failed to resolve package", "spec", spec)
+	slog.InfoContext(ctx, "Failed to resolve package", "spec", redactPackageSpec(spec))
 	return nil, &PackageNotFoundError{
 		Package:     spec.Source,
 		Version:     spec.Version,

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -38,7 +38,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -147,12 +146,6 @@ type (
 		ParameterizationArgs []string
 	}
 )
-
-func redactPackageSpec(spec workspace.PackageSpec) workspace.PackageSpec {
-	spec.Source = httputil.RedactURL(spec.Source)
-	spec.PluginDownloadURL = httputil.RedactURL(spec.PluginDownloadURL)
-	return spec
-}
 
 // parameterizeArgs returns the arguments used to parameterize a package on install.
 func parameterizeArgs(spec workspace.PackageSpec) []string {
@@ -303,7 +296,7 @@ func Resolve(
 	spec workspace.PackageSpec,
 	options Options,
 ) (Resolution, error) {
-	slog.InfoContext(ctx, "Resolving package", "spec", redactPackageSpec(spec))
+	slog.InfoContext(ctx, "Resolving package", "spec", spec)
 	if plugin.IsLocalPluginPath(ctx, spec.Source) {
 		return PathResolution{
 			Path:                 spec.Source,
@@ -333,7 +326,7 @@ func Resolve(
 
 	remoteResolution := func() (Resolution, error) {
 		slog.InfoContext(ctx, "Resolved package to an external source",
-			"spec", redactPackageSpec(spec), "descriptor", naivePackageDescriptor)
+			"spec", spec, "descriptor", naivePackageDescriptor)
 		installed, atVersion, err := IsPluginInstalled(ctx, naivePackageDescriptor.PluginDescriptor, ws, options)
 		if err != nil {
 			return nil, err
@@ -435,11 +428,11 @@ func Resolve(
 	}
 
 	if registryQueryErr != nil {
-		slog.InfoContext(ctx, "Failed to resolve package", "spec", redactPackageSpec(spec))
+		slog.InfoContext(ctx, "Failed to resolve package", "spec", spec)
 		return nil, registryQueryErr
 	}
 
-	slog.InfoContext(ctx, "Failed to resolve package", "spec", redactPackageSpec(spec))
+	slog.InfoContext(ctx, "Failed to resolve package", "spec", spec)
 	return nil, &PackageNotFoundError{
 		Package:     spec.Source,
 		Version:     spec.Version,

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -756,7 +756,8 @@ func (source *httpSource) Download(
 ) (io.ReadCloser, int64, error) {
 	serverURL := interpolateURL(source.url, source.name, version, opSy, arch)
 	serverURL = strings.TrimSuffix(serverURL, "/")
-	logging.V(1).Infof("%s downloading from %s", source.name, httputil.RedactURL(serverURL))
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(serverURL), "[credential]")
+	logging.V(1).Infof("%s downloading from %s", source.name, serverURL)
 
 	endpoint := fmt.Sprintf("%s/%s",
 		serverURL,
@@ -832,8 +833,8 @@ func (source *fallbackSource) Download(
 	// which returns the GitHub URL, not the get.pulumi.com URL. When we actually fall back to
 	// get.pulumi.com here, we need to check if there's an override for that specific URL.
 	if overrideURL, ok := pluginDownloadURLOverridesParsed.get(pulumi.url()); ok {
-		logging.V(1).Infof("Applying URL override for %s: %s -> %s",
-			source.name, pulumi.url(), httputil.RedactURL(overrideURL))
+		logging.AddGlobalSecretFilter(httputil.URLSecrets(overrideURL), "[credential]")
+		logging.V(1).Infof("Applying URL override for %s: %s -> %s", source.name, pulumi.url(), overrideURL)
 		overrideSource, err := newPluginSource(source.name, source.kind, overrideURL)
 		if err != nil {
 			return nil, 0, fmt.Errorf("unable to construct override for %q: %w", source.name, err)
@@ -2141,6 +2142,7 @@ func getPluginInfoAndPath(
 	projectPlugins []ProjectPlugin,
 	markUsed bool,
 ) (*PluginInfo, string, error) {
+	logging.AddGlobalSecretFilter(httputil.URLSecrets(spec.PluginDownloadURL), "[credential]")
 	filename := spec.File()
 
 	for i, p1 := range projectPlugins {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -985,6 +986,12 @@ type UnresolvedPackageDescriptor struct {
 
 	// The parameterization args to be applied against the plugin descriptor.
 	ParameterizationArgs []string
+}
+
+func (u UnresolvedPackageDescriptor) LogValue() slog.Value {
+	u.PluginDownloadURL = httputil.RedactURL(u.PluginDownloadURL)
+	type plain UnresolvedPackageDescriptor
+	return slog.AnyValue(plain(u))
 }
 
 func NewPackageDescriptor(spec PluginDescriptor, parameterization *Parameterization) PackageDescriptor {

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"math"
 	"os"
@@ -41,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/httputil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"gopkg.in/yaml.v3"
@@ -135,6 +137,13 @@ type PackageSpec struct {
 
 	// CLI args passed to the extension's Parameterize call. This must be implemented in the provider.
 	Extensions []string
+}
+
+func (p PackageSpec) LogValue() slog.Value {
+	p.Source = httputil.RedactURL(p.Source)
+	p.PluginDownloadURL = httputil.RedactURL(p.PluginDownloadURL)
+	type plain PackageSpec
+	return slog.AnyValue(plain(p))
 }
 
 func (p PackageSpec) String() string {

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -17,6 +17,7 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -1865,4 +1866,22 @@ func TestAddPackage(t *testing.T) {
 		// Verify the internal representation was converted to PackageSpec
 		requireTextualRepresentationIsSpec(t, proj.Packages["string-package"])
 	})
+}
+
+func TestPackageSpecLogValueRedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	spec := PackageSpec{
+		Source:            "git://user:sourcesecret@github.com/org/repo",
+		Version:           "1.2.3",
+		PluginDownloadURL: "https://user:downloadsecret@example.com/plugin",
+	}
+
+	var buf bytes.Buffer
+	slog.New(slog.NewTextHandler(&buf, nil)).Info("resolving", "spec", spec)
+	out := buf.String()
+
+	require.NotContains(t, out, "sourcesecret")
+	require.NotContains(t, out, "downloadsecret")
+	require.Contains(t, out, "1.2.3", "non-secret fields should still be logged")
 }


### PR DESCRIPTION
There's 2 remaining potential leakages:
- The agent claim token
- Logging a package spec, which contains URLs

Fix them here.
