### PR TITLE
deployment settings: fix the patches `edit` builds for clearing and for the executor image

### DIFF
--- a/changelog/pending/cli-deployment-fix-20260811-120400.yaml
+++ b/changelog/pending/cli-deployment-fix-20260811-120400.yaml
@@ -1,0 +1,4 @@
+component: cli/deployment
+kind: fix
+body: "Stop `pulumi deployment settings edit` clearing settings it was not asked to change, let `--branch` and `--commit` replace one another rather than be combined, and reject `--oidc-*-clear=false` instead of ignoring it"
+time: 2026-08-11T12:04:00+00:00

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -136,12 +136,12 @@ const (
 	flagOIDCAWSSessionName = "oidc-aws-session-name"
 	flagOIDCAWSDuration    = "oidc-aws-duration"
 	flagOIDCAWSPolicyARN   = "oidc-aws-policy-arn"
-	flagOIDCAWSClear       = "oidc-aws-clear"
+	flagRemoveOIDCAWS      = "remove-oidc-aws"
 
 	flagOIDCAzureClientID       = "oidc-azure-client-id"
 	flagOIDCAzureTenantID       = "oidc-azure-tenant-id"
 	flagOIDCAzureSubscriptionID = "oidc-azure-subscription-id"
-	flagOIDCAzureClear          = "oidc-azure-clear"
+	flagRemoveOIDCAzure         = "remove-oidc-azure"
 
 	flagOIDCGCPProjectNumber  = "oidc-gcp-project-number"
 	flagOIDCGCPWorkloadPoolID = "oidc-gcp-workload-pool-id" //nolint:gosec // flag name, not a credential
@@ -149,8 +149,17 @@ const (
 	flagOIDCGCPServiceAccount = "oidc-gcp-service-account"
 	flagOIDCGCPRegion         = "oidc-gcp-region"
 	flagOIDCGCPTokenLifetime  = "oidc-gcp-token-lifetime" //nolint:gosec // flag name, not a credential
-	flagOIDCGCPClear          = "oidc-gcp-clear"
+	flagRemoveOIDCGCP         = "remove-oidc-gcp"
 )
+
+// deprecatedEditFlags maps a flag to the superseded spelling that still works. Both spellings write
+// the same variable and flagsChanged resolves one to the other, so the rest of the command only ever
+// names the current flag.
+var deprecatedEditFlags = map[string]string{
+	flagRemoveOIDCAWS:   "oidc-aws-clear",
+	flagRemoveOIDCAzure: "oidc-azure-clear",
+	flagRemoveOIDCGCP:   "oidc-gcp-clear",
+}
 
 func newDeploymentSettingsEditCmd() *cobra.Command {
 	return newDeploymentSettingsEditCmdWith(defaultDeploymentSettingsEditClientFactory)
@@ -181,13 +190,19 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 			"    --oidc-aws-role-arn arn:aws:iam::123:role/pulumi-deploy \\\n" +
 			"    --oidc-aws-session-name pulumi-deploy --oidc-aws-duration 30m\n\n" +
 			"  # Remove the AWS OIDC configuration entirely.\n" +
-			"  pulumi deployment settings edit --oidc-aws-clear\n\n" +
+			"  pulumi deployment settings edit --remove-oidc-aws\n\n" +
 			"  # Clear the agent pool back to the Pulumi-hosted default.\n" +
 			"  pulumi deployment settings edit --runner-pool \"\"\n\n" +
 			"  # Clear the pre-run command list.\n" +
 			"  pulumi deployment settings edit --pre-run-command \"\"",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			args.flagsChanged = cmd.Flags().Changed
+			args.flagsChanged = func(name string) bool {
+				if cmd.Flags().Changed(name) {
+					return true
+				}
+				deprecated, ok := deprecatedEditFlags[name]
+				return ok && cmd.Flags().Changed(deprecated)
+			}
 			return runDeploymentSettingsEdit(cmd.Context(), cmd.OutOrStdout(), factory, args)
 		},
 	}
@@ -249,8 +264,8 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 		"AWS OIDC: assume-role session duration (e.g. 30m, 1h)")
 	f.StringSliceVar(&args.oidcAWSPolicyARNs, flagOIDCAWSPolicyARN, nil,
 		"AWS OIDC: replace the session policy ARN list (repeatable or comma-separated)")
-	f.BoolVar(&args.oidcAWSClear, flagOIDCAWSClear, false,
-		"Remove the entire AWS OIDC configuration")
+	f.BoolVar(&args.oidcAWSClear, flagRemoveOIDCAWS, false,
+		"AWS OIDC: remove the entire configuration")
 
 	// OIDC — Azure
 	f.StringVar(&args.oidcAzureClientID, flagOIDCAzureClientID, "",
@@ -259,8 +274,8 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 		"Azure OIDC: federated workload identity tenant ID")
 	f.StringVar(&args.oidcAzureSubscriptionID, flagOIDCAzureSubscriptionID, "",
 		"Azure OIDC: federated workload identity subscription ID")
-	f.BoolVar(&args.oidcAzureClear, flagOIDCAzureClear, false,
-		"Remove the entire Azure OIDC configuration")
+	f.BoolVar(&args.oidcAzureClear, flagRemoveOIDCAzure, false,
+		"Azure OIDC: remove the entire configuration")
 
 	// OIDC — GCP
 	f.StringVar(&args.oidcGCPProjectNumber, flagOIDCGCPProjectNumber, "",
@@ -275,8 +290,15 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 		"GCP OIDC: region")
 	f.StringVar(&args.oidcGCPTokenLifetime, flagOIDCGCPTokenLifetime, "",
 		"GCP OIDC: lifetime of the temporary credentials (e.g. 30m, 1h)")
-	f.BoolVar(&args.oidcGCPClear, flagOIDCGCPClear, false,
-		"Remove the entire GCP OIDC configuration")
+	f.BoolVar(&args.oidcGCPClear, flagRemoveOIDCGCP, false,
+		"GCP OIDC: remove the entire configuration")
+
+	f.BoolVar(&args.oidcAWSClear, deprecatedEditFlags[flagRemoveOIDCAWS], false, "")
+	f.BoolVar(&args.oidcAzureClear, deprecatedEditFlags[flagRemoveOIDCAzure], false, "")
+	f.BoolVar(&args.oidcGCPClear, deprecatedEditFlags[flagRemoveOIDCGCP], false, "")
+	for current, deprecated := range deprecatedEditFlags {
+		_ = f.MarkDeprecated(deprecated, "use --"+current)
+	}
 
 	cmd.MarkFlagsMutuallyExclusive(flagGitHubRepo, flagGitURL)
 	cmd.MarkFlagsMutuallyExclusive(flagBranch, flagCommit)

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -73,10 +73,12 @@ type deploymentSettingsEditArgs struct {
 	executorRootPath string
 
 	// Operation
-	preRunCommands []string
-	envVars        []string // each "KEY=VALUE"; plaintext.
-	secretEnvVars  []string // each "KEY=VALUE"; encrypted before send.
-	removeEnv      []string // each "KEY"; sent as null to delete.
+	preRunCommands      []string
+	clearPreRunCommands bool
+	envVars             []string // each "KEY=VALUE"; plaintext.
+	secretEnvVars       []string // each "KEY=VALUE"; encrypted before send.
+	removeEnv           []string // each "KEY"; sent as null to delete.
+	clearEnv            bool
 
 	skipInstallDeps    bool
 	skipIntermediate   bool
@@ -109,26 +111,28 @@ type deploymentSettingsEditArgs struct {
 }
 
 const (
-	flagGitHubRepo         = "github-repo"
-	flagGitURL             = "git-url"
-	flagBranch             = "branch"
-	flagCommit             = "commit"
-	flagFolder             = "folder"
-	flagPreviewPRs         = "preview-prs"
-	flagPushToDeploy       = "push-to-deploy"
-	flagPRTemplate         = "pr-template"
-	flagPathFilter         = "path-filter"
-	flagRunnerPool         = "runner-pool"
-	flagExecutorImage      = "executor-image"
-	flagExecutorRootPath   = "executor-root-path"
-	flagPreRunCommand      = "pre-run-command"
-	flagEnv                = "env"
-	flagSecretEnv          = "secret-env"
-	flagRemoveEnv          = "remove-env"
-	flagSkipInstallDeps    = "skip-install-deps"
-	flagSkipIntermediate   = "skip-intermediate-deployments"
-	flagShell              = "shell"
-	flagDeleteAfterDestroy = "delete-after-destroy"
+	flagGitHubRepo          = "github-repo"
+	flagGitURL              = "git-url"
+	flagBranch              = "branch"
+	flagCommit              = "commit"
+	flagFolder              = "folder"
+	flagPreviewPRs          = "preview-prs"
+	flagPushToDeploy        = "push-to-deploy"
+	flagPRTemplate          = "pr-template"
+	flagPathFilter          = "path-filter"
+	flagRunnerPool          = "runner-pool"
+	flagExecutorImage       = "executor-image"
+	flagExecutorRootPath    = "executor-root-path"
+	flagPreRunCommand       = "pre-run-command"
+	flagClearPreRunCommands = "clear-pre-run-commands"
+	flagEnv                 = "env"
+	flagSecretEnv           = "secret-env"
+	flagRemoveEnv           = "remove-env"
+	flagClearEnv            = "clear-env"
+	flagSkipInstallDeps     = "skip-install-deps"
+	flagSkipIntermediate    = "skip-intermediate-deployments"
+	flagShell               = "shell"
+	flagDeleteAfterDestroy  = "delete-after-destroy"
 
 	flagOIDCAWSRoleARN     = "oidc-aws-role-arn"
 	flagOIDCAWSSessionName = "oidc-aws-session-name"
@@ -219,13 +223,15 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 
 	// Operation
 	f.StringArrayVar(&args.preRunCommands, flagPreRunCommand, nil,
-		"Replace the pre-run command list (repeatable; pass once per command")
+		"Replace the pre-run command list (repeatable; pass once per command)")
+	f.BoolVar(&args.clearPreRunCommands, flagClearPreRunCommands, false, "Remove every pre-run command")
 	f.StringArrayVar(&args.envVars, flagEnv, nil,
 		"Set a plaintext environment variable (repeatable, KEY=VALUE)")
 	f.StringArrayVar(&args.secretEnvVars, flagSecretEnv, nil,
 		"Set an encrypted environment variable (repeatable, KEY=VALUE)")
 	f.StringSliceVar(&args.removeEnv, flagRemoveEnv, nil,
-		"Delete an environment variable by key (repeatable, comma-separated)")
+		"Delete an environment variable by key (repeatable or comma-separated)")
+	f.BoolVar(&args.clearEnv, flagClearEnv, false, "Remove every environment variable")
 
 	f.BoolVar(&args.skipInstallDeps, flagSkipInstallDeps, false,
 		"Skip automatic dependency installation")
@@ -243,7 +249,7 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 	f.StringVar(&args.oidcAWSDuration, flagOIDCAWSDuration, "",
 		"AWS OIDC: assume-role session duration (e.g. 30m, 1h)")
 	f.StringSliceVar(&args.oidcAWSPolicyARNs, flagOIDCAWSPolicyARN, nil,
-		"AWS OIDC: replace the session policy ARN list (repeatable, comma-separated)")
+		"AWS OIDC: replace the session policy ARN list (repeatable or comma-separated)")
 	f.BoolVar(&args.oidcAWSClear, flagOIDCAWSClear, false,
 		"Remove the entire AWS OIDC configuration")
 
@@ -274,6 +280,11 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 		"Remove the entire GCP OIDC configuration")
 
 	cmd.MarkFlagsMutuallyExclusive(flagGitHubRepo, flagGitURL)
+	cmd.MarkFlagsMutuallyExclusive(flagBranch, flagCommit)
+	cmd.MarkFlagsMutuallyExclusive(flagPreRunCommand, flagClearPreRunCommands)
+	cmd.MarkFlagsMutuallyExclusive(flagEnv, flagClearEnv)
+	cmd.MarkFlagsMutuallyExclusive(flagSecretEnv, flagClearEnv)
+	cmd.MarkFlagsMutuallyExclusive(flagRemoveEnv, flagClearEnv)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -73,12 +73,11 @@ type deploymentSettingsEditArgs struct {
 	executorRootPath string
 
 	// Operation
-	preRunCommands      []string
-	clearPreRunCommands bool
-	envVars             []string // each "KEY=VALUE"; plaintext.
-	secretEnvVars       []string // each "KEY=VALUE"; encrypted before send.
-	removeEnv           []string // each "KEY"; sent as null to delete.
-	clearEnv            bool
+	preRunCommands []string
+	envVars        []string // each "KEY=VALUE"; plaintext.
+	secretEnvVars  []string // each "KEY=VALUE"; encrypted before send.
+	removeEnv      []string // each "KEY"; sent as null to delete.
+	removeAllEnv   bool
 
 	skipInstallDeps    bool
 	skipIntermediate   bool
@@ -111,28 +110,27 @@ type deploymentSettingsEditArgs struct {
 }
 
 const (
-	flagGitHubRepo          = "github-repo"
-	flagGitURL              = "git-url"
-	flagBranch              = "branch"
-	flagCommit              = "commit"
-	flagFolder              = "folder"
-	flagPreviewPRs          = "preview-prs"
-	flagPushToDeploy        = "push-to-deploy"
-	flagPRTemplate          = "pr-template"
-	flagPathFilter          = "path-filter"
-	flagRunnerPool          = "runner-pool"
-	flagExecutorImage       = "executor-image"
-	flagExecutorRootPath    = "executor-root-path"
-	flagPreRunCommand       = "pre-run-command"
-	flagClearPreRunCommands = "clear-pre-run-commands"
-	flagEnv                 = "env"
-	flagSecretEnv           = "secret-env"
-	flagRemoveEnv           = "remove-env"
-	flagClearEnv            = "clear-env"
-	flagSkipInstallDeps     = "skip-install-deps"
-	flagSkipIntermediate    = "skip-intermediate-deployments"
-	flagShell               = "shell"
-	flagDeleteAfterDestroy  = "delete-after-destroy"
+	flagGitHubRepo         = "github-repo"
+	flagGitURL             = "git-url"
+	flagBranch             = "branch"
+	flagCommit             = "commit"
+	flagFolder             = "folder"
+	flagPreviewPRs         = "preview-prs"
+	flagPushToDeploy       = "push-to-deploy"
+	flagPRTemplate         = "pr-template"
+	flagPathFilter         = "path-filter"
+	flagRunnerPool         = "runner-pool"
+	flagExecutorImage      = "executor-image"
+	flagExecutorRootPath   = "executor-root-path"
+	flagPreRunCommand      = "pre-run-command"
+	flagEnv                = "env"
+	flagSecretEnv          = "secret-env"
+	flagRemoveEnv          = "remove-env"
+	flagRemoveAllEnv       = "remove-all-env"
+	flagSkipInstallDeps    = "skip-install-deps"
+	flagSkipIntermediate   = "skip-intermediate-deployments"
+	flagShell              = "shell"
+	flagDeleteAfterDestroy = "delete-after-destroy"
 
 	flagOIDCAWSRoleARN     = "oidc-aws-role-arn"
 	flagOIDCAWSSessionName = "oidc-aws-session-name"
@@ -185,7 +183,9 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 			"  # Remove the AWS OIDC configuration entirely.\n" +
 			"  pulumi deployment settings edit --oidc-aws-clear\n\n" +
 			"  # Clear the agent pool back to the Pulumi-hosted default.\n" +
-			"  pulumi deployment settings edit --runner-pool \"\"",
+			"  pulumi deployment settings edit --runner-pool \"\"\n\n" +
+			"  # Clear the pre-run command list.\n" +
+			"  pulumi deployment settings edit --pre-run-command \"\"",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			args.flagsChanged = cmd.Flags().Changed
 			return runDeploymentSettingsEdit(cmd.Context(), cmd.OutOrStdout(), factory, args)
@@ -223,15 +223,14 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 
 	// Operation
 	f.StringArrayVar(&args.preRunCommands, flagPreRunCommand, nil,
-		"Replace the pre-run command list (repeatable; pass once per command)")
-	f.BoolVar(&args.clearPreRunCommands, flagClearPreRunCommands, false, "Remove every pre-run command")
+		"Replace the pre-run command list (repeatable; pass once per command); empty string clears it")
 	f.StringArrayVar(&args.envVars, flagEnv, nil,
 		"Set a plaintext environment variable (repeatable, KEY=VALUE)")
 	f.StringArrayVar(&args.secretEnvVars, flagSecretEnv, nil,
 		"Set an encrypted environment variable (repeatable, KEY=VALUE)")
 	f.StringSliceVar(&args.removeEnv, flagRemoveEnv, nil,
 		"Delete an environment variable by key (repeatable or comma-separated)")
-	f.BoolVar(&args.clearEnv, flagClearEnv, false, "Remove every environment variable")
+	f.BoolVar(&args.removeAllEnv, flagRemoveAllEnv, false, "Remove every environment variable")
 
 	f.BoolVar(&args.skipInstallDeps, flagSkipInstallDeps, false,
 		"Skip automatic dependency installation")
@@ -281,10 +280,9 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 
 	cmd.MarkFlagsMutuallyExclusive(flagGitHubRepo, flagGitURL)
 	cmd.MarkFlagsMutuallyExclusive(flagBranch, flagCommit)
-	cmd.MarkFlagsMutuallyExclusive(flagPreRunCommand, flagClearPreRunCommands)
-	cmd.MarkFlagsMutuallyExclusive(flagEnv, flagClearEnv)
-	cmd.MarkFlagsMutuallyExclusive(flagSecretEnv, flagClearEnv)
-	cmd.MarkFlagsMutuallyExclusive(flagRemoveEnv, flagClearEnv)
+	cmd.MarkFlagsMutuallyExclusive(flagEnv, flagRemoveAllEnv)
+	cmd.MarkFlagsMutuallyExclusive(flagSecretEnv, flagRemoveAllEnv)
+	cmd.MarkFlagsMutuallyExclusive(flagRemoveEnv, flagRemoveAllEnv)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
@@ -30,29 +30,28 @@ var editFlagNames = []string{
 	flagRunnerPool, flagExecutorImage, flagExecutorRootPath,
 	flagPreRunCommand, flagEnv, flagSecretEnv, flagRemoveEnv, flagRemoveAllEnv,
 	flagSkipInstallDeps, flagSkipIntermediate, flagShell, flagDeleteAfterDestroy,
-	flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN, flagOIDCAWSClear,
-	flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID, flagOIDCAzureClear,
+	flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN, flagRemoveOIDCAWS,
+	flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID, flagRemoveOIDCAzure,
 	flagOIDCGCPProjectNumber, flagOIDCGCPWorkloadPoolID, flagOIDCGCPProviderID,
-	flagOIDCGCPServiceAccount, flagOIDCGCPRegion, flagOIDCGCPTokenLifetime, flagOIDCGCPClear,
+	flagOIDCGCPServiceAccount, flagOIDCGCPRegion, flagOIDCGCPTokenLifetime, flagRemoveOIDCGCP,
 }
 
-// clearEditFlags are presence-only: passing one with an explicit false value is rejected rather
-// than silently ignored.
-var clearEditFlags = []string{
+// presenceOnlyEditFlags reject an explicit false value rather than silently ignoring it.
+var presenceOnlyEditFlags = []string{
 	flagRemoveAllEnv,
-	flagOIDCAWSClear, flagOIDCAzureClear, flagOIDCGCPClear,
+	flagRemoveOIDCAWS, flagRemoveOIDCAzure, flagRemoveOIDCGCP,
 }
 
 // oidcProviderFlags lists the field-setter flags for each OIDC provider so
 // validateEditArgs can refuse combining --oidc-<provider>-clear with any of them.
 var oidcProviderFlags = map[string][]string{
-	flagOIDCAWSClear: {
+	flagRemoveOIDCAWS: {
 		flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN,
 	},
-	flagOIDCAzureClear: {
+	flagRemoveOIDCAzure: {
 		flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID,
 	},
-	flagOIDCGCPClear: {
+	flagRemoveOIDCGCP: {
 		flagOIDCGCPProjectNumber, flagOIDCGCPWorkloadPoolID, flagOIDCGCPProviderID,
 		flagOIDCGCPServiceAccount, flagOIDCGCPRegion, flagOIDCGCPTokenLifetime,
 	},
@@ -65,15 +64,15 @@ func anyEditFlagSet(args deploymentSettingsEditArgs) bool {
 	return slices.ContainsFunc(editFlagNames, args.flagsChanged)
 }
 
-func clearFlagValue(args deploymentSettingsEditArgs, flag string) bool {
+func presenceOnlyFlagValue(args deploymentSettingsEditArgs, flag string) bool {
 	switch flag {
 	case flagRemoveAllEnv:
 		return args.removeAllEnv
-	case flagOIDCAWSClear:
+	case flagRemoveOIDCAWS:
 		return args.oidcAWSClear
-	case flagOIDCAzureClear:
+	case flagRemoveOIDCAzure:
 		return args.oidcAzureClear
-	case flagOIDCGCPClear:
+	case flagRemoveOIDCGCP:
 		return args.oidcGCPClear
 	}
 	return false
@@ -132,8 +131,8 @@ func validateEditArgs(args deploymentSettingsEditArgs) error {
 			}
 		}
 	}
-	for _, clearFlag := range clearEditFlags {
-		if args.flagsChanged(clearFlag) && !clearFlagValue(args, clearFlag) {
+	for _, clearFlag := range presenceOnlyEditFlags {
+		if args.flagsChanged(clearFlag) && !presenceOnlyFlagValue(args, clearFlag) {
 			return fmt.Errorf("--%s does not accept a false value; omit it to leave the setting alone", clearFlag)
 		}
 	}
@@ -276,7 +275,7 @@ func buildEditFlagPatch(
 	}
 
 	// OIDC — AWS
-	if changed(flagOIDCAWSClear) {
+	if changed(flagRemoveOIDCAWS) {
 		setNested(patch, []string{"operationContext", "oidc", "aws"}, nil)
 	}
 	if changed(flagOIDCAWSRoleARN) {
@@ -297,7 +296,7 @@ func buildEditFlagPatch(
 	}
 
 	// OIDC — Azure
-	if changed(flagOIDCAzureClear) {
+	if changed(flagRemoveOIDCAzure) {
 		setNested(patch, []string{"operationContext", "oidc", "azure"}, nil)
 	}
 	if changed(flagOIDCAzureClientID) {
@@ -311,7 +310,7 @@ func buildEditFlagPatch(
 	}
 
 	// OIDC — GCP
-	if changed(flagOIDCGCPClear) {
+	if changed(flagRemoveOIDCGCP) {
 		setNested(patch, []string{"operationContext", "oidc", "gcp"}, nil)
 	}
 	if changed(flagOIDCGCPProjectNumber) {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
@@ -28,7 +28,7 @@ var editFlagNames = []string{
 	flagGitHubRepo, flagGitURL, flagBranch, flagCommit, flagFolder,
 	flagPreviewPRs, flagPushToDeploy, flagPRTemplate, flagPathFilter,
 	flagRunnerPool, flagExecutorImage, flagExecutorRootPath,
-	flagPreRunCommand, flagClearPreRunCommands, flagEnv, flagSecretEnv, flagRemoveEnv, flagClearEnv,
+	flagPreRunCommand, flagEnv, flagSecretEnv, flagRemoveEnv, flagRemoveAllEnv,
 	flagSkipInstallDeps, flagSkipIntermediate, flagShell, flagDeleteAfterDestroy,
 	flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN, flagOIDCAWSClear,
 	flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID, flagOIDCAzureClear,
@@ -39,7 +39,7 @@ var editFlagNames = []string{
 // clearEditFlags are presence-only: passing one with an explicit false value is rejected rather
 // than silently ignored.
 var clearEditFlags = []string{
-	flagClearPreRunCommands, flagClearEnv,
+	flagRemoveAllEnv,
 	flagOIDCAWSClear, flagOIDCAzureClear, flagOIDCGCPClear,
 }
 
@@ -67,10 +67,8 @@ func anyEditFlagSet(args deploymentSettingsEditArgs) bool {
 
 func clearFlagValue(args deploymentSettingsEditArgs, flag string) bool {
 	switch flag {
-	case flagClearPreRunCommands:
-		return args.clearPreRunCommands
-	case flagClearEnv:
-		return args.clearEnv
+	case flagRemoveAllEnv:
+		return args.removeAllEnv
 	case flagOIDCAWSClear:
 		return args.oidcAWSClear
 	case flagOIDCAzureClear:
@@ -117,6 +115,9 @@ func validateEditArgs(args deploymentSettingsEditArgs) error {
 			return fmt.Errorf("--env / --secret-env / --remove-env set %q multiple times (previously via --%s)", k, prev)
 		}
 		envKeys[k] = flagRemoveEnv
+	}
+	if slices.Contains(args.preRunCommands, "") && len(args.preRunCommands) > 1 {
+		return fmt.Errorf("--%s \"\" clears the list and cannot be combined with other commands", flagPreRunCommand)
 	}
 	if args.flagsChanged == nil {
 		return nil
@@ -231,11 +232,14 @@ func buildEditFlagPatch(
 		setNested(patch, []string{"executorContext", "executorRootPath"}, v)
 	}
 
-	switch {
-	case changed(flagClearPreRunCommands):
-		setNested(patch, []string{"operationContext", "preRunCommands"}, nil)
-	case changed(flagPreRunCommand):
-		setNested(patch, []string{"operationContext", "preRunCommands"}, args.preRunCommands)
+	if changed(flagPreRunCommand) {
+		// A lone empty string clears the list: an empty list would be a no-op, since the server
+		// copies through every key the patch does not mention.
+		var v any = args.preRunCommands
+		if len(args.preRunCommands) == 1 && args.preRunCommands[0] == "" {
+			v = nil
+		}
+		setNested(patch, []string{"operationContext", "preRunCommands"}, v)
 	}
 
 	envEntries := map[string]any{}
@@ -250,7 +254,7 @@ func buildEditFlagPatch(
 		envEntries[key] = nil
 	}
 	switch {
-	case changed(flagClearEnv):
+	case changed(flagRemoveAllEnv):
 		// An empty map would be a no-op: the server copies through every stored key the patch does
 		// not mention.
 		setNested(patch, []string{"operationContext", "environmentVariables"}, nil)

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
@@ -28,12 +28,19 @@ var editFlagNames = []string{
 	flagGitHubRepo, flagGitURL, flagBranch, flagCommit, flagFolder,
 	flagPreviewPRs, flagPushToDeploy, flagPRTemplate, flagPathFilter,
 	flagRunnerPool, flagExecutorImage, flagExecutorRootPath,
-	flagPreRunCommand, flagEnv, flagSecretEnv, flagRemoveEnv,
+	flagPreRunCommand, flagClearPreRunCommands, flagEnv, flagSecretEnv, flagRemoveEnv, flagClearEnv,
 	flagSkipInstallDeps, flagSkipIntermediate, flagShell, flagDeleteAfterDestroy,
 	flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN, flagOIDCAWSClear,
 	flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID, flagOIDCAzureClear,
 	flagOIDCGCPProjectNumber, flagOIDCGCPWorkloadPoolID, flagOIDCGCPProviderID,
 	flagOIDCGCPServiceAccount, flagOIDCGCPRegion, flagOIDCGCPTokenLifetime, flagOIDCGCPClear,
+}
+
+// clearEditFlags are presence-only: passing one with an explicit false value is rejected rather
+// than silently ignored.
+var clearEditFlags = []string{
+	flagClearPreRunCommands, flagClearEnv,
+	flagOIDCAWSClear, flagOIDCAzureClear, flagOIDCGCPClear,
 }
 
 // oidcProviderFlags lists the field-setter flags for each OIDC provider so
@@ -56,6 +63,22 @@ func anyEditFlagSet(args deploymentSettingsEditArgs) bool {
 		return false
 	}
 	return slices.ContainsFunc(editFlagNames, args.flagsChanged)
+}
+
+func clearFlagValue(args deploymentSettingsEditArgs, flag string) bool {
+	switch flag {
+	case flagClearPreRunCommands:
+		return args.clearPreRunCommands
+	case flagClearEnv:
+		return args.clearEnv
+	case flagOIDCAWSClear:
+		return args.oidcAWSClear
+	case flagOIDCAzureClear:
+		return args.oidcAzureClear
+	case flagOIDCGCPClear:
+		return args.oidcGCPClear
+	}
+	return false
 }
 
 // validateEditArgs catches conflicts that cobra can't express on its own
@@ -95,16 +118,22 @@ func validateEditArgs(args deploymentSettingsEditArgs) error {
 		}
 		envKeys[k] = flagRemoveEnv
 	}
-	if args.flagsChanged != nil {
-		for clearFlag, fieldFlags := range oidcProviderFlags {
-			if !args.flagsChanged(clearFlag) {
-				continue
+	if args.flagsChanged == nil {
+		return nil
+	}
+	for clearFlag, fieldFlags := range oidcProviderFlags {
+		if !args.flagsChanged(clearFlag) {
+			continue
+		}
+		for _, f := range fieldFlags {
+			if args.flagsChanged(f) {
+				return fmt.Errorf("--%s cannot be combined with --%s", clearFlag, f)
 			}
-			for _, f := range fieldFlags {
-				if args.flagsChanged(f) {
-					return fmt.Errorf("--%s cannot be combined with --%s", clearFlag, f)
-				}
-			}
+		}
+	}
+	for _, clearFlag := range clearEditFlags {
+		if args.flagsChanged(clearFlag) && !clearFlagValue(args, clearFlag) {
+			return fmt.Errorf("--%s does not accept a false value; omit it to leave the setting alone", clearFlag)
 		}
 	}
 	return nil
@@ -141,11 +170,23 @@ func buildEditFlagPatch(
 	if changed(flagGitURL) {
 		setNested(patch, []string{"sourceContext", "git", "repoUrl"}, args.gitURL)
 	}
+	// Branch, commit and tag are mutually exclusive: the service validates the merged object and
+	// rejects any pair. Setting one therefore has to null the others rather than leave them stored.
+	// Tag is service-set on a tag-triggered deployment, so a stack can hold one without ever having
+	// been given one from here.
 	if changed(flagBranch) {
-		setNested(patch, []string{"sourceContext", "git", "branch"}, args.branch)
+		setNested(patch, []string{"sourceContext", "git", "branch"}, nullIfEmpty(args.branch))
+		if args.branch != "" {
+			setNested(patch, []string{"sourceContext", "git", "commit"}, nil)
+			setNested(patch, []string{"sourceContext", "git", "tag"}, nil)
+		}
 	}
 	if changed(flagCommit) {
-		setNested(patch, []string{"sourceContext", "git", "commit"}, args.commit)
+		setNested(patch, []string{"sourceContext", "git", "commit"}, nullIfEmpty(args.commit))
+		if args.commit != "" {
+			setNested(patch, []string{"sourceContext", "git", "branch"}, nil)
+			setNested(patch, []string{"sourceContext", "git", "tag"}, nil)
+		}
 	}
 	if changed(flagFolder) {
 		setNested(patch, []string{"sourceContext", "git", "repoDir"}, args.folder)
@@ -173,11 +214,12 @@ func buildEditFlagPatch(
 		patch["agentPoolID"] = v
 	}
 	if changed(flagExecutorImage) {
-		// Map empty string to null so `--executor-image ""` clears the field
-		// back to the default image. Matches the --runner-pool convention.
-		var v any = args.executorImage
-		if args.executorImage == "" {
-			v = nil
+		// Only the keys the user set are emitted: a bare-string image decodes server-side to an
+		// object whose credentials are explicitly null, which erases the stored registry
+		// credentials. Empty string still clears the whole image, per the --runner-pool convention.
+		var v any
+		if args.executorImage != "" {
+			v = map[string]any{"reference": args.executorImage}
 		}
 		setNested(patch, []string{"executorContext", "executorImage"}, v)
 	}
@@ -189,9 +231,13 @@ func buildEditFlagPatch(
 		setNested(patch, []string{"executorContext", "executorRootPath"}, v)
 	}
 
-	if changed(flagPreRunCommand) {
+	switch {
+	case changed(flagClearPreRunCommands):
+		setNested(patch, []string{"operationContext", "preRunCommands"}, nil)
+	case changed(flagPreRunCommand):
 		setNested(patch, []string{"operationContext", "preRunCommands"}, args.preRunCommands)
 	}
+
 	envEntries := map[string]any{}
 	for _, spec := range args.envVars {
 		key, value, _ := strings.Cut(spec, "=")
@@ -203,7 +249,12 @@ func buildEditFlagPatch(
 	for _, key := range args.removeEnv {
 		envEntries[key] = nil
 	}
-	if len(envEntries) > 0 {
+	switch {
+	case changed(flagClearEnv):
+		// An empty map would be a no-op: the server copies through every stored key the patch does
+		// not mention.
+		setNested(patch, []string{"operationContext", "environmentVariables"}, nil)
+	case len(envEntries) > 0:
 		setNested(patch, []string{"operationContext", "environmentVariables"}, envEntries)
 	}
 
@@ -221,7 +272,7 @@ func buildEditFlagPatch(
 	}
 
 	// OIDC — AWS
-	if changed(flagOIDCAWSClear) && args.oidcAWSClear {
+	if changed(flagOIDCAWSClear) {
 		setNested(patch, []string{"operationContext", "oidc", "aws"}, nil)
 	}
 	if changed(flagOIDCAWSRoleARN) {
@@ -231,14 +282,18 @@ func buildEditFlagPatch(
 		setNested(patch, []string{"operationContext", "oidc", "aws", "sessionName"}, args.oidcAWSSessionName)
 	}
 	if changed(flagOIDCAWSDuration) {
-		setNested(patch, []string{"operationContext", "oidc", "aws", "duration"}, args.oidcAWSDuration)
+		var v any = args.oidcAWSDuration
+		if args.oidcAWSDuration == "" {
+			v = nil
+		}
+		setNested(patch, []string{"operationContext", "oidc", "aws", "duration"}, v)
 	}
 	if changed(flagOIDCAWSPolicyARN) {
 		setNested(patch, []string{"operationContext", "oidc", "aws", "policyArns"}, args.oidcAWSPolicyARNs)
 	}
 
 	// OIDC — Azure
-	if changed(flagOIDCAzureClear) && args.oidcAzureClear {
+	if changed(flagOIDCAzureClear) {
 		setNested(patch, []string{"operationContext", "oidc", "azure"}, nil)
 	}
 	if changed(flagOIDCAzureClientID) {
@@ -252,7 +307,7 @@ func buildEditFlagPatch(
 	}
 
 	// OIDC — GCP
-	if changed(flagOIDCGCPClear) && args.oidcGCPClear {
+	if changed(flagOIDCGCPClear) {
 		setNested(patch, []string{"operationContext", "oidc", "gcp"}, nil)
 	}
 	if changed(flagOIDCGCPProjectNumber) {
@@ -271,10 +326,23 @@ func buildEditFlagPatch(
 		setNested(patch, []string{"operationContext", "oidc", "gcp", "region"}, args.oidcGCPRegion)
 	}
 	if changed(flagOIDCGCPTokenLifetime) {
-		setNested(patch, []string{"operationContext", "oidc", "gcp", "tokenLifetime"}, args.oidcGCPTokenLifetime)
+		var v any = args.oidcGCPTokenLifetime
+		if args.oidcGCPTokenLifetime == "" {
+			v = nil
+		}
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "tokenLifetime"}, v)
 	}
 
 	return patch
+}
+
+// nullIfEmpty maps an empty flag value to a JSON null so the server clears the stored field, since
+// an empty string is a value the server would store as-is.
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }
 
 func setNested(m map[string]any, path []string, value any) {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -439,17 +439,17 @@ func TestDeploymentSettingsEdit_OIDCClearFlags(t *testing.T) {
 	}{
 		{
 			"aws",
-			deploymentSettingsEditArgs{oidcAWSClear: true, flagsChanged: flagsSet(flagOIDCAWSClear)},
+			deploymentSettingsEditArgs{oidcAWSClear: true, flagsChanged: flagsSet(flagRemoveOIDCAWS)},
 			`{"operationContext":{"oidc":{"aws":null}}}`,
 		},
 		{
 			"azure",
-			deploymentSettingsEditArgs{oidcAzureClear: true, flagsChanged: flagsSet(flagOIDCAzureClear)},
+			deploymentSettingsEditArgs{oidcAzureClear: true, flagsChanged: flagsSet(flagRemoveOIDCAzure)},
 			`{"operationContext":{"oidc":{"azure":null}}}`,
 		},
 		{
 			"gcp",
-			deploymentSettingsEditArgs{oidcGCPClear: true, flagsChanged: flagsSet(flagOIDCGCPClear)},
+			deploymentSettingsEditArgs{oidcGCPClear: true, flagsChanged: flagsSet(flagRemoveOIDCGCP)},
 			`{"operationContext":{"oidc":{"gcp":null}}}`,
 		},
 	} {
@@ -472,7 +472,7 @@ func TestDeploymentSettingsEdit_OIDCClearConflictsWithSetters(t *testing.T) {
 			deploymentSettingsEditArgs{
 				oidcAWSClear:   true,
 				oidcAWSRoleARN: "arn:aws:iam::123:role/x",
-				flagsChanged:   flagsSet(flagOIDCAWSClear, flagOIDCAWSRoleARN),
+				flagsChanged:   flagsSet(flagRemoveOIDCAWS, flagOIDCAWSRoleARN),
 			},
 		},
 		{
@@ -480,7 +480,7 @@ func TestDeploymentSettingsEdit_OIDCClearConflictsWithSetters(t *testing.T) {
 			deploymentSettingsEditArgs{
 				oidcAzureClear:    true,
 				oidcAzureClientID: "cid",
-				flagsChanged:      flagsSet(flagOIDCAzureClear, flagOIDCAzureClientID),
+				flagsChanged:      flagsSet(flagRemoveOIDCAzure, flagOIDCAzureClientID),
 			},
 		},
 		{
@@ -488,7 +488,7 @@ func TestDeploymentSettingsEdit_OIDCClearConflictsWithSetters(t *testing.T) {
 			deploymentSettingsEditArgs{
 				oidcGCPClear:         true,
 				oidcGCPProjectNumber: "123",
-				flagsChanged:         flagsSet(flagOIDCGCPClear, flagOIDCGCPProjectNumber),
+				flagsChanged:         flagsSet(flagRemoveOIDCGCP, flagOIDCGCPProjectNumber),
 			},
 		},
 	} {
@@ -638,7 +638,7 @@ func TestDeploymentSettingsEdit_ClearListAndMapFlags(t *testing.T) {
 
 func TestDeploymentSettingsEdit_ClearFlagsRejectFalse(t *testing.T) {
 	t.Parallel()
-	for _, flag := range clearEditFlags {
+	for _, flag := range presenceOnlyEditFlags {
 		t.Run(flag, func(t *testing.T) {
 			t.Parallel()
 			err := runEditArgs(t, deploymentSettingsEditArgs{flagsChanged: flagsSet(flag)},
@@ -664,6 +664,35 @@ func TestDeploymentSettingsEdit_PreRunCommandEmptyStringRejectsCompanions(t *tes
 		"--pre-run-command", "echo hi", "--pre-run-command", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be combined with other commands")
+}
+
+// The superseded spellings shipped in v3.242.0, so they have to keep producing the same patch and
+// keep telling the user what replaced them.
+func TestDeploymentSettingsEdit_DeprecatedOIDCFlags(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		deprecated string
+		want       string
+	}{
+		{"oidc-aws-clear", `{"operationContext":{"oidc":{"aws":null}}}`},
+		{"oidc-azure-clear", `{"operationContext":{"oidc":{"azure":null}}}`},
+		{"oidc-gcp-clear", `{"operationContext":{"oidc":{"gcp":null}}}`},
+	} {
+		t.Run(tc.deprecated, func(t *testing.T) {
+			t.Parallel()
+			captured, err := runEditCmd(t, &mockDeploymentSettingsEditClient{}, "--"+tc.deprecated)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(captured.patch))
+		})
+	}
+	for current, deprecated := range deprecatedEditFlags {
+		t.Run(deprecated+" is marked deprecated", func(t *testing.T) {
+			t.Parallel()
+			cmd := newDeploymentSettingsEditCmdWith(
+				stubSettingsEditFactory(&mockDeploymentSettingsEditClient{}))
+			assert.Contains(t, cmd.Flags().Lookup(deprecated).Deprecated, current)
+		})
+	}
 }
 
 func TestDeploymentSettingsEdit_DurationFlagsClearWithNull(t *testing.T) {
@@ -714,12 +743,12 @@ func TestDeploymentSettingsEdit_MutuallyExclusiveFlags(t *testing.T) {
 }
 
 // Driven through cobra so an explicit --flag=false really is parsed, which the args-level test
-// cannot express. Passing the flag as true must be accepted: clearFlagValue reads each clear flag
+// cannot express. Passing the flag as true must be accepted: presenceOnlyFlagValue reads each clear flag
 // out of the args struct by name, and a missing case there returns false, which would otherwise
 // turn a valid clear into this same error.
 func TestDeploymentSettingsEdit_ClearFlagsArePresenceOnly(t *testing.T) {
 	t.Parallel()
-	for _, flag := range clearEditFlags {
+	for _, flag := range presenceOnlyEditFlags {
 		t.Run(flag+" rejects false", func(t *testing.T) {
 			t.Parallel()
 			_, err := runEditCmd(t, &mockDeploymentSettingsEditClient{}, "--"+flag+"=false")
@@ -743,8 +772,13 @@ func TestDeploymentSettingsEdit_ClearFlagsArePresenceOnly(t *testing.T) {
 func TestDeploymentSettingsEdit_EditFlagNamesCoversEveryFlag(t *testing.T) {
 	t.Parallel()
 
-	// --stack and --output are wiring, not settings.
-	excluded := []string{"stack", "output"}
+	// --stack and --output are wiring, not settings. A deprecated spelling is resolved to its
+	// replacement by flagsChanged, so only the replacement belongs in the table.
+	excluded := make([]string, 0, 2+len(deprecatedEditFlags))
+	excluded = append(excluded, "stack", "output")
+	for _, deprecated := range deprecatedEditFlags {
+		excluded = append(excluded, deprecated)
+	}
 
 	cmd := newDeploymentSettingsEditCmdWith(stubSettingsEditFactory(&mockDeploymentSettingsEditClient{}))
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -19,7 +19,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"slices"
 	"testing"
+
+	"github.com/spf13/pflag"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -122,7 +126,7 @@ func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 
 	assert.Equal(t, testStackID, captured.stack)
 	require.NotNil(t, captured.patch)
-	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature"}}}`, string(captured.patch))
+	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature","commit":null,"tag":null}}}`, string(captured.patch))
 
 	assert.Equal(t, `Source: GitHub
   Repository:                    acme/infra
@@ -240,7 +244,50 @@ func TestDeploymentSettingsEdit_BranchFlag(t *testing.T) {
 		branch:       "feature",
 		flagsChanged: flagsSet(flagBranch),
 	}, &mockDeploymentSettingsEditClient{})
-	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature"}}}`, string(got))
+	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature","commit":null,"tag":null}}}`, string(got))
+}
+
+// The service rejects a merged source that carries both a branch and a commit, so setting one has to
+// null the other. Clearing one must not null the other, or nothing is left to deploy from.
+func TestDeploymentSettingsEdit_BranchAndCommitReplaceEachOther(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args deploymentSettingsEditArgs
+		want string
+	}{
+		{
+			"branch replaces commit",
+			deploymentSettingsEditArgs{branch: "main", flagsChanged: flagsSet(flagBranch)},
+			`{"sourceContext":{"git":{"branch":"main","commit":null,"tag":null}}}`,
+		},
+		{
+			"commit replaces branch",
+			deploymentSettingsEditArgs{commit: "abc123", flagsChanged: flagsSet(flagCommit)},
+			`{"sourceContext":{"git":{"commit":"abc123","branch":null,"tag":null}}}`,
+		},
+		{
+			"branch replaces a service-set tag",
+			deploymentSettingsEditArgs{branch: "main", flagsChanged: flagsSet(flagBranch)},
+			`{"sourceContext":{"git":{"branch":"main","commit":null,"tag":null}}}`,
+		},
+		{
+			"empty branch clears only the branch",
+			deploymentSettingsEditArgs{flagsChanged: flagsSet(flagBranch)},
+			`{"sourceContext":{"git":{"branch":null}}}`,
+		},
+		{
+			"empty commit clears only the commit",
+			deploymentSettingsEditArgs{flagsChanged: flagsSet(flagCommit)},
+			`{"sourceContext":{"git":{"commit":null}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := captureEditPatch(t, tc.args, &mockDeploymentSettingsEditClient{})
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
 }
 
 func TestDeploymentSettingsEdit_GitHubSourceFlags(t *testing.T) {
@@ -262,7 +309,7 @@ func TestDeploymentSettingsEdit_GitHubSourceFlags(t *testing.T) {
 			"deployCommits": true,
 			"paths": ["stacks/prod/**"]
 		},
-		"sourceContext": {"git": {"branch": "main", "repoDir": "stacks/prod"}}
+		"sourceContext": {"git": {"branch": "main", "commit": null, "tag": null, "repoDir": "stacks/prod"}}
 	}`, string(got))
 }
 
@@ -293,6 +340,19 @@ func TestDeploymentSettingsEdit_ExecutorImageEmptyClears(t *testing.T) {
 		flagsChanged:  flagsSet(flagExecutorImage),
 	}, &mockDeploymentSettingsEditClient{})
 	assert.JSONEq(t, `{"executorContext":{"executorImage":null}}`, string(got))
+}
+
+// A bare-string executorImage decodes server-side to an image whose credentials are explicitly
+// null, wiping the stored registry credentials, so the patch carries an object with no credentials
+// key at all.
+func TestDeploymentSettingsEdit_ExecutorImageSendsObjectWithoutCredentials(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		executorImage: "acme/executor:1",
+		flagsChanged:  flagsSet(flagExecutorImage),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{"executorContext":{"executorImage":{"reference":"acme/executor:1"}}}`, string(got))
+	assert.NotContains(t, string(got), "credentials")
 }
 
 func TestDeploymentSettingsEdit_EnvVarsAndRemove(t *testing.T) {
@@ -509,6 +569,178 @@ func TestDeploymentSettingsEdit_AdvancedToggles(t *testing.T) {
 			"options": {"skipInstallDependencies": true, "shell": "bash"}
 		}
 	}`, string(got))
+}
+
+// runEditArgs drives runDeploymentSettingsEdit for the cases that assert on the error rather than
+// on the emitted patch.
+func runEditArgs(t *testing.T, args deploymentSettingsEditArgs, c *mockDeploymentSettingsEditClient) error {
+	t.Helper()
+	if c.getResp == nil {
+		c.getResp = &apitype.DeploymentSettings{}
+	}
+	if c.captured == nil {
+		c.captured = &capturedEditPatch{}
+	}
+	args.outputFormat = defaultDeploymentSettingsGetOutputFormat()
+	var buf bytes.Buffer
+	return runDeploymentSettingsEdit(t.Context(), &buf, stubSettingsEditFactory(c), args)
+}
+
+// runEditCmd exercises the cobra command itself, so flag registration, flag kinds and the
+// mutual-exclusion rules are part of what is under test.
+func runEditCmd(
+	t *testing.T, c *mockDeploymentSettingsEditClient, argv ...string,
+) (*capturedEditPatch, error) {
+	t.Helper()
+	captured := &capturedEditPatch{}
+	c.captured = captured
+	if c.getResp == nil {
+		c.getResp = &apitype.DeploymentSettings{}
+	}
+	cmd := newDeploymentSettingsEditCmdWith(stubSettingsEditFactory(c))
+	cmd.SetArgs(argv)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+	return captured, cmd.ExecuteContext(t.Context())
+}
+
+// Both list and map clears send null: an empty map is a no-op, because the server copies through
+// every stored key the patch does not mention.
+func TestDeploymentSettingsEdit_ClearListAndMapFlags(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args deploymentSettingsEditArgs
+		want string
+	}{
+		{
+			"env",
+			deploymentSettingsEditArgs{clearEnv: true, flagsChanged: flagsSet(flagClearEnv)},
+			`{"operationContext":{"environmentVariables":null}}`,
+		},
+		{
+			"pre-run commands",
+			deploymentSettingsEditArgs{
+				clearPreRunCommands: true,
+				flagsChanged:        flagsSet(flagClearPreRunCommands),
+			},
+			`{"operationContext":{"preRunCommands":null}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := captureEditPatch(t, tc.args, &mockDeploymentSettingsEditClient{})
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestDeploymentSettingsEdit_ClearFlagsRejectFalse(t *testing.T) {
+	t.Parallel()
+	for _, flag := range clearEditFlags {
+		t.Run(flag, func(t *testing.T) {
+			t.Parallel()
+			err := runEditArgs(t, deploymentSettingsEditArgs{flagsChanged: flagsSet(flag)},
+				&mockDeploymentSettingsEditClient{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), flag)
+		})
+	}
+}
+
+func TestDeploymentSettingsEdit_DurationFlagsClearWithNull(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args deploymentSettingsEditArgs
+		want string
+	}{
+		{
+			"aws duration",
+			deploymentSettingsEditArgs{flagsChanged: flagsSet(flagOIDCAWSDuration)},
+			`{"operationContext":{"oidc":{"aws":{"duration":null}}}}`,
+		},
+		{
+			"gcp token lifetime",
+			deploymentSettingsEditArgs{flagsChanged: flagsSet(flagOIDCGCPTokenLifetime)},
+			`{"operationContext":{"oidc":{"gcp":{"tokenLifetime":null}}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := captureEditPatch(t, tc.args, &mockDeploymentSettingsEditClient{})
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestDeploymentSettingsEdit_MutuallyExclusiveFlags(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{"branch and commit", []string{"--branch", "main", "--commit", "abc123"}, "[branch commit]"},
+		{
+			"pre-run command and its clear",
+			[]string{"--pre-run-command", "echo hi", "--clear-pre-run-commands"},
+			"[pre-run-command clear-pre-run-commands]",
+		},
+		{"env and its clear", []string{"--env", "A=1", "--clear-env"}, "[env clear-env]"},
+		{"secret env and clear env", []string{"--secret-env", "A=1", "--clear-env"}, "[secret-env clear-env]"},
+		{"remove env and clear env", []string{"--remove-env", "A", "--clear-env"}, "[remove-env clear-env]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := runEditCmd(t, &mockDeploymentSettingsEditClient{}, tc.argv...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// Driven through cobra so an explicit --flag=false really is parsed, which the args-level test
+// cannot express. Passing the flag as true must be accepted: clearFlagValue reads each clear flag
+// out of the args struct by name, and a missing case there returns false, which would otherwise
+// turn a valid clear into this same error.
+func TestDeploymentSettingsEdit_ClearFlagsArePresenceOnly(t *testing.T) {
+	t.Parallel()
+	for _, flag := range clearEditFlags {
+		t.Run(flag+" rejects false", func(t *testing.T) {
+			t.Parallel()
+			_, err := runEditCmd(t, &mockDeploymentSettingsEditClient{}, "--"+flag+"=false")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "does not accept a false value")
+		})
+		t.Run(flag+" accepts true", func(t *testing.T) {
+			t.Parallel()
+			// A stored provider so that clear flags writing into vcs have one to resolve against.
+			c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{
+				VCS: &apitype.DeploymentSettingsVCS{Provider: apitype.VCSProviderGitHub},
+			}}
+			_, err := runEditCmd(t, c, "--"+flag)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// Every flag the command registers has to appear in editFlagNames, or anyEditFlagSet reports
+// "nothing to do" and the flag silently does nothing.
+func TestDeploymentSettingsEdit_EditFlagNamesCoversEveryFlag(t *testing.T) {
+	t.Parallel()
+
+	// --stack and --output are wiring, not settings.
+	excluded := []string{"stack", "output"}
+
+	cmd := newDeploymentSettingsEditCmdWith(stubSettingsEditFactory(&mockDeploymentSettingsEditClient{}))
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if slices.Contains(excluded, f.Name) {
+			return
+		}
+		assert.Contains(t, editFlagNames, f.Name)
+	})
 }
 
 func TestDeploymentSettingsEdit_SecretEnvWireForm(t *testing.T) {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -616,14 +616,14 @@ func TestDeploymentSettingsEdit_ClearListAndMapFlags(t *testing.T) {
 	}{
 		{
 			"env",
-			deploymentSettingsEditArgs{clearEnv: true, flagsChanged: flagsSet(flagClearEnv)},
+			deploymentSettingsEditArgs{removeAllEnv: true, flagsChanged: flagsSet(flagRemoveAllEnv)},
 			`{"operationContext":{"environmentVariables":null}}`,
 		},
 		{
 			"pre-run commands",
 			deploymentSettingsEditArgs{
-				clearPreRunCommands: true,
-				flagsChanged:        flagsSet(flagClearPreRunCommands),
+				preRunCommands: []string{""},
+				flagsChanged:   flagsSet(flagPreRunCommand),
 			},
 			`{"operationContext":{"preRunCommands":null}}`,
 		},
@@ -647,6 +647,23 @@ func TestDeploymentSettingsEdit_ClearFlagsRejectFalse(t *testing.T) {
 			assert.Contains(t, err.Error(), flag)
 		})
 	}
+}
+
+// The clear has to survive the real flag parser: --pre-run-command "" must reach the patch builder
+// as a one-element list rather than as an unset flag.
+func TestDeploymentSettingsEdit_PreRunCommandEmptyStringClears(t *testing.T) {
+	t.Parallel()
+	captured, err := runEditCmd(t, &mockDeploymentSettingsEditClient{}, "--pre-run-command", "")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"operationContext":{"preRunCommands":null}}`, string(captured.patch))
+}
+
+func TestDeploymentSettingsEdit_PreRunCommandEmptyStringRejectsCompanions(t *testing.T) {
+	t.Parallel()
+	_, err := runEditCmd(t, &mockDeploymentSettingsEditClient{},
+		"--pre-run-command", "echo hi", "--pre-run-command", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined with other commands")
 }
 
 func TestDeploymentSettingsEdit_DurationFlagsClearWithNull(t *testing.T) {
@@ -683,14 +700,9 @@ func TestDeploymentSettingsEdit_MutuallyExclusiveFlags(t *testing.T) {
 		want string
 	}{
 		{"branch and commit", []string{"--branch", "main", "--commit", "abc123"}, "[branch commit]"},
-		{
-			"pre-run command and its clear",
-			[]string{"--pre-run-command", "echo hi", "--clear-pre-run-commands"},
-			"[pre-run-command clear-pre-run-commands]",
-		},
-		{"env and its clear", []string{"--env", "A=1", "--clear-env"}, "[env clear-env]"},
-		{"secret env and clear env", []string{"--secret-env", "A=1", "--clear-env"}, "[secret-env clear-env]"},
-		{"remove env and clear env", []string{"--remove-env", "A", "--clear-env"}, "[remove-env clear-env]"},
+		{"env and remove-all-env", []string{"--env", "A=1", "--remove-all-env"}, "[env remove-all-env]"},
+		{"secret env and remove-all-env", []string{"--secret-env", "A=1", "--remove-all-env"}, "[secret-env remove-all-env]"},
+		{"remove env and remove-all-env", []string{"--remove-env", "A", "--remove-all-env"}, "[remove-env remove-all-env]"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Five ways `pulumi deployment settings edit` built its PATCH body did not do what the flag promised.

- `--executor-image acme/img` sent a bare string, which the service decodes into an image object whose credentials field is explicitly null, so setting an image deleted the registry credentials stored beside it. The patch now sends an object with only the reference key; `--executor-image ""` still clears the whole image.
- `--oidc-aws-duration ""` and `--oidc-gcp-token-lifetime ""` sent an empty string, which the service stores as an empty duration rather than removing it. Both send null now, matching every other clear-by-empty-string flag on this command.
- The removal flags were accepted with an explicit `=false` and then ignored, because the patch was written only when the flag was both present and true. They are presence-only now and reject a false value.
- Emptying a list was impossible. `--pre-run-command ""` and `--remove-all-env` send null; an empty list or map is a no-op, since every key the patch does not mention is copied through.
- `--branch` and `--commit` each null the other, and setting either also nulls `tag`, which the service sets on a tag-triggered deployment. The service validates the merged source and rejects an object carrying more than one, so patching one key and leaving another stored failed every edit against a stack that already had one set, with no way to move a commit-pinned stack back onto a branch. An empty value still clears only the flag's own key, and the two flags are marked mutually exclusive.

Removal is also spelled one way now, matching `--remove-env` and `pulumi config remove`. `--remove-oidc-aws`, `--remove-oidc-azure` and `--remove-oidc-gcp` replace the `--oidc-*-clear` names, which shipped in v3.242.0 and stay registered as deprecated aliases; `--remove-all-env` replaces `--clear-env`; and `--pre-run-command ""` replaces `--clear-pre-run-commands`, following the empty-string convention `--runner-pool` and `--executor-image` already use.

Split out of #24285, which reviewers asked to break up, and revised since that review. #24285 will be closed in favor of this stack.
