### PR TITLE
[cli/display] Route diagnostics by severity in the diff display

### DIFF
--- a/changelog/pending/20260902--cli-display--diag-severity-stream.yaml
+++ b/changelog/pending/20260902--cli-display--diag-severity-stream.yaml
@@ -1,0 +1,4 @@
+component: cli/display
+kind: fix
+body: Send info-level diagnostics to stdout in the diff display, so only warnings and errors go to stderr
+time: 2026-09-02T11:34:16.711983+02:00

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -80,7 +80,10 @@ func ShowDiffEvents(op string, events <-chan engine.Event, done chan<- bool, opt
 
 			out := stdout
 			if event.Type == engine.DiagEvent {
-				out = stderr
+				payload := event.Payload().(engine.DiagEventPayload)
+				if payload.Severity == diag.Error || payload.Severity == diag.Warning {
+					out = stderr
+				}
 			}
 			if event.Type == engine.ResourceOperationFailed {
 				resourcesErrored++

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -557,4 +558,48 @@ func TestRenderDiffPolicyViolationEvent_StackLevel(t *testing.T) {
 	resourceLevel.ResourceURN = "urn:pulumi:stack::project::aws:s3/bucket:Bucket::my-bucket"
 	resourceOut := renderDiffPolicyViolationEvent(resourceLevel, "", "", opts)
 	assert.Contains(t, resourceOut, "(aws:s3:Bucket: my-bucket)")
+}
+
+func TestShowDiffEventsRoutesDiagnosticsBySeverity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		severity       diag.Severity
+		expectedStdout string
+		expectedStderr string
+	}{
+		{diag.Info, "hello from the program\n", ""},
+		{diag.Warning, "", "careful\n"},
+		{diag.Error, "", "boom\n"},
+	}
+
+	messages := map[diag.Severity]string{
+		diag.Info:    "hello from the program\n",
+		diag.Warning: "careful\n",
+		diag.Error:   "boom\n",
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.severity), func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			events, done := make(chan engine.Event), make(chan bool)
+			go ShowDiffEvents("test", events, done, Options{
+				Color:  colors.Raw,
+				Stdout: &stdout,
+				Stderr: &stderr,
+			})
+
+			events <- engine.NewEvent(engine.DiagEventPayload{
+				Severity: c.severity,
+				Message:  messages[c.severity],
+			})
+			events <- engine.NewCancelEvent()
+			<-done
+
+			assert.Equal(t, c.expectedStdout, stdout.String())
+			assert.Equal(t, c.expectedStderr, stderr.String())
+		})
+	}
 }

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>
 <{%fg 3%}>~ pkgA:m:typA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/urns-diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/urns-diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/1/urns-diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "foo.bar"<{%reset%}>
 <{%fg 3%}>~ urn:pulumi:test::test::pkgA:m:typA::resA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%fg 1%}>  - foo: <{%reset%}><{%fg 1%}>{

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
 <{%fg 3%}>~ pkgA:m:typA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/urns-diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/urns-diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/2/urns-diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
 <{%fg 3%}>~ urn:pulumi:test::test::pkgA:m:typA::resA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%fg 1%}>  - foo: <{%reset%}><{%fg 1%}>{

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
 <{%fg 3%}>~ pkgA:m:typA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/urns-diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/urns-diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/3/urns-diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[0]"<{%reset%}>
 <{%fg 3%}>~ urn:pulumi:test::test::pkgA:m:typA::resA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%fg 1%}>  - foo: <{%reset%}><{%fg 1%}>{

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>
 <{%fg 3%}>~ pkgA:m:typA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%reset%}>    [urn=urn:pulumi:test::test::pkgA:m:typA::resA]

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/urns-diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/urns-diff.stderr.txt
@@ -1,2 +1,0 @@
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>
-<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/urns-diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestIgnoreChangesInvalidPaths/4/urns-diff.stdout.txt
@@ -1,3 +1,5 @@
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>
+<{%reset%}>cannot ignore changes in added or removed elements of the path: "qux[1]"<{%reset%}>
 <{%fg 3%}>~ urn:pulumi:test::test::pkgA:m:typA::resA: (update)
 <{%reset%}>    [id=3]
 <{%reset%}><{%fg 1%}>  - foo: <{%reset%}><{%fg 1%}>{


### PR DESCRIPTION
## Summary

The diff display sends every diagnostic event to stderr, regardless of severity. Info-level diagnostics — program stdout, compiler output, and the output providers such as `command.local.Command` stream back — are therefore reported as errors: the Automation API wires the CLI's stderr straight to `onError`, so callers see ordinary logs on their error handler.

Restore the severity-based routing that predated #20632: warnings and errors go to stderr, everything else to stdout. This matches the progress display, which sends all diagnostics to stdout.

Fixes #24186

**This reverts the user-visible part of #20632**, which moved info-level diagnostics to stderr so #20504 could filter compiler output out of the diff. The two issues are in direct tension, so this needs a maintainer call rather than a straight merge. If #20504's use case still needs serving, `Options.SuppressDiagEventsInDiff` already exists for exactly that and is currently wired to nothing — a `--suppress-diagnostics` flag would fit the `--suppress-outputs`/`--suppress-progress` family.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [x] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestShowDiffEventsRoutesDiagnosticsBySeverity` asserts info goes to stdout and warning/error to stderr; its `info` subtest fails before this change. The `TestIgnoreChangesInvalidPaths` goldens were regenerated with `PULUMI_ACCEPT=1` — two lines move from `diff.stderr.txt` to `diff.stdout.txt` in four cases.

## Validation
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

`make lint` could not run — another process held the golangci-lint lock on this machine — so `go vet ./backend/display/...` and `gofmt` were run instead. `go test ./engine/lifecycletest/... ./backend/display/...` passes; `make test_fast` was not run in full.

## Changelog
- [x] Changelog entry added.

## Risk

Public CLI behaviour change: anyone parsing `pulumi up --diff` / `preview --diff` output, or the Automation API's `onOutput`/`onError` with `diff: true`, sees info diagnostics move from stderr back to stdout. Blast radius is the diff display only — the progress display (the default) is untouched. No API surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)