### PR TITLE
nodejs: add helper methods to transform ResourceOptions to InvokeOptions

### DIFF
--- a/changelog/pending/sdk-nodejs-improvement-20260901-155706.yaml
+++ b/changelog/pending/sdk-nodejs-improvement-20260901-155706.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: improvement
+body: Add helper methods to transform ResourceOptions to InvokeOptions
+time: 2026-09-01T15:57:06.581803925+02:00

--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { Inputs, Input } from "./output";
-import { ProviderResource, Resource } from "./resource";
+import { ProviderResource, Resource, ResourceOptions } from "./resource";
 
 /**
  * {@link InvokeOptions} is a bag of options that control the behavior of a call
@@ -64,6 +64,35 @@ export interface InvokeOutputOptions extends InvokeOptions {
      * An optional set of additional explicit dependencies on other resources.
      */
     dependsOn?: Input<Input<Resource>[]> | Input<Resource>;
+}
+
+/**
+ * Creates an {@link InvokeOptions} from the given {@link ResourceOptions},
+ * copying the `parent`, `provider`, `version` and `pluginDownloadURL` options.
+ * All other resource options, including `dependsOn`, have no equivalent for
+ * plain invokes and are dropped; use
+ * {@link invokeOutputOptionsFromResourceOptions} to preserve `dependsOn`.
+ */
+export function invokeOptionsFromResourceOptions(opts: ResourceOptions): InvokeOptions {
+    return {
+        parent: opts.parent,
+        provider: opts.provider,
+        version: opts.version,
+        pluginDownloadURL: opts.pluginDownloadURL,
+    };
+}
+
+/**
+ * Creates an {@link InvokeOutputOptions} from the given {@link ResourceOptions},
+ * copying the `parent`, `provider`, `version`, `pluginDownloadURL` and
+ * `dependsOn` options. All other resource options have no invoke equivalent and
+ * are dropped.
+ */
+export function invokeOutputOptionsFromResourceOptions(opts: ResourceOptions): InvokeOutputOptions {
+    return {
+        ...invokeOptionsFromResourceOptions(opts),
+        dependsOn: opts.dependsOn,
+    };
 }
 
 /**

--- a/sdk/nodejs/tests/options.spec.ts
+++ b/sdk/nodejs/tests/options.spec.ts
@@ -15,7 +15,16 @@
 /* eslint-disable */
 
 import * as assert from "assert";
-import { ComponentResourceOptions, ErrorHookFunction, ProviderResource, merge, mergeOptions } from "../resource";
+import { invokeOptionsFromResourceOptions, invokeOutputOptionsFromResourceOptions } from "../invoke";
+import {
+    ComponentResourceOptions,
+    ErrorHookFunction,
+    ProviderResource,
+    Resource,
+    ResourceOptions,
+    merge,
+    mergeOptions,
+} from "../resource";
 
 describe("options", () => {
     describe("merge", () => {
@@ -279,6 +288,42 @@ describe("options", () => {
                     { envVarMappings: { VAR_B: "TARGET_B" } },
                 );
                 assert.deepStrictEqual(result.envVarMappings, { VAR_B: "TARGET_B" });
+            });
+        });
+    });
+
+    describe("fromResourceOptions", () => {
+        const provider = <ProviderResource>{ getPackage: () => "aws" };
+        const parent = <Resource>(<unknown>{ getProvider: () => provider });
+        const dep = <Resource>(<unknown>{});
+        const resOpts: ResourceOptions = {
+            parent,
+            provider,
+            version: "1.2.3",
+            pluginDownloadURL: "https://example.com/plugin",
+            dependsOn: [dep],
+            protect: true,
+            ignoreChanges: ["prop"],
+        };
+
+        it("copies the invoke-relevant options and drops the rest", () => {
+            const result = invokeOptionsFromResourceOptions(resOpts);
+            assert.deepStrictEqual(result, {
+                parent,
+                provider,
+                version: "1.2.3",
+                pluginDownloadURL: "https://example.com/plugin",
+            });
+        });
+
+        it("preserves dependsOn for output invokes", () => {
+            const result = invokeOutputOptionsFromResourceOptions(resOpts);
+            assert.deepStrictEqual(result, {
+                parent,
+                provider,
+                version: "1.2.3",
+                pluginDownloadURL: "https://example.com/plugin",
+                dependsOn: [dep],
             });
         });
     });


### PR DESCRIPTION
It can be useful to pass the same options to an invoke as to a resource (the part that's available at least).  Add a helper to do that, to make it easier for users, and to be able to document this better.

Similar to https://github.com/pulumi/pulumi/pull/24533 for python

Fixes #17413
