### PR TITLE
Show downstream stacks after updates and in `pulumi stack`

### DIFF
--- a/changelog/pending/20260831--cli--downstream-stacks.yaml
+++ b/changelog/pending/20260831--cli--downstream-stacks.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: List the stacks that reference the updated stack at the end of updates on Pulumi Cloud stacks
+time: 2026-08-31T00:00:00Z

--- a/changelog/pending/20260831--cli--stack-downstream-stacks.yaml
+++ b/changelog/pending/20260831--cli--stack-downstream-stacks.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Show downstream stacks in the output of `pulumi stack`
+time: 2026-08-31T00:00:00Z

--- a/changelog/pending/20260831--cli--stack-table-headers.yaml
+++ b/changelog/pending/20260831--cli--stack-table-headers.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Remove header styling from the resource table printed by `pulumi stack`
+time: 2026-08-31T00:00:00Z

--- a/pkg/backend/display/downstream.go
+++ b/pkg/backend/display/downstream.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"cmp"
+	"iter"
+	"slices"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+// maxDownstreamStackLines caps how many lines DownstreamStackLines renders before truncating.
+const maxDownstreamStackLines = 5
+
+// DownstreamStackLines renders the stacks that reference another stack as the body of a summary
+// section, sorted by organization, project, and stack name and indented to match other sections.
+// In interactive, colorized sessions stacks are grouped per project on one line, with each project
+// and stack name a terminal hyperlink into the console. Otherwise each stack's console URL is
+// listed on its own line so the link survives in logs. Output is truncated to
+// maxDownstreamStackLines followed by an ellipsis line. consoleURL builds a console URL from path
+// segments. The lines carry color directives and must be colorized before printing.
+func DownstreamStackLines(
+	refs []apitype.StackReference, consoleURL func(...string) string, color colors.Colorization, interactive bool,
+) iter.Seq[string] {
+	slices.SortFunc(refs, func(a, b apitype.StackReference) int {
+		return cmp.Or(
+			cmp.Compare(a.Organization, b.Organization),
+			cmp.Compare(a.RoutingProject, b.RoutingProject),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	var lines []string
+	if interactive && color != colors.Never {
+		for i := 0; i < len(refs); {
+			org, project := refs[i].Organization, refs[i].RoutingProject
+			var stacks []string
+			for ; i < len(refs) && refs[i].Organization == org && refs[i].RoutingProject == project; i++ {
+				stacks = append(stacks, color.Hyperlink(consoleURL(org, project, refs[i].Name), refs[i].Name))
+			}
+			lines = append(lines,
+				"    "+color.Hyperlink(consoleURL(org, project), org+"/"+project)+": "+strings.Join(stacks, ", "))
+		}
+	} else {
+		for _, ref := range refs {
+			url := consoleURL(ref.Organization, ref.RoutingProject, ref.Name)
+			lines = append(lines, "    "+colors.Underline+colors.BrightBlue+url+colors.Reset)
+		}
+	}
+
+	if len(lines) > maxDownstreamStackLines {
+		lines = append(lines[:maxDownstreamStackLines], "    ...")
+	}
+	return slices.Values(lines)
+}

--- a/pkg/backend/display/downstream_test.go
+++ b/pkg/backend/display/downstream_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+func TestDownstreamStackLines(t *testing.T) {
+	t.Parallel()
+
+	consoleURL := func(paths ...string) string { return "https://console/" + strings.Join(paths, "/") }
+	ref := func(org, project, name string) apitype.StackReference {
+		return apitype.StackReference{Organization: org, RoutingProject: project, Name: name}
+	}
+	lines := func(refs []apitype.StackReference, color colors.Colorization, interactive bool) []string {
+		return slices.Collect(DownstreamStackLines(refs, consoleURL, color, interactive))
+	}
+	urlLine := func(s string) string {
+		return "    " + colors.Underline + colors.BrightBlue + "https://console/" + s + colors.Reset
+	}
+	link := func(path, text string) string { return colors.Always.Hyperlink("https://console/"+path, text) }
+
+	assert.Empty(t, lines(nil, colors.Always, true))
+
+	// Non-interactive output lists one console URL per stack.
+	assert.Equal(t, []string{urlLine("org/net/dev")},
+		lines([]apitype.StackReference{ref("org", "net", "dev")}, colors.Always, false))
+	assert.Equal(t,
+		[]string{
+			urlLine("org/net/a"), urlLine("org/net/b"), urlLine("org/net/c"), urlLine("org/net/d"), urlLine("org/net/e"),
+			"    ...",
+		},
+		lines([]apitype.StackReference{
+			ref("org", "net", "a"), ref("org", "net", "b"), ref("org", "net", "c"),
+			ref("org", "net", "d"), ref("org", "net", "e"), ref("org", "net", "f"),
+		}, colors.Always, false))
+
+	// Colors off while interactive: still the URL list, since hyperlinks would be dropped.
+	assert.Equal(t, []string{urlLine("org/net/dev")},
+		lines([]apitype.StackReference{ref("org", "net", "dev")}, colors.Never, true))
+
+	// Interactive output groups by org/project, sorted, with hyperlinked names.
+	assert.Equal(t,
+		[]string{
+			"    " + link("org/app", "org/app") + ": " + link("org/app/dev", "dev"),
+			"    " + link("org/net", "org/net") + ": " + link("org/net/dev", "dev") + ", " + link("org/net/prod", "prod"),
+			"    " + link("other/svc", "other/svc") + ": " + link("other/svc/prod", "prod"),
+		},
+		lines([]apitype.StackReference{
+			ref("org", "net", "prod"), ref("other", "svc", "prod"), ref("org", "net", "dev"), ref("org", "app", "dev"),
+		}, colors.Always, true))
+
+	// Interactive output truncates by project line.
+	assert.Equal(t,
+		[]string{
+			"    " + link("org/p1", "org/p1") + ": " + link("org/p1/dev", "dev"),
+			"    " + link("org/p2", "org/p2") + ": " + link("org/p2/dev", "dev"),
+			"    " + link("org/p3", "org/p3") + ": " + link("org/p3/dev", "dev"),
+			"    " + link("org/p4", "org/p4") + ": " + link("org/p4/dev", "dev"),
+			"    " + link("org/p5", "org/p5") + ": " + link("org/p5/dev", "dev"),
+			"    ...",
+		},
+		lines([]apitype.StackReference{
+			ref("org", "p1", "dev"), ref("org", "p2", "dev"), ref("org", "p3", "dev"),
+			ref("org", "p4", "dev"), ref("org", "p5", "dev"), ref("org", "p6", "dev"),
+		}, colors.Always, true))
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2162,7 +2162,54 @@ func (b *cloudBackend) runEngineAction(
 		updateErr = result.MergeBails(updateErr, fmt.Errorf("failed to complete update: %w", completeErr))
 	}
 
+	if updateErr == nil && !op.Opts.Display.JSONDisplay && !op.Opts.Display.SummaryJSON {
+		b.printDownstreamStacks(ctx, update.StackIdentifier, op.Opts.Display)
+	}
+
 	return plan, changes, updateErr
+}
+
+// printDownstreamStacks lists the stacks that hold a stack reference to the updated stack, so the
+// user knows which stacks may need updating next. This output is advisory: failures to fetch the
+// list are logged and otherwise ignored.
+func (b *cloudBackend) printDownstreamStacks(
+	ctx context.Context, stackID client.StackIdentifier, opts display.Options,
+) {
+	resp, err := b.client.ListDownstreamStackReferences(ctx, stackID)
+	if err != nil {
+		logging.V(3).Infof("listing downstream stack references for %v: %v", stackID, err)
+		return
+	}
+	out := opts.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	fmt.Fprint(out, opts.Color.Colorize(formatDownstreamStacks(resp.ReferencedStacks, b.CloudConsoleURL, opts)))
+}
+
+// formatDownstreamStacks renders the downstream stacks as a summary section in the style of the
+// update display. It returns the empty string when there are no stacks.
+func formatDownstreamStacks(
+	refs []apitype.StackReference, consoleURL func(...string) string, opts display.Options,
+) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	noun := "Downstream Stacks"
+	if len(refs) == 1 {
+		noun = "Downstream Stack"
+	}
+	var sb strings.Builder
+	// The progress display ends its summary with a blank line; the diff display does not.
+	if opts.Type == display.DisplayDiff {
+		sb.WriteString("\n")
+	}
+	fmt.Fprintf(&sb, "%s%s: (%d)%s\n", colors.SpecHeadline, noun, len(refs), colors.Reset)
+	for line := range display.DownstreamStackLines(refs, consoleURL, opts.Color, opts.IsInteractive) {
+		sb.WriteString(line + "\n")
+	}
+	sb.WriteString("\n")
+	return sb.String()
 }
 
 func (b *cloudBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error {

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -3360,4 +3361,32 @@ func TestPermalinkForDisplayWithAgentCredentials(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFormatDownstreamStacks(t *testing.T) {
+	t.Parallel()
+
+	consoleURL := func(paths ...string) string { return "https://console/" + strings.Join(paths, "/") }
+	refs := func(names ...string) []apitype.StackReference {
+		out := make([]apitype.StackReference, 0, len(names))
+		for _, name := range names {
+			out = append(out, apitype.StackReference{Organization: "org", RoutingProject: "net", Name: name})
+		}
+		return out
+	}
+	urlLine := func(s string) string {
+		return "    " + colors.Underline + colors.BrightBlue + "https://console/org/net/" + s + colors.Reset + "\n"
+	}
+
+	assert.Equal(t, "", formatDownstreamStacks(nil, consoleURL, display.Options{}))
+	assert.Equal(t,
+		colors.SpecHeadline+"Downstream Stack: (1)"+colors.Reset+"\n"+urlLine("dev")+"\n",
+		formatDownstreamStacks(refs("dev"), consoleURL, display.Options{}))
+	assert.Equal(t,
+		colors.SpecHeadline+"Downstream Stacks: (2)"+colors.Reset+"\n"+urlLine("dev")+urlLine("prod")+"\n",
+		formatDownstreamStacks(refs("dev", "prod"), consoleURL, display.Options{}))
+	// The diff display does not end with a blank line, so one is added before the header.
+	assert.Equal(t,
+		"\n"+colors.SpecHeadline+"Downstream Stack: (1)"+colors.Reset+"\n"+urlLine("dev")+"\n",
+		formatDownstreamStacks(refs("dev"), consoleURL, display.Options{Type: display.DisplayDiff}))
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -958,6 +958,17 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 	return stack, nil
 }
 
+// ListDownstreamStackReferences returns the stacks whose programs hold a stack reference to the given stack.
+func (pc *Client) ListDownstreamStackReferences(
+	ctx context.Context, stackID StackIdentifier,
+) (apitype.ListDownstreamStackReferencesResponse, error) {
+	var resp apitype.ListDownstreamStackReferencesResponse
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "downstreamreferences"), nil, nil, &resp); err != nil {
+		return apitype.ListDownstreamStackReferencesResponse{}, err
+	}
+	return resp, nil
+}
+
 // ListDriftRuns returns a paginated list of drift detection runs for the given stack.
 func (pc *Client) ListDriftRuns(
 	ctx context.Context, stackID StackIdentifier, page, pageSize int,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -2165,3 +2165,27 @@ func TestClientInsecure(t *testing.T) {
 	assert.True(t, NewClient("https://api.example.com", "tok", true, nil).Insecure())
 	assert.False(t, NewClient("https://api.example.com", "tok", false, nil).Insecure())
 }
+
+func TestListDownstreamStackReferences(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		_, err := rw.Write([]byte(`{"referencedStacks":[` +
+			`{"organization":"org","routingProject":"consumer","name":"prod","version":7}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	resp, err := NewClient(server.URL, "", true, nil).ListDownstreamStackReferences(t.Context(), StackIdentifier{
+		Owner: "org", Project: "proj", Stack: tokens.MustParseStackName("dev"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/api/stacks/org/proj/dev/downstreamreferences", gotPath)
+	assert.Equal(t, apitype.ListDownstreamStackReferencesResponse{
+		ReferencedStacks: []apitype.StackReference{
+			{Organization: "org", RoutingProject: "consumer", Name: "prod", Version: 7},
+		},
+	}, resp)
+}

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -225,11 +226,14 @@ func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stac
 			}
 		}
 
-		ui.FprintTable(out, cmdutil.Table{
+		err := cmdutil.FprintTable(out, cmdutil.Table{
 			Headers: []string{"TYPE", "NAME"},
 			Rows:    rows,
 			Prefix:  "    ",
-		}, nil)
+		})
+		if err != nil {
+			return err
+		}
 
 		outputs, err := getStackOutputs(snap, args.showSecrets)
 		if err == nil {
@@ -243,6 +247,9 @@ func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stac
 	}
 
 	if isCloud {
+		if cs, ok := s.(httpstate.Stack); ok {
+			fprintDownstreamStacks(ctx, out, cloudBe, cs)
+		}
 		if consoleURL, err := cloudBe.StackConsoleURL(s.Ref()); err == nil {
 			fmt.Fprintf(out, "\n")
 			fmt.Fprintf(out, "More information at: %s\n", consoleURL)
@@ -254,6 +261,25 @@ func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stac
 	fmt.Fprintf(out, "Use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones\n")
 
 	return nil
+}
+
+// fprintDownstreamStacks prints the stacks that hold a stack reference to the given stack, if any.
+// This section is advisory: failures to fetch the list are logged and otherwise ignored.
+func fprintDownstreamStacks(ctx context.Context, out io.Writer, be httpstate.Backend, s httpstate.Stack) {
+	resp, err := be.Client().ListDownstreamStackReferences(ctx, s.StackIdentifier())
+	if err != nil {
+		slog.DebugContext(ctx, "listing downstream stack references failed", "stack", s.StackIdentifier(), "err", err)
+		return
+	}
+	if len(resp.ReferencedStacks) == 0 {
+		return
+	}
+	consoleURL := func(paths ...string) string { return client.CloudConsoleURL(be.CloudURL(), paths...) }
+	color := cmdutil.GetGlobalColorization()
+	fmt.Fprintf(out, "\nDownstream stacks (%d):\n", len(resp.ReferencedStacks))
+	for line := range display.DownstreamStackLines(resp.ReferencedStacks, consoleURL, color, cmdutil.Interactive()) {
+		fmt.Fprintln(out, color.Colorize(line))
+	}
 }
 
 func fprintStackOutputs(w io.Writer, outputs map[string]any) error {

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -139,3 +139,20 @@ type ImportStackRequest UntypedDeployment
 type ImportStackResponse struct {
 	UpdateID string `json:"updateId"`
 }
+
+// StackReference identifies a stack that is related to another stack by a stack reference.
+type StackReference struct {
+	// Organization is the organization that owns the stack.
+	Organization string `json:"organization"`
+	// RoutingProject is the project name used to route to the stack.
+	RoutingProject string `json:"routingProject"`
+	// Name is the name of the stack.
+	Name string `json:"name"`
+	// Version is the version of the referenced stack at the time it was referenced.
+	Version int `json:"version"`
+}
+
+// ListDownstreamStackReferencesResponse lists the stacks whose programs reference a given stack.
+type ListDownstreamStackReferencesResponse struct {
+	ReferencedStacks []StackReference `json:"referencedStacks"`
+}


### PR DESCRIPTION
Stacks on Pulumi Cloud now list the stacks that hold a stack reference to
them, so users know what may need updating next. The list comes from the
service's `downstreamreferences` endpoint and is printed after the summary
of `pulumi up`, `preview`, `refresh`, and `destroy`, and in the output of
`pulumi stack`.

In interactive, colorized sessions the stacks are grouped per project on
one line, with each project and stack name rendered as a terminal
hyperlink into the console. Otherwise each stack's console URL is listed
on its own line so the link survives in logs. The list is truncated to
five lines followed by an ellipsis, and the section is omitted entirely
when there are no downstream stacks.

The resource table printed by `pulumi stack` no longer styles its
`TYPE`/`NAME` header, matching the rest of that command's output.