### PR TITLE
cmd/pulumi/stack: document the fix for #16412 secret decryption failures

### DIFF
--- a/changelog/pending/20260904--cli--document-fallback-to-state-secrets-manager.yaml
+++ b/changelog/pending/20260904--cli--document-fallback-to-state-secrets-manager.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Document PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER as the fix for secret decryption errors when running from a workspace without local stack configuration, such as the Automation API or a saved update plan applied from a different directory
+time: 2026-09-04T00:00:00+00:00

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -284,6 +284,8 @@ func (l *SecretsManagerLoader) GetSecretsManager(
 				ps.EncryptedKey = ""
 			}
 		} else {
+			// See PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER (env.go) and
+			// https://github.com/pulumi/pulumi/issues/16412.
 			sm, err = s.DefaultSecretManager(ctx, ps)
 		}
 	}

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -298,6 +298,11 @@ func NewStackPromptingPassphraseSecretsManagerFromState(
 	}
 }
 
+// NewPromptingPassphraseSecretsManager returns a passphrase secrets manager for the given stack,
+// reusing info.EncryptionSalt if set, or otherwise minting a new one. If info is missing a salt only
+// because local config isn't available (e.g. Automation API, saved plans), this mints an unrelated
+// salt; set PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER=true to reuse the checkpoint's provider instead.
+// See https://github.com/pulumi/pulumi/issues/16412.
 func NewPromptingPassphraseSecretsManager(info *workspace.ProjectStack,
 	rotateSecretsProvider bool,
 ) (secrets.Manager, error) {

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -130,7 +130,10 @@ var NeoSummaryMaxLen = env.Int("NEO_SUMMARY_MAXLEN",
 var CopilotSummaryMaxLen = NeoSummaryMaxLen
 
 var FallbackToStateSecretsManager = env.Bool("FALLBACK_TO_STATE_SECRETS_MANAGER",
-	"Use the snapshot secrets manager as a fallback when the stack configuration is missing or incomplete.")
+	"Use the snapshot secrets manager as a fallback when the stack configuration is missing or incomplete. "+
+		"Set this if you see secret decryption errors when running from a workspace that doesn't carry local "+
+		"stack configuration between invocations, such as the Automation API or a saved update plan applied "+
+		"from a different directory (see https://github.com/pulumi/pulumi/issues/16412).")
 
 var Parallel = env.Int("PARALLEL",
 	"Allow P resource operations to run in parallel at once (1 for no parallelism)")


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

## Where this ended up

Per the discussion below, actually fixing #16412 by default requires avoiding a double load of the backend's deployment state (a checkpoint export to check for a fallback secrets manager, then a full snapshot load once the deployment operation runs) — a bigger architectural change (caching across the `Stack`/backend layers) than fits a PR like this. See the thread for the full back-and-forth.

Scaled this down to a documentation-only change: `PULUMI_FALLBACK_TO_STATE_SECRETS_MANAGER` already does what's needed, it's just hard to discover if you're hitting this blind. This adds a pointer to it in the three places someone debugging this failure is likely to end up:

- The env var's own description (`sdk/go/common/env/env.go`), shown in `pulumi help environment-variables`.
- `SecretsManagerLoader.GetSecretsManager`'s fallback branch (`pkg/cmd/pulumi/stack/secrets.go`), where the decision *not* to reuse the checkpoint's secrets provider is made.
- `passphrase.NewPromptingPassphraseSecretsManager` (`pkg/secrets/passphrase/manager.go`), which is where the unrelated new salt actually gets minted.

No functional change — just comments/doc strings plus a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
