### PR TITLE
Show downstream stacks after updates and in `pulumi stack`

### DIFF
--- a/changelog/pending/20260831--cli--colors-hyperlink.yaml
+++ b/changelog/pending/20260831--cli--colors-hyperlink.yaml
@@ -1,4 +1,0 @@
-component: cli
-kind: improvement
-body: Style terminal hyperlinks in Neo output as links
-time: 2026-08-31T00:00:00Z

--- a/changelog/pending/20260831--cli--colors-hyperlink.yaml
+++ b/changelog/pending/20260831--cli--colors-hyperlink.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Style terminal hyperlinks in Neo output as links
+time: 2026-08-31T00:00:00Z

--- a/changelog/pending/20260831--cli--downstream-stacks.yaml
+++ b/changelog/pending/20260831--cli--downstream-stacks.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: List the stacks that reference the updated stack at the end of updates on Pulumi Cloud stacks
+time: 2026-08-31T00:00:00Z

--- a/pkg/backend/display/downstream.go
+++ b/pkg/backend/display/downstream.go
@@ -1,0 +1,90 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+const maxDownstreamStackLines = 5
+
+// FormatDownstreamStacks writes the "Downstream Stacks" summary section to w, colorized per
+// opts.Color. Nothing is written when refs is empty. consoleURL builds a console URL from path
+// segments.
+func FormatDownstreamStacks(
+	w io.Writer, refs []apitype.StackReference, consoleURL func(...string) string, opts Options,
+) {
+	if len(refs) == 0 {
+		return
+	}
+	noun := "Downstream Stacks"
+	if len(refs) == 1 {
+		noun = "Downstream Stack"
+	}
+	fmt.Fprint(w, opts.Color.Colorize(fmt.Sprintf("%s%s: (%d)%s\n", colors.SpecHeadline, noun, len(refs), colors.Reset)))
+	downstreamStackLines(w, refs, consoleURL, opts.Color, opts.IsInteractive)
+}
+
+// downstreamStackLines writes the section body. Interactive, colorized sessions get stacks
+// grouped per project, hyperlinked into the console; other sessions get one console URL per line
+// so the link survives in logs.
+func downstreamStackLines(
+	w io.Writer, refs []apitype.StackReference, consoleURL func(...string) string,
+	color colors.Colorization, interactive bool,
+) {
+	slices.SortFunc(refs, func(a, b apitype.StackReference) int {
+		return cmp.Or(
+			cmp.Compare(a.Organization, b.Organization),
+			cmp.Compare(a.RoutingProject, b.RoutingProject),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	written := 0
+	line := func(s string) {
+		fmt.Fprint(w, color.Colorize(s+"\n"))
+		written++
+	}
+	if interactive && color != colors.Never {
+		for i := 0; i < len(refs); {
+			if written == maxDownstreamStackLines {
+				line("    ...")
+				return
+			}
+			org, project := refs[i].Organization, refs[i].RoutingProject
+			var stacks []string
+			for ; i < len(refs) && refs[i].Organization == org && refs[i].RoutingProject == project; i++ {
+				stacks = append(stacks, color.Hyperlink(consoleURL(org, project, refs[i].Name), refs[i].Name))
+			}
+			line("    " + color.Hyperlink(consoleURL(org, project), org+"/"+project) + ": " + strings.Join(stacks, ", "))
+		}
+	} else {
+		for _, ref := range refs {
+			if written == maxDownstreamStackLines {
+				line("    ...")
+				return
+			}
+			url := consoleURL(ref.Organization, ref.RoutingProject, ref.Name)
+			line("    " + colors.Underline + colors.BrightBlue + url + colors.Reset)
+		}
+	}
+}

--- a/pkg/backend/display/downstream_test.go
+++ b/pkg/backend/display/downstream_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+func TestFormatDownstreamStacks(t *testing.T) {
+	t.Parallel()
+
+	consoleURL := func(paths ...string) string { return "https://console/" + strings.Join(paths, "/") }
+	format := func(refs []apitype.StackReference, opts Options) string {
+		var buf bytes.Buffer
+		FormatDownstreamStacks(&buf, refs, consoleURL, opts)
+		return buf.String()
+	}
+	ref := func(org, project, name string) apitype.StackReference {
+		return apitype.StackReference{Organization: org, RoutingProject: project, Name: name}
+	}
+	// Raw keeps color directives verbatim, so expectations stay readable.
+	raw := func(interactive bool) Options { return Options{Color: colors.Raw, IsInteractive: interactive} }
+	header := func(s string) string { return colors.SpecHeadline + s + colors.Reset + "\n" }
+	urlLine := func(s string) string {
+		return "    " + colors.Underline + colors.BrightBlue + "https://console/" + s + colors.Reset + "\n"
+	}
+	link := func(path, text string) string { return colors.Raw.Hyperlink("https://console/"+path, text) }
+
+	assert.Equal(t, "", format(nil, raw(true)))
+
+	// colors.Never renders a plain-text section, as used by `pulumi stack`.
+	assert.Equal(t,
+		"Downstream Stacks: (2)\n"+
+			"    https://console/org/net/dev\n"+
+			"    https://console/org/net/prod\n",
+		format([]apitype.StackReference{ref("org", "net", "prod"), ref("org", "net", "dev")},
+			Options{Color: colors.Never, IsInteractive: true}))
+
+	// Non-interactive output lists one console URL per stack.
+	assert.Equal(t,
+		header("Downstream Stack: (1)")+urlLine("org/net/dev"),
+		format([]apitype.StackReference{ref("org", "net", "dev")}, raw(false)))
+	assert.Equal(t,
+		header("Downstream Stacks: (6)")+
+			urlLine("org/net/a")+urlLine("org/net/b")+urlLine("org/net/c")+urlLine("org/net/d")+urlLine("org/net/e")+
+			"    ...\n",
+		format([]apitype.StackReference{
+			ref("org", "net", "a"), ref("org", "net", "b"), ref("org", "net", "c"),
+			ref("org", "net", "d"), ref("org", "net", "e"), ref("org", "net", "f"),
+		}, raw(false)))
+
+	// Interactive output groups by org/project, sorted, with hyperlinked names.
+	assert.Equal(t,
+		header("Downstream Stacks: (4)")+
+			"    "+link("org/app", "org/app")+": "+link("org/app/dev", "dev")+"\n"+
+			"    "+link("org/net", "org/net")+": "+link("org/net/dev", "dev")+", "+link("org/net/prod", "prod")+"\n"+
+			"    "+link("other/svc", "other/svc")+": "+link("other/svc/prod", "prod")+"\n",
+		format([]apitype.StackReference{
+			ref("org", "net", "prod"), ref("other", "svc", "prod"), ref("org", "net", "dev"), ref("org", "app", "dev"),
+		}, raw(true)))
+
+	// Interactive output truncates by project line.
+	assert.Equal(t,
+		header("Downstream Stacks: (6)")+
+			"    "+link("org/p1", "org/p1")+": "+link("org/p1/dev", "dev")+"\n"+
+			"    "+link("org/p2", "org/p2")+": "+link("org/p2/dev", "dev")+"\n"+
+			"    "+link("org/p3", "org/p3")+": "+link("org/p3/dev", "dev")+"\n"+
+			"    "+link("org/p4", "org/p4")+": "+link("org/p4/dev", "dev")+"\n"+
+			"    "+link("org/p5", "org/p5")+": "+link("org/p5/dev", "dev")+"\n"+
+			"    ...\n",
+		format([]apitype.StackReference{
+			ref("org", "p1", "dev"), ref("org", "p2", "dev"), ref("org", "p3", "dev"),
+			ref("org", "p4", "dev"), ref("org", "p5", "dev"), ref("org", "p6", "dev"),
+		}, raw(true)))
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2162,7 +2162,37 @@ func (b *cloudBackend) runEngineAction(
 		updateErr = result.MergeBails(updateErr, fmt.Errorf("failed to complete update: %w", completeErr))
 	}
 
+	if updateErr == nil && !op.Opts.Display.JSONDisplay && !op.Opts.Display.SummaryJSON {
+		opts := op.Opts.Display
+		if opts.Stdout == nil {
+			opts.Stdout = os.Stdout
+		}
+		b.printDownstreamStacks(ctx, update.StackIdentifier, opts)
+	}
+
 	return plan, changes, updateErr
+}
+
+// printDownstreamStacks lists the stacks that hold a stack reference to the updated stack, so the
+// user knows which stacks may need updating next. This output is advisory: failures to fetch the
+// list are logged and otherwise ignored.
+func (b *cloudBackend) printDownstreamStacks(
+	ctx context.Context, stackID client.StackIdentifier, opts display.Options,
+) {
+	resp, err := b.client.ListDownstreamStackReferences(ctx, stackID)
+	if err != nil {
+		logging.V(3).Infof("listing downstream stack references for %v: %v", stackID, err)
+		return
+	}
+	if len(resp.ReferencedStacks) == 0 {
+		return
+	}
+	// The progress display ends its summary with a blank line; the diff display does not.
+	if opts.Type == display.DisplayDiff {
+		fmt.Fprint(opts.Stdout, "\n")
+	}
+	display.FormatDownstreamStacks(opts.Stdout, resp.ReferencedStacks, b.CloudConsoleURL, opts)
+	fmt.Fprint(opts.Stdout, "\n")
 }
 
 func (b *cloudBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -958,6 +958,17 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 	return stack, nil
 }
 
+// ListDownstreamStackReferences returns the stacks whose programs hold a stack reference to the given stack.
+func (pc *Client) ListDownstreamStackReferences(
+	ctx context.Context, stackID StackIdentifier,
+) (apitype.ListDownstreamStackReferencesResponse, error) {
+	var resp apitype.ListDownstreamStackReferencesResponse
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "downstreamreferences"), nil, nil, &resp); err != nil {
+		return apitype.ListDownstreamStackReferencesResponse{}, err
+	}
+	return resp, nil
+}
+
 // ListDriftRuns returns a paginated list of drift detection runs for the given stack.
 func (pc *Client) ListDriftRuns(
 	ctx context.Context, stackID StackIdentifier, page, pageSize int,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -2165,3 +2165,27 @@ func TestClientInsecure(t *testing.T) {
 	assert.True(t, NewClient("https://api.example.com", "tok", true, nil).Insecure())
 	assert.False(t, NewClient("https://api.example.com", "tok", false, nil).Insecure())
 }
+
+func TestListDownstreamStackReferences(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		_, err := rw.Write([]byte(`{"referencedStacks":[` +
+			`{"organization":"org","routingProject":"consumer","name":"prod","version":7}]}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	resp, err := NewClient(server.URL, "", true, nil).ListDownstreamStackReferences(t.Context(), StackIdentifier{
+		Owner: "org", Project: "proj", Stack: tokens.MustParseStackName("dev"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/api/stacks/org/proj/dev/downstreamreferences", gotPath)
+	assert.Equal(t, apitype.ListDownstreamStackReferencesResponse{
+		ReferencedStacks: []apitype.StackReference{
+			{Organization: "org", RoutingProject: "consumer", Name: "prod", Version: 7},
+		},
+	}, resp)
+}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 // ctrlCArmTimeout is how long the "press Ctrl+C again to exit" gate stays
@@ -1111,7 +1112,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// CreateNeoTask sends UISessionURL immediately after taskID is set,
 		// so this is the natural moment to lift the post-Enter toggle freeze.
 		m.taskCreated = true
-		cmds = append(cmds, m.printlnBlock("  "+inputHintStyle.Render("⟡ "+osc8Hyperlink(msg.URL, msg.URL))))
+		cmds = append(cmds, m.printlnBlock("  "+inputHintStyle.Render("⟡ "+colors.Always.Hyperlink(msg.URL, msg.URL))))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIUserMessage:

--- a/pkg/cmd/pulumi/neo/tui_links.go
+++ b/pkg/cmd/pulumi/neo/tui_links.go
@@ -17,20 +17,9 @@ package neo
 import (
 	"regexp"
 	"strings"
-)
 
-// osc8Hyperlink wraps displayText as a clickable hyperlink to url using the
-// OSC 8 escape sequence. Terminals that support OSC 8 render displayText as
-// a click target; terminals that don't strip the escapes and show displayText
-// as plain text.
-//
-// The wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
-func osc8Hyperlink(url, displayText string) string {
-	if url == "" {
-		return displayText
-	}
-	return "\x1b]8;;" + url + "\x1b\\" + displayText + "\x1b]8;;\x1b\\"
-}
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
 
 // urlPattern matches bare http/https URLs in text. It excludes whitespace,
 // ANSI escape (so we never split a URL across an escape boundary), and
@@ -38,10 +27,10 @@ func osc8Hyperlink(url, displayText string) string {
 var urlPattern = regexp.MustCompile(`https?://[^\s\x1b<>"']+`)
 
 // osc8Pattern matches a complete OSC 8 hyperlink sequence — the opener with
-// its URL, the visible text, and the closer. linkifyURLs uses it to skip
+// its URL, the visible text (which may carry SGR styling), and the closer. linkifyURLs uses it to skip
 // past existing hyperlinks rather than re-wrapping URLs that are already
 // clickable.
-var osc8Pattern = regexp.MustCompile(`\x1b\]8;;[^\x1b]*\x1b\\[^\x1b]*\x1b\]8;;\x1b\\`)
+var osc8Pattern = regexp.MustCompile(`\x1b\]8;;[^\x1b]*\x1b\\(?:[^\x1b]|\x1b\[[0-9;]*m)*\x1b\]8;;\x1b\\`)
 
 // urlAlwaysStripPunct lists characters we unconditionally strip from the tail
 // of a matched URL — they're sentence punctuation that practically never
@@ -91,7 +80,7 @@ func linkifyPlain(s string) string {
 		if match == "" {
 			return trail
 		}
-		return osc8Hyperlink(match, match) + trail
+		return colors.Always.Hyperlink(match, match) + trail
 	})
 }
 

--- a/pkg/cmd/pulumi/neo/tui_links_test.go
+++ b/pkg/cmd/pulumi/neo/tui_links_test.go
@@ -19,34 +19,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
-
-func TestOSC8Hyperlink_WrapsURL(t *testing.T) {
-	t.Parallel()
-
-	got := osc8Hyperlink("https://example.com", "click me")
-	// The OSC 8 wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
-	// Pinning the exact bytes here so a refactor that drops one of the escape
-	// terminators (a common mistake) gets caught immediately rather than
-	// silently producing visible garbage in scrollback.
-	assert.Equal(t, "\x1b]8;;https://example.com\x1b\\click me\x1b]8;;\x1b\\", got)
-}
-
-func TestOSC8Hyperlink_EmptyURLPassesText(t *testing.T) {
-	t.Parallel()
-
-	// With no URL we have nothing to hyperlink to — return the display text
-	// unchanged rather than emitting an empty-target escape, which some
-	// terminals render as a broken link.
-	assert.Equal(t, "plain", osc8Hyperlink("", "plain"))
-}
 
 func TestLinkifyURLs_WrapsBareURL(t *testing.T) {
 	t.Parallel()
 
 	got := linkifyURLs("see https://example.com for details")
-	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\")
-	assert.Contains(t, got, "https://example.com\x1b]8;;\x1b\\")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://example.com", "https://example.com"))
 	assert.Contains(t, got, "for details")
 }
 
@@ -57,7 +38,7 @@ func TestLinkifyURLs_StripsTrailingPunctuation(t *testing.T) {
 	// "see https://example.com." should hyperlink "https://example.com" and
 	// leave the period outside, otherwise clicking opens the wrong URL.
 	got := linkifyURLs("see https://example.com.")
-	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\.")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://example.com", "https://example.com")+".")
 	assert.NotContains(t, got, "https://example.com.\x1b\\", "period must not be inside the hyperlink target")
 }
 
@@ -68,7 +49,7 @@ func TestLinkifyURLs_HandlesParenthesizedURL(t *testing.T) {
 	// The trailing ")" belongs to the surrounding prose, not the URL, so it
 	// must land outside the hyperlink — otherwise terminals try to open
 	// "example.com)" which 404s.
-	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\)")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://example.com", "https://example.com")+")")
 }
 
 func TestLinkifyURLs_WrapsMultipleURLs(t *testing.T) {
@@ -87,10 +68,10 @@ func TestLinkifyURLs_LeavesExistingOSC8Alone(t *testing.T) {
 	t.Parallel()
 
 	// If the text is already a hyperlink (e.g. the welcome banner already ran
-	// it through osc8Hyperlink) we must not add a second pair of escapes —
+	// it through colors.Hyperlink) we must not add a second pair of escapes —
 	// nested OSC 8 sequences confuse some terminals into rendering nothing
 	// clickable at all.
-	already := osc8Hyperlink("https://example.com", "https://example.com")
+	already := colors.Always.Hyperlink("https://example.com", "https://example.com")
 	got := linkifyURLs(already)
 	assert.Equal(t, already, got)
 }
@@ -101,14 +82,14 @@ func TestLinkifyURLs_MixesPlainAndExisting(t *testing.T) {
 	// A line containing a pre-wrapped URL plus a bare URL should end up with
 	// the pre-wrapped one untouched and the bare one freshly wrapped — two
 	// hyperlinks total, not three (no double-wrapping).
-	already := osc8Hyperlink("https://a.example", "a")
+	already := colors.Always.Hyperlink("https://a.example", "a")
 	input := already + " then https://b.example"
 	got := linkifyURLs(input)
 	// Two complete hyperlinks = 4 `\x1b]8;;` occurrences (each has an opener
 	// and a closer). If linkify re-wrapped the existing one we'd see 6.
 	assert.Equal(t, 4, strings.Count(got, "\x1b]8;;"))
 	assert.Contains(t, got, already)
-	assert.Contains(t, got, "\x1b]8;;https://b.example\x1b\\https://b.example\x1b]8;;\x1b\\")
+	assert.Contains(t, got, colors.Always.Hyperlink("https://b.example", "https://b.example"))
 }
 
 func TestLinkifyURLs_NoURLs(t *testing.T) {
@@ -129,11 +110,10 @@ func TestLinkifyURLs_EmptyString(t *testing.T) {
 
 // hyperlink is a test helper that builds the exact OSC 8 envelope we expect
 // linkifyURLs to emit for a given target URL and display text. Pinning the
-// full byte sequence in each assertion catches regressions where one of the
-// escape terminators gets dropped — a common refactor mistake that produces
-// visible garbage rather than a silent wrong-link bug.
+// full sequence in each assertion catches regressions where linkify wraps the
+// wrong span or drops part of the envelope.
 func hyperlink(target, display string) string {
-	return "\x1b]8;;" + target + "\x1b\\" + display + "\x1b]8;;\x1b\\"
+	return colors.Always.Hyperlink(target, display)
 }
 
 func TestLinkifyURLs_PreservesBalancedTrailingParens(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_welcome.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 )
 
 //go:embed neo.ans
@@ -146,7 +148,7 @@ func (w welcomeModel) View() string {
 		if len([]rune(linkText)) > maxLink && maxLink > 3 {
 			linkText = string([]rune(linkText)[:maxLink-3]) + "..."
 		}
-		parts = append(parts, dim.Render("⟡ "+osc8Hyperlink(w.consoleURL, linkText)))
+		parts = append(parts, dim.Render("⟡ "+colors.Always.Hyperlink(w.consoleURL, linkText)))
 	}
 
 	return renderLeftBracket(bracketStyle, strings.Join(parts, "\n"))

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -243,6 +245,9 @@ func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stac
 	}
 
 	if isCloud {
+		if cs, ok := s.(httpstate.Stack); ok {
+			fprintDownstreamStacks(ctx, out, cloudBe, cs)
+		}
 		if consoleURL, err := cloudBe.StackConsoleURL(s.Ref()); err == nil {
 			fmt.Fprintf(out, "\n")
 			fmt.Fprintf(out, "More information at: %s\n", consoleURL)
@@ -254,6 +259,22 @@ func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stac
 	fmt.Fprintf(out, "Use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones\n")
 
 	return nil
+}
+
+// fprintDownstreamStacks prints the stacks that hold a stack reference to the given stack, if any.
+// This section is advisory: failures to fetch the list are logged and otherwise ignored.
+func fprintDownstreamStacks(ctx context.Context, out io.Writer, be httpstate.Backend, s httpstate.Stack) {
+	resp, err := be.Client().ListDownstreamStackReferences(ctx, s.StackIdentifier())
+	if err != nil {
+		slog.WarnContext(ctx, "listing downstream stack references failed", "stack", s.StackIdentifier(), "err", err)
+		return
+	}
+	if len(resp.ReferencedStacks) == 0 {
+		return
+	}
+	consoleURL := func(paths ...string) string { return client.CloudConsoleURL(be.CloudURL(), paths...) }
+	fmt.Fprintf(out, "\n")
+	display.FormatDownstreamStacks(out, resp.ReferencedStacks, consoleURL, display.Options{Color: colors.Never})
 }
 
 func fprintStackOutputs(w io.Writer, outputs map[string]any) error {

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -139,3 +139,20 @@ type ImportStackRequest UntypedDeployment
 type ImportStackResponse struct {
 	UpdateID string `json:"updateId"`
 }
+
+// StackReference identifies a stack that is related to another stack by a stack reference.
+type StackReference struct {
+	// Organization is the organization that owns the stack.
+	Organization string `json:"organization"`
+	// RoutingProject is the project name used to route to the stack.
+	RoutingProject string `json:"routingProject"`
+	// Name is the name of the stack.
+	Name string `json:"name"`
+	// Version is the version of the referenced stack at the time it was referenced.
+	Version int `json:"version"`
+}
+
+// ListDownstreamStackReferencesResponse lists the stacks whose programs reference a given stack.
+type ListDownstreamStackReferencesResponse struct {
+	ReferencedStacks []StackReference `json:"referencedStacks"`
+}

--- a/sdk/go/common/diag/colors/colors_test.go
+++ b/sdk/go/common/diag/colors/colors_test.go
@@ -140,3 +140,20 @@ func TestTrimColorizedString(t *testing.T) {
 	assert.Equal(t, uniseg.StringWidth("hello, world!!"), measureText(str))
 	assert.Equal(t, uniseg.StringWidth(Never.Colorize(str)), measureText(str))
 }
+
+func TestHyperlink(t *testing.T) {
+	t.Parallel()
+
+	// Pin the exact OSC 8 bytes so that dropping one of the escape terminators is caught here rather than
+	// as visible garbage in a terminal.
+	assert.Equal(t,
+		"\x1b]8;;https://example.com\x1b\\"+Always.Colorize(Underline+BrightBlue+"click me"+Reset)+"\x1b]8;;\x1b\\",
+		Always.Hyperlink("https://example.com", "click me"))
+	assert.Equal(t,
+		"\x1b]8;;https://example.com\x1b\\"+Underline+BrightBlue+"click me"+Reset+"\x1b]8;;\x1b\\",
+		Raw.Hyperlink("https://example.com", "click me"))
+	assert.Equal(t, "click me", Never.Hyperlink("https://example.com", "click me"))
+	// With no URL there is nothing to link to; an empty-target escape renders as a broken link in
+	// some terminals.
+	assert.Equal(t, "plain", Always.Hyperlink("", "plain"))
+}

--- a/sdk/go/common/diag/colors/diag.go
+++ b/sdk/go/common/diag/colors/diag.go
@@ -65,3 +65,16 @@ func TrimColorizedString(v string, maxWidth int) string {
 func MeasureColorizedString(v string) int {
 	return measureText(v)
 }
+
+// Hyperlink wraps displayText in an OSC 8 terminal hyperlink to url and styles it as a link, so
+// terminals that support it render displayText as a click target. Terminals without support show
+// the styled displayText. When colorization is disabled, or url is empty, displayText is returned
+// as-is.
+//
+// The wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
+func (c Colorization) Hyperlink(url, displayText string) string {
+	if disableColorization || c == Never || url == "" {
+		return displayText
+	}
+	return "\x1b]8;;" + url + "\x1b\\" + c.Colorize(Underline+BrightBlue+displayText+Reset) + "\x1b]8;;\x1b\\"
+}


### PR DESCRIPTION
Stacks on Pulumi Cloud now list the stacks that hold a stack reference to them, so users know what may need updating next:

```console
𝛌 pulumi preview
Previewing update (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/pulumi/ian-test-python/dev/previews/e7574117-c36e-4c84-89d3-a09ada4cac04

     Type                 Name                 Plan     Info
     pulumi:pulumi:Stack  ian-test-python-dev           3 warnings

Policies:
    ✅ pulumi-internal-policies@v0.0.7

Diagnostics:
  pulumi:pulumi:Stack (ian-test-python-dev):

Resources:
    2 unchanged

Downstream Stacks: (2)
    [pulumi/ian-hcl-dev](https://app.pulumi.com/pulumi/ian-hcl-dev): [test](https://app.pulumi.com/pulumi/ian-hcl-dev/test)
    [pulumi/ts](https://app.pulumi.com/pulumi/ts): [dev](https://app.pulumi.com/pulumi/ts/dev)
```

(links are rendered)

<img width="1213" height="679" alt="Screenshot 2026-08-31 at 5 01 03 PM" src="https://github.com/user-attachments/assets/aed02914-0370-48fc-9ca4-6972f170481b" />
