### PR TITLE
Print the Go import path that matches the generated SDK

### DIFF
--- a/changelog/pending/sdkgen-go-fix-20260903-113422.yaml
+++ b/changelog/pending/sdkgen-go-fix-20260903-113422.yaml
@@ -1,0 +1,4 @@
+component: sdkgen/go
+kind: fix
+body: Print the Go import path that matches the generated SDK when a schema sets a custom module or import base path
+time: 2026-09-03T11:34:22.837331+02:00

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -4183,6 +4183,42 @@ func ExtractModulePath(extPkg schema.PackageReference) string {
 	return fmt.Sprintf("%s/sdk%s", root, vPath)
 }
 
+// SDKModulePath returns the Go module path of the SDK generated for pkg, honouring any explicit
+// module or import base path set in the schema's `language.go` block.
+func SDKModulePath(pkg schema.PackageReference) string {
+	def, err := pkg.Definition()
+	contract.AssertNoErrorf(err, "Could not load definition for %q", pkg.Name())
+	if def.ExtensionParameterization != nil {
+		return pkg.Name()
+	}
+
+	info := goPackageInfo(pkg)
+	switch {
+	case info.ModulePath != "":
+		return info.ModulePath
+	case info.ImportBasePath != "":
+		return path.Dir(info.ImportBasePath)
+	}
+	return ExtractModulePath(pkg)
+}
+
+// SDKImportPath returns the import path of the SDK generated for pkg. Unlike ExtractImportBasePath
+// it honours the schema's `language.go` block, so it matches the layout GeneratePackage writes.
+func SDKImportPath(pkg schema.PackageReference) string {
+	info := goPackageInfo(pkg)
+	if info.ImportBasePath != "" {
+		return info.ImportBasePath
+	}
+	// Legacy (non support-pack) SDKs put the package under <module>/go rather than directly under
+	// the module root.
+	if !pkg.SupportPack() {
+		return ExtractImportBasePath(pkg)
+	}
+	root, err := packageRoot(pkg)
+	contract.AssertNoErrorf(err, "Could not load definition for %q", pkg.Name())
+	return path.Join(SDKModulePath(pkg), root)
+}
+
 // ExtractImportBasePath returns the import path to be used in Go code for a package reference. For example we might
 // have the module path "github.com/pulumi/pulumi-aws/sdk/v7" as returned by `ExtractModulePath` and the matching import
 // path "github.com/pulumi/pulumi-aws/sdk/v7/go/aws" returned by `ExtractImportBasePath`.
@@ -5490,20 +5526,7 @@ func GeneratePackage(tool string,
 
 	// create a go.mod file with references to local dependencies
 	if pkg.SupportPack {
-		modulePath := ExtractModulePath(pkg.Reference())
-		if langInfo, found := pkg.Language["go"]; found {
-			goInfo, ok := langInfo.(GoPackageInfo)
-			if ok && goInfo.ModulePath != "" {
-				modulePath = goInfo.ModulePath
-			} else if ok && goInfo.ImportBasePath != "" {
-				// if support pack is enabled we can infer the module path from the
-				// import base path, which is one up from the import base (ie without the package name).
-				modulePath = path.Dir(goInfo.ImportBasePath)
-			}
-		}
-		if pkg.ExtensionParameterization != nil {
-			modulePath = pkg.Name
-		}
+		modulePath := SDKModulePath(pkg.Reference())
 
 		var gomod modfile.File
 		err = gomod.AddModuleStmt(modulePath)

--- a/pkg/codegen/go/sdk_paths_test.go
+++ b/pkg/codegen/go/sdk_paths_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils"
+)
+
+// The import path we tell users to write must address the SDK we just generated: the module in its
+// go.mod plus the directory the package was written to.
+func TestSDKPathsMatchGeneratedLayout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		language string
+	}{
+		{"no go info", `{}`},
+		{"import base path", `{"go":{"importBasePath":"github.com/example/File/sdk/go/File"}}`},
+		{"module path", `{"go":{"modulePath":"github.com/example/File/sdk/go"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var spec schema.PackageSpec
+			require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{
+				"name": "file",
+				"namespace": "example",
+				"version": "1.0.0",
+				"meta": {"supportPack": true},
+				"language": %s,
+				"resources": {
+					"file:index:Thing": {
+						"properties": {"x": {"type": "string"}},
+						"inputProperties": {"x": {"type": "string"}}
+					}
+				}
+			}`, tt.language)), &spec))
+
+			loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
+			pkg, diags, err := schema.BindSpec(spec, loader, schema.ValidationOptions{})
+			require.NoError(t, err)
+			require.False(t, diags.HasErrors(), diags.Error())
+
+			files, err := GeneratePackage("test", pkg, nil)
+			require.NoError(t, err)
+
+			gomod, err := modfile.Parse("go.mod", files["go.mod"], nil)
+			require.NoError(t, err)
+			assert.Equal(t, gomod.Module.Mod.Path, SDKModulePath(pkg.Reference()))
+
+			var dirs []string
+			for file := range files {
+				if dir, _, found := strings.Cut(file, "/"); found && !slices.Contains(dirs, dir) {
+					dirs = append(dirs, dir)
+				}
+			}
+			require.Len(t, dirs, 1, "expected a single package directory")
+			assert.Equal(t, path.Join(gomod.Module.Mod.Path, dirs[0]), SDKImportPath(pkg.Reference()))
+		})
+	}
+}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -1665,20 +1664,7 @@ func (host *goLanguageHost) Link(
 		if err := pkg.ImportLanguages(map[string]schema.Language{"go": codegen.Importer}); err != nil {
 			return nil, err
 		}
-		var modulePath string
-		if info, ok := pkg.Language["go"]; ok {
-			if info, ok := info.(codegen.GoPackageInfo); ok {
-				modulePath = info.ModulePath
-				if modulePath == "" {
-					if info.ImportBasePath != "" {
-						modulePath = path.Dir(info.ImportBasePath)
-					}
-				}
-			}
-		}
-		if modulePath == "" {
-			modulePath = codegen.ExtractModulePath(pkg.Reference())
-		}
+		modulePath := codegen.SDKModulePath(pkg.Reference())
 
 		modules[modulePath] = dep.Path
 		// The relative path used in the replace directive must start with `./` or `.\`.
@@ -1690,7 +1676,7 @@ func (host *goLanguageHost) Link(
 		if !strings.HasPrefix(dep.Path, start) {
 			modules[modulePath] = start + dep.Path
 		}
-		fmt.Fprintf(&imports, "    \"%s\"\n", codegen.ExtractImportBasePath(pkg.Reference()))
+		fmt.Fprintf(&imports, "    \"%s\"\n", codegen.SDKImportPath(pkg.Reference()))
 	}
 	instructions += imports.String()
 	instructions += "  )\n"


### PR DESCRIPTION
## Summary

`pulumi package add` computed the printed Go import path from the package's namespace and name, ignoring the `modulePath`/`importBasePath` set in the schema's `language.go` block — which is what the SDK generator uses for the go.mod module and the package directory. For a package with a namespace and a custom import base path the two disagreed, so following the printed instructions made `go mod tidy` fetch a module that does not exist.

Add `SDKModulePath` and `SDKImportPath`, which resolve the paths the way the generator lays the SDK out, and use them both when writing the SDK's go.mod and when linking a package into a program.

Fixes #24433

## Test plan
- [x] Added appropriate unit tests - For all changes

`TestSDKPathsMatchGeneratedLayout` generates the SDK and asserts the resolved paths against the go.mod module and the package directory that were actually written. It fails on `master` with exactly the paths from the issue.

## Validation
- [x] `make format` — clean
- [x] `bin/custom-gcl run ./...` in `pkg/codegen/go` and `sdk/go/pulumi-language-go` — clean
- [x] `go test ./codegen/go/...` — all pass

Full `make lint`/`make test_fast` left to CI.

## Changelog
- [x] Changelog entry added.

## Risk
Low: the new helpers fall back to the existing `Extract*` functions when the schema sets no Go language info, so packages without a `language.go` block resolve exactly as before.