### PR TITLE
Add package `propertyrpc`

### DIFF
--- a/pkg/resource/plugin/rpc.go
+++ b/pkg/resource/plugin/rpc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -61,28 +62,16 @@ type MarshalOptions struct {
 	skipLogging bool
 }
 
+// Sentinels indicating that a property's value is not known, because it depends on a computation
+// with values whose values themselves are not yet known (e.g., dependent upon an output property).
 const (
-	// UnknownBoolValue is a sentinel indicating that a bool property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownBoolValue = "1c4a061d-8072-4f0a-a4cb-0ff528b18fe7"
-	// UnknownNumberValue is a sentinel indicating that a number property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownNumberValue = "3eeb2bf0-c639-47a8-9e75-3b44932eb421"
-	// UnknownStringValue is a sentinel indicating that a string property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownStringValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
-	// UnknownArrayValue is a sentinel indicating that an array property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownArrayValue = "6a19a0b0-7e62-4c92-b797-7f8e31da9cc2"
-	// UnknownAssetValue is a sentinel indicating that an asset property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownAssetValue = "030794c1-ac77-496b-92df-f27374a8bd58"
-	// UnknownArchiveValue is a sentinel indicating that an archive property's value is not known, because it depends
-	// on a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownArchiveValue = "e48ece36-62e2-4504-bad9-02848725956a"
-	// UnknownObjectValue is a sentinel indicating that an archive property's value is not known, because it depends
-	// on a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownObjectValue = "dd056dcd-154b-4c76-9bd3-c8f88648b5ff"
+	UnknownBoolValue    = sig.UnknownBoolValue
+	UnknownNumberValue  = sig.UnknownNumberValue
+	UnknownStringValue  = sig.UnknownStringValue
+	UnknownArrayValue   = sig.UnknownArrayValue
+	UnknownAssetValue   = sig.UnknownAssetValue
+	UnknownArchiveValue = sig.UnknownArchiveValue
+	UnknownObjectValue  = sig.UnknownObjectValue
 )
 
 // MarshalProperties marshals a resource's property map as a "JSON-like" protobuf structure.

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -61,28 +62,16 @@ type MarshalOptions struct {
 	skipLogging bool
 }
 
+// Sentinels indicating that a property's value is not known, because it depends on a computation
+// with values whose values themselves are not yet known (e.g., dependent upon an output property).
 const (
-	// UnknownBoolValue is a sentinel indicating that a bool property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownBoolValue = "1c4a061d-8072-4f0a-a4cb-0ff528b18fe7"
-	// UnknownNumberValue is a sentinel indicating that a number property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownNumberValue = "3eeb2bf0-c639-47a8-9e75-3b44932eb421"
-	// UnknownStringValue is a sentinel indicating that a string property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownStringValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
-	// UnknownArrayValue is a sentinel indicating that an array property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownArrayValue = "6a19a0b0-7e62-4c92-b797-7f8e31da9cc2"
-	// UnknownAssetValue is a sentinel indicating that an asset property's value is not known, because it depends on
-	// a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownAssetValue = "030794c1-ac77-496b-92df-f27374a8bd58"
-	// UnknownArchiveValue is a sentinel indicating that an archive property's value is not known, because it depends
-	// on a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownArchiveValue = "e48ece36-62e2-4504-bad9-02848725956a"
-	// UnknownObjectValue is a sentinel indicating that an archive property's value is not known, because it depends
-	// on a computation with values whose values themselves are not yet known (e.g., dependent upon an output property).
-	UnknownObjectValue = "dd056dcd-154b-4c76-9bd3-c8f88648b5ff"
+	UnknownBoolValue    = sig.UnknownBoolValue
+	UnknownNumberValue  = sig.UnknownNumberValue
+	UnknownStringValue  = sig.UnknownStringValue
+	UnknownArrayValue   = sig.UnknownArrayValue
+	UnknownAssetValue   = sig.UnknownAssetValue
+	UnknownArchiveValue = sig.UnknownArchiveValue
+	UnknownObjectValue  = sig.UnknownObjectValue
 )
 
 // MarshalProperties marshals a resource's property map as a "JSON-like" protobuf structure.

--- a/sdk/go/common/resource/sig/sig.go
+++ b/sdk/go/common/resource/sig/sig.go
@@ -40,3 +40,39 @@ const (
 	// a randomly assigned archive type signature.
 	ArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7"
 )
+
+// Unknown values are transported as sentinel strings. Each sentinel records the type of the value
+// that is not yet known, so that the receiver can recover the type.
+const (
+	// UnknownBoolValue is the sentinel for a bool value that is not known.
+	UnknownBoolValue = "1c4a061d-8072-4f0a-a4cb-0ff528b18fe7"
+
+	// UnknownNumberValue is the sentinel for a number value that is not known.
+	UnknownNumberValue = "3eeb2bf0-c639-47a8-9e75-3b44932eb421"
+
+	// UnknownStringValue is the sentinel for a string value that is not known.
+	UnknownStringValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+
+	// UnknownArrayValue is the sentinel for an array value that is not known.
+	UnknownArrayValue = "6a19a0b0-7e62-4c92-b797-7f8e31da9cc2"
+
+	// UnknownAssetValue is the sentinel for an asset value that is not known.
+	UnknownAssetValue = "030794c1-ac77-496b-92df-f27374a8bd58"
+
+	// UnknownArchiveValue is the sentinel for an archive value that is not known.
+	UnknownArchiveValue = "e48ece36-62e2-4504-bad9-02848725956a"
+
+	// UnknownObjectValue is the sentinel for an object value that is not known.
+	UnknownObjectValue = "dd056dcd-154b-4c76-9bd3-c8f88648b5ff"
+)
+
+// IsUnknown reports if s is one of the sentinels that describe a value that is not known.
+func IsUnknown(s string) bool {
+	switch s {
+	case UnknownBoolValue, UnknownNumberValue, UnknownStringValue, UnknownArrayValue,
+		UnknownAssetValue, UnknownArchiveValue, UnknownObjectValue:
+		return true
+	default:
+		return false
+	}
+}

--- a/sdk/go/propertyrpc/marshal.go
+++ b/sdk/go/propertyrpc/marshal.go
@@ -1,0 +1,150 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propertyrpc
+
+import (
+	"encoding/base64"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+func Marshal(m property.Map) *structpb.Struct {
+	fields := make(map[string]*structpb.Value, m.Len())
+	for k, v := range m.All {
+		fields[k] = MarshalValue(v)
+	}
+	return &structpb.Struct{Fields: fields}
+}
+
+func MarshalValue(v property.Value) *structpb.Value {
+	// If we have dependencies, this must be an output
+	if deps := v.Dependencies(); len(deps) > 0 || (v.Secret() && v.IsComputed()) {
+		fields := map[string]*structpb.Value{
+			sig.Key: structpb.NewStringValue(sig.OutputValue),
+		}
+		if !v.IsComputed() {
+			fields["value"] = marshalPlainValue(v)
+		}
+		if v.Secret() {
+			fields["secret"] = trueValue
+		}
+		if len(deps) > 0 {
+			urns := make([]*structpb.Value, len(deps))
+			for i, urn := range deps {
+				urns[i] = structpb.NewStringValue(string(urn))
+			}
+			fields["dependencies"] = structpb.NewListValue(&structpb.ListValue{Values: urns})
+		}
+		return structpb.NewStructValue(&structpb.Struct{Fields: fields})
+	}
+
+	if v.Secret() {
+		return structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+			sig.Key: structpb.NewStringValue(sig.Secret),
+			"value": marshalPlainValue(v),
+		}})
+	}
+
+	return marshalPlainValue(v)
+}
+
+func marshalPlainValue(v property.Value) *structpb.Value {
+	switch {
+	case v.IsBool():
+		return structpb.NewBoolValue(v.AsBool())
+	case v.IsNumber():
+		return structpb.NewNumberValue(v.AsNumber())
+	case v.IsString():
+		return marshalString(v.AsString())
+	case v.IsArray():
+		return structpb.NewListValue(marshalArray(v.AsArray()))
+	case v.IsMap():
+		return structpb.NewStructValue(Marshal(v.AsMap()))
+	case v.IsAsset():
+		return marshalSerialized(v.AsAsset().Serialize())
+	case v.IsArchive():
+		return marshalSerialized(v.AsArchive().Serialize())
+	case v.IsResourceReference():
+		return marshalResourceReference(v.AsResourceReference())
+	case v.IsNull():
+		return structpb.NewNullValue()
+	case v.IsComputed():
+		return computedValue
+	default:
+		contract.Failf("%T of unknown type %#v", v, v)
+		return nil
+	}
+}
+
+// marshalString marshals a string. A protobuf string field must contain valid UTF-8, so a string
+// with other bytes is marshalled as the base64 encoding of its bytes.
+func marshalString(s string) *structpb.Value {
+	if utf8.ValidString(s) {
+		return structpb.NewStringValue(s)
+	}
+	return structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+		sig.Key: structpb.NewStringValue(sig.ByteString),
+		"value": structpb.NewStringValue(base64.StdEncoding.EncodeToString([]byte(s))),
+	}})
+}
+
+// marshalSerialized marshals the weakly typed map produced by [asset.Asset.Serialize] and
+// [archive.Archive.Serialize]. Those maps contain only strings and nested serialized maps.
+func marshalSerialized(m map[string]any) *structpb.Value {
+	s, err := structpb.NewStruct(m)
+	contract.AssertNoErrorf(err, "failed to marshal %#v", m)
+	return structpb.NewStructValue(s)
+}
+
+func marshalResourceReference(ref property.ResourceReference) *structpb.Value {
+	fields := map[string]*structpb.Value{
+		sig.Key: structpb.NewStringValue(sig.ResourceReference),
+		"urn":   structpb.NewStringValue(string(ref.URN)),
+	}
+	if ref.Name != "" {
+		fields["name"] = structpb.NewStringValue(ref.Name)
+	}
+	if ref.Type != "" {
+		fields["type"] = structpb.NewStringValue(ref.Type)
+	}
+	if id, hasID := ref.IDString(); hasID {
+		fields["id"] = structpb.NewStringValue(id)
+	}
+	if ref.PackageVersion != "" {
+		fields["packageVersion"] = structpb.NewStringValue(ref.PackageVersion)
+	}
+	return structpb.NewStructValue(&structpb.Struct{Fields: fields})
+}
+
+var computedValue = structpb.NewStructValue(&structpb.Struct{
+	Fields: map[string]*structpb.Value{
+		sig.Key: structpb.NewStringValue(sig.OutputValue),
+	},
+})
+
+var trueValue = structpb.NewBoolValue(true)
+
+func marshalArray(array property.Array) *structpb.ListValue {
+	values := make([]*structpb.Value, array.Len())
+	for i, v := range array.All {
+		values[i] = MarshalValue(v)
+	}
+	return &structpb.ListValue{Values: values}
+}

--- a/sdk/go/propertyrpc/propertyrpc.go
+++ b/sdk/go/propertyrpc/propertyrpc.go
@@ -1,0 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package propertyrpc handles serialization and deserialization between
+// [google.golang.org/protobuf/types/known/structpb] & [github.com/pulumi/pulumi/sdk/v3/go/property] values.
+package propertyrpc

--- a/sdk/go/propertyrpc/propertyrpc_test.go
+++ b/sdk/go/propertyrpc/propertyrpc_test.go
@@ -19,10 +19,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	"pgregory.net/rapid"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pTest "github.com/pulumi/pulumi/sdk/v3/go/property/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/propertyrpc"
 )
@@ -47,5 +53,315 @@ func TestMarshalThroughGRPC(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, source, resource.FromResourcePropertyMap(unmarshalled))
+	})
+}
+
+// TestUnmarshalThroughGRPC checks that a [property.Map] survives a round trip through
+// [plugin.MarshalProperties] and [propertyrpc.Unmarshal].
+func TestUnmarshalThroughGRPC(t *testing.T) {
+	t.Parallel()
+
+	opts := plugin.MarshalOptions{
+		KeepUnknowns:          true,
+		KeepSecrets:           true,
+		KeepResources:         true,
+		KeepOutputValues:      true,
+		UpgradeToOutputValues: true,
+	}
+
+	m := pTest.Map(10)
+	rapid.Check(t, func(t *rapid.T) {
+		source := m.Draw(t, "round-trip map")
+
+		marshalled, err := plugin.MarshalProperties(resource.ToResourcePropertyMap(source), opts)
+		require.NoError(t, err)
+
+		actual, err := propertyrpc.Unmarshal(marshalled)
+		require.NoError(t, err)
+
+		assert.Equal(t, source, actual)
+	})
+}
+
+// TestRoundTrip checks that [propertyrpc.Unmarshal] inverts [propertyrpc.Marshal].
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	m := pTest.Map(10)
+	rapid.Check(t, func(t *rapid.T) {
+		source := m.Draw(t, "round-trip map")
+
+		actual, err := propertyrpc.Unmarshal(propertyrpc.Marshal(source))
+		require.NoError(t, err)
+
+		assert.Equal(t, source, actual)
+	})
+}
+
+// TestResourceReferenceRoundTrip checks resource references, which [pTest.Map] does not
+// generate.
+func TestResourceReferenceRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  property.ResourceReference
+	}{
+		{"known-id", property.ResourceReference{
+			URN:            "urn:pulumi:stack::proj::pkg:index:Res::name",
+			Name:           "name",
+			Type:           "pkg:index:Res",
+			ID:             property.New("id"),
+			PackageVersion: "1.2.3",
+		}},
+		{"unknown-id", property.ResourceReference{
+			URN: "urn:pulumi:stack::proj::pkg:index:Res::name",
+			ID:  property.New(property.Computed),
+		}},
+		{"component", property.ResourceReference{
+			URN: "urn:pulumi:stack::proj::pkg:index:Component::name",
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := property.New(tt.ref)
+			actual, err := propertyrpc.UnmarshalValue(propertyrpc.MarshalValue(source))
+			require.NoError(t, err)
+			assert.Equal(t, source, actual)
+		})
+	}
+}
+
+func TestUnmarshalErrors(t *testing.T) {
+	t.Parallel()
+
+	obj := func(fields map[string]*structpb.Value) *structpb.Value {
+		return structpb.NewStructValue(&structpb.Struct{Fields: fields})
+	}
+	list := func(values ...*structpb.Value) *structpb.Value {
+		return structpb.NewListValue(&structpb.ListValue{Values: values})
+	}
+	key, index := property.NewSegment[string], property.NewSegment[int]
+	bogus := obj(map[string]*structpb.Value{sig.Key: structpb.NewStringValue("bogus")})
+
+	tests := []struct {
+		name         string
+		input        *structpb.Value
+		expectedPath property.Path
+		expected     string
+	}{
+		{
+			name:         "root",
+			input:        bogus,
+			expectedPath: property.PathFromSegments(),
+			expected:     `<root>: unknown signature "bogus"`,
+		},
+		{
+			name:         "map-key",
+			input:        obj(map[string]*structpb.Value{"k": bogus}),
+			expectedPath: property.PathFromSegments(key("k")),
+			expected:     `k: unknown signature "bogus"`,
+		},
+		{
+			name:         "array-index",
+			input:        list(structpb.NewNumberValue(0), bogus),
+			expectedPath: property.PathFromSegments(index(1)),
+			expected:     `[1]: unknown signature "bogus"`,
+		},
+		{
+			name:         "quoted-key",
+			input:        obj(map[string]*structpb.Value{"a.b": bogus}),
+			expectedPath: property.PathFromSegments(key("a.b")),
+			expected:     `["a.b"]: unknown signature "bogus"`,
+		},
+		{
+			name: "non-string-signature",
+			input: obj(map[string]*structpb.Value{"k": obj(map[string]*structpb.Value{
+				sig.Key: structpb.NewNumberValue(1),
+			})}),
+			expectedPath: property.PathFromSegments(key("k")),
+			expected:     `k: unknown signature ""`,
+		},
+		{
+			// The secret marker does not add a segment to the path.
+			name: "in-secret",
+			input: obj(map[string]*structpb.Value{"s": obj(map[string]*structpb.Value{
+				sig.Key: structpb.NewStringValue(sig.Secret),
+				"value": obj(map[string]*structpb.Value{"k": bogus}),
+			})}),
+			expectedPath: property.PathFromSegments(key("s"), key("k")),
+			expected:     `s.k: unknown signature "bogus"`,
+		},
+		{
+			// The output marker does not add a segment to the path.
+			name: "in-output-value",
+			input: obj(map[string]*structpb.Value{"o": obj(map[string]*structpb.Value{
+				sig.Key: structpb.NewStringValue(sig.OutputValue),
+				"value": list(bogus),
+			})}),
+			expectedPath: property.PathFromSegments(key("o"), index(0)),
+			expected:     `o[0]: unknown signature "bogus"`,
+		},
+		{
+			name: "missing-secret-value",
+			input: list(obj(map[string]*structpb.Value{
+				sig.Key: structpb.NewStringValue(sig.Secret),
+			})),
+			expectedPath: property.PathFromSegments(index(0)),
+			expected:     "[0]: malformed secret: missing value",
+		},
+		{
+			name: "non-bool-secret",
+			input: obj(map[string]*structpb.Value{"a": obj(map[string]*structpb.Value{"b": obj(
+				map[string]*structpb.Value{
+					sig.Key:  structpb.NewStringValue(sig.OutputValue),
+					"secret": structpb.NewStringValue("true"),
+				})})}),
+			expectedPath: property.PathFromSegments(key("a"), key("b")),
+			expected:     "a.b: malformed output value: secret is not a bool",
+		},
+		{
+			name: "non-array-dependencies",
+			input: obj(map[string]*structpb.Value{
+				sig.Key:        structpb.NewStringValue(sig.OutputValue),
+				"dependencies": structpb.NewStringValue("urn"),
+			}),
+			expectedPath: property.PathFromSegments(),
+			expected:     "<root>: malformed output value: dependencies is not an array",
+		},
+		{
+			name: "non-string-dependency",
+			input: list(list(obj(map[string]*structpb.Value{
+				sig.Key:        structpb.NewStringValue(sig.OutputValue),
+				"dependencies": list(structpb.NewStringValue("urn"), structpb.NewNumberValue(0)),
+			}))),
+			expectedPath: property.PathFromSegments(index(0), index(0)),
+			expected:     "[0][0]: malformed output value: dependency 1 is not a string",
+		},
+		{
+			name: "missing-urn",
+			input: obj(map[string]*structpb.Value{"ref": obj(map[string]*structpb.Value{
+				sig.Key: structpb.NewStringValue(sig.ResourceReference),
+			})}),
+			expectedPath: property.PathFromSegments(key("ref")),
+			expected:     "ref: malformed resource reference: missing urn",
+		},
+		{
+			name: "non-string-urn",
+			input: obj(map[string]*structpb.Value{"ref": obj(map[string]*structpb.Value{
+				sig.Key: structpb.NewStringValue(sig.ResourceReference),
+				"urn":   structpb.NewBoolValue(true),
+			})}),
+			expectedPath: property.PathFromSegments(key("ref")),
+			expected:     "ref: malformed resource reference: urn is not a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := propertyrpc.UnmarshalValue(tt.input)
+
+			var unmarshalErr propertyrpc.UnmarshalError
+			require.ErrorAs(t, err, &unmarshalErr)
+			assert.Equal(t, tt.expectedPath, unmarshalErr.Path)
+			assert.EqualError(t, err, tt.expected)
+		})
+	}
+}
+
+// TestUnmarshalUnknownSentinel checks that [propertyrpc.Unmarshal] recovers a computed value
+// from each unknown sentinel. Peers that marshal without KeepOutputValues send these sentinels
+// instead of output values.
+func TestUnmarshalUnknownSentinel(t *testing.T) {
+	t.Parallel()
+
+	source := resource.PropertyMap{
+		"bool":    resource.MakeComputed(resource.NewProperty(false)),
+		"number":  resource.MakeComputed(resource.NewProperty(0.0)),
+		"string":  resource.MakeComputed(resource.NewProperty("")),
+		"array":   resource.MakeComputed(resource.NewProperty([]resource.PropertyValue{})),
+		"asset":   resource.MakeComputed(resource.NewProperty(&asset.Asset{})),
+		"archive": resource.MakeComputed(resource.NewProperty(&archive.Archive{})),
+		"object":  resource.MakeComputed(resource.NewProperty(resource.PropertyMap{})),
+	}
+
+	marshalled, err := plugin.MarshalProperties(source, plugin.MarshalOptions{
+		KeepUnknowns: true,
+		KeepSecrets:  true,
+	})
+	require.NoError(t, err)
+
+	actual, err := propertyrpc.Unmarshal(marshalled)
+	require.NoError(t, err)
+
+	computed := property.New(property.Computed)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"bool":    computed,
+		"number":  computed,
+		"string":  computed,
+		"array":   computed,
+		"asset":   computed,
+		"archive": computed,
+		"object":  computed,
+	}), actual)
+}
+
+// TestByteString checks strings that contain bytes which are not valid UTF-8. A protobuf string
+// field cannot hold such a string, so it travels as a base64 encoded object.
+func TestByteString(t *testing.T) {
+	t.Parallel()
+
+	const invalid = "hello\xff\xfeworld"
+	source := property.NewMap(map[string]property.Value{
+		"bytes": property.New(invalid),
+	})
+
+	t.Run("round-trip", func(t *testing.T) {
+		t.Parallel()
+
+		// The marshalled value must survive protobuf serialization, which rejects a string
+		// field that is not valid UTF-8.
+		wire, err := proto.Marshal(propertyrpc.Marshal(source))
+		require.NoError(t, err)
+		var received structpb.Struct
+		require.NoError(t, proto.Unmarshal(wire, &received))
+
+		actual, err := propertyrpc.Unmarshal(&received)
+		require.NoError(t, err)
+		assert.Equal(t, source, actual)
+	})
+
+	t.Run("marshal-through-grpc", func(t *testing.T) {
+		t.Parallel()
+
+		unmarshalled, err := plugin.UnmarshalProperties(propertyrpc.Marshal(source), plugin.MarshalOptions{
+			KeepUnknowns:     true,
+			KeepSecrets:      true,
+			KeepResources:    true,
+			KeepOutputValues: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, source, resource.FromResourcePropertyMap(unmarshalled))
+	})
+
+	t.Run("unmarshal-through-grpc", func(t *testing.T) {
+		t.Parallel()
+
+		marshalled, err := plugin.MarshalProperties(resource.ToResourcePropertyMap(source), plugin.MarshalOptions{
+			KeepUnknowns:   true,
+			KeepSecrets:    true,
+			KeepResources:  true,
+			KeepByteString: true,
+		})
+		require.NoError(t, err)
+
+		actual, err := propertyrpc.Unmarshal(marshalled)
+		require.NoError(t, err)
+		assert.Equal(t, source, actual)
 	})
 }

--- a/sdk/go/propertyrpc/propertyrpc_test.go
+++ b/sdk/go/propertyrpc/propertyrpc_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propertyrpc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pTest "github.com/pulumi/pulumi/sdk/v3/go/property/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/propertyrpc"
+)
+
+// TestMarshalThroughGRPC checks that a [property.Map] survives a round trip through [propertyrpc.Marshal] and
+// [plugin.UnmarshalProperties].
+func TestMarshalThroughGRPC(t *testing.T) {
+	t.Parallel()
+
+	opts := plugin.MarshalOptions{
+		KeepUnknowns:     true,
+		KeepSecrets:      true,
+		KeepResources:    true,
+		KeepOutputValues: true,
+	}
+
+	m := pTest.Map(10)
+	rapid.Check(t, func(t *rapid.T) {
+		source := m.Draw(t, "round-trip map")
+
+		unmarshalled, err := plugin.UnmarshalProperties(propertyrpc.Marshal(source), opts)
+		require.NoError(t, err)
+
+		assert.Equal(t, source, resource.FromResourcePropertyMap(unmarshalled))
+	})
+}

--- a/sdk/go/propertyrpc/unmarshal.go
+++ b/sdk/go/propertyrpc/unmarshal.go
@@ -1,0 +1,272 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propertyrpc
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/sig"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// UnmarshalError describes why a value could not be unmarshalled, and where in the value
+// the problem was found.
+type UnmarshalError struct {
+	Path   property.Path
+	Reason error
+}
+
+func (e UnmarshalError) Error() string {
+	var path string
+	if (e.Path == property.Path{}) {
+		path = "<root>"
+	} else if p, err := e.Path.MarshalText(); err != nil {
+		path = "PathError(" + err.Error() + ")"
+	} else {
+		path = string(p)
+	}
+	return fmt.Sprintf("%s: %s", path, e.Reason)
+}
+
+func (e UnmarshalError) Unwrap() error { return e.Reason }
+
+func Unmarshal(s *structpb.Struct) (property.Map, error) {
+	return unmarshalStruct(s, nil)
+}
+
+func UnmarshalValue(v *structpb.Value) (property.Value, error) {
+	return unmarshalValue(v, nil)
+}
+
+// path is the location of the value that is currently unmarshalled, relative to the value
+// that [Unmarshal] or [UnmarshalValue] received.
+type path = []property.PathSegment
+
+func errAt(p path, msg string, args ...any) error {
+	return wrapAt(p, fmt.Errorf(msg, args...))
+}
+
+func wrapAt(p path, err error) error {
+	return UnmarshalError{Path: property.PathFromSegments(p...), Reason: err}
+}
+
+func unmarshalStruct(s *structpb.Struct, p path) (property.Map, error) {
+	fields := make(map[string]property.Value, len(s.GetFields()))
+	for k, v := range s.GetFields() {
+		v, err := unmarshalValue(v, append(p, property.NewSegment(k)))
+		if err != nil {
+			return property.Map{}, err
+		}
+		fields[k] = v
+	}
+	return property.NewMap(fields), nil
+}
+
+func unmarshalValue(v *structpb.Value, p path) (property.Value, error) {
+	switch v := v.GetKind().(type) {
+	case nil, *structpb.Value_NullValue:
+		return property.Value{}, nil
+	case *structpb.Value_BoolValue:
+		return property.New(v.BoolValue), nil
+	case *structpb.Value_NumberValue:
+		return property.New(v.NumberValue), nil
+	case *structpb.Value_StringValue:
+		if sig.IsUnknown(v.StringValue) {
+			return property.New(property.Computed), nil
+		}
+		return property.New(v.StringValue), nil
+	case *structpb.Value_ListValue:
+		return unmarshalArray(v.ListValue, p)
+	case *structpb.Value_StructValue:
+		return unmarshalStructValue(v.StructValue, p)
+	default:
+		return property.Value{}, errAt(p, "unknown value kind %T", v)
+	}
+}
+
+func unmarshalArray(list *structpb.ListValue, p path) (property.Value, error) {
+	values := make([]property.Value, len(list.GetValues()))
+	for i, v := range list.GetValues() {
+		v, err := unmarshalValue(v, append(p, property.NewSegment(i)))
+		if err != nil {
+			return property.Value{}, err
+		}
+		values[i] = v
+	}
+	return property.New(values), nil
+}
+
+// unmarshalStructValue unmarshals a struct, which is either a plain map or one of the
+// types that [sig.Key] describes.
+func unmarshalStructValue(s *structpb.Struct, p path) (property.Value, error) {
+	signature, hasSignature := s.GetFields()[sig.Key]
+	if !hasSignature {
+		m, err := unmarshalStruct(s, p)
+		if err != nil {
+			return property.Value{}, err
+		}
+		return property.New(m), nil
+	}
+
+	switch signature := signature.GetStringValue(); signature {
+	case sig.Secret:
+		value, ok := s.GetFields()["value"]
+		if !ok {
+			return property.Value{}, errAt(p, "malformed secret: missing value")
+		}
+		// The secret marker is not part of the path, so p is not extended here.
+		v, err := unmarshalValue(value, p)
+		if err != nil {
+			return property.Value{}, err
+		}
+		return v.WithSecret(true), nil
+	case sig.OutputValue:
+		return unmarshalOutputValue(s, p)
+	case sig.ResourceReference:
+		return unmarshalResourceReference(s, p)
+	case sig.ByteString:
+		return unmarshalByteString(s, p)
+	case asset.AssetSig:
+		a, _, err := asset.Deserialize(s.AsMap())
+		if err != nil {
+			return property.Value{}, wrapAt(p, err)
+		}
+		return property.New(a), nil
+	case archive.ArchiveSig:
+		a, _, err := archive.Deserialize(s.AsMap())
+		if err != nil {
+			return property.Value{}, wrapAt(p, err)
+		}
+		return property.New(a), nil
+	default:
+		return property.Value{}, errAt(p, "unknown signature %q", signature)
+	}
+}
+
+// unmarshalByteString unmarshals a string that contains bytes which are not valid UTF-8. Such
+// strings are transported as the base64 encoding of their bytes.
+func unmarshalByteString(s *structpb.Struct, p path) (property.Value, error) {
+	value, ok := s.GetFields()["value"]
+	if !ok {
+		return property.Value{}, errAt(p, "malformed byte string: missing value")
+	}
+	str, ok := value.GetKind().(*structpb.Value_StringValue)
+	if !ok {
+		return property.Value{}, errAt(p, "malformed byte string: value is not a string")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(str.StringValue)
+	if err != nil {
+		return property.Value{}, errAt(p, "malformed byte string: value is not valid base64: %s", err)
+	}
+	return property.New(string(decoded)), nil
+}
+
+func unmarshalOutputValue(s *structpb.Struct, p path) (property.Value, error) {
+	fields := s.GetFields()
+
+	// An output value without a value is unknown.
+	v := property.New(property.Computed)
+	if value, known := fields["value"]; known {
+		var err error
+		// The output marker is not part of the path, so p is not extended here.
+		v, err = unmarshalValue(value, p)
+		if err != nil {
+			return property.Value{}, err
+		}
+	}
+
+	if secret, ok := fields["secret"]; ok {
+		b, ok := secret.GetKind().(*structpb.Value_BoolValue)
+		if !ok {
+			return property.Value{}, errAt(p, "malformed output value: secret is not a bool")
+		}
+		v = v.WithSecret(b.BoolValue)
+	}
+
+	if dependencies, ok := fields["dependencies"]; ok {
+		list, ok := dependencies.GetKind().(*structpb.Value_ListValue)
+		if !ok {
+			return property.Value{}, errAt(p, "malformed output value: dependencies is not an array")
+		}
+		urns := make([]urn.URN, len(list.ListValue.GetValues()))
+		for i, dependency := range list.ListValue.GetValues() {
+			d, ok := dependency.GetKind().(*structpb.Value_StringValue)
+			if !ok {
+				return property.Value{}, errAt(p, "malformed output value: dependency %d is not a string", i)
+			}
+			urns[i] = urn.URN(d.StringValue)
+		}
+		if len(urns) > 0 {
+			v = v.WithDependencies(urns)
+		}
+	}
+
+	return v, nil
+}
+
+func unmarshalResourceReference(s *structpb.Struct, p path) (property.Value, error) {
+	var err error
+	// field returns the value of a string field, and if the field was present.
+	field := func(name string) (string, bool) {
+		if err != nil {
+			return "", false
+		}
+		v, ok := s.GetFields()[name]
+		if !ok {
+			return "", false
+		}
+		str, ok := v.GetKind().(*structpb.Value_StringValue)
+		if !ok {
+			err = errAt(p, "malformed resource reference: %s is not a string", name)
+			return "", false
+		}
+		return str.StringValue, true
+	}
+
+	resourceURN, hasURN := field("urn")
+	name, _ := field("name")
+	typ, _ := field("type")
+	id, hasID := field("id")
+	packageVersion, _ := field("packageVersion")
+	if err != nil {
+		return property.Value{}, err
+	}
+	if !hasURN {
+		return property.Value{}, errAt(p, "malformed resource reference: missing urn")
+	}
+
+	ref := property.ResourceReference{
+		URN:            urn.URN(resourceURN),
+		Name:           name,
+		Type:           typ,
+		PackageVersion: packageVersion,
+	}
+	switch {
+	case !hasID:
+		// A reference to a component resource has no ID, so ref.ID stays null.
+	case id == "":
+		// An empty ID marks a resource whose ID is not yet known.
+		ref.ID = property.New(property.Computed)
+	default:
+		ref.ID = property.New(id)
+	}
+	return property.New(ref), nil
+}


### PR DESCRIPTION
Add a package to convert between `property.{Map,Value}` and `*pbstruct.{Struct,Value}` types, matching our `resource.Property{Map,Value}` converters. Unlike our existing marshalers, this system does not have any affordances to drop types or simplify on marshalling or unmarshalling. Instead, users should transform their `property.Map` into the desired shape, then marshal it.

Unmarshaling expects to recognize all special keys it receives, and will error on unfamiliar keys or mistyped values. Marshalling always succeeds.