### PR TITLE
sdk/go: support Outputs nested inside structs, slices, maps, and pointers in JSONMarshal

### DIFF
--- a/changelog/pending/20260904--sdk-go--jsonmarshal-nested-outputs.yaml
+++ b/changelog/pending/20260904--sdk-go--jsonmarshal-nested-outputs.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: fix
+body: Support Outputs nested inside structs, slices, arrays, maps, and pointers passed to JSONMarshal, instead of only Outputs at the top level
+time: 2026-09-04T00:00:00+00:00

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -32,8 +32,9 @@ import (
 type Output = internal.Output
 
 var (
-	outputType = reflect.TypeFor[Output]()
-	inputType  = reflect.TypeFor[Input]()
+	outputType   = reflect.TypeFor[Output]()
+	inputType    = reflect.TypeFor[Input]()
+	resourceType = reflect.TypeFor[Resource]()
 )
 
 // RegisterOutputType registers an Output type with the Pulumi runtime. If a value of this type's concrete type is
@@ -149,47 +150,197 @@ func AllWithContext(ctx context.Context, inputs ...any) ArrayOutput {
 	return ToOutputWithContext(ctx, inputs).(ArrayOutput)
 }
 
-// JSONMarshal uses "encoding/json".Marshal to serialize the given Output value into a JSON string.
-//
-// JSONMarshal *does not* support marshaling values that contain nested unknowns. You will need to manually create
-// a top level unknown with [pulumi.Input.ApplyT] or [All]. This does not work:
+// JSONMarshal uses "encoding/json".Marshal to serialize the given Output value into a JSON string. It
+// supports marshaling values that contain Outputs nested arbitrarily deep within structs, slices,
+// arrays, maps, and pointers, for example:
 //
 //	pulumi.JSONMarshal(map[string]any{"key": myResource.Name})
 //
-// You need to move the output myResource.Name to a top level output:
+// If any of the nested Outputs are unknown (e.g. during a preview), the returned StringOutput will
+// itself be unknown, same as if you had called [pulumi.Input.ApplyT] directly.
 //
-//	pulumi.JSONMarshal(myResource.Name.Apply(func(name string) map[string]any{
-//		return map[string]any{"key": name}
-//	}))
-//
-// Supporting nested unknowns is tracked in https://github.com/pulumi/pulumi/issues/12460
+// One case remains unsupported: a struct field whose *static* type is itself a concrete
+// Output-implementing type (e.g. a field of type [StringOutput], rather than `any` or a plain Go
+// type) can't be resolved in place, since doing so would require changing the struct's type. Prefer
+// declaring such fields as `any` or their plain Go equivalent.
 func JSONMarshal(v any) StringOutput {
 	return JSONMarshalWithContext(context.Background(), v)
 }
 
-// JSONMarshalWithContext uses "encoding/json".Marshal to serialize the given Output value into a JSON string.
-//
-// JSONMarshalWithContext *does not* support marshaling values that contain nested unknowns. You will need to
-// manually create a top level unknown with [pulumi.Input.ApplyT] or [All]. This does not work:
-//
-//	pulumi.JSONMarshalWithContext(ctx.Context(), map[string]any{"key": myResource.Name})
-//
-// You need to move the output myResource.Name to a top level output:
-//
-//	pulumi.JSONMarshalWithContext(ctx.Context(), myResource.Name.Apply(func(name string) map[string]any{
-//		return map[string]any{"key": name}
-//	}))
-//
-// Supporting nested unknowns is tracked in https://github.com/pulumi/pulumi/issues/12460
+// JSONMarshalWithContext uses "encoding/json".Marshal to serialize the given Output value into a JSON
+// string. See [JSONMarshal] for details, including the one remaining unsupported case.
 func JSONMarshalWithContext(ctx context.Context, v any) StringOutput {
 	o := ToOutputWithContext(ctx, v)
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v any) (string, error) {
-		json, err := json.Marshal(v)
+	return o.ApplyTWithContext(ctx, func(ctx context.Context, v any) (string, error) {
+		resolved, err := resolveNestedOutputsForJSON(ctx, v)
 		if err != nil {
 			return "", err
 		}
-		return string(json), nil
+		b, err := json.Marshal(resolved)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
 	}).(StringOutput)
+}
+
+// resolveNestedOutputsForJSON returns the value that should actually be marshaled to JSON in place of
+// v: any Output found anywhere within v (in struct fields, slice/array elements, map values, or
+// through pointers and interfaces) is replaced with its already-resolved value. By the time this is
+// called from JSONMarshalWithContext, v has already been through ToOutputWithContext's own await, so
+// any Output found here is expected to resolve immediately.
+//
+// Values that don't contain any Output anywhere are returned completely untouched, so any custom
+// json.Marshaler implementation they may have is preserved.
+func resolveNestedOutputsForJSON(ctx context.Context, v any) (any, error) {
+	resolved, _, err := resolveNestedOutputForJSON(ctx, reflect.ValueOf(v))
+	return resolved, err
+}
+
+// resolveNestedOutputForJSON does the actual work for resolveNestedOutputsForJSON. It returns the
+// resolved value, whether it differs from v (so callers only rebuild containers that actually need
+// it), and any error encountered while awaiting a nested Output.
+func resolveNestedOutputForJSON(ctx context.Context, v reflect.Value) (result any, changed bool, err error) {
+	if !v.IsValid() {
+		return nil, false, nil
+	}
+
+	if v.Type().Implements(outputType) {
+		o, ok := v.Interface().(Output)
+		if !ok {
+			return v.Interface(), false, nil
+		}
+		e, known, _, _, err := internal.AwaitOutput(ctx, o)
+		if err != nil {
+			return nil, false, err
+		}
+		if !known {
+			return nil, false, errors.New("cannot marshal an unknown value to JSON")
+		}
+		// The awaited value may itself still contain further nested Outputs (e.g. if it was
+		// produced by directly resolving an Output to a value that embeds other Outputs), so
+		// resolve recursively.
+		resolved, _, err := resolveNestedOutputForJSON(ctx, reflect.ValueOf(e))
+		if err != nil {
+			return nil, false, err
+		}
+		return resolved, true, nil
+	}
+
+	// Resources are treated as opaque, mirroring how the general Input/Output await machinery
+	// handles them: we don't reflect into their fields.
+	if v.Type().Implements(resourceType) {
+		return v.Interface(), false, nil
+	}
+
+	//nolint:exhaustive // the remaining kinds have nothing to recurse into
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if v.IsNil() {
+			return v.Interface(), false, nil
+		}
+		inner, innerChanged, err := resolveNestedOutputForJSON(ctx, v.Elem())
+		if err != nil {
+			return nil, false, err
+		}
+		if !innerChanged {
+			return v.Interface(), false, nil
+		}
+		return inner, true, nil
+
+	case reflect.Struct:
+		var newStruct reflect.Value
+		anyChanged := false
+		for i := range v.NumField() {
+			f := v.Field(i)
+			if !f.CanInterface() {
+				continue // unexported; encoding/json ignores these too
+			}
+			fv, fChanged, err := resolveNestedOutputForJSON(ctx, f)
+			if err != nil {
+				return nil, false, err
+			}
+			if !fChanged {
+				continue
+			}
+			rv := reflect.ValueOf(fv)
+			if !rv.IsValid() {
+				rv = reflect.Zero(f.Type())
+			}
+			if !rv.Type().AssignableTo(f.Type()) {
+				// The resolved value doesn't fit this field's static type (e.g. the field is
+				// itself a concrete Output type). Leave the field as it was; json.Marshal will
+				// error on it if it's still a raw Output.
+				continue
+			}
+			if !newStruct.IsValid() {
+				newStruct = reflect.New(v.Type()).Elem()
+				newStruct.Set(v)
+			}
+			newStruct.Field(i).Set(rv)
+			anyChanged = true
+		}
+		if !anyChanged {
+			return v.Interface(), false, nil
+		}
+		return newStruct.Interface(), true, nil
+
+	case reflect.Array, reflect.Slice:
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			return v.Interface(), false, nil
+		}
+		l := v.Len()
+		elems := make([]any, l)
+		anyChanged := false
+		for i := range l {
+			ev, eChanged, err := resolveNestedOutputForJSON(ctx, v.Index(i))
+			if err != nil {
+				return nil, false, err
+			}
+			elems[i] = ev
+			anyChanged = anyChanged || eChanged
+		}
+		if !anyChanged {
+			return v.Interface(), false, nil
+		}
+		return elems, true, nil
+
+	case reflect.Map:
+		if v.IsNil() {
+			return v.Interface(), false, nil
+		}
+		keys := make([]reflect.Value, 0, v.Len())
+		values := make([]any, 0, v.Len())
+		anyChanged := false
+		iter := v.MapRange()
+		for iter.Next() {
+			vv, vChanged, err := resolveNestedOutputForJSON(ctx, iter.Value())
+			if err != nil {
+				return nil, false, err
+			}
+			keys = append(keys, iter.Key())
+			values = append(values, vv)
+			anyChanged = anyChanged || vChanged
+		}
+		if !anyChanged {
+			return v.Interface(), false, nil
+		}
+		// Preserve the map's original key type (e.g. non-string keys, or key types with custom
+		// MarshalText), but widen the value type to `any` since it may now hold a resolved value of
+		// a different type than the map's original value type.
+		out := reflect.MakeMapWithSize(reflect.MapOf(v.Type().Key(), anyType), len(keys))
+		for i, k := range keys {
+			rv := reflect.ValueOf(values[i])
+			if !rv.IsValid() {
+				rv = reflect.Zero(anyType)
+			}
+			out.SetMapIndex(k, rv)
+		}
+		return out.Interface(), true, nil
+
+	default:
+		return v.Interface(), false, nil
+	}
 }
 
 // JSONUnmarshal uses "encoding/json".Unmarshal to deserialize the given Input JSON string into a value.

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -1114,11 +1114,71 @@ func TestJSONMarshalNested(t *testing.T) {
 	}()
 	json := JSONMarshal(out)
 	v, known, secret, deps, err := await(json)
-	assert.EqualError(t, err, "json: error calling MarshalJSON for type *pulumi.AnyOutput: outputs can not be marshaled to JSON")
+	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
 	assert.Nil(t, deps)
+	assert.Equal(t, "[0,1]", v.(string))
+}
+
+// TestJSONMarshalNestedInMap covers https://github.com/pulumi/pulumi/issues/12460: JSONMarshal must
+// support Outputs nested inside plain Go containers (maps, slices, structs, pointers), not just at
+// the top level.
+func TestJSONMarshalNestedInMap(t *testing.T) {
+	t.Parallel()
+
+	name, resolveName, _ := NewOutput()
+	go func() {
+		resolveName("hello")
+	}()
+
+	json := JSONMarshal(map[string]any{"key": name})
+	v, known, secret, deps, err := await(json)
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.False(t, secret)
+	assert.Nil(t, deps)
+	assert.Equal(t, `{"key":"hello"}`, v.(string))
+}
+
+// TestJSONMarshalNestedUnknown covers the unknown (preview-time) counterpart of
+// TestJSONMarshalNestedInMap: an unknown Output nested inside a plain Go container should make the
+// overall result unknown, not error.
+func TestJSONMarshalNestedUnknown(t *testing.T) {
+	t.Parallel()
+
+	unk := UnsafeUnknownOutput(nil)
+
+	json := JSONMarshal(map[string]any{"key": unk})
+	v, known, secret, deps, err := await(json)
+	require.NoError(t, err)
+	assert.False(t, known)
+	assert.False(t, secret)
+	assert.Nil(t, deps)
 	assert.Nil(t, v)
+}
+
+// TestJSONMarshalOutputSlice covers a slice whose *static* element type is the Output interface
+// itself (as opposed to `any`), which requires widening the slice's element type during marshaling.
+func TestJSONMarshalOutputSlice(t *testing.T) {
+	t.Parallel()
+
+	a, resolvea, _ := NewOutput()
+	go func() {
+		resolvea(0)
+	}()
+	b, resolveb, _ := NewOutput()
+	go func() {
+		resolveb(1)
+	}()
+
+	json := JSONMarshal([]Output{a, b})
+	v, known, secret, deps, err := await(json)
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.False(t, secret)
+	assert.Nil(t, deps)
+	assert.Equal(t, "[0,1]", v.(string))
 }
 
 func TestJSONUnmarshalBasic(t *testing.T) {


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

## Problem

Fixes #12460.

`pulumi.JSONMarshal`/`JSONMarshalWithContext` documented that any `Output` passed in had to be at the top level of the value, since nesting one inside a struct, slice, array, map, or pointer would make `json.Marshal` encounter a raw, un-awaited `Output` and fail with `outputs can not be marshaled to JSON` (each generated Output type's `MarshalJSON` deliberately errors, to guard against direct misuse of `encoding/json.Marshal` on an Output).

## Root cause

The underlying Input/Output await machinery (`ToOutputWithContext`) already correctly awaits and propagates unknown-ness for Outputs nested inside `any`-typed positions — e.g. `map[string]any{"key": myResource.Name}` (the exact example from the old doc comment) or a struct field typed `any` already worked correctly before this change.

What remained broken is specifically containers whose *static* element/field type is itself a concrete Output-implementing type rather than `any` — e.g. `[]pulumi.Output{a, b}`, or one of the SDK's typed builtin containers. In that case the destination type constrains what can be substituted in place during the await, so the raw `Output` reference survives and is handed to `json.Marshal` directly.

## Fix

Added a self-contained post-processing pass in `JSONMarshalWithContext` (`resolveNestedOutputsForJSON` in [sdk/go/pulumi/types.go](https://github.com/pulumi/pulumi/blob/master/sdk/go/pulumi/types.go)) that walks the already-awaited value and replaces any `Output` still found nested within it — recursively, through pointers, interfaces, structs, slices, arrays, and maps — with its resolved value, widening container element/value types to `any` as needed (this is always safe for JSON purposes, since `encoding/json` produces identical output for e.g. `[]any{1,2}` and `[]int{1,2}`). Values that don't contain any `Output` anywhere are returned **completely untouched**, so any custom `json.Marshaler` implementation they may have is preserved.

This is scoped entirely to `JSONMarshal`/`JSONMarshalWithContext` — it does not touch the shared internal Input/Output await machinery (`internal.awaitInputs`) used throughout the rest of the SDK, to keep the change low-risk and narrowly targeted.

One case remains unsupported: a struct field whose *static* type is itself a concrete Output-implementing type (e.g. a field of type `pulumi.StringOutput`, rather than `any` or a plain Go type) can't be substituted in place without changing the struct's type. This is narrower than the previous "no nesting at all" limitation and is documented on `JSONMarshal`.

## Testing

- Updated `TestJSONMarshalNested` in `sdk/go/pulumi/types_test.go`, which previously asserted the buggy `"outputs can not be marshaled to JSON"` error as expected behavior — it now asserts the corrected, successful result.
- Added `TestJSONMarshalNestedInMap` (the exact scenario from the old doc comment/issue), `TestJSONMarshalNestedUnknown` (unknown-value propagation still works, no error), and `TestJSONMarshalOutputSlice` (`[]Output` with a concrete Output element type, the specific case that was broken).
- `go test ./...` passes across the whole `sdk/go` module (the only failure, `auto.TestProjectSettingsRespected`, is pre-existing/environmental — it requires the built `pulumi` CLI binary on `PATH`, unrelated to this change).
