### PR TITLE
Add `colors.Hyperlink` as the shared OSC 8 terminal hyperlink helper

### DIFF
--- a/changelog/pending/20260831--cli--colors-hyperlink.yaml
+++ b/changelog/pending/20260831--cli--colors-hyperlink.yaml
@@ -1,4 +1,0 @@
-component: cli
-kind: improvement
-body: Style terminal hyperlinks in Neo output as links
-time: 2026-08-31T00:00:00Z

--- a/changelog/pending/20260831--cli--colors-hyperlink.yaml
+++ b/changelog/pending/20260831--cli--colors-hyperlink.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Style terminal hyperlinks in Neo output as links
+time: 2026-08-31T00:00:00Z

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 // ctrlCArmTimeout is how long the "press Ctrl+C again to exit" gate stays
@@ -1111,7 +1112,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// CreateNeoTask sends UISessionURL immediately after taskID is set,
 		// so this is the natural moment to lift the post-Enter toggle freeze.
 		m.taskCreated = true
-		cmds = append(cmds, m.printlnBlock("  "+inputHintStyle.Render("⟡ "+osc8Hyperlink(msg.URL, msg.URL))))
+		cmds = append(cmds, m.printlnBlock("  "+inputHintStyle.Render("⟡ "+colors.Always.Hyperlink(msg.URL, msg.URL))))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIUserMessage:

--- a/pkg/cmd/pulumi/neo/tui_links.go
+++ b/pkg/cmd/pulumi/neo/tui_links.go
@@ -17,20 +17,9 @@ package neo
 import (
 	"regexp"
 	"strings"
-)
 
-// osc8Hyperlink wraps displayText as a clickable hyperlink to url using the
-// OSC 8 escape sequence. Terminals that support OSC 8 render displayText as
-// a click target; terminals that don't strip the escapes and show displayText
-// as plain text.
-//
-// The wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
-func osc8Hyperlink(url, displayText string) string {
-	if url == "" {
-		return displayText
-	}
-	return "\x1b]8;;" + url + "\x1b\\" + displayText + "\x1b]8;;\x1b\\"
-}
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
 
 // urlPattern matches bare http/https URLs in text. It excludes whitespace,
 // ANSI escape (so we never split a URL across an escape boundary), and
@@ -38,10 +27,10 @@ func osc8Hyperlink(url, displayText string) string {
 var urlPattern = regexp.MustCompile(`https?://[^\s\x1b<>"']+`)
 
 // osc8Pattern matches a complete OSC 8 hyperlink sequence — the opener with
-// its URL, the visible text, and the closer. linkifyURLs uses it to skip
+// its URL, the visible text (which may carry SGR styling), and the closer. linkifyURLs uses it to skip
 // past existing hyperlinks rather than re-wrapping URLs that are already
 // clickable.
-var osc8Pattern = regexp.MustCompile(`\x1b\]8;;[^\x1b]*\x1b\\[^\x1b]*\x1b\]8;;\x1b\\`)
+var osc8Pattern = regexp.MustCompile(`\x1b\]8;;[^\x1b]*\x1b\\(?:[^\x1b]|\x1b\[[0-9;]*m)*\x1b\]8;;\x1b\\`)
 
 // urlAlwaysStripPunct lists characters we unconditionally strip from the tail
 // of a matched URL — they're sentence punctuation that practically never
@@ -91,7 +80,7 @@ func linkifyPlain(s string) string {
 		if match == "" {
 			return trail
 		}
-		return osc8Hyperlink(match, match) + trail
+		return colors.Always.Hyperlink(match, match) + trail
 	})
 }
 

--- a/pkg/cmd/pulumi/neo/tui_links_test.go
+++ b/pkg/cmd/pulumi/neo/tui_links_test.go
@@ -19,34 +19,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
-
-func TestOSC8Hyperlink_WrapsURL(t *testing.T) {
-	t.Parallel()
-
-	got := osc8Hyperlink("https://example.com", "click me")
-	// The OSC 8 wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
-	// Pinning the exact bytes here so a refactor that drops one of the escape
-	// terminators (a common mistake) gets caught immediately rather than
-	// silently producing visible garbage in scrollback.
-	assert.Equal(t, "\x1b]8;;https://example.com\x1b\\click me\x1b]8;;\x1b\\", got)
-}
-
-func TestOSC8Hyperlink_EmptyURLPassesText(t *testing.T) {
-	t.Parallel()
-
-	// With no URL we have nothing to hyperlink to — return the display text
-	// unchanged rather than emitting an empty-target escape, which some
-	// terminals render as a broken link.
-	assert.Equal(t, "plain", osc8Hyperlink("", "plain"))
-}
 
 func TestLinkifyURLs_WrapsBareURL(t *testing.T) {
 	t.Parallel()
 
 	got := linkifyURLs("see https://example.com for details")
-	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\")
-	assert.Contains(t, got, "https://example.com\x1b]8;;\x1b\\")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://example.com", "https://example.com"))
 	assert.Contains(t, got, "for details")
 }
 
@@ -57,7 +38,7 @@ func TestLinkifyURLs_StripsTrailingPunctuation(t *testing.T) {
 	// "see https://example.com." should hyperlink "https://example.com" and
 	// leave the period outside, otherwise clicking opens the wrong URL.
 	got := linkifyURLs("see https://example.com.")
-	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\.")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://example.com", "https://example.com")+".")
 	assert.NotContains(t, got, "https://example.com.\x1b\\", "period must not be inside the hyperlink target")
 }
 
@@ -68,7 +49,7 @@ func TestLinkifyURLs_HandlesParenthesizedURL(t *testing.T) {
 	// The trailing ")" belongs to the surrounding prose, not the URL, so it
 	// must land outside the hyperlink — otherwise terminals try to open
 	// "example.com)" which 404s.
-	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\)")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://example.com", "https://example.com")+")")
 }
 
 func TestLinkifyURLs_WrapsMultipleURLs(t *testing.T) {
@@ -87,10 +68,10 @@ func TestLinkifyURLs_LeavesExistingOSC8Alone(t *testing.T) {
 	t.Parallel()
 
 	// If the text is already a hyperlink (e.g. the welcome banner already ran
-	// it through osc8Hyperlink) we must not add a second pair of escapes —
+	// it through colors.Hyperlink) we must not add a second pair of escapes —
 	// nested OSC 8 sequences confuse some terminals into rendering nothing
 	// clickable at all.
-	already := osc8Hyperlink("https://example.com", "https://example.com")
+	already := colors.Always.Hyperlink("https://example.com", "https://example.com")
 	got := linkifyURLs(already)
 	assert.Equal(t, already, got)
 }
@@ -101,14 +82,14 @@ func TestLinkifyURLs_MixesPlainAndExisting(t *testing.T) {
 	// A line containing a pre-wrapped URL plus a bare URL should end up with
 	// the pre-wrapped one untouched and the bare one freshly wrapped — two
 	// hyperlinks total, not three (no double-wrapping).
-	already := osc8Hyperlink("https://a.example", "a")
+	already := colors.Always.Hyperlink("https://a.example", "a")
 	input := already + " then https://b.example"
 	got := linkifyURLs(input)
 	// Two complete hyperlinks = 4 `\x1b]8;;` occurrences (each has an opener
 	// and a closer). If linkify re-wrapped the existing one we'd see 6.
 	assert.Equal(t, 4, strings.Count(got, "\x1b]8;;"))
 	assert.Contains(t, got, already)
-	assert.Contains(t, got, "\x1b]8;;https://b.example\x1b\\https://b.example\x1b]8;;\x1b\\")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://b.example", "https://b.example"))
 }
 
 func TestLinkifyURLs_NoURLs(t *testing.T) {
@@ -129,11 +110,10 @@ func TestLinkifyURLs_EmptyString(t *testing.T) {
 
 // hyperlink is a test helper that builds the exact OSC 8 envelope we expect
 // linkifyURLs to emit for a given target URL and display text. Pinning the
-// full byte sequence in each assertion catches regressions where one of the
-// escape terminators gets dropped — a common refactor mistake that produces
-// visible garbage rather than a silent wrong-link bug.
+// full sequence in each assertion catches regressions where linkify wraps the
+// wrong span or drops part of the envelope.
 func hyperlink(target, display string) string {
-	return "\x1b]8;;" + target + "\x1b\\" + display + "\x1b]8;;\x1b\\"
+	return colors.Always.Hyperlink(target, display)
 }
 
 func TestLinkifyURLs_PreservesBalancedTrailingParens(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_welcome.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 //go:embed neo.ans
@@ -146,7 +148,7 @@ func (w welcomeModel) View() string {
 		if len([]rune(linkText)) > maxLink && maxLink > 3 {
 			linkText = string([]rune(linkText)[:maxLink-3]) + "..."
 		}
-		parts = append(parts, dim.Render("⟡ "+osc8Hyperlink(w.consoleURL, linkText)))
+		parts = append(parts, dim.Render("⟡ "+colors.Always.Hyperlink(w.consoleURL, linkText)))
 	}
 
 	return renderLeftBracket(bracketStyle, strings.Join(parts, "\n"))

--- a/sdk/go/common/diag/colors/colors_test.go
+++ b/sdk/go/common/diag/colors/colors_test.go
@@ -140,3 +140,20 @@ func TestTrimColorizedString(t *testing.T) {
 	assert.Equal(t, uniseg.StringWidth("hello, world!!"), measureText(str))
 	assert.Equal(t, uniseg.StringWidth(Never.Colorize(str)), measureText(str))
 }
+
+func TestHyperlink(t *testing.T) {
+	t.Parallel()
+
+	// Pin the exact OSC 8 bytes so that dropping one of the escape terminators is caught here rather than
+	// as visible garbage in a terminal.
+	assert.Equal(t,
+		"\x1b]8;;https://example.com\x1b\\"+Always.Colorize(Underline+BrightBlue+"click me"+Reset)+"\x1b]8;;\x1b\\",
+		Always.Hyperlink("https://example.com", "click me"))
+	assert.Equal(t,
+		"\x1b]8;;https://example.com\x1b\\"+Underline+BrightBlue+"click me"+Reset+"\x1b]8;;\x1b\\",
+		Raw.Hyperlink("https://example.com", "click me"))
+	assert.Equal(t, "click me", Never.Hyperlink("https://example.com", "click me"))
+	// With no URL there is nothing to link to; an empty-target escape renders as a broken link in
+	// some terminals.
+	assert.Equal(t, "plain", Always.Hyperlink("", "plain"))
+}

--- a/sdk/go/common/diag/colors/diag.go
+++ b/sdk/go/common/diag/colors/diag.go
@@ -65,3 +65,16 @@ func TrimColorizedString(v string, maxWidth int) string {
 func MeasureColorizedString(v string) int {
 	return measureText(v)
 }
+
+// Hyperlink wraps displayText in an OSC 8 terminal hyperlink to url and styles it as a link, so
+// terminals that support it render displayText as a click target. Terminals without support show
+// the styled displayText. When colorization is disabled, or url is empty, displayText is returned
+// as-is.
+//
+// The wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
+func (c Colorization) Hyperlink(url, displayText string) string {
+	if disableColorization || c == Never || url == "" {
+		return displayText
+	}
+	return "\x1b]8;;" + url + "\x1b\\" + c.Colorize(Underline+BrightBlue+displayText+Reset) + "\x1b]8;;\x1b\\"
+}


### PR DESCRIPTION
Extract the Neo TUI's private `osc8Hyperlink` into the `colors` package so
other output paths can render terminal hyperlinks.