### PR TITLE
Add Go state migration callbacks

### DIFF
--- a/changelog/pending/sdk-go-feat-state-migrations.yaml
+++ b/changelog/pending/sdk-go-feat-state-migrations.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: feat
+body: Add component state migration callbacks to resource options
+time: 2026-08-31T08:42:59+02:00

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -82,6 +82,7 @@ type contextState struct {
 	supportsResourceHooks    bool         // true if resource hooks are supported by pulumi
 	supportsErrorHooks       bool         // true if error hooks are supported by pulumi
 	supportsInvokeDependsOn  bool         // true if the monitor gates invokes on their declared dependencies.
+	supportsStateMigrations  bool         // true if state migrations are supported by pulumi
 	rpcs                     int          // the number of outstanding RPC requests.
 	rpcsDone                 *sync.Cond   // an event signaling completion of RPCs.
 	rpcsLock                 sync.Mutex   // a lock protecting the RPC count and event.
@@ -189,6 +190,7 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 		supportsResourceHooks:    has(pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS),
 		supportsErrorHooks:       has(pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_ERROR_HOOKS),
 		supportsInvokeDependsOn:  has(pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_INVOKE_DEPENDS_ON),
+		supportsStateMigrations:  has(pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_STATE_MIGRATIONS),
 		registeredOutputs:        make(map[URN]bool),
 	}
 	contextState.rpcsDone = sync.NewCond(&contextState.rpcsLock)
@@ -1856,6 +1858,17 @@ func (ctx *Context) registerResource(
 			transforms = append(transforms, cb)
 		}
 
+		// Register the state migration functions.
+		stateMigrations := make([]*pulumirpc.Callback, 0, len(options.StateMigrations))
+		for _, migration := range options.StateMigrations {
+			var cb *pulumirpc.Callback
+			cb, err = ctx.registerStateMigration(migration)
+			if err != nil {
+				return
+			}
+			stateMigrations = append(stateMigrations, cb)
+		}
+
 		// Collect all the hooks, waiting for their registrations.
 		var hooks *pulumirpc.RegisterResourceRequest_ResourceHooksBinding
 		if options.Hooks != nil {
@@ -1940,6 +1953,7 @@ func (ctx *Context) registerResource(
 				SourcePosition:             sourcePosition,
 				StackTrace:                 stackTrace,
 				Transforms:                 transforms,
+				StateMigrations:            stateMigrations,
 				SupportsResultReporting:    true,
 				PackageRef:                 packageRef,
 				Hooks:                      hooks,

--- a/sdk/go/pulumi/mocks.go
+++ b/sdk/go/pulumi/mocks.go
@@ -206,6 +206,7 @@ func (m *mockMonitor) GetDeploymentInfo(ctx context.Context, in *emptypb.Empty,
 		pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_PARAMETERIZATION,
 		pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_RESOURCE_HOOKS,
 		pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_ERROR_HOOKS,
+		pulumirpc.ResourceMonitorFeature_RESOURCE_MONITOR_FEATURE_STATE_MIGRATIONS,
 	}
 
 	return &pulumirpc.DeploymentInfo{

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -519,6 +519,10 @@ type ResourceOptions struct {
 	// the resource's properties during construction.
 	Transforms []ResourceTransform
 
+	// StateMigrations is a list of functions that migrate the resource's prior
+	// state before the engine compares it with the current resource graph.
+	StateMigrations []StateMigration
+
 	// URN is the URN of a previously-registered resource of this type.
 	URN string
 
@@ -583,6 +587,7 @@ type resourceOptions struct {
 	ReplacementTrigger      Input
 	Transformations         []ResourceTransformation
 	Transforms              []ResourceTransform
+	StateMigrations         []StateMigration
 	URN                     string
 	Version                 string
 	PluginDownloadURL       string
@@ -652,6 +657,7 @@ func resourceOptionsSnapshot(ro *resourceOptions) *ResourceOptions {
 		ReplacementTrigger:      ro.ReplacementTrigger,
 		Transformations:         ro.Transformations,
 		Transforms:              ro.Transforms,
+		StateMigrations:         ro.StateMigrations,
 		URN:                     ro.URN,
 		Version:                 ro.Version,
 		PluginDownloadURL:       ro.PluginDownloadURL,
@@ -1106,6 +1112,13 @@ func Transformations(o []ResourceTransformation) ResourceOption {
 func Transforms(o []ResourceTransform) ResourceOption {
 	return resourceOption(func(ro *resourceOptions) {
 		ro.Transforms = append(ro.Transforms, o...)
+	})
+}
+
+// StateMigrations applies an ordered list of state migrations to the prior state of this resource and its descendants.
+func StateMigrations(o []StateMigration) ResourceOption {
+	return resourceOption(func(ro *resourceOptions) {
+		ro.StateMigrations = append(ro.StateMigrations, o...)
 	})
 }
 

--- a/sdk/go/pulumi/state_migration.go
+++ b/sdk/go/pulumi/state_migration.go
@@ -1,0 +1,117 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/protobuf/proto"
+)
+
+// StateMigrationArgs contains the prior checkpoint state passed to a state migration callback.
+type StateMigrationArgs struct {
+	// URN is the current-program URN of the resource the migration is attached to.
+	URN URN
+	// OldState contains the prior state of the resource followed by all resources transitively parented to it.
+	OldState []map[string]any
+}
+
+// StateMigrationResult is returned by a state migration callback when it changes the state.
+type StateMigrationResult struct {
+	// NewState replaces the complete prior subtree supplied in StateMigrationArgs.OldState.
+	NewState []map[string]any
+	// Successors maps each omitted prior resource URN to a resource URN present in NewState.
+	Successors map[string]string
+}
+
+// StateMigration is the callback signature for the StateMigrations resource option.
+//
+// A migration receives the prior checkpoint state of the resource it is attached to and all resources transitively
+// parented to it. It may return a transformed state that the engine splices into its view of prior state before
+// diffing. Returning a nil result leaves the state unchanged. Migrations run during normal updates when prior state
+// exists and must be idempotent.
+//
+// Secret values are supplied in plaintext inside their secret envelopes. The callback must only transform the
+// supplied state: it must not perform Pulumi runtime operations or wait for unresolved Outputs. Every resource omitted
+// from NewState must identify a returned successor, and provider resource states must be returned unchanged.
+type StateMigration func(context.Context, *StateMigrationArgs) (*StateMigrationResult, error)
+
+// registerStateMigration starts the callback server if necessary and registers the given migration function.
+func (ctx *Context) registerStateMigration(migration StateMigration) (*pulumirpc.Callback, error) {
+	if !ctx.state.supportsStateMigrations {
+		return nil, errors.New("the Pulumi CLI does not support state migrations. Please update the Pulumi CLI")
+	}
+
+	callback := func(innerCtx context.Context, request []byte) (proto.Message, error) {
+		var rpcRequest pulumirpc.StateMigrationRequest
+		if err := proto.Unmarshal(request, &rpcRequest); err != nil {
+			return nil, fmt.Errorf("unmarshaling state migration request: %w", err)
+		}
+
+		decoder := json.NewDecoder(bytes.NewReader(rpcRequest.GetOldState()))
+		decoder.UseNumber()
+		var oldState []map[string]any
+		if err := decoder.Decode(&oldState); err != nil {
+			return nil, fmt.Errorf("unmarshaling state migration old state: %w", err)
+		}
+
+		result, err := migration(innerCtx, &StateMigrationArgs{
+			URN:      URN(rpcRequest.GetUrn()),
+			OldState: oldState,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			return &pulumirpc.StateMigrationResponse{}, nil
+		}
+
+		newState, err := json.Marshal(result.NewState)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling state migration new state: %w", err)
+		}
+		return &pulumirpc.StateMigrationResponse{
+			NewState:   newState,
+			Successors: result.Successors,
+		}, nil
+	}
+
+	err := func() error {
+		ctx.state.callbacksLock.Lock()
+		defer ctx.state.callbacksLock.Unlock()
+		if ctx.state.callbacks == nil {
+			callbacks, err := newCallbackServer()
+			if err != nil {
+				return fmt.Errorf("creating callback server: %w", err)
+			}
+			ctx.state.callbacks = callbacks
+		}
+		return nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	registered, err := ctx.state.callbacks.RegisterCallback(callback)
+	if err != nil {
+		return nil, fmt.Errorf("registering callback: %w", err)
+	}
+	return registered, nil
+}

--- a/sdk/go/pulumi/state_migration_test.go
+++ b/sdk/go/pulumi/state_migration_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func TestStateMigrationCallback(t *testing.T) {
+	t.Parallel()
+
+	const (
+		componentURN = "urn:pulumi:stack::project::example:index:Component::component"
+		oldChildURN  = componentURN + "$example:index:Old::child"
+		newChildURN  = componentURN + "$example:index:New::child"
+		oldStateJSON = `[
+			{"urn":"` + componentURN + `","type":"example:index:Component"},
+			{"urn":"` + oldChildURN + `","type":"example:index:Old","outputs":{"large":9007199254740993}}
+		]`
+	)
+
+	callbacks := &callbackServer{functions: map[string]callbackFunction{}}
+	ctx := &Context{state: &contextState{
+		supportsStateMigrations: true,
+		callbacks:               callbacks,
+	}}
+
+	migration, err := ctx.registerStateMigration(func(
+		_ context.Context, args *StateMigrationArgs,
+	) (*StateMigrationResult, error) {
+		assert.Equal(t, URN(componentURN), args.URN)
+		assert.Equal(t, json.Number("9007199254740993"), args.OldState[1]["outputs"].(map[string]any)["large"])
+
+		args.OldState[1]["urn"] = newChildURN
+		args.OldState[1]["type"] = "example:index:New"
+		return &StateMigrationResult{
+			NewState: args.OldState,
+			Successors: map[string]string{
+				oldChildURN: newChildURN,
+			},
+		}, nil
+	})
+	require.NoError(t, err)
+
+	request, err := proto.Marshal(&pulumirpc.StateMigrationRequest{
+		Urn:      componentURN,
+		OldState: []byte(oldStateJSON),
+	})
+	require.NoError(t, err)
+
+	response, err := callbacks.Invoke(t.Context(), &pulumirpc.CallbackInvokeRequest{
+		Token:   migration.Token,
+		Request: request,
+	})
+	require.NoError(t, err)
+
+	var migrationResponse pulumirpc.StateMigrationResponse
+	require.NoError(t, proto.Unmarshal(response.Response, &migrationResponse))
+	assert.Contains(t, string(migrationResponse.NewState), "9007199254740993")
+	assert.Equal(t, map[string]string{oldChildURN: newChildURN}, migrationResponse.Successors)
+
+	var newState []map[string]any
+	require.NoError(t, json.Unmarshal(migrationResponse.NewState, &newState))
+	assert.Equal(t, newChildURN, newState[1]["urn"])
+}
+
+func TestStateMigrationCallbackNoop(t *testing.T) {
+	t.Parallel()
+
+	callbacks := &callbackServer{functions: map[string]callbackFunction{}}
+	ctx := &Context{state: &contextState{
+		supportsStateMigrations: true,
+		callbacks:               callbacks,
+	}}
+	migration, err := ctx.registerStateMigration(func(
+		context.Context, *StateMigrationArgs,
+	) (*StateMigrationResult, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	request, err := proto.Marshal(&pulumirpc.StateMigrationRequest{OldState: []byte("[]")})
+	require.NoError(t, err)
+	response, err := callbacks.Invoke(t.Context(), &pulumirpc.CallbackInvokeRequest{
+		Token:   migration.Token,
+		Request: request,
+	})
+	require.NoError(t, err)
+
+	var migrationResponse pulumirpc.StateMigrationResponse
+	require.NoError(t, proto.Unmarshal(response.Response, &migrationResponse))
+	assert.Empty(t, migrationResponse.NewState)
+	assert.Empty(t, migrationResponse.Successors)
+}
+
+func TestStateMigrationRequiresFeatureSupport(t *testing.T) {
+	t.Parallel()
+
+	ctx := &Context{state: &contextState{}}
+	_, err := ctx.registerStateMigration(func(
+		context.Context, *StateMigrationArgs,
+	) (*StateMigrationResult, error) {
+		return nil, nil
+	})
+	require.ErrorContains(t, err, "does not support state migrations")
+}
+
+func TestStateMigrationsResourceOption(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	first := func(context.Context, *StateMigrationArgs) (*StateMigrationResult, error) {
+		calls = append(calls, "first")
+		return nil, nil
+	}
+	second := func(context.Context, *StateMigrationArgs) (*StateMigrationResult, error) {
+		calls = append(calls, "second")
+		return nil, nil
+	}
+
+	opts, err := NewResourceOptions(
+		StateMigrations([]StateMigration{first}),
+		StateMigrations([]StateMigration{second}),
+	)
+	require.NoError(t, err)
+	require.Len(t, opts.StateMigrations, 2)
+	for _, migration := range opts.StateMigrations {
+		_, err := migration(t.Context(), &StateMigrationArgs{})
+		require.NoError(t, err)
+	}
+	assert.Equal(t, []string{"first", "second"}, calls)
+}
+
+func TestStateMigrationsSentWithRegistration(t *testing.T) {
+	t.Parallel()
+
+	var registered []*pulumirpc.Callback
+	mocks := &testMonitor{
+		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+			if args.Name == "component" {
+				registered = args.RegisterRPC.GetStateMigrations()
+			}
+			return args.Name, resource.PropertyMap{}, nil
+		},
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		ctx.state.callbacks = &callbackServer{functions: map[string]callbackFunction{}}
+		var component testComp
+		return ctx.RegisterComponentResource(
+			"example:index:Component",
+			"component",
+			&component,
+			StateMigrations([]StateMigration{
+				func(context.Context, *StateMigrationArgs) (*StateMigrationResult, error) {
+					return nil, nil
+				},
+			}),
+		)
+	}, WithMocks("project", "stack", mocks))
+	require.NoError(t, err)
+	require.Len(t, registered, 1)
+	assert.NotEmpty(t, registered[0].GetToken())
+}


### PR DESCRIPTION
State migrations let components evolve their internal resource structure while preserving existing infrastructure. Callbacks transform the recorded state of a resource and its descendants before the engine computes the update, allowing resources to be renamed, moved, or reorganized without unnecessary replacements.

Callbacks run in order during updates and previews, with engine validation to preserve resource identity and references.

[Draft developer docs on how migrations work](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html)

Ref https://github.com/pulumi/pulumi/issues/24045