### PR TITLE
Bound the length of git plugin cache directory names

### DIFF
--- a/changelog/pending/20260902--cli-plugin--git-plugin-name-length.yaml
+++ b/changelog/pending/20260902--cli-plugin--git-plugin-name-length.yaml
@@ -1,0 +1,4 @@
+component: cli/plugin
+kind: fix
+body: Shorten long git-based plugin cache directory names to avoid exceeding Windows path limits
+time: 2026-09-02T00:00:00Z

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1293,6 +1294,25 @@ func (spec PluginDescriptor) IsGitPlugin() bool {
 	return strings.HasPrefix(spec.PluginDownloadURL, "git://")
 }
 
+// maxLocalNameLen bounds the length of a git plugin's local name. A git plugin's name embeds
+// the repository URL and the plugin's path within that repository, and that path is repeated
+// again as a subdirectory of the plugin's cache directory. Left unbounded this easily pushes
+// the plugin's own files past Windows' 260 character MAX_PATH limit, which breaks tools that
+// don't opt in to long paths (for example Python's DLL loader).
+// See https://github.com/pulumi/pulumi/issues/21154.
+const maxLocalNameLen = 48
+
+// shortenLocalName truncates name to maxLocalNameLen, appending a hash of the full name so that
+// plugins that share a prefix still get distinct cache directories.
+func shortenLocalName(name string) string {
+	if len(name) <= maxLocalNameLen {
+		return name
+	}
+	sum := sha256.Sum256([]byte(name))
+	suffix := "-h" + hex.EncodeToString(sum[:4])
+	return name[:maxLocalNameLen-len(suffix)] + suffix
+}
+
 // LocalName returns the local name of the plugin, which is used in the directory name, and a path
 // within that directory if the plugin is located in a subdirectory.
 func (spec PluginDescriptor) LocalName() (string, string) {
@@ -1300,13 +1320,13 @@ func (spec PluginDescriptor) LocalName() (string, string) {
 		trimmed := strings.TrimPrefix(spec.PluginDownloadURL, "git://")
 		url, path, err := gitutil.ParseGitRepoURL("https://" + strings.TrimPrefix(trimmed, "git://"))
 		if err != nil {
-			return strings.ReplaceAll(trimmed, "/", "_"), ""
+			return shortenLocalName(strings.ReplaceAll(trimmed, "/", "_")), ""
 		}
 		pathWithPrefix := path
 		if path != "" {
 			pathWithPrefix = "_" + path
 		}
-		return strings.ReplaceAll(strings.TrimPrefix(url, "https://")+pathWithPrefix, "/", "_"), path
+		return shortenLocalName(strings.ReplaceAll(strings.TrimPrefix(url, "https://")+pathWithPrefix, "/", "_")), path
 	}
 	return spec.Name, ""
 }

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -2322,3 +2322,44 @@ func TestIsExternalURL(t *testing.T) {
 	isnot(".hidden")
 	isnot("local.exe")
 }
+
+func TestLocalNameIsBoundedForWindowsPaths(t *testing.T) {
+	t.Parallel()
+
+	// The path within the repo is repeated inside the plugin's cache directory, so a deeply
+	// nested component must not also make the directory name grow without bound.
+	// See https://github.com/pulumi/pulumi/issues/21154.
+	longSpec := PluginDescriptor{
+		Name: "pulumi-example",
+		PluginDownloadURL: "git://github.com/MitchellGerdisch/multiple-components-single-repo/" +
+			"components/components-random",
+	}
+	name, path := longSpec.LocalName()
+	require.LessOrEqual(t, len(name), maxLocalNameLen)
+	require.Equal(t, "components/components-random", path)
+
+	// Sibling components in the same repo still get distinct cache directories.
+	siblingSpec := PluginDescriptor{
+		Name: "pulumi-example",
+		PluginDownloadURL: "git://github.com/MitchellGerdisch/multiple-components-single-repo/" +
+			"components/components-static-page",
+	}
+	siblingName, _ := siblingSpec.LocalName()
+	require.LessOrEqual(t, len(siblingName), maxLocalNameLen)
+	require.NotEqual(t, name, siblingName)
+
+	// Shortened names must still round-trip through the plugin directory scanner, otherwise
+	// installed plugins would never be found in the cache.
+	dir := t.TempDir()
+	installed := PluginDescriptor{
+		Kind:              apitype.ResourcePlugin,
+		Name:              longSpec.Name,
+		Version:           &semver.Version{Major: 1, Minor: 2, Patch: 3},
+		PluginDownloadURL: longSpec.PluginDownloadURL,
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, installed.Dir()), 0o700))
+	plugins, err := GetPluginsFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+	require.Equal(t, name, plugins[0].Name)
+}


### PR DESCRIPTION
## Summary

A git plugin's local name embeds the repository URL and the plugin's path within
that repository, and `getPluginInfoAndPath` then appends that same path again as
a subdirectory of the plugin's cache directory. Left unbounded, this pushes the
plugin's own files past Windows' 260 character `MAX_PATH` limit, breaking tools
that don't opt in to long paths — for instance Python's DLL loader:

```
C:\Users\RUNNER~1\...\plugins\resource-github.com_pulumi_component-test-providers.git_test-provider-2-v0.0.0-x52a8a71...\test-provider-2\.venv\Lib\site-packages\grpc\_compression.py
ImportError: DLL load failed while importing cygrpc: The filename or extension is too long.
```

`LocalName` now truncates names over 48 characters and appends a hash of the full
name, so distinct plugins still get distinct cache directories:

```
 48 -> github.com_pulumi_component-test-provi-he5fa83c0   (was 62)
 48 -> github.com_MitchellGerdisch_multiple-c-hf469b6e4   (was 92)
 36 -> github.com_pulumi_pulumi-example.git               (unchanged)
```

The local name is what both writes and reads the plugin cache directory
(`Dir()` on the way in, `tryPlugin` plus the selection functions on the way out),
so the scanner keeps round-tripping with no further changes. The hex suffix keeps
the name matching `pluginRegexp`.

Fixes #21154

This does not remove the duplication itself — the path still appears both in the
directory name and as a real subdirectory. That is the storage/symlink redesign
in #21147. The other large contributor to the budget is the 40 character commit
hash in `v0.0.0-x<sha1>`; shortening it would save another ~28 characters but
changes plugin identity, so it is left alone here.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`TestLocalNameIsBoundedForWindowsPaths` covers the bound, that sibling components
in the same repo still get distinct directories, and that a shortened name still
round-trips through `GetPluginsFromDir`. It fails without the change
(`"92" is not less than or equal to "48"`).

## Validation
- [x] `make lint` — clean (scoped to `sdk/go/common/workspace/...`; `bin/custom-gcl` needed a rebuild first, it was stale against Go 1.27)
- [x] `make test_fast` — the `sdk/go/common/workspace` package passes; `pkg/` builds
- [ ] `make tidy_fix` — not run, no module changes
- [x] `make format` — clean (`gofumpt` reports nothing)
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
- [x] Changelog entry added.

## Risk

Plugins already cached under a name longer than 48 characters will no longer be
found and get re-downloaded once. That is a cache, and it only affects the
long-named plugins that were broken on Windows anyway.

48 is a single tunable constant, chosen so the CI failure above (~250 characters)
drops to ~236.
