### PR TITLE
lower threshold for TestPerfSecretsBatchUpdate

### DIFF
--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -117,10 +117,9 @@ func TestPerfParentChainUpdate(t *testing.T) {
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfSecretsBatchUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
-		T: t,
-		// TODO https://github.com/pulumi/pulumi/issues/20476: lower threshold back to 5 seconds
-		MaxPreviewDuration: 10 * time.Second,
-		MaxUpdateDuration:  10 * time.Second,
+		T:                  t,
+		MaxPreviewDuration: 7 * time.Second,
+		MaxUpdateDuration:  7 * time.Second,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
@@ -140,10 +139,9 @@ func TestPerfSecretsBatchUpdate(t *testing.T) {
 //nolint:paralleltest // Do not run in parallel to avoid resource contention
 func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 	benchmarkEnforcer := &integration.AssertPerfBenchmark{
-		T: t,
-		// TODO https://github.com/pulumi/pulumi/issues/20476: lower threshold back to 5 seconds
-		MaxPreviewDuration: 10 * time.Second,
-		MaxUpdateDuration:  10 * time.Second,
+		T:                  t,
+		MaxPreviewDuration: 7 * time.Second,
+		MaxUpdateDuration:  7 * time.Second,
 	}
 
 	// Create an initial stack that contains secrets.


### PR DESCRIPTION
Reduce the threshold to 7 seconds.  5 seems to be too low to not be flaky, so let's split the difference and make it 7 seconds, and lock that target in.

Fixes https://github.com/pulumi/pulumi/issues/20476
