### PR TITLE
Sort resources deterministically in Snapshot.Toposort

### DIFF
--- a/changelog/pending/engine-fix-20260902-160759.yaml
+++ b/changelog/pending/engine-fix-20260902-160759.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Run state migrations for aliased remote components
+time: 2026-09-02T16:07:59.471844+02:00

--- a/changelog/pending/engine-fix-20260902-172723.yaml
+++ b/changelog/pending/engine-fix-20260902-172723.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Sort resources deterministically when repairing a snapshot
+time: 2026-09-02T17:27:23.995995+02:00

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -1017,14 +1017,19 @@ func TestStateMigrationS3BucketFold(t *testing.T) {
 
 // TestStateMigrationConstruct exercises this migration inside a remote component:
 //
-//	remote component
-//	└─ resA (managed) -> resB (managed, retaining resA's ID)
+//	pkgA:m:typC "comp"                 pkgA:m:typD "comp"
+//	└─ typA "resA" (managed)    ->     └─ typA "resB" (same ID)
 //
-// The callback attached to the program's remote registration must run before the component provider constructs it.
+// The callback and alias from the program's registration must reach the component provider's registration.
 func TestStateMigrationConstruct(t *testing.T) {
 	t.Parallel()
 
-	childName := "resA"
+	const (
+		oldComponentType = "pkgA:m:typC"
+		newComponentType = "pkgA:m:typD"
+	)
+
+	upgrade := false
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
@@ -1036,6 +1041,10 @@ func TestStateMigrationConstruct(t *testing.T) {
 					resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{})
 					require.NoError(t, err)
 
+					childName := "resA"
+					if upgrade {
+						childName = "resB"
+					}
 					_, err = monitor.RegisterResource("pkgA:m:typA", childName, true, deploytest.ResourceOptions{
 						Parent: resp.URN,
 						Inputs: resource.PropertyMap{"foo": resource.NewProperty(1.0)},
@@ -1053,9 +1062,18 @@ func TestStateMigrationConstruct(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, callbacks.Close()) }()
 
-		_, err = monitor.RegisterResource("pkgA:m:typC", "comp", false, deploytest.ResourceOptions{
+		componentType := oldComponentType
+		var aliases []*pulumirpc.Alias
+		if upgrade {
+			componentType = newComponentType
+			aliases = []*pulumirpc.Alias{{
+				Alias: &pulumirpc.Alias_Spec_{Spec: &pulumirpc.Alias_Spec{Type: oldComponentType}},
+			}}
+		}
+		_, err = monitor.RegisterResource(tokens.Type(componentType), "comp", false, deploytest.ResourceOptions{
 			Remote:          true,
 			StateMigrations: []*pulumirpc.Callback{renameMigration(t, callbacks, "resA", "resB")},
+			Aliases:         aliases,
 		})
 		return err
 	})
@@ -1064,14 +1082,15 @@ func TestStateMigrationConstruct(t *testing.T) {
 
 	snap, err := runUpdate(t, p, nil, nil)
 	require.NoError(t, err)
-	require.Contains(t, snapURNs(snap), resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
+	require.Contains(t, snapURNs(snap),
+		resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
 
-	childName = "resB"
+	upgrade = true
 	snap, err = runUpdate(t, p, snap,
 		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
 	require.NoError(t, err)
 	urns := snapURNs(snap)
-	assert.Contains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resB"))
+	assert.Contains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typD$pkgA:m:typA::resB"))
 	assert.NotContains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
 }
 

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -15,9 +15,11 @@
 package deploy
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -304,8 +306,14 @@ func (snap *Snapshot) Toposort() error {
 		}
 	}
 
+	// Visit dependencies in snapshot order so that sorting is deterministic
+	indices := make(map[*pkgresource.State]int, len(snap.Resources))
+	for i, state := range snap.Resources {
+		indices[state] = i
+	}
+
 	for _, state := range snap.Resources {
-		err := topoVisit(state, &sorted, oldsByURN, newsByURN, visiting, visited)
+		err := topoVisit(state, &sorted, oldsByURN, newsByURN, indices, visiting, visited)
 		if err != nil {
 			return err
 		}
@@ -469,6 +477,7 @@ func topoVisit(
 	sorted *[]*pkgresource.State,
 	oldsByURN map[resource.URN]*pkgresource.State,
 	newsByURN map[resource.URN]*pkgresource.State,
+	indices map[*pkgresource.State]int,
 	visiting map[*pkgresource.State]bool,
 	visited map[*pkgresource.State]bool,
 ) error {
@@ -526,8 +535,11 @@ func topoVisit(
 			}
 		}
 
-		for next := range nexts {
-			if err := topoVisit(next, sorted, oldsByURN, newsByURN, visiting, visited); err != nil {
+		ordered := slices.SortedFunc(maps.Keys(nexts), func(a, b *pkgresource.State) int {
+			return cmp.Compare(indices[a], indices[b])
+		})
+		for _, next := range ordered {
+			if err := topoVisit(next, sorted, oldsByURN, newsByURN, indices, visiting, visited); err != nil {
 				return err
 			}
 		}

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -1319,3 +1319,37 @@ func TestSnapshotVerifyIntegrity_SnippetUUID(t *testing.T) {
 			`duplicate snippet uuid "e970a91d-4f4c-5793-8d27-dd27a0d96cf7" at indexes 0 and 1`)
 	})
 }
+
+func TestSnapshotToposort_IsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	for range 20 {
+		snap := &Snapshot{Resources: []*pkgresource.State{
+			{
+				URN:  "urn:pulumi:stack::project::t::dependent",
+				Type: "pulumi:pulumi:Stack",
+				Dependencies: []resource.URN{
+					"urn:pulumi:stack::project::t::c",
+					"urn:pulumi:stack::project::t::b",
+					"urn:pulumi:stack::project::t::a",
+				},
+			},
+			{URN: "urn:pulumi:stack::project::t::a", Type: "pulumi:pulumi:Stack"},
+			{URN: "urn:pulumi:stack::project::t::b", Type: "pulumi:pulumi:Stack"},
+			{URN: "urn:pulumi:stack::project::t::c", Type: "pulumi:pulumi:Stack"},
+		}}
+
+		require.NoError(t, snap.Toposort())
+
+		urns := make([]resource.URN, len(snap.Resources))
+		for i, res := range snap.Resources {
+			urns[i] = res.URN
+		}
+		require.Equal(t, []resource.URN{
+			"urn:pulumi:stack::project::t::a",
+			"urn:pulumi:stack::project::t::b",
+			"urn:pulumi:stack::project::t::c",
+			"urn:pulumi:stack::project::t::dependent",
+		}, urns)
+	}
+}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -438,6 +438,11 @@ type extensionRef struct {
 	extension apitype.Extension
 }
 
+type pendingStateMigration struct {
+	functions []StateMigrationFunction
+	aliases   []*pulumirpc.Alias
+}
+
 // resmon implements the pulumirpc.ResourceMonitor interface and acts as the gateway between a language runtime's
 // evaluation of a program and the internal resource planning and deployment logic.
 type resmon struct {
@@ -446,8 +451,8 @@ type resmon struct {
 	pendingTransforms     map[string][]TransformFunction // pending transformation functions for a constructed resource
 	pendingTransformsLock sync.Mutex
 
-	// pending state migration functions for a constructed resource
-	pendingStateMigrations     map[string][]StateMigrationFunction
+	// pending state migrations for a constructed resource
+	pendingStateMigrations     map[string]pendingStateMigration
 	pendingStateMigrationsLock sync.Mutex
 
 	parents     map[resource.URN]resource.URN // map of child URNs to their parent URNs
@@ -557,7 +562,7 @@ func newResourceMonitor(
 		workingDirectory:        src.runinfo.Pwd,
 		sourcePositions:         newSourcePositions(src.runinfo.ProjectRoot),
 		pendingTransforms:       map[string][]TransformFunction{},
-		pendingStateMigrations:  map[string][]StateMigrationFunction{},
+		pendingStateMigrations:  map[string]pendingStateMigration{},
 		parents:                 map[resource.URN]resource.URN{},
 		resGoals:                map[resource.URN]pkgresource.Goal{},
 		componentProviders:      map[resource.URN]map[string]string{},
@@ -2540,7 +2545,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 
 		if pending, ok := rm.pendingStateMigrations[pendingKey]; ok {
 			delete(rm.pendingStateMigrations, pendingKey)
-			stateMigrations = pending
+			stateMigrations = pending.functions
+			// The constructed registration may omit aliases from the original remote registration. Keep them so the
+			// migration can find the prior state.
+			opts.Aliases = append(slices.Clone(pending.aliases), opts.Aliases...)
 		} else {
 			stateMigrations, err = slice.MapError(req.StateMigrations, rm.wrapStateMigrationCallback)
 			if err != nil {
@@ -2548,7 +2556,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			}
 			// We only need to save this for remote calls
 			if remote && len(stateMigrations) > 0 {
-				rm.pendingStateMigrations[pendingKey] = stateMigrations
+				rm.pendingStateMigrations[pendingKey] = pendingStateMigration{
+					functions: stateMigrations,
+					aliases:   slices.Clone(opts.Aliases),
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Visit dependencies in snapshot order so that repairing or reordering a snapshot always produces the same result instead of depending on map iteration order.

Ref https://github.com/pulumi/pulumi/issues/24045