### PR TITLE
Read stack outputs through the stack outputs endpoint

### DIFF
--- a/changelog/pending/20260902--cli--stack-outputs-endpoint.yaml
+++ b/changelog/pending/20260902--cli--stack-outputs-endpoint.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: improvement
+body: Read stack outputs for stack references through the Pulumi Cloud stack outputs
+    endpoint when the service advertises it, instead of exporting the whole deployment
+time: 2026-09-02T00:00:00Z

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -19,6 +19,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,12 +53,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/securestore"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // testJWT is a test JWT token used in tests.
@@ -3360,4 +3363,84 @@ func TestPermalinkForDisplayWithAgentCredentials(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSnapshotStackOutputs(t *testing.T) {
+	t.Parallel()
+
+	secretsProvider := (&secrets.MockProvider{}).Add(b64.Type, func(json.RawMessage) (secrets.Manager, error) {
+		return b64.NewBase64SecretsManager(), nil
+	})
+	serializedOutputs := map[string]any{
+		"plain": "value",
+		"secret": map[string]any{
+			sig.Key:      sig.Secret,
+			"ciphertext": base64.StdEncoding.EncodeToString([]byte(`"hunter2"`)),
+		},
+	}
+	wantOutputs := property.NewMap(map[string]property.Value{
+		"plain":  property.New("value"),
+		"secret": property.New("hunter2").WithSecret(true),
+	})
+
+	newBackend := func(
+		t *testing.T, caps apitype.Capabilities, handler http.HandlerFunc,
+	) (*cloudBackend, backend.StackReference) {
+		server := httptest.NewServer(handler)
+		t.Cleanup(server.Close)
+		sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+		b := &cloudBackend{
+			d:      sink,
+			url:    server.URL,
+			client: client.NewClient(server.URL, "token", false, sink).WithHTTPClient(server.Client()),
+			capabilities: promise.Run(func() (apitype.Capabilities, error) {
+				return caps, nil
+			}),
+		}
+		return b, cloudBackendReference{
+			name:    tokens.MustParseStackName("stack"),
+			project: "project",
+			owner:   "owner",
+			b:       b,
+		}
+	}
+
+	t.Run("capability present", func(t *testing.T) {
+		t.Parallel()
+		b, ref := newBackend(t, apitype.Capabilities{StackOutputs: true}, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/stacks/owner/project/stack/outputs", r.URL.Path)
+			require.NoError(t, json.NewEncoder(w).Encode(apitype.StackOutputsResponse{
+				Outputs:          serializedOutputs,
+				SecretsProviders: &apitype.SecretsProvidersV1{Type: b64.Type},
+			}))
+		})
+
+		outputs, err := b.getSnapshotStackOutputs(t.Context(), secretsProvider, ref)
+		require.NoError(t, err)
+		assert.Equal(t, wantOutputs, outputs)
+	})
+
+	t.Run("capability absent falls back to export", func(t *testing.T) {
+		t.Parallel()
+		deployment, err := json.Marshal(apitype.DeploymentV3{
+			SecretsProviders: &apitype.SecretsProvidersV1{Type: b64.Type},
+			Resources: []apitype.ResourceV3{{
+				URN:     "urn:pulumi:stack::project::pulumi:pulumi:Stack::project-stack",
+				Type:    resource.RootStackType,
+				Outputs: serializedOutputs,
+			}},
+		})
+		require.NoError(t, err)
+		b, ref := newBackend(t, apitype.Capabilities{}, func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/stacks/owner/project/stack/export", r.URL.Path)
+			require.NoError(t, json.NewEncoder(w).Encode(apitype.ExportStackResponse{
+				Version:    3,
+				Deployment: deployment,
+			}))
+		})
+
+		outputs, err := b.getSnapshotStackOutputs(t.Context(), secretsProvider, ref)
+		require.NoError(t, err)
+		assert.Equal(t, wantOutputs, outputs)
+	})
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1472,6 +1472,21 @@ func (pc *Client) ExportStackDeployment(
 	return apitype.UntypedDeployment(resp), nil
 }
 
+// GetStackOutputs reads the outputs of the latest deployment of the indicated stack.
+func (pc *Client) GetStackOutputs(
+	ctx context.Context, stack StackIdentifier,
+) (apitype.StackOutputsResponse, error) {
+	tracer := otel.Tracer("pulumi-cli")
+	ctx, span := cmdutil.StartSpan(ctx, tracer, "GetStackOutputs")
+	defer span.End()
+
+	var resp apitype.StackOutputsResponse
+	if err := pc.restCall(ctx, "GET", getStackPath(stack, "outputs"), nil, nil, &resp); err != nil {
+		return apitype.StackOutputsResponse{}, err
+	}
+	return resp, nil
+}
+
 // ImportStackDeployment imports a new deployment into the indicated stack.
 func (pc *Client) ImportStackDeployment(ctx context.Context, stack StackIdentifier,
 	deployment *apitype.UntypedDeployment,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -2200,3 +2200,26 @@ func TestDownloadTemplateForeignURLInheritsInsecure(t *testing.T) {
 	require.True(t, captured, "a foreign template URL should build a fresh client")
 	assert.False(t, capturedInsecure, "the fresh client must inherit the caller's TLS verification setting")
 }
+
+func TestGetStackOutputs(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		gotPath = req.URL.Path
+		return `{"outputs":{"foo":"bar"},"secretsProviders":{"type":"b64"}}`
+	})
+	defer server.Close()
+
+	resp, err := newMockClient(server).GetStackOutputs(t.Context(), StackIdentifier{
+		Owner:   "owner",
+		Project: "project",
+		Stack:   tokens.MustParseStackName("stack"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/api/stacks/owner/project/stack/outputs", gotPath)
+	assert.Equal(t, apitype.StackOutputsResponse{
+		Outputs:          map[string]any{"foo": "bar"},
+		SecretsProviders: &apitype.SecretsProvidersV1{Type: "b64"},
+	}, resp)
+}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -235,6 +235,22 @@ func (b *cloudBackend) getSnapshotStackOutputs(ctx context.Context,
 	ctx, span := cmdutil.StartSpan(ctx, tracer, "cloudBackend.getSnapshotStackOutputs")
 	defer span.End()
 
+	if b.Capabilities(ctx).StackOutputs {
+		stackID, err := b.getCloudStackIdentifier(stackRef)
+		if err != nil {
+			return property.Map{}, err
+		}
+		resp, err := b.client.GetStackOutputs(ctx, stackID)
+		if err != nil {
+			return property.Map{}, err
+		}
+		outputs, err := stack.DecryptStackOutputs(ctx, resp.Outputs, resp.SecretsProviders, secretsProvider)
+		if err != nil {
+			return property.Map{}, err
+		}
+		return resource.FromResourcePropertyMap(outputs), nil
+	}
+
 	untypedDeployment, err := b.exportDeployment(ctx, stackRef, nil /* get latest */)
 	if err != nil {
 		return property.Map{}, err

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -538,7 +538,18 @@ func DeserializeStackOutputs(
 		return nil, nil
 	}
 
-	secretsManager, err := initializeSecretsManager(ctx, deployment, secretsProv)
+	return DecryptStackOutputs(ctx, stackResource.Outputs, deployment.SecretsProviders, secretsProv)
+}
+
+// DecryptStackOutputs deserializes the serialized outputs of a root stack resource. It resolves
+// secret values with the secrets manager that secretsProviders describes.
+func DecryptStackOutputs(
+	ctx context.Context,
+	outputs map[string]any,
+	secretsProviders *apitype.SecretsProvidersV1,
+	secretsProv secrets.Provider,
+) (resource.PropertyMap, error) {
+	secretsManager, err := initializeSecretsManager(ctx, secretsProviders, secretsProv)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +558,7 @@ func DeserializeStackOutputs(
 		ctx,
 		secretsManager,
 		func(ctx context.Context, dec config.Decrypter) (resource.PropertyMap, error) {
-			return DeserializeProperties(stackResource.Outputs, dec)
+			return DeserializeProperties(outputs, dec)
 		},
 	)
 }
@@ -568,7 +579,7 @@ func DeserializeDeploymentV3(
 		return nil, err
 	}
 
-	secretsManager, err := initializeSecretsManager(ctx, deployment, secretsProv)
+	secretsManager, err := initializeSecretsManager(ctx, deployment.SecretsProviders, secretsProv)
 	if err != nil {
 		return nil, err
 	}
@@ -632,16 +643,16 @@ func DeserializeDeploymentV3(
 // initializeSecretsManager initializes the secrets manager for a deployment.
 func initializeSecretsManager(
 	ctx context.Context,
-	deployment apitype.DeploymentV3,
+	secretsProviders *apitype.SecretsProvidersV1,
 	secretsProv secrets.Provider,
 ) (secrets.Manager, error) {
 	var secretsManager secrets.Manager
-	if deployment.SecretsProviders != nil && deployment.SecretsProviders.Type != "" {
+	if secretsProviders != nil && secretsProviders.Type != "" {
 		if secretsProv == nil {
 			return nil, errors.New("deployment uses a SecretsProvider but no SecretsProvider was provided")
 		}
 
-		sm, err := secretsProv.OfType(ctx, deployment.SecretsProviders.Type, deployment.SecretsProviders.State)
+		sm, err := secretsProv.OfType(ctx, secretsProviders.Type, secretsProviders.State)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -1252,6 +1252,44 @@ func TestDeserializeStackOutputs_SecretsInStackOutputs_Decrypted(t *testing.T) {
 	}, outputs)
 }
 
+// Test that DecryptStackOutputs resolves a plaintext-form secret without a decrypt call.
+func TestDecryptStackOutputs_PlaintextSecret_Resolved(t *testing.T) {
+	t.Parallel()
+
+	outputs := map[string]any{
+		"hello": "world",
+		"secret": map[string]any{
+			"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+			"plaintext":                        "\"super secret\"",
+		},
+	}
+
+	provider := (&secrets.MockProvider{}).Add(
+		"mock", func(_ json.RawMessage) (secrets.Manager, error) {
+			return &secrets.MockSecretsManager{
+				TypeF: func() string { return "mock" },
+				DecrypterF: func() config.Decrypter {
+					return &secrets.MockDecrypter{
+						DecryptValueF: func(_ string) string {
+							panic("should not be called")
+						},
+						BatchDecryptF: func(_ []string) []string {
+							panic("should not be called")
+						},
+					}
+				},
+			}, nil
+		},
+	)
+
+	got, err := DecryptStackOutputs(t.Context(), outputs, &apitype.SecretsProvidersV1{Type: "mock"}, provider)
+	require.NoError(t, err)
+	assert.Equal(t, resource.PropertyMap{
+		"hello":  resource.NewProperty("world"),
+		"secret": resource.MakeSecret(resource.NewProperty("super secret")),
+	}, got)
+}
+
 func TestSerializeByteString(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -58,6 +58,10 @@ const (
 
 	// Indicates that the service supports the combined begin-update endpoint.
 	BeginUpdate APICapability = "begin-update"
+
+	// Indicates that the service supports reading a stack's outputs directly, without
+	// exporting the whole deployment.
+	StackOutputs APICapability = "stack-outputs"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -157,6 +161,9 @@ type Capabilities struct {
 
 	// Indicates whether the service supports the combined begin-update endpoint.
 	BeginUpdate bool
+
+	// Indicates whether the service supports reading a stack's outputs directly.
+	StackOutputs bool
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -222,6 +229,10 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 		case BeginUpdate:
 			if entry.Version == 1 {
 				parsed.BeginUpdate = true
+			}
+		case StackOutputs:
+			if entry.Version == 1 {
+				parsed.StackOutputs = true
 			}
 		default:
 			continue

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -176,6 +176,23 @@ func TestCapabilities(t *testing.T) {
 		}, actual)
 	})
 
+	t.Run("parse stack outputs", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability: StackOutputs,
+					Version:    1,
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			StackOutputs: true,
+		}, actual)
+	})
+
 	t.Run("parse api version v1", func(t *testing.T) {
 		t.Parallel()
 		response := CapabilitiesResponse{

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -132,6 +132,18 @@ type BatchDecryptResponse struct {
 // ExportStackResponse defines the response body for exporting a Stack.
 type ExportStackResponse UntypedDeployment
 
+// StackOutputsResponse defines the response body for reading a Stack's outputs.
+type StackOutputsResponse struct {
+	// Outputs holds the root stack resource's outputs exactly as the checkpoint stores them.
+	// Secret values use the same secret object representation as an exported deployment.
+	// Resolve them with the secrets provider in SecretsProviders and treat them as sensitive.
+	// Outputs is absent when the stack has no state.
+	Outputs map[string]any `json:"outputs,omitempty"`
+	// SecretsProviders is the secrets provider for the secret values in Outputs.
+	// It is absent when the stack has no state.
+	SecretsProviders *SecretsProvidersV1 `json:"secretsProviders,omitempty"`
+}
+
 // ImportStackRequest defines the request body for importing a Stack.
 type ImportStackRequest UntypedDeployment
 


### PR DESCRIPTION
The Pulumi Cloud service now (https://github.com/pulumi/pulumi-service/pull/48964) exposes the outputs of a stack's latest deployment at `GET /api/stacks/{org}/{project}/{stack}/outputs` and advertises the endpoint with the `"stack-outputs"` capability. The response carries the root stack resource's serialized outputs and the checkpoint's secrets provider configuration.

When the backend advertises the capability, the cloud backend reads stack outputs from the endpoint instead of exporting the whole deployment. When the capability is absent, the backend keeps the export-based path so that older servers continue to work.