### PR TITLE
python: add helper methods to transform ResourceOptions to InvokeOptions

### DIFF
--- a/changelog/pending/sdk-python-improvement-20260901-155723.yaml
+++ b/changelog/pending/sdk-python-improvement-20260901-155723.yaml
@@ -1,0 +1,4 @@
+component: sdk/python
+kind: improvement
+body: Add helper methods to transform ResourceOptions to InvokeOptions
+time: 2026-09-01T15:57:23.640715602+02:00

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -24,7 +24,7 @@ from collections.abc import Awaitable, Sequence
 
 if TYPE_CHECKING:
     from .output import Inputs, Input
-    from .resource import Resource, ProviderResource
+    from .resource import Resource, ProviderResource, ResourceOptions
 
 
 class InvokeOptions:
@@ -74,6 +74,22 @@ class InvokeOptions:
         self.provider = provider
         self.version = version
         self.plugin_download_url = plugin_download_url
+
+    @classmethod
+    def from_resource_options(cls, opts: "ResourceOptions") -> "InvokeOptions":
+        """
+        Creates an InvokeOptions from the given ResourceOptions, copying the
+        `parent`, `provider`, `version` and `plugin_download_url` options.
+        All other resource options, including `depends_on`, have no equivalent
+        for plain invokes and are dropped; use
+        `InvokeOutputOptions.from_resource_options` to preserve `depends_on`.
+        """
+        return InvokeOptions(
+            parent=opts.parent,
+            provider=opts.provider,
+            version=opts.version,
+            plugin_download_url=opts.plugin_download_url,
+        )
 
     def merge(
         opts1: Optional["InvokeOptions"],
@@ -155,6 +171,22 @@ class InvokeOutputOptions(InvokeOptions):
             plugin_download_url=plugin_download_url,
         )
         self.depends_on = depends_on
+
+    @classmethod
+    def from_resource_options(cls, opts: "ResourceOptions") -> "InvokeOutputOptions":
+        """
+        Creates an InvokeOutputOptions from the given ResourceOptions, copying
+        the `parent`, `provider`, `version`, `plugin_download_url` and
+        `depends_on` options. All other resource options have no invoke
+        equivalent and are dropped.
+        """
+        return InvokeOutputOptions(
+            parent=opts.parent,
+            provider=opts.provider,
+            version=opts.version,
+            plugin_download_url=opts.plugin_download_url,
+            depends_on=opts.depends_on,
+        )
 
     def merge(
         opts1: Optional[Union["InvokeOptions", "InvokeOutputOptions"]],

--- a/sdk/python/lib/test/test_invoke.py
+++ b/sdk/python/lib/test/test_invoke.py
@@ -53,6 +53,11 @@ class MockComponentResource(pulumi.ComponentResource):
         super().__init__("python:test:MockComponentResource", name, {}, opts)
 
 
+class MockProvider(pulumi.ProviderResource):
+    def __init__(self, name: str, opts: Optional[pulumi.ResourceOptions] = None):
+        super().__init__("test", name, {}, opts)
+
+
 @pytest.mark.parametrize(
     "tok,version,empty,expected",
     [
@@ -377,3 +382,36 @@ def test_invoke_merge(
         assert InvokeOutputOptions.merge(a, b).version == expected
     else:
         assert InvokeOptions.merge(a, b).version == expected
+
+
+@pulumi.runtime.test
+def test_invoke_options_from_resource_options() -> None:
+    pulumi.runtime.mocks.set_mocks(MyMocks())
+
+    parent = MockComponentResource(name="parent")
+    provider = MockProvider(name="prov")
+    dep = MockResource(name="dep")
+    res_opts = pulumi.ResourceOptions(
+        parent=parent,
+        provider=provider,
+        version="1.2.3",
+        plugin_download_url="https://example.com/plugin",
+        depends_on=[dep],
+        protect=True,
+        ignore_changes=["prop"],
+    )
+
+    opts = InvokeOptions.from_resource_options(res_opts)
+    assert type(opts) is InvokeOptions
+    assert opts.parent is parent
+    assert opts.provider is provider
+    assert opts.version == "1.2.3"
+    assert opts.plugin_download_url == "https://example.com/plugin"
+
+    output_opts = InvokeOutputOptions.from_resource_options(res_opts)
+    assert type(output_opts) is InvokeOutputOptions
+    assert output_opts.parent is parent
+    assert output_opts.provider is provider
+    assert output_opts.version == "1.2.3"
+    assert output_opts.plugin_download_url == "https://example.com/plugin"
+    assert output_opts.depends_on == [dep]


### PR DESCRIPTION
It can be useful to pass the same options to an invoke as to a resource (the part that's available at least).  Add a helper to do that, to make it easier for users, and to be able to document this better.

Part of #17413 