### PR TITLE
Clear stale output secret markers on same steps

### DIFF
--- a/changelog/pending/engine-fix-20260902-113122.yaml
+++ b/changelog/pending/engine-fix-20260902-113122.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Clear the secret marker on a resource output when the program stops marking the matching input as secret
+time: 2026-09-02T11:31:22.197672+02:00

--- a/pkg/engine/lifecycletest/secret_test.go
+++ b/pkg/engine/lifecycletest/secret_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	. "github.com/pulumi/pulumi/pkg/v3/engine"
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveSecretFromInputs tests that dropping pulumi.secret from a program input also clears the
+// secret bit the engine mirrored onto the matching output, even when the provider reports no diff.
+// See https://github.com/pulumi/pulumi/issues/13877.
+func TestRemoveSecretFromInputs(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			// A bridged-style provider: it does not accept secrets, so it only ever sees, diffs and
+			// returns plaintext.
+			return &deploytest.Provider{
+				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
+					if plaintext(req.OldOutputs["bucket"]).DeepEquals(plaintext(req.NewInputs["bucket"])) {
+						return plugin.DiffResult{Changes: plugin.DiffNone}, nil
+					}
+					return plugin.DiffResult{Changes: plugin.DiffSome, ChangedKeys: []resource.PropertyKey{"bucket"}}, nil
+				},
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					bucket := plaintext(req.Properties["bucket"])
+					return plugin.CreateResponse{
+						ID: "id123",
+						Properties: resource.PropertyMap{
+							"bucket": bucket,
+							// An output the provider generates itself, unrelated to any input.
+							"arn": resource.NewProperty("arn:" + bucket.StringValue()),
+						},
+						Status: resource.StatusOK,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	var inputs resource.PropertyMap
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs:                  inputs,
+			AdditionalSecretOutputs: []resource.PropertyKey{"arn"},
+		})
+		require.NoError(t, err)
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+	p := &lt.TestPlan{
+		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+		Steps:   []lt.TestStep{{Op: Update, SkipPreview: true}},
+	}
+
+	// The program marks the input as secret.
+	inputs = resource.PropertyMap{"bucket": resource.MakeSecret(resource.NewProperty("b"))}
+	snap := p.Run(t, nil)
+
+	resA := snap.Resources[len(snap.Resources)-1]
+	require.Equal(t, "resA", resA.URN.Name())
+	assert.True(t, resA.Inputs["bucket"].IsSecret())
+	assert.True(t, resA.Outputs["bucket"].IsSecret())
+
+	// The program stops marking the input as secret. The provider still reports no diff, so this is a
+	// same step, but the state must no longer claim the value is a secret.
+	inputs = resource.PropertyMap{"bucket": resource.NewProperty("b")}
+	snap = p.Run(t, snap)
+
+	resA = snap.Resources[len(snap.Resources)-1]
+	require.Equal(t, "resA", resA.URN.Name())
+	assert.False(t, resA.Inputs["bucket"].IsSecret())
+	assert.False(t, resA.Outputs["bucket"].IsSecret())
+	// Outputs that are secret for reasons other than the input keep their secret bit.
+	assert.True(t, resA.Outputs["arn"].IsSecret())
+}
+
+// plaintext models a provider that does not accept secrets and so only ever sees unwrapped values.
+func plaintext(v resource.PropertyValue) resource.PropertyValue {
+	if v.IsSecret() {
+		return v.SecretValue().Element
+	}
+	return v
+}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -176,7 +176,7 @@ func (s *SameStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 	// Retain the ID and outputs
 	s.new.ID = s.old.ID
-	s.new.Outputs = s.old.Outputs
+	s.new.Outputs = unmirrorSecretOutputs(s.old.Outputs, s.new.Inputs, s.new.AdditionalSecretOutputs)
 
 	// If the resource is a provider, ensure that it is present in the registry under the appropriate URNs.
 	// We can only do this if the provider is actually a same, not a skipped create or an untargeted same;
@@ -211,6 +211,35 @@ func (s *SameStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 	}
 	return resource.StatusOK, complete, nil
+}
+
+// unmirrorSecretOutputs undoes the input -> output secret mirroring that the step executor applies, for
+// outputs whose plaintext is already stored in the resource's (no longer secret) inputs. A same step
+// carries the old outputs forward verbatim, so without this a property stays secret in the state forever
+// once the program stops wrapping it in pulumi.secret.
+func unmirrorSecretOutputs(
+	outputs, inputs resource.PropertyMap, additionalSecretOutputs []resource.PropertyKey,
+) resource.PropertyMap {
+	var result resource.PropertyMap
+	for k, out := range outputs {
+		in, has := inputs[k]
+		if !out.IsSecret() || !has || in.IsSecret() || slices.Contains(additionalSecretOutputs, k) {
+			continue
+		}
+		// Only drop the secret bit when the output is the input value verbatim: the same plaintext is then
+		// already being written to the state as an input, so nothing new is revealed.
+		if !out.SecretValue().Element.DeepEquals(in) {
+			continue
+		}
+		if result == nil {
+			result = outputs.Copy()
+		}
+		result[k] = in
+	}
+	if result == nil {
+		return outputs
+	}
+	return result
 }
 
 func (s *SameStep) IsSkippedCreate() bool {


### PR DESCRIPTION
## Summary

Fixes #13877. Removing `pulumi.secret` from a program input did not stick: the property stayed marked secret in the state forever.

Two pieces combine to cause it:

- `pkg/resource/deploy/step_executor.go` mirrors the secret bit from a resource's inputs onto matching outputs after every step ("If an input secret is potentially leaked as an output, preemptively mark it as secret"). That loop only ever *adds* the bit.
- `SameStep.Apply` copies `old.Outputs` forward verbatim. Providers that do not accept secrets (bridged providers) see only plaintext, so a secretness-only change reports `DiffNone` — precisely the case where the mirrored bit is never recomputed.

The inputs in the state are updated correctly; it is the outputs that go stale.

This undoes the mirroring on same steps, but only for an output whose plaintext is byte-identical to the (no longer secret) input. That same plaintext is being written to the state as an input in the same update, so nothing is revealed that is not already there. Outputs the provider derived differently from the input, and outputs listed in `additionalSecretOutputs`, keep their secret bit.

Alternatives considered and rejected: forcing an `Update` when only secretness changes (calls the provider for a metadata-only change), and recording in the state which secret bits the engine itself added (touches state serialization).

## Test plan

- [x] Added appropriate unit tests - For all changes
- [x] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestRemoveSecretFromInputs` in `pkg/engine/lifecycletest/secret_test.go` drives a bridged-style provider that only ever sees plaintext: an update with a secret input, then the same update with the input plain. It asserts the output loses its secret bit, and that a provider-generated output in `additionalSecretOutputs` keeps its own. Without the change it fails on `assert.False(t, resA.Outputs["bucket"].IsSecret())`.

## Validation

- [x] `make lint` — clean for `pkg/resource/deploy` and `pkg/engine/lifecycletest` (the full run fails on a pre-existing, unrelated `nolintlint` issue in `sdk/go/common/util/securestore/keychainstatus_darwin.go:87`)
- [ ] `make test_fast` — not run in full; `go test ./resource/deploy/... ./engine/lifecycletest/...` passes
- [ ] `make tidy_fix` — not run; no dependency changes
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes) — no SDK changes
- [ ] `make check_proto` — no proto changes

## Changelog

- [x] Changelog entry added.

## Risk

Touches the resource lifecycle: the outputs written to the state on a same step. Clearing a secret marker is the risky direction, so it is gated on the output being the input value verbatim — the plaintext is already in the state's inputs at that point. Conservative in the other direction: a secret input that the provider transforms into a different output leaves that output secret. No public API or event surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)