### PR TITLE
Defer secrets manager construction failures when reading stack outputs

### DIFF
--- a/changelog/pending/engine-fix-20260901-111435.yaml
+++ b/changelog/pending/engine-fix-20260901-111435.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: No longer require stack secrets to be decryptable when reading a stack's non-secret outputs
+time: 2026-09-01T11:14:35.735222+02:00

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -538,9 +538,12 @@ func DeserializeStackOutputs(
 		return nil, nil
 	}
 
+	// Constructing the secrets manager can fail for reasons unrelated to the outputs we are about to read -- for
+	// example, the caller may not have decrypt permission on the stack's key. Defer the failure until we actually
+	// need to decrypt something, so that stacks without secret outputs can still be read.
 	secretsManager, err := initializeSecretsManager(ctx, deployment, secretsProv)
 	if err != nil {
-		return nil, err
+		secretsManager = deferredErrorSecretsManager{err}
 	}
 
 	return BatchDecrypt(

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -18,6 +18,7 @@ package stack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1212,6 +1213,66 @@ func TestDeserializeStackOutputs_SecretsInSnapshotButNotInStackOutputs_NoDecrypt
 		"foo":   resource.NewProperty(42.0),
 		"hello": resource.NewProperty("world"),
 	}, outputs)
+}
+
+// Tests that stack outputs can still be read when the stack's secrets manager cannot be constructed (for example
+// because the caller lacks decrypt permission on the stack's key), as long as none of the outputs are secret.
+func TestDeserializeStackOutputs_SecretsManagerFails_NoSecretOutputs(t *testing.T) {
+	t.Parallel()
+
+	deployment := apitype.DeploymentV3{
+		Resources: []apitype.ResourceV3{
+			{
+				URN:  resource.DefaultRootStackURN("test_stack", "test_project"),
+				Type: resource.RootStackType,
+				Outputs: map[string]any{
+					"foo":   42.0,
+					"hello": "world",
+				},
+			},
+		},
+		SecretsProviders: &apitype.SecretsProvidersV1{Type: "mock"},
+	}
+
+	provider := (&secrets.MockProvider{}).Add("mock", func(_ json.RawMessage) (secrets.Manager, error) {
+		return nil, errors.New("403 Forbidden: caller is not authorized to decrypt")
+	})
+
+	outputs, err := DeserializeStackOutputs(t.Context(), deployment, provider)
+	require.NoError(t, err)
+	assert.Equal(t, resource.PropertyMap{
+		"foo":   resource.NewProperty(42.0),
+		"hello": resource.NewProperty("world"),
+	}, outputs)
+}
+
+// Tests that a failure to construct the stack's secrets manager is still reported, with its original message, when
+// the stack outputs actually contain a secret.
+func TestDeserializeStackOutputs_SecretsManagerFails_SecretOutput(t *testing.T) {
+	t.Parallel()
+
+	deployment := apitype.DeploymentV3{
+		Resources: []apitype.ResourceV3{
+			{
+				URN:  resource.DefaultRootStackURN("test_stack", "test_project"),
+				Type: resource.RootStackType,
+				Outputs: map[string]any{
+					"secret": map[string]any{
+						resource.SigKey: resource.SecretSig,
+						"ciphertext":    "v1:xRi3+sQJSJHR8sha:RM8BfzSAJI84QMl+zLGjzPvwSqV6zOSdd/I/V34h",
+					},
+				},
+			},
+		},
+		SecretsProviders: &apitype.SecretsProvidersV1{Type: "mock"},
+	}
+
+	provider := (&secrets.MockProvider{}).Add("mock", func(_ json.RawMessage) (secrets.Manager, error) {
+		return nil, errors.New("403 Forbidden: caller is not authorized to decrypt")
+	})
+
+	_, err := DeserializeStackOutputs(t.Context(), deployment, provider)
+	assert.ErrorContains(t, err, "403 Forbidden: caller is not authorized to decrypt")
 }
 
 // Test that DeserializeStackOutputs correctly decrypts secrets found in the stack outputs.

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -582,3 +582,21 @@ func BatchDecrypt[T any](
 	err = errors.Join(err, fnerr)
 	return result, err
 }
+
+// deferredErrorSecretsManager is a secrets.Manager whose crypters always fail with the error that prevented a real
+// secrets manager from being constructed. It allows callers to defer that failure until they know whether anything
+// actually needs decrypting.
+type deferredErrorSecretsManager struct{ err error }
+
+var _ secrets.Manager = deferredErrorSecretsManager{}
+
+func (m deferredErrorSecretsManager) Type() string           { return "error" }
+func (m deferredErrorSecretsManager) State() json.RawMessage { return nil }
+
+func (m deferredErrorSecretsManager) Encrypter() config.Encrypter {
+	return config.NewErrorCrypter(m.err.Error())
+}
+
+func (m deferredErrorSecretsManager) Decrypter() config.Decrypter {
+	return config.NewErrorCrypter(m.err.Error())
+}


### PR DESCRIPTION
## Summary

Reading a stack's outputs eagerly constructed the stack's secrets manager before knowing whether any output actually needed decrypting:

```go
secretsManager, err := initializeSecretsManager(ctx, deployment, secretsProv)
if err != nil {
    return nil, err
}
```

If that construction failed the whole read failed, even when every output was plain. In #21436 the caller has no `decrypt` permission on the stack's Azure Key Vault key, so a `StackReference` to a stack exporting only `pulumi.Output.unsecret(...)` values dies with a 403 before a single ciphertext is looked at.

`errorCatchingSecretsProvider` already tolerates *decrypt* failures (it elides the secret and lets plain values through); it just had no way to tolerate a *construction* failure, because `OfType` propagates the error.

This substitutes a `secrets.Manager` whose crypters fail with the original error, so the failure only surfaces if a secret is actually encountered. `BatchDecrypt` only reaches for the decrypter when it finds a ciphertext, so a stack with no secret outputs never touches the key.

`pulumi stack output` goes through the same path, so it also stops requiring decrypt permission to print plain outputs.

Scope notes:

- `DeserializeDeploymentV3` is deliberately left eager — the manager it builds is stored on the snapshot and used to *re-encrypt* on write, so a deferred failure there would be a footgun.
- This only partly addresses #21143: with the `passphrase` provider in an interactive terminal, `OfType` prompts rather than failing, so the prompt still appears. Removing that needs the fully lazy wrapper suggested in #21436, which is a larger change.

Fixes #21436

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Two tests in `pkg/resource/stack/deployment_test.go`:

- `TestDeserializeStackOutputs_SecretsManagerFails_NoSecretOutputs` — a provider whose `OfType` returns a 403, and a root stack with only plain outputs. Fails on `master` with `Received unexpected error: 403 Forbidden...`, passes with this change.
- `TestDeserializeStackOutputs_SecretsManagerFails_SecretOutput` — same provider, but the outputs contain a secret. Asserts the original 403 message still reaches the caller. Passes both before and after; it's a guard against swallowing the error.

## Validation

- [x] `make lint` — clean
- [ ] `make test_fast` — not run in full; `go test ./resource/stack/... ./backend/` in `pkg/` passes
- [ ] `make tidy_fix` — not run (no `go.mod`/`go.sum` changes)
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes) — no SDK changes
- [ ] `make check_proto` — clean (if proto changes) — no proto changes

## Changelog

- [x] Changelog entry added.

## Risk

Low and narrow. The only behavioural change is in `DeserializeStackOutputs`: an error that previously aborted the read is now deferred to the point of first decryption. Callers that do hit a secret still get the same error, with the same message — the second test pins that. No public API surface, no state serialization format change; the deferred manager is only ever handed to `BatchDecrypt` and never written back to a snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
