### PR TITLE
Run state migrations for aliased remote components

### DIFF
--- a/changelog/pending/engine-fix-20260902-160759.yaml
+++ b/changelog/pending/engine-fix-20260902-160759.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Run state migrations for aliased remote components
+time: 2026-09-02T16:07:59.471844+02:00

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -1017,14 +1017,19 @@ func TestStateMigrationS3BucketFold(t *testing.T) {
 
 // TestStateMigrationConstruct exercises this migration inside a remote component:
 //
-//	remote component
-//	└─ resA (managed) -> resB (managed, retaining resA's ID)
+//	pkgA:m:typC "comp"                 pkgA:m:typD "comp"
+//	└─ typA "resA" (managed)    ->     └─ typA "resB" (same ID)
 //
-// The callback attached to the program's remote registration must run before the component provider constructs it.
+// The callback and alias from the program's registration must reach the component provider's registration.
 func TestStateMigrationConstruct(t *testing.T) {
 	t.Parallel()
 
-	childName := "resA"
+	const (
+		oldComponentType = "pkgA:m:typC"
+		newComponentType = "pkgA:m:typD"
+	)
+
+	upgrade := false
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
@@ -1036,6 +1041,10 @@ func TestStateMigrationConstruct(t *testing.T) {
 					resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{})
 					require.NoError(t, err)
 
+					childName := "resA"
+					if upgrade {
+						childName = "resB"
+					}
 					_, err = monitor.RegisterResource("pkgA:m:typA", childName, true, deploytest.ResourceOptions{
 						Parent: resp.URN,
 						Inputs: resource.PropertyMap{"foo": resource.NewProperty(1.0)},
@@ -1053,9 +1062,18 @@ func TestStateMigrationConstruct(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, callbacks.Close()) }()
 
-		_, err = monitor.RegisterResource("pkgA:m:typC", "comp", false, deploytest.ResourceOptions{
+		componentType := oldComponentType
+		var aliases []*pulumirpc.Alias
+		if upgrade {
+			componentType = newComponentType
+			aliases = []*pulumirpc.Alias{{
+				Alias: &pulumirpc.Alias_Spec_{Spec: &pulumirpc.Alias_Spec{Type: oldComponentType}},
+			}}
+		}
+		_, err = monitor.RegisterResource(tokens.Type(componentType), "comp", false, deploytest.ResourceOptions{
 			Remote:          true,
 			StateMigrations: []*pulumirpc.Callback{renameMigration(t, callbacks, "resA", "resB")},
+			Aliases:         aliases,
 		})
 		return err
 	})
@@ -1064,14 +1082,15 @@ func TestStateMigrationConstruct(t *testing.T) {
 
 	snap, err := runUpdate(t, p, nil, nil)
 	require.NoError(t, err)
-	require.Contains(t, snapURNs(snap), resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
+	require.Contains(t, snapURNs(snap),
+		resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
 
-	childName = "resB"
+	upgrade = true
 	snap, err = runUpdate(t, p, snap,
 		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
 	require.NoError(t, err)
 	urns := snapURNs(snap)
-	assert.Contains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resB"))
+	assert.Contains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typD$pkgA:m:typA::resB"))
 	assert.NotContains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
 }
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -438,6 +438,11 @@ type extensionRef struct {
 	extension apitype.Extension
 }
 
+type pendingStateMigration struct {
+	functions []StateMigrationFunction
+	aliases   []*pulumirpc.Alias
+}
+
 // resmon implements the pulumirpc.ResourceMonitor interface and acts as the gateway between a language runtime's
 // evaluation of a program and the internal resource planning and deployment logic.
 type resmon struct {
@@ -446,8 +451,8 @@ type resmon struct {
 	pendingTransforms     map[string][]TransformFunction // pending transformation functions for a constructed resource
 	pendingTransformsLock sync.Mutex
 
-	// pending state migration functions for a constructed resource
-	pendingStateMigrations     map[string][]StateMigrationFunction
+	// pending state migrations for a constructed resource
+	pendingStateMigrations     map[string]pendingStateMigration
 	pendingStateMigrationsLock sync.Mutex
 
 	parents     map[resource.URN]resource.URN // map of child URNs to their parent URNs
@@ -557,7 +562,7 @@ func newResourceMonitor(
 		workingDirectory:        src.runinfo.Pwd,
 		sourcePositions:         newSourcePositions(src.runinfo.ProjectRoot),
 		pendingTransforms:       map[string][]TransformFunction{},
-		pendingStateMigrations:  map[string][]StateMigrationFunction{},
+		pendingStateMigrations:  map[string]pendingStateMigration{},
 		parents:                 map[resource.URN]resource.URN{},
 		resGoals:                map[resource.URN]pkgresource.Goal{},
 		componentProviders:      map[resource.URN]map[string]string{},
@@ -2540,7 +2545,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 
 		if pending, ok := rm.pendingStateMigrations[pendingKey]; ok {
 			delete(rm.pendingStateMigrations, pendingKey)
-			stateMigrations = pending
+			stateMigrations = pending.functions
+			// The constructed registration may omit aliases from the original remote registration. Keep them so the
+			// migration can find the prior state.
+			opts.Aliases = append(slices.Clone(pending.aliases), opts.Aliases...)
 		} else {
 			stateMigrations, err = slice.MapError(req.StateMigrations, rm.wrapStateMigrationCallback)
 			if err != nil {
@@ -2548,7 +2556,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			}
 			// We only need to save this for remote calls
 			if remote && len(stateMigrations) > 0 {
-				rm.pendingStateMigrations[pendingKey] = stateMigrations
+				rm.pendingStateMigrations[pendingKey] = pendingStateMigration{
+					functions: stateMigrations,
+					aliases:   slices.Clone(opts.Aliases),
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Remote components are registered twice. The program first asks a component provider to construct the component, and the provider then registers the constructed component with the engine.

The engine already carries state migration callbacks from the first registration to the second. However, there's no guarantee that component providers repeat the resource aliases when they register the constructed component. Without those aliases, the engine cannot find the previous component state, so it skips the migration and treats the component as new.

To fix that, we track the aliases along with the migration callbacks for remote components.

Ref https://github.com/pulumi/pulumi/issues/24045