### PR TITLE
Fix state migration ordering for components interleaved with other resources

### DIFF
--- a/changelog/pending/engine-fix-20260902-172734.yaml
+++ b/changelog/pending/engine-fix-20260902-172734.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Fix state migration ordering for components interleaved with other resources
+time: 2026-09-02T17:27:34.576637+02:00

--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -158,7 +158,7 @@ func SerializeJournalEntry(
 		Extension:             je.Extension,
 		Snippets:              snippets,
 		RequiresByteString:    requiresByteString,
-		RemoveOlds:            je.RemoveOlds,
+		Layout:                je.Layout,
 		States:                resultStates,
 		BaseStatePatches:      baseStatePatches,
 		NewStatePatches:       newStatePatches,

--- a/pkg/backend/journal_state_migration.go
+++ b/pkg/backend/journal_state_migration.go
@@ -39,27 +39,45 @@ func (r *JournalReplayer) applyStateMigration(entry apitype.JournalEntry) error 
 				"state migration journal entry cannot be applied with incomplete operation %d", operationID)
 		}
 	}
-	if len(entry.RemoveOlds) == 0 {
-		return errors.New("state migration journal entry removes no resources")
-	}
 	if len(entry.States) == 0 {
 		return errors.New("state migration journal entry inserts no resources")
 	}
 
-	removed := make(map[int64]struct{}, len(entry.RemoveOlds))
-	var greatestRemovedIndex int64 = -1
-	for _, index := range entry.RemoveOlds {
-		if index < 0 || index >= int64(len(r.base.Resources)) {
-			return fmt.Errorf("state migration remove index %d is outside base snapshot with %d resources",
-				index, len(r.base.Resources))
+	newIndices := make(map[int64]int64, len(entry.Layout))
+	placedStates := make(map[int64]struct{}, len(entry.States))
+	for position, item := range entry.Layout {
+		switch {
+		case item.BaseIndex != nil && item.StateIndex != nil:
+			return fmt.Errorf("state migration layout item %d refers to both a base resource and an inserted state",
+				position)
+		case item.BaseIndex != nil:
+			index := *item.BaseIndex
+			if index < 0 || index >= int64(len(r.base.Resources)) {
+				return fmt.Errorf("state migration layout refers to base index %d outside base snapshot with %d resources",
+					index, len(r.base.Resources))
+			}
+			if _, duplicate := newIndices[index]; duplicate {
+				return fmt.Errorf("state migration layout places base resource %d more than once", index)
+			}
+			newIndices[index] = int64(position)
+		case item.StateIndex != nil:
+			index := *item.StateIndex
+			if index < 0 || index >= int64(len(entry.States)) {
+				return fmt.Errorf("state migration layout refers to inserted state %d, but the entry has %d states",
+					index, len(entry.States))
+			}
+			if _, duplicate := placedStates[index]; duplicate {
+				return fmt.Errorf("state migration layout places inserted state %d more than once", index)
+			}
+			placedStates[index] = struct{}{}
+		default:
+			return fmt.Errorf("state migration layout item %d refers to neither a base resource nor an inserted state",
+				position)
 		}
-		if _, duplicate := removed[index]; duplicate {
-			return fmt.Errorf("state migration contains duplicate remove index %d", index)
-		}
-		removed[index] = struct{}{}
-		if index > greatestRemovedIndex {
-			greatestRemovedIndex = index
-		}
+	}
+	if len(placedStates) != len(entry.States) {
+		return fmt.Errorf("state migration layout places %d of %d inserted states",
+			len(placedStates), len(entry.States))
 	}
 
 	// Apply changes to a copy so an error leaves the replayer unchanged.
@@ -74,8 +92,8 @@ func (r *JournalReplayer) applyStateMigration(entry apitype.JournalEntry) error 
 			return fmt.Errorf("state migration base patch index %d is outside base snapshot with %d resources",
 				patch.Index, len(baseResources))
 		}
-		if _, removed := removed[patch.Index]; removed {
-			return fmt.Errorf("state migration base patch index %d is also removed", patch.Index)
+		if _, retained := newIndices[patch.Index]; !retained {
+			return fmt.Errorf("state migration base patch index %d is not retained by the layout", patch.Index)
 		}
 		if _, duplicate := patchedBase[patch.Index]; duplicate {
 			return fmt.Errorf("state migration contains duplicate base patch index %d", patch.Index)
@@ -142,18 +160,13 @@ func (r *JournalReplayer) applyStateMigration(entry apitype.JournalEntry) error 
 		insertedURNs[state.URN] = struct{}{}
 	}
 
-	// Replace the old subtree and track the new index of each remaining resource.
-	newIndices := make(map[int64]int64, len(baseResources))
-	resources := make([]apitype.ResourceV3, 0, len(baseResources)-len(entry.RemoveOlds)+len(entry.States))
-	for i, res := range baseResources {
-		if _, ok := removed[int64(i)]; ok {
-			if int64(i) == greatestRemovedIndex {
-				resources = append(resources, entry.States...)
-			}
-			continue
+	resources := make([]apitype.ResourceV3, 0, len(entry.Layout))
+	for _, item := range entry.Layout {
+		if item.BaseIndex != nil {
+			resources = append(resources, baseResources[*item.BaseIndex])
+		} else {
+			resources = append(resources, entry.States[*item.StateIndex])
 		}
-		newIndices[int64(i)] = int64(len(resources))
-		resources = append(resources, res)
 	}
 
 	newBase := *r.base

--- a/pkg/backend/journal_state_migration_test.go
+++ b/pkg/backend/journal_state_migration_test.go
@@ -55,17 +55,26 @@ func stateMigrationComponentBase() *apitype.DeploymentV3 {
 	}
 }
 
+func layoutBase(index int64) apitype.JournalLayoutItem {
+	return apitype.JournalLayoutItem{BaseIndex: &index}
+}
+
+func layoutState(index int64) apitype.JournalLayoutItem {
+	return apitype.JournalLayoutItem{StateIndex: &index}
+}
+
+// validComponentStateMigrationEntry replaces base resource "a" with "successor".
 func validComponentStateMigrationEntry() apitype.JournalEntry {
 	return apitype.JournalEntry{
-		Version:    2,
-		Kind:       apitype.JournalEntryKindStateMigration,
-		RemoveOlds: []int64{0},
-		States:     []apitype.ResourceV3{stateMigrationComponent("successor")},
+		Version: 2,
+		Kind:    apitype.JournalEntryKindStateMigration,
+		Layout:  []apitype.JournalLayoutItem{layoutState(0), layoutBase(1), layoutBase(2)},
+		States:  []apitype.ResourceV3{stateMigrationComponent("successor")},
 	}
 }
 
-// TestJournalReplayerStateMigration tests that a state migration journal entry removes the given base indices
-// and inserts the migrated states at the greatest removed base index.
+// TestJournalReplayerStateMigration tests that a state migration journal entry rebuilds the base snapshot from its
+// layout, dropping the base resources the layout omits.
 func TestJournalReplayerStateMigration(t *testing.T) {
 	t.Parallel()
 
@@ -74,10 +83,10 @@ func TestJournalReplayerStateMigration(t *testing.T) {
 
 	migrated := stateMigrationComponent("d")
 	require.NoError(t, replayer.Add(apitype.JournalEntry{
-		Version:    2,
-		Kind:       apitype.JournalEntryKindStateMigration,
-		RemoveOlds: []int64{2, 0},
-		States:     []apitype.ResourceV3{migrated},
+		Version: 2,
+		Kind:    apitype.JournalEntryKindStateMigration,
+		Layout:  []apitype.JournalLayoutItem{layoutBase(1), layoutState(0)},
+		States:  []apitype.ResourceV3{migrated},
 	}))
 
 	deployment, err := replayer.GenerateDeployment()
@@ -87,7 +96,7 @@ func TestJournalReplayerStateMigration(t *testing.T) {
 	for i, res := range deployment.Deployment.Resources {
 		urns[i] = res.URN
 	}
-	// "a" and "c" are removed; "d" takes the position of "c", which has the greatest removed index.
+	// "a" and "c" are removed; "d" is inserted after "b".
 	assert.Equal(t, []resource.URN{
 		"urn:pulumi:test::test::pkgA:m:typA::b",
 		"urn:pulumi:test::test::pkgA:m:typA::d",
@@ -119,10 +128,10 @@ func TestJournalReplayerStateMigrationRemapsIndices(t *testing.T) {
 	// into "d", moving "c" to index 1. The pending deletion must follow "c" to its new index. Once "c" is removed,
 	// ordinary refresh cleanup prunes "e"'s dangling dependency on it.
 	require.NoError(t, replayer.Add(apitype.JournalEntry{
-		Version:    2,
-		Kind:       apitype.JournalEntryKindStateMigration,
-		RemoveOlds: []int64{0, 1},
-		States:     []apitype.ResourceV3{stateMigrationComponent("d")},
+		Version: 2,
+		Kind:    apitype.JournalEntryKindStateMigration,
+		Layout:  []apitype.JournalLayoutItem{layoutState(0), layoutBase(2), layoutBase(3)},
+		States:  []apitype.ResourceV3{stateMigrationComponent("d")},
 	}))
 
 	deployment, err := replayer.GenerateDeployment()
@@ -169,10 +178,10 @@ func TestJournalReplayerStateMigrationPatchReplacesEarlierOutputs(t *testing.T) 
 		"reference": stateMigrationResourceReference(migrated.URN),
 	}
 	require.NoError(t, replayer.Add(apitype.JournalEntry{
-		Version:    2,
-		Kind:       apitype.JournalEntryKindStateMigration,
-		RemoveOlds: []int64{0, 1},
-		States:     []apitype.ResourceV3{migrated},
+		Version: 2,
+		Kind:    apitype.JournalEntryKindStateMigration,
+		Layout:  []apitype.JournalLayoutItem{layoutState(0), layoutBase(2)},
+		States:  []apitype.ResourceV3{migrated},
 		BaseStatePatches: []apitype.JournalBaseStatePatch{{
 			Index: 2,
 			State: migrationPatch,
@@ -221,10 +230,10 @@ func TestJournalReplayerStateMigrationAppliesPatches(t *testing.T) {
 	}
 	// A migration folds "a" and "c" into "d".
 	require.NoError(t, replayer.Add(apitype.JournalEntry{
-		Version:    2,
-		Kind:       apitype.JournalEntryKindStateMigration,
-		RemoveOlds: []int64{0, 2},
-		States:     []apitype.ResourceV3{d},
+		Version: 2,
+		Kind:    apitype.JournalEntryKindStateMigration,
+		Layout:  []apitype.JournalLayoutItem{layoutBase(1), layoutState(0), layoutBase(3)},
+		States:  []apitype.ResourceV3{d},
 		BaseStatePatches: []apitype.JournalBaseStatePatch{{
 			Index: 3,
 			State: patched,
@@ -364,13 +373,56 @@ func TestJournalReplayerRejectsMalformedStateMigration(t *testing.T) {
 		require.ErrorContains(t, err, "must use version 2")
 	})
 
-	t.Run("duplicate remove index", func(t *testing.T) {
+	for name, c := range map[string]struct {
+		layout []apitype.JournalLayoutItem
+		err    string
+	}{
+		"base resource placed twice": {
+			layout: []apitype.JournalLayoutItem{layoutState(0), layoutBase(1), layoutBase(1)},
+			err:    "places base resource 1 more than once",
+		},
+		"inserted state placed twice": {
+			layout: []apitype.JournalLayoutItem{layoutState(0), layoutState(0), layoutBase(1), layoutBase(2)},
+			err:    "places inserted state 0 more than once",
+		},
+		"inserted state not placed": {
+			layout: []apitype.JournalLayoutItem{layoutBase(1), layoutBase(2)},
+			err:    "places 0 of 1 inserted states",
+		},
+		"base index out of range": {
+			layout: []apitype.JournalLayoutItem{layoutState(0), layoutBase(3)},
+			err:    "base index 3 outside base snapshot with 3 resources",
+		},
+		"state index out of range": {
+			layout: []apitype.JournalLayoutItem{layoutState(1), layoutBase(1), layoutBase(2)},
+			err:    "inserted state 1, but the entry has 1 states",
+		},
+		"item with both references": {
+			layout: []apitype.JournalLayoutItem{{BaseIndex: layoutBase(1).BaseIndex, StateIndex: layoutState(0).StateIndex}},
+			err:    "refers to both a base resource and an inserted state",
+		},
+		"item without references": {
+			layout: []apitype.JournalLayoutItem{layoutState(0), {}},
+			err:    "refers to neither a base resource nor an inserted state",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			base := stateMigrationComponentBase()
+			entry := validComponentStateMigrationEntry()
+			entry.Layout = c.layout
+			err := NewJournalReplayer(base).Add(entry)
+			require.ErrorContains(t, err, c.err)
+		})
+	}
+
+	t.Run("patch for removed base resource", func(t *testing.T) {
 		t.Parallel()
 		base := stateMigrationComponentBase()
 		entry := validComponentStateMigrationEntry()
-		entry.RemoveOlds = []int64{0, 0}
+		entry.BaseStatePatches = []apitype.JournalBaseStatePatch{{Index: 0, State: base.Resources[0]}}
 		err := NewJournalReplayer(base).Add(entry)
-		require.ErrorContains(t, err, "duplicate remove index 0")
+		require.ErrorContains(t, err, "base patch index 0 is not retained by the layout")
 	})
 
 	t.Run("inserted pending-delete state", func(t *testing.T) {
@@ -419,4 +471,42 @@ func TestJournalReplayerRejectsMalformedStateMigration(t *testing.T) {
 		err := NewJournalReplayer(base).Add(entry)
 		require.ErrorContains(t, err, "references unknown extension")
 	})
+}
+
+// TestJournalReplayerStateMigrationReordersRetainedResources tests that a layout can move retained base resources
+// and that lifecycle markers recorded by earlier entries follow them to their new positions.
+func TestJournalReplayerStateMigrationReordersRetainedResources(t *testing.T) {
+	t.Parallel()
+
+	base := stateMigrationComponentBase()
+	replayer := NewJournalReplayer(base)
+
+	// An earlier entry marks base resource "b" (index 1) as deleted.
+	deleteOld := int64(1)
+	require.NoError(t, replayer.Add(apitype.JournalEntry{
+		Version:   1,
+		Kind:      apitype.JournalEntryKindSuccess,
+		DeleteOld: &deleteOld,
+	}))
+
+	// The migration replaces "a" with "d" and moves "c" ahead of both.
+	require.NoError(t, replayer.Add(apitype.JournalEntry{
+		Version: 2,
+		Kind:    apitype.JournalEntryKindStateMigration,
+		Layout:  []apitype.JournalLayoutItem{layoutBase(2), layoutState(0), layoutBase(1)},
+		States:  []apitype.ResourceV3{stateMigrationComponent("d")},
+	}))
+
+	deployment, err := replayer.GenerateDeployment()
+	require.NoError(t, err)
+	urns := make([]resource.URN, len(deployment.Deployment.Resources))
+	for i, res := range deployment.Deployment.Resources {
+		urns[i] = res.URN
+	}
+	assert.Equal(t, []resource.URN{
+		"urn:pulumi:test::test::pkgA:m:typA::c",
+		"urn:pulumi:test::test::pkgA:m:typA::d",
+		"urn:pulumi:test::test::pkgA:m:typA::b",
+	}, urns)
+	assert.True(t, deployment.Deployment.Resources[2].Delete)
 }

--- a/pkg/backend/journal_test.go
+++ b/pkg/backend/journal_test.go
@@ -201,7 +201,7 @@ func TestStateMigrationPatchesRewriteBeforeEncryptionAndReplayVerbatim(t *testin
 	secretsManager := b64.NewBase64SecretsManager()
 	entry, err := SerializeJournalEntry(t.Context(), engine.JournalEntry{
 		Kind:         engine.JournalEntryStateMigration,
-		RemoveOlds:   []int64{0},
+		Layout:       []apitype.JournalLayoutItem{layoutState(0), layoutBase(1)},
 		ResultStates: []*pkgresource.State{successor},
 		BaseStatePatches: []engine.JournalBaseStatePatch{{
 			Index: 1,

--- a/pkg/engine/journal_snapshot.go
+++ b/pkg/engine/journal_snapshot.go
@@ -198,14 +198,15 @@ type JournalEntry struct {
 	// Snippets is the complete snippet list to persist when Kind is JournalEntrySnippets.
 	Snippets []resource.Snippet
 
-	// RemoveOlds holds the indices of the resources in the base snapshot that a state migration removes.
-	// Only set for JournalEntryStateMigration entries.
-	RemoveOlds []int64
-	// ResultStates holds the result subtree a state migration splices into the base snapshot, in order. It takes
-	// the position of the resource with the greatest removed index. Only set for JournalEntryStateMigration entries.
+	// Layout lists the complete base snapshot produced by a state migration, in order: retained resources by their
+	// index in the current base snapshot and inserted resources by their index in ResultStates. Base resources absent
+	// from Layout are removed. Only set for JournalEntryStateMigration entries.
+	Layout []apitype.JournalLayoutItem
+	// ResultStates holds the resources a state migration inserts into the base snapshot, in Layout order. Only set for
+	// JournalEntryStateMigration entries.
 	ResultStates []*pkgresource.State
 	// BaseStatePatches contains complete replacements for retained base resources whose references were rewritten.
-	// Indices refer to the base snapshot before RemoveOlds is applied.
+	// Indices refer to the base snapshot before the migration.
 	BaseStatePatches []JournalBaseStatePatch
 	// NewStatePatches contains complete replacements for resources produced by operations earlier in this update.
 	NewStatePatches []JournalNewStatePatch

--- a/pkg/engine/journal_state_migration.go
+++ b/pkg/engine/journal_state_migration.go
@@ -22,6 +22,7 @@ import (
 
 	pkgresource "github.com/pulumi/pulumi/pkg/v3/resource"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -33,8 +34,9 @@ func (sm *JournalSnapshotManager) SupportsStateMigrations() bool {
 // reconstructed by applying operation entries to an immutable base snapshot, but a migration can change both that
 // base and resource states produced by earlier entries. One journal-v2 entry therefore records the complete change:
 //
-//   - RemoveOlds identifies PriorSubtree entries by their indices in the original base snapshot.
-//   - ResultStates contains the complete replacement subtree to splice into the base.
+//   - Layout lists the complete post-migration base snapshot: retained resources by their index in the current base
+//     snapshot and inserted resources by their index in ResultStates. Base resources absent from Layout are removed.
+//   - ResultStates contains the complete inserted resources, in Layout order.
 //   - BaseStatePatches contains complete replacement states for retained base resources whose references changed.
 //   - NewStatePatches does the same for resources produced earlier in the update, identified by operation ID.
 func (sm *JournalSnapshotManager) StateMigration(transaction *deploy.StateMigrationTransaction) error {
@@ -47,32 +49,9 @@ func (sm *JournalSnapshotManager) StateMigration(transaction *deploy.StateMigrat
 			"the state migration cannot be applied")
 	}
 
-	removedSet := make(map[*pkgresource.State]bool, len(transaction.PriorSubtree))
-	for _, res := range transaction.PriorSubtree {
-		removedSet[res] = true
-	}
-	indices := make([]int64, 0, len(transaction.PriorSubtree))
-	basePatches := make([]JournalBaseStatePatch, 0)
-	for i, res := range sm.baseSnapshot.Resources {
-		if removedSet[res] {
-			indices = append(indices, int64(i))
-			continue
-		}
-		if rewritten, ok := transaction.RetainedResourceRewrites[res]; ok && rewritten != res {
-			basePatches = append(basePatches, JournalBaseStatePatch{
-				Index: int64(i),
-				State: rewritten.Copy(),
-			})
-		}
-	}
-	if len(indices) != len(transaction.PriorSubtree) {
-		return fmt.Errorf("state migration: only found %d of %d removed resources in the base snapshot",
-			len(indices), len(transaction.PriorSubtree))
-	}
-
-	states := make([]*pkgresource.State, len(transaction.ResultSubtree))
-	for i, res := range transaction.ResultSubtree {
-		states[i] = res.Copy()
+	entry := sm.newJournalEntry(JournalEntryStateMigration, 0)
+	if err := layOutStateMigration(&entry, sm.baseSnapshot.Resources, transaction); err != nil {
+		return err
 	}
 
 	// Rewrite surviving resources produced earlier in this update. JournalReplayer stores these separately from the
@@ -102,11 +81,90 @@ func (sm *JournalSnapshotManager) StateMigration(transaction *deploy.StateMigrat
 			State:       rewrittenNew[i].Copy(),
 		})
 	}
-
-	entry := sm.newJournalEntry(JournalEntryStateMigration, 0)
-	entry.RemoveOlds = indices
-	entry.ResultStates = states
-	entry.BaseStatePatches = basePatches
 	entry.NewStatePatches = newPatches
 	return sm.addJournalEntry(entry)
+}
+
+func layOutStateMigration(
+	entry *JournalEntry, base []*pkgresource.State, transaction *deploy.StateMigrationTransaction,
+) error {
+	baseIndices := make(map[*pkgresource.State]int64, len(base))
+	for i, state := range base {
+		baseIndices[state] = int64(i)
+	}
+	removed := make(map[*pkgresource.State]bool, len(transaction.PriorSubtree))
+	for _, state := range transaction.PriorSubtree {
+		removed[state] = true
+	}
+	inserted := make(map[*pkgresource.State]bool, len(transaction.ResultSubtree))
+	for _, state := range transaction.ResultSubtree {
+		inserted[state] = true
+	}
+	// Retained resources whose references were rewritten appear in the prepared list as copies. Map each copy back to
+	// the base resource it replaces.
+	retainedOrigins := make(map[*pkgresource.State]*pkgresource.State, len(transaction.RetainedResourceRewrites))
+	for original, prepared := range transaction.RetainedResourceRewrites {
+		retainedOrigins[prepared] = original
+	}
+
+	layout := make([]apitype.JournalLayoutItem, 0, len(transaction.PreparedPriorResources))
+	states := make([]*pkgresource.State, 0, len(transaction.ResultSubtree))
+	patches := make([]JournalBaseStatePatch, 0, len(transaction.RetainedResourceRewrites))
+	placedStates := make(map[*pkgresource.State]bool, len(transaction.ResultSubtree))
+	placedBase := make(map[int64]bool, len(base))
+	for _, state := range transaction.PreparedPriorResources {
+		if inserted[state] {
+			if placedStates[state] {
+				return fmt.Errorf("state migration: prepared snapshot contains result resource %s more than once",
+					state.URN)
+			}
+			placedStates[state] = true
+			states = append(states, state.Copy())
+			layout = append(layout, layoutStateItem(int64(len(states)-1)))
+			continue
+		}
+
+		original, rewritten := retainedOrigins[state]
+		if !rewritten {
+			original = state
+		}
+		index, inBase := baseIndices[original]
+		if !inBase || removed[original] {
+			return fmt.Errorf("state migration: prepared snapshot retains %s, which is not a retained base resource",
+				state.URN)
+		}
+		if placedBase[index] {
+			return fmt.Errorf("state migration: prepared snapshot contains base resource %s more than once", state.URN)
+		}
+		placedBase[index] = true
+		if rewritten {
+			patches = append(patches, JournalBaseStatePatch{Index: index, State: state.Copy()})
+		}
+		layout = append(layout, layoutBaseItem(index))
+	}
+	if len(states) != len(transaction.ResultSubtree) {
+		return fmt.Errorf("state migration: only found %d of %d result resources in the prepared snapshot",
+			len(states), len(transaction.ResultSubtree))
+	}
+	retainedCount := 0
+	for _, state := range base {
+		if !removed[state] {
+			retainedCount++
+		}
+	}
+	if len(placedBase) != retainedCount {
+		return fmt.Errorf("state migration: only found %d of %d retained base resources in the prepared snapshot",
+			len(placedBase), retainedCount)
+	}
+
+	entry.Layout, entry.ResultStates, entry.BaseStatePatches = layout, states, patches
+	return nil
+}
+
+func layoutBaseItem(index int64) apitype.JournalLayoutItem {
+	return apitype.JournalLayoutItem{BaseIndex: &index}
+}
+
+func layoutStateItem(index int64) apitype.JournalLayoutItem {
+	return apitype.JournalLayoutItem{StateIndex: &index}
 }

--- a/pkg/engine/journal_state_migration.go
+++ b/pkg/engine/journal_state_migration.go
@@ -50,9 +50,11 @@ func (sm *JournalSnapshotManager) StateMigration(transaction *deploy.StateMigrat
 	}
 
 	entry := sm.newJournalEntry(JournalEntryStateMigration, 0)
-	if err := layOutStateMigration(&entry, sm.baseSnapshot.Resources, transaction); err != nil {
+	layout, states, patches, err := layOutStateMigration(sm.baseSnapshot.Resources, transaction)
+	if err != nil {
 		return err
 	}
+	entry.Layout, entry.ResultStates, entry.BaseStatePatches = layout, states, patches
 
 	// Rewrite surviving resources produced earlier in this update. JournalReplayer stores these separately from the
 	// base snapshot and looks them up by operation ID, so each changed state is recorded as a NewStatePatch for that
@@ -86,8 +88,8 @@ func (sm *JournalSnapshotManager) StateMigration(transaction *deploy.StateMigrat
 }
 
 func layOutStateMigration(
-	entry *JournalEntry, base []*pkgresource.State, transaction *deploy.StateMigrationTransaction,
-) error {
+	base []*pkgresource.State, transaction *deploy.StateMigrationTransaction,
+) ([]apitype.JournalLayoutItem, []*pkgresource.State, []JournalBaseStatePatch, error) {
 	baseIndices := make(map[*pkgresource.State]int64, len(base))
 	for i, state := range base {
 		baseIndices[state] = int64(i)
@@ -115,12 +117,13 @@ func layOutStateMigration(
 	for _, state := range transaction.PreparedPriorResources {
 		if inserted[state] {
 			if placedStates[state] {
-				return fmt.Errorf("state migration: prepared snapshot contains result resource %s more than once",
+				return nil, nil, nil, fmt.Errorf("state migration: prepared snapshot contains result resource %s more than once",
 					state.URN)
 			}
 			placedStates[state] = true
 			states = append(states, state.Copy())
-			layout = append(layout, layoutStateItem(int64(len(states)-1)))
+			index := int64(len(states) - 1)
+			layout = append(layout, apitype.JournalLayoutItem{StateIndex: &index})
 			continue
 		}
 
@@ -130,20 +133,22 @@ func layOutStateMigration(
 		}
 		index, inBase := baseIndices[original]
 		if !inBase || removed[original] {
-			return fmt.Errorf("state migration: prepared snapshot retains %s, which is not a retained base resource",
+			return nil, nil, nil, fmt.Errorf(
+				"state migration: prepared snapshot retains %s, which is not a retained base resource",
 				state.URN)
 		}
 		if placedBase[index] {
-			return fmt.Errorf("state migration: prepared snapshot contains base resource %s more than once", state.URN)
+			return nil, nil, nil, fmt.Errorf(
+				"state migration: prepared snapshot contains base resource %s more than once", state.URN)
 		}
 		placedBase[index] = true
 		if rewritten {
 			patches = append(patches, JournalBaseStatePatch{Index: index, State: state.Copy()})
 		}
-		layout = append(layout, layoutBaseItem(index))
+		layout = append(layout, apitype.JournalLayoutItem{BaseIndex: &index})
 	}
 	if len(states) != len(transaction.ResultSubtree) {
-		return fmt.Errorf("state migration: only found %d of %d result resources in the prepared snapshot",
+		return nil, nil, nil, fmt.Errorf("state migration: only found %d of %d result resources in the prepared snapshot",
 			len(states), len(transaction.ResultSubtree))
 	}
 	retainedCount := 0
@@ -153,18 +158,10 @@ func layOutStateMigration(
 		}
 	}
 	if len(placedBase) != retainedCount {
-		return fmt.Errorf("state migration: only found %d of %d retained base resources in the prepared snapshot",
+		return nil, nil, nil, fmt.Errorf(
+			"state migration: only found %d of %d retained base resources in the prepared snapshot",
 			len(placedBase), retainedCount)
 	}
 
-	entry.Layout, entry.ResultStates, entry.BaseStatePatches = layout, states, patches
-	return nil
-}
-
-func layoutBaseItem(index int64) apitype.JournalLayoutItem {
-	return apitype.JournalLayoutItem{BaseIndex: &index}
-}
-
-func layoutStateItem(index int64) apitype.JournalLayoutItem {
-	return apitype.JournalLayoutItem{StateIndex: &index}
+	return layout, states, patches, nil
 }

--- a/pkg/engine/journal_state_migration_test.go
+++ b/pkg/engine/journal_state_migration_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // TestJournalStateMigrationVersionGate tests that a state migration is rejected when the negotiated journal
-// version is too old to encode it, and journaled with the removed base indices when it is supported.
+// version is too old to encode it, and journaled with the post-migration layout when it is supported.
 func TestJournalStateMigrationVersionGate(t *testing.T) {
 	t.Parallel()
 
@@ -81,15 +81,134 @@ func TestJournalStateMigrationVersionGate(t *testing.T) {
 			PreparedPriorResources: []*pkgresource.State{b, d},
 		}))
 
-		var entry *JournalEntry
-		for i := range journal.entries {
-			if journal.entries[i].Kind == JournalEntryStateMigration {
-				entry = &journal.entries[i]
-			}
-		}
-		require.NotNil(t, entry, "expected a state migration journal entry")
-		assert.Equal(t, []int64{0, 2}, entry.RemoveOlds)
+		entry := stateMigrationEntry(t, journal)
+		assert.Equal(t, []apitype.JournalLayoutItem{layoutBaseItem(1), layoutStateItem(0)}, entry.Layout)
 		require.Len(t, entry.ResultStates, 1)
 		assert.Equal(t, d.URN, entry.ResultStates[0].URN)
 	})
+}
+
+func TestJournalStateMigrationLayout(t *testing.T) {
+	t.Parallel()
+
+	newState := func(name string) *pkgresource.State {
+		urn := resource.URN("urn:pulumi:test::test::pkgA:m:typA::" + name)
+		return &pkgresource.State{URN: urn, Type: urn.Type(), Custom: true, ID: resource.ID("id-" + name)}
+	}
+	root, oldChild, consumer, lastChild :=
+		newState("root"), newState("old-child"), newState("consumer"), newState("last-child")
+	consumer.Dependencies = []resource.URN{oldChild.URN}
+	base := &deploy.Snapshot{Resources: []*pkgresource.State{root, oldChild, consumer, lastChild}}
+
+	newRoot := root.Copy()
+	newChild := newState("new-child")
+	newLastChild := lastChild.Copy()
+	rewrittenConsumer := consumer.Copy()
+	rewrittenConsumer.Dependencies = []resource.URN{newChild.URN}
+
+	newTransaction := func(prepared ...*pkgresource.State) *deploy.StateMigrationTransaction {
+		return &deploy.StateMigrationTransaction{
+			RootURN:                root.URN,
+			PriorSubtree:           []*pkgresource.State{root, oldChild, lastChild},
+			ResultSubtree:          []*pkgresource.State{newRoot, newChild, newLastChild},
+			SuccessorURNs:          map[resource.URN]resource.URN{oldChild.URN: newChild.URN},
+			PreparedPriorResources: prepared,
+			RetainedResourceRewrites: map[*pkgresource.State]*pkgresource.State{
+				consumer: rewrittenConsumer,
+			},
+		}
+	}
+	newManager := func(t *testing.T) (*JournalSnapshotManager, *captureJournal) {
+		journal := &captureJournal{}
+		sm, err := NewJournalSnapshotManagerWithVersion(
+			journal, base, b64.NewBase64SecretsManager(), apitype.LatestJournalVersion)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, sm.Close()) })
+		return sm, journal
+	}
+
+	t.Run("retained resource between inserted resources", func(t *testing.T) {
+		t.Parallel()
+		sm, journal := newManager(t)
+		require.NoError(t, sm.StateMigration(newTransaction(newRoot, newChild, rewrittenConsumer, newLastChild)))
+
+		entry := stateMigrationEntry(t, journal)
+		assert.Equal(t, []apitype.JournalLayoutItem{
+			layoutStateItem(0), layoutStateItem(1), layoutBaseItem(2), layoutStateItem(2),
+		}, entry.Layout)
+		assertCopiedStates(t, []*pkgresource.State{newRoot, newChild, newLastChild}, entry.ResultStates)
+		require.Len(t, entry.BaseStatePatches, 1)
+		patch := entry.BaseStatePatches[0]
+		assert.Equal(t, int64(2), patch.Index)
+		assert.Equal(t, consumer.URN, patch.State.URN)
+		assert.Equal(t, []resource.URN{newChild.URN}, patch.State.Dependencies)
+		assert.NotSame(t, rewrittenConsumer, patch.State)
+	})
+
+	t.Run("inserted resources in prepared order", func(t *testing.T) {
+		t.Parallel()
+		sm, journal := newManager(t)
+		require.NoError(t, sm.StateMigration(newTransaction(newRoot, newLastChild, newChild, rewrittenConsumer)))
+
+		entry := stateMigrationEntry(t, journal)
+		assert.Equal(t, []apitype.JournalLayoutItem{
+			layoutStateItem(0), layoutStateItem(1), layoutStateItem(2), layoutBaseItem(2),
+		}, entry.Layout)
+		assertCopiedStates(t, []*pkgresource.State{newRoot, newLastChild, newChild}, entry.ResultStates)
+	})
+
+	t.Run("missing result resource", func(t *testing.T) {
+		t.Parallel()
+		sm, journal := newManager(t)
+		err := sm.StateMigration(newTransaction(newRoot, rewrittenConsumer, newLastChild))
+		assert.ErrorContains(t, err, "only found 2 of 3 result resources")
+		assertNoStateMigrationEntry(t, journal)
+	})
+
+	t.Run("missing retained resource", func(t *testing.T) {
+		t.Parallel()
+		sm, journal := newManager(t)
+		err := sm.StateMigration(newTransaction(newRoot, newChild, newLastChild))
+		assert.ErrorContains(t, err, "only found 0 of 1 retained base resources")
+		assertNoStateMigrationEntry(t, journal)
+	})
+
+	t.Run("retains a removed resource", func(t *testing.T) {
+		t.Parallel()
+		sm, journal := newManager(t)
+		err := sm.StateMigration(newTransaction(newRoot, oldChild, newChild, rewrittenConsumer, newLastChild))
+		assert.ErrorContains(t, err, "is not a retained base resource")
+		assertNoStateMigrationEntry(t, journal)
+	})
+}
+
+func findStateMigrationEntry(journal *captureJournal) *JournalEntry {
+	for i := range journal.entries {
+		if journal.entries[i].Kind == JournalEntryStateMigration {
+			return &journal.entries[i]
+		}
+	}
+	return nil
+}
+
+func stateMigrationEntry(t *testing.T, journal *captureJournal) *JournalEntry {
+	t.Helper()
+	entry := findStateMigrationEntry(journal)
+	require.NotNil(t, entry, "expected a state migration journal entry")
+	return entry
+}
+
+func assertNoStateMigrationEntry(t *testing.T, journal *captureJournal) {
+	t.Helper()
+	assert.Nil(t, findStateMigrationEntry(journal), "expected no state migration journal entry")
+}
+
+func assertCopiedStates(t *testing.T, expected, actual []*pkgresource.State) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+	for i, state := range expected {
+		assert.Equal(t, state.URN, actual[i].URN)
+		assert.Equal(t, state.ID, actual[i].ID)
+		assert.NotSame(t, state, actual[i])
+	}
 }

--- a/pkg/engine/journal_state_migration_test.go
+++ b/pkg/engine/journal_state_migration_test.go
@@ -136,8 +136,10 @@ func TestJournalStateMigrationLayout(t *testing.T) {
 
 		entry := stateMigrationEntry(t, journal)
 		assert.Equal(t, []apitype.JournalLayoutItem{
-			{StateIndex: new(int64(0))}, {StateIndex: new(int64(1))},
-			{BaseIndex: new(int64(2))}, {StateIndex: new(int64(2))},
+			{StateIndex: new(int64(0))},
+			{StateIndex: new(int64(1))},
+			{BaseIndex: new(int64(2))},
+			{StateIndex: new(int64(2))},
 		}, entry.Layout)
 		assertCopiedStates(t, []*pkgresource.State{newRoot, newChild, newLastChild}, entry.ResultStates)
 		require.Len(t, entry.BaseStatePatches, 1)
@@ -155,8 +157,10 @@ func TestJournalStateMigrationLayout(t *testing.T) {
 
 		entry := stateMigrationEntry(t, journal)
 		assert.Equal(t, []apitype.JournalLayoutItem{
-			{StateIndex: new(int64(0))}, {StateIndex: new(int64(1))},
-			{StateIndex: new(int64(2))}, {BaseIndex: new(int64(2))},
+			{StateIndex: new(int64(0))},
+			{StateIndex: new(int64(1))},
+			{StateIndex: new(int64(2))},
+			{BaseIndex: new(int64(2))},
 		}, entry.Layout)
 		assertCopiedStates(t, []*pkgresource.State{newRoot, newLastChild, newChild}, entry.ResultStates)
 	})

--- a/pkg/engine/journal_state_migration_test.go
+++ b/pkg/engine/journal_state_migration_test.go
@@ -82,7 +82,9 @@ func TestJournalStateMigrationVersionGate(t *testing.T) {
 		}))
 
 		entry := stateMigrationEntry(t, journal)
-		assert.Equal(t, []apitype.JournalLayoutItem{layoutBaseItem(1), layoutStateItem(0)}, entry.Layout)
+		assert.Equal(t, []apitype.JournalLayoutItem{
+			{BaseIndex: new(int64(1))}, {StateIndex: new(int64(0))},
+		}, entry.Layout)
 		require.Len(t, entry.ResultStates, 1)
 		assert.Equal(t, d.URN, entry.ResultStates[0].URN)
 	})
@@ -134,7 +136,8 @@ func TestJournalStateMigrationLayout(t *testing.T) {
 
 		entry := stateMigrationEntry(t, journal)
 		assert.Equal(t, []apitype.JournalLayoutItem{
-			layoutStateItem(0), layoutStateItem(1), layoutBaseItem(2), layoutStateItem(2),
+			{StateIndex: new(int64(0))}, {StateIndex: new(int64(1))},
+			{BaseIndex: new(int64(2))}, {StateIndex: new(int64(2))},
 		}, entry.Layout)
 		assertCopiedStates(t, []*pkgresource.State{newRoot, newChild, newLastChild}, entry.ResultStates)
 		require.Len(t, entry.BaseStatePatches, 1)
@@ -152,7 +155,8 @@ func TestJournalStateMigrationLayout(t *testing.T) {
 
 		entry := stateMigrationEntry(t, journal)
 		assert.Equal(t, []apitype.JournalLayoutItem{
-			layoutStateItem(0), layoutStateItem(1), layoutStateItem(2), layoutBaseItem(2),
+			{StateIndex: new(int64(0))}, {StateIndex: new(int64(1))},
+			{StateIndex: new(int64(2))}, {BaseIndex: new(int64(2))},
 		}, entry.Layout)
 		assertCopiedStates(t, []*pkgresource.State{newRoot, newLastChild, newChild}, entry.ResultStates)
 	})

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -282,6 +282,15 @@ func snapURNs(snap *deploy.Snapshot) []resource.URN {
 	return urns
 }
 
+// snapIndices returns the index of each resource in the snapshot by URN.
+func snapIndices(snap *deploy.Snapshot) map[resource.URN]int {
+	indices := make(map[resource.URN]int, len(snap.Resources))
+	for i, res := range snap.Resources {
+		indices[res.URN] = i
+	}
+	return indices
+}
+
 // renameMigration returns a migration callback that renames the child resource and maps its old URN to the new one.
 func renameMigration(t *testing.T, callbacks *deploytest.CallbackServer, oldName, newName string) *pulumirpc.Callback {
 	callback, err := callbacks.Allocate(
@@ -379,6 +388,95 @@ func TestStateMigrationRenameChild(t *testing.T) {
 		validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
 	require.NoError(t, err)
 	assert.Contains(t, snapURNs(snap), childBURN)
+}
+
+// TestStateMigrationOrdersInterleavedExternalDependent tests migrating states where the component is non-contiguous,
+// with a resource depending on part of the component tree interleaved:
+//
+//   - Component `comp` with the children `childA` and `tail`
+//
+//   - A resource `consumer`, that isn't part of the component, that depends on `childA`
+//
+//   - Migration replaces `childA` with `childB`
+//
+//   - prior snapshot:  comp, childA, consumer, tail
+//
+// After the migration we should have `comp, childB, consumer, tail`. Inserting `[comp, childB, tail]` as one block
+// where `tail` was would put consumer before childB, so the migrated subtree must be split around consumer.
+func TestStateMigrationOrdersInterleavedExternalDependent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		consumerURN = resource.URN("urn:pulumi:test::test::pkgA:m:consumer::consumer")
+		tailURN     = resource.URN("urn:pulumi:test::test::my:module:Comp$my:module:Tail::tail")
+	)
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	var migrate bool
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		options := deploytest.ResourceOptions{}
+		if migrate {
+			options.StateMigrations = []*pulumirpc.Callback{
+				renameMigration(t, callbacks, "childA", "childB"),
+			}
+		}
+		comp, err := monitor.RegisterResource("my:module:Comp", "comp", false, options)
+		if err != nil {
+			return err
+		}
+
+		childName := "childA"
+		if migrate {
+			childName = "childB"
+		}
+		child, err := monitor.RegisterResource("pkgA:m:typA", childName, true, deploytest.ResourceOptions{
+			Parent: comp.URN,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = monitor.RegisterResource("pkgA:m:consumer", "consumer", true, deploytest.ResourceOptions{
+			Dependencies: []resource.URN{child.URN},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = monitor.RegisterResource("my:module:Tail", "tail", false, deploytest.ResourceOptions{
+			Parent: comp.URN,
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	p := &lt.TestPlan{Options: stateMigrationTestOptions(t, hostF)}
+
+	snap, err := runUpdate(t, p, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, snap.VerifyIntegrity())
+	indices := snapIndices(snap)
+	require.Less(t, indices[childAURN], indices[consumerURN])
+	require.Less(t, indices[consumerURN], indices[tailURN])
+
+	migrate = true
+	snap, err = runUpdate(t, p, snap,
+		validateOps(t, map[display.StepOp]int{deploy.OpSame: 5}))
+	require.NoError(t, err)
+	require.NoError(t, snap.VerifyIntegrity())
+
+	indices = snapIndices(snap)
+	assert.NotContains(t, indices, childAURN)
+	require.Contains(t, indices, childBURN)
+	require.Contains(t, indices, tailURN)
+	require.Contains(t, indices, consumerURN)
+	assert.Equal(t, []resource.URN{childBURN}, snap.Resources[indices[consumerURN]].Dependencies)
+	assert.Less(t, indices[childBURN], indices[consumerURN])
 }
 
 // TestStateMigrationNormalizesProgramReferences verifies that references retained by the program are rewritten after

--- a/pkg/resource/deploy/state_migration_transaction.go
+++ b/pkg/resource/deploy/state_migration_transaction.go
@@ -40,21 +40,11 @@ func (sg *stepGenerator) prepareStateMigrationTransaction(
 	}
 	lastPriorResource := priorSubtree[len(priorSubtree)-1]
 
-	// Put ResultSubtree at the last prior resource's position so it remains after anything it may reference.
-	preparedPriorResources := make(
-		[]*pkgresource.State, 0, len(d.prev.Resources)-len(priorSubtree)+len(resultSubtree))
 	retainedResources := make([]*pkgresource.State, 0, len(d.prev.Resources)-len(priorSubtree))
-	preparedPriorIndices := make(map[*pkgresource.State]int, len(d.prev.Resources)-len(priorSubtree))
 	for _, state := range d.prev.Resources {
-		if priorSubtreeSet[state] {
-			if state == lastPriorResource {
-				preparedPriorResources = append(preparedPriorResources, resultSubtree...)
-			}
-			continue // The state is part of the prior subtree; skip it.
+		if !priorSubtreeSet[state] {
+			retainedResources = append(retainedResources, state)
 		}
-		preparedPriorIndices[state] = len(preparedPriorResources)
-		retainedResources = append(retainedResources, state)
-		preparedPriorResources = append(preparedPriorResources, state)
 	}
 
 	// Resources outside PriorSubtree remain in the snapshot, but their references to removed subtree resources must
@@ -70,19 +60,46 @@ func (sg *stepGenerator) prepareStateMigrationTransaction(
 		return nil, err
 	}
 
-	// Put each changed prepared copy into the candidate prior-resource list. Also remember the live resource's index so
-	// the migration commit can copy the prepared fields back into that object without changing its pointer identity.
-	retainedRewriteIndices := make(map[*pkgresource.State]int, len(retainedRewrites))
-	for old, rewritten := range retainedRewrites {
-		index := preparedPriorIndices[old]
-		preparedPriorResources[index] = rewritten
-		retainedRewriteIndices[old] = index
+	preparedRetained := make(map[*pkgresource.State]*pkgresource.State, len(retainedResources))
+	for i, state := range retainedResources {
+		preparedRetained[state] = rewrittenRetainedResources[i]
+	}
+
+	// Start with the replacement at the last prior resource, which is after everything the prior subtree depended on.
+	// We toposort below to move successors ahead of interleaved resources that now depend on them.
+	preparedPriorResources := make(
+		[]*pkgresource.State, 0, len(d.prev.Resources)-len(priorSubtree)+len(resultSubtree))
+	for _, state := range d.prev.Resources {
+		if priorSubtreeSet[state] {
+			if state == lastPriorResource {
+				preparedPriorResources = append(preparedPriorResources, resultSubtree...)
+			}
+			continue
+		}
+		preparedPriorResources = append(preparedPriorResources, preparedRetained[state])
 	}
 
 	verifySnap := &Snapshot{Manifest: d.prev.Manifest, Resources: preparedPriorResources}
+	if err := verifySnap.Toposort(); err != nil {
+		return nil, fmt.Errorf(
+			"state migration for %s produced an invalid state; no changes were made: %w", registrationURN, err)
+	}
 	if err := verifySnap.VerifyIntegrity(); err != nil {
 		return nil, fmt.Errorf(
 			"state migration for %s produced an invalid state; no changes were made: %w", registrationURN, err)
+	}
+	preparedPriorResources = verifySnap.Resources
+
+	// Remember where each rewritten retained resource landed so commit can restore its live pointer.
+	preparedIndices := make(map[*pkgresource.State]int, len(preparedPriorResources))
+	for i, state := range preparedPriorResources {
+		preparedIndices[state] = i
+	}
+	retainedRewriteIndices := make(map[*pkgresource.State]int, len(retainedRewrites))
+	for original, prepared := range retainedRewrites {
+		index, ok := preparedIndices[prepared]
+		contract.Assertf(ok, "state migration for %s lost a rewritten retained resource", registrationURN)
+		retainedRewriteIndices[original] = index
 	}
 
 	transaction := &StateMigrationTransaction{

--- a/sdk/go/common/apitype/journal.go
+++ b/sdk/go/common/apitype/journal.go
@@ -78,6 +78,14 @@ type JournalNewStatePatch struct {
 	State       ResourceV3 `json:"state"`
 }
 
+// JournalLayoutItem places one resource in the base snapshot produced by a state migration. Exactly one of BaseIndex
+// and StateIndex is set: BaseIndex refers to a retained resource by its index in the base snapshot before the
+// migration, and StateIndex refers to one of the entry's inserted States.
+type JournalLayoutItem struct {
+	BaseIndex  *int64 `json:"baseIndex,omitempty"`
+	StateIndex *int64 `json:"stateIndex,omitempty"`
+}
+
 type JournalEntry struct {
 	// Version of the journal entry format.
 	Version int `json:"version"`
@@ -124,15 +132,14 @@ type JournalEntry struct {
 	// time for replay to gate rebuilt deployments on the byteString feature.
 	RequiresByteString bool `json:"requiresByteString,omitempty"`
 
-	// RemoveOlds holds the indices of the resources in the base snapshot that a state migration removes.
+	// Layout lists the complete base snapshot produced by a state migration, in order. Base resources absent from
+	// Layout are removed. Only set for JournalEntryKindStateMigration entries.
+	Layout []JournalLayoutItem `json:"layout,omitempty"`
+	// States holds the resources a state migration inserts into the base snapshot at the positions given by Layout.
 	// Only set for JournalEntryKindStateMigration entries.
-	RemoveOlds []int64 `json:"removeOlds,omitempty"`
-	// States holds the resources a state migration splices into the base snapshot, in order. They take the
-	// position of the resource with the greatest removed index. Only set for JournalEntryKindStateMigration entries.
 	States []ResourceV3 `json:"states,omitempty"`
 	// BaseStatePatches contains complete replacements for retained base resources whose references were rewritten.
-	// Indices refer to the base snapshot before RemoveOlds is applied. Only set for JournalEntryKindStateMigration
-	// entries.
+	// Indices refer to the base snapshot before the migration. Only set for JournalEntryKindStateMigration entries.
 	BaseStatePatches []JournalBaseStatePatch `json:"baseStatePatches,omitempty"`
 	// NewStatePatches contains complete replacements for resources produced by operations earlier in this update.
 	// Only set for JournalEntryKindStateMigration entries.
@@ -179,8 +186,8 @@ func (e JournalEntry) String() string {
 	if e.Snippets != nil {
 		fmt.Fprintf(&sb, ", snippets(%v)", len(e.Snippets))
 	}
-	if e.RemoveOlds != nil {
-		fmt.Fprintf(&sb, ", removeOlds(%v)", len(e.RemoveOlds))
+	if e.Layout != nil {
+		fmt.Fprintf(&sb, ", layout(%v)", len(e.Layout))
 	}
 	if e.States != nil {
 		fmt.Fprintf(&sb, ", states(%v)", len(e.States))

--- a/sdk/go/common/apitype/journal.go
+++ b/sdk/go/common/apitype/journal.go
@@ -187,16 +187,39 @@ func (e JournalEntry) String() string {
 		fmt.Fprintf(&sb, ", snippets(%v)", len(e.Snippets))
 	}
 	if e.Layout != nil {
-		fmt.Fprintf(&sb, ", layout(%v)", len(e.Layout))
+		items := make([]string, len(e.Layout))
+		for i, item := range e.Layout {
+			var indices []string
+			if item.BaseIndex != nil {
+				indices = append(indices, fmt.Sprintf("base:%d", *item.BaseIndex))
+			}
+			if item.StateIndex != nil {
+				indices = append(indices, fmt.Sprintf("state:%d", *item.StateIndex))
+			}
+			items[i] = "{" + strings.Join(indices, " ") + "}"
+		}
+		fmt.Fprintf(&sb, ", layout(%v)", items)
 	}
 	if e.States != nil {
-		fmt.Fprintf(&sb, ", states(%v)", len(e.States))
+		urns := make([]string, len(e.States))
+		for i, state := range e.States {
+			urns[i] = string(state.URN)
+		}
+		fmt.Fprintf(&sb, ", states(%v)", urns)
 	}
 	if e.BaseStatePatches != nil {
-		fmt.Fprintf(&sb, ", baseStatePatches(%v)", len(e.BaseStatePatches))
+		patches := make([]string, len(e.BaseStatePatches))
+		for i, patch := range e.BaseStatePatches {
+			patches[i] = fmt.Sprintf("%d:%s", patch.Index, patch.State.URN)
+		}
+		fmt.Fprintf(&sb, ", baseStatePatches(%v)", patches)
 	}
 	if e.NewStatePatches != nil {
-		fmt.Fprintf(&sb, ", newStatePatches(%v)", len(e.NewStatePatches))
+		patches := make([]string, len(e.NewStatePatches))
+		for i, patch := range e.NewStatePatches {
+			patches[i] = fmt.Sprintf("%d:%s", patch.OperationID, patch.State.URN)
+		}
+		fmt.Fprintf(&sb, ", newStatePatches(%v)", patches)
 	}
 
 	return sb.String()

--- a/sdk/go/common/apitype/journal_test.go
+++ b/sdk/go/common/apitype/journal_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJournalEntryStringStateMigration(t *testing.T) {
+	t.Parallel()
+	baseIndex, stateIndex := int64(3), int64(0)
+	state := ResourceV3{
+		URN:     "urn:pulumi:test::project::pkg:m:Resource::resource",
+		Inputs:  map[string]any{"password": "sensitive-input"},
+		Outputs: map[string]any{"password": "sensitive-output"},
+	}
+	entry := JournalEntry{
+		SequenceID: 12, Kind: JournalEntryKindStateMigration,
+		Layout:           []JournalLayoutItem{{BaseIndex: &baseIndex}, {StateIndex: &stateIndex}},
+		States:           []ResourceV3{state},
+		BaseStatePatches: []JournalBaseStatePatch{{Index: 3, State: state}},
+		NewStatePatches:  []JournalNewStatePatch{{OperationID: 7, State: state}},
+	}
+	actual := entry.String()
+	assert.Equal(t, "(12, 0): state-migration, layout([{base:3} {state:0}]), "+
+		"states([urn:pulumi:test::project::pkg:m:Resource::resource]), "+
+		"baseStatePatches([3:urn:pulumi:test::project::pkg:m:Resource::resource]), "+
+		"newStatePatches([7:urn:pulumi:test::project::pkg:m:Resource::resource])", actual)
+	assert.NotContains(t, actual, "sensitive-input")
+	assert.NotContains(t, actual, "sensitive-output")
+}


### PR DESCRIPTION
For a migration that replaces a component subtree with another, we were placing the entire replacement subtree at the position of the last resource of the prior subtree. This ensured that the component’s dependencies would come before it, and generally, resources that depend on the component are after it.

However, it is possible for external (as in external to the component) resources to be interleaved with the component’s resources, and for those resources to depend on some resources of the component.

```
component:         comp with childA and tail
migration:         childA -> childB
external resource: consumer, depends on childA
initial state:     comp, childA, consumer, tail
```

Placing the replacement subtree at the position of the last prior resource leads to the invalid order

```
consumer (depends on childB), comp, childB, tail
```

Similarly, placing the replacement subtree at the first prior resource does not work because a component child resource might depend on an external resource that’s interleaved within it. For example if we have a component with a `childZ` depending on the external resource `external`:

```
comp, childA, external, childZ (depends on external)
```

Placing the replacement subtree at the first resource would move `childZ` before `external`.

To fix this, we first toposort states. The journal entry then records the complete order of the new base snapshot. The layout is a list of index entries that point either into the old base, or to the replacement subtree.

For example, for the old base snapshot:

```
index 0: comp
index 1: childA
index 2: consumer (depends on childA)
index 3: tail
```

and a migration that replaces `childA` with `childB`, we get the journal entry:

```
{
  "kind": "state-migration",
  "states": [comp, childB, tail],
  "layout": [
    {"stateIndex": 0},
    {"stateIndex": 1},
    {"baseIndex": 2},
    {"stateIndex": 2}
  ],
  "baseStatePatches": [
    {"index": 2, "state": consumer with its dependency changed to childB}
  ]
}
```

`states` is the replacement subtree, `layout` shows how to place all the resources, either from `states` or the previous `base`, and `baseStatePatches` records the changes to apply to resources coming from the prior base.


Journal replay iterates over the layout to produce the new base. Any base resources that are not listed in the layout are dropped.

[Developer docs](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html) (updated for the changes here)

Ref https://github.com/pulumi/pulumi/issues/24045