### PR TITLE
Use `propertyrpc` to marshal property values

### DIFF
--- a/pkg/resource/plugin/property_handler.go
+++ b/pkg/resource/plugin/property_handler.go
@@ -21,17 +21,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi/sdk/v3/go/propertyrpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
-
-var propertyLogMarshalOpts = MarshalOptions{
-	KeepSecrets:      true,
-	KeepUnknowns:     true,
-	KeepOutputValues: true,
-	// Suppress verbose marshal logging: this marshal runs *inside* the logging path (to build a log
-	// attribute), and logging here would re-enter and recurse.
-	skipLogging: true,
-}
 
 // PropertyExportHandler wraps the OTLP export handler, converting
 // property-typed attributes into logging.PropertyValue for OTLP transport.
@@ -87,22 +79,14 @@ func MarshalPropertyLogAttr(a slog.Attr) *structpb.Value {
 	case *structpb.Struct:
 		return structpb.NewStructValue(val)
 	case resource.PropertyMap:
-		return marshalResourceLogProperty(resource.NewProperty(val))
+		return structpb.NewStructValue(propertyrpc.Marshal(resource.FromResourcePropertyMap(val)))
 	case resource.PropertyValue:
-		return marshalResourceLogProperty(val)
+		return propertyrpc.MarshalValue(resource.FromResourcePropertyValue(val))
 	case property.Map:
-		return marshalResourceLogProperty(resource.NewProperty(resource.ToResourcePropertyMap(val)))
+		return structpb.NewStructValue(propertyrpc.Marshal(val))
 	case property.Value:
-		return marshalResourceLogProperty(resource.ToResourcePropertyValue(val))
+		return propertyrpc.MarshalValue(val)
 	default:
 		return nil
 	}
-}
-
-func marshalResourceLogProperty(pv resource.PropertyValue) *structpb.Value {
-	sv, err := MarshalPropertyValue("", pv, propertyLogMarshalOpts)
-	if err != nil || sv == nil {
-		return nil
-	}
-	return sv
 }

--- a/pkg/testing/pulumi-test-language/providers/component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi/sdk/v3/go/propertyrpc"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -566,31 +567,17 @@ func (p *ComponentProvider) constructComponentCustomRefInputOutput(
 	}
 
 	// Create resource references for the inputRef and outputRef component outputs.
-	inputRefPropVal := resource.ToResourcePropertyValue(property.New(inputRef))
-	inputRefStruct, err := plugin.MarshalPropertyValue("inputRef", inputRefPropVal, plugin.MarshalOptions{
-		KeepResources: true,
-		KeepSecrets:   true,
-	})
-	if err != nil {
-		return plugin.ConstructResponse{}, fmt.Errorf("marshal input ref: %w", err)
-	}
-
-	outputRefPropVal := resource.MakeCustomResourceReference(resource.URN(child.Urn), resource.ID(child.Id), "")
-	outputRefStruct, err := plugin.MarshalPropertyValue("outputRef", outputRefPropVal, plugin.MarshalOptions{
-		KeepResources: true,
-		KeepSecrets:   true,
-	})
-	if err != nil {
-		return plugin.ConstructResponse{}, fmt.Errorf("marshal output ref: %w", err)
-	}
+	inputRefVal := property.New(inputRef)
+	outputRefVal := resource.FromResourcePropertyValue(
+		resource.MakeCustomResourceReference(resource.URN(child.Urn), resource.ID(child.Id), ""))
 
 	// Register the component's outputs and finish up.
 	_, err = monitor.RegisterResourceOutputs(ctx, &pulumirpc.RegisterResourceOutputsRequest{
 		Urn: parent.Urn,
 		Outputs: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"inputRef":  inputRefStruct,
-				"outputRef": outputRefStruct,
+				"inputRef":  propertyrpc.MarshalValue(inputRefVal),
+				"outputRef": propertyrpc.MarshalValue(outputRefVal),
 			},
 		},
 	})
@@ -601,8 +588,8 @@ func (p *ComponentProvider) constructComponentCustomRefInputOutput(
 	return plugin.ConstructResponse{
 		URN: resource.URN(parent.Urn),
 		Outputs: property.NewMap(map[string]property.Value{
-			"inputRef":  resource.FromResourcePropertyValue(inputRefPropVal),
-			"outputRef": resource.FromResourcePropertyValue(outputRefPropVal),
+			"inputRef":  inputRefVal,
+			"outputRef": outputRefVal,
 		}),
 	}, nil
 }

--- a/sdk/go/common/resource/plugin/property_handler.go
+++ b/sdk/go/common/resource/plugin/property_handler.go
@@ -21,17 +21,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi/sdk/v3/go/propertyrpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
-
-var propertyLogMarshalOpts = MarshalOptions{
-	KeepSecrets:      true,
-	KeepUnknowns:     true,
-	KeepOutputValues: true,
-	// Suppress verbose marshal logging: this marshal runs *inside* the logging path (to build a log
-	// attribute), and logging here would re-enter and recurse.
-	skipLogging: true,
-}
 
 // PropertyExportHandler wraps the OTLP export handler, converting
 // property-typed attributes into logging.PropertyValue for OTLP transport.
@@ -87,22 +79,14 @@ func MarshalPropertyLogAttr(a slog.Attr) *structpb.Value {
 	case *structpb.Struct:
 		return structpb.NewStructValue(val)
 	case resource.PropertyMap:
-		return marshalResourceLogProperty(resource.NewProperty(val))
+		return structpb.NewStructValue(propertyrpc.Marshal(resource.FromResourcePropertyMap(val)))
 	case resource.PropertyValue:
-		return marshalResourceLogProperty(val)
+		return propertyrpc.MarshalValue(resource.FromResourcePropertyValue(val))
 	case property.Map:
-		return marshalResourceLogProperty(resource.NewProperty(resource.ToResourcePropertyMap(val)))
+		return structpb.NewStructValue(propertyrpc.Marshal(val))
 	case property.Value:
-		return marshalResourceLogProperty(resource.ToResourcePropertyValue(val))
+		return propertyrpc.MarshalValue(val)
 	default:
 		return nil
 	}
-}
-
-func marshalResourceLogProperty(pv resource.PropertyValue) *structpb.Value {
-	sv, err := MarshalPropertyValue("", pv, propertyLogMarshalOpts)
-	if err != nil || sv == nil {
-		return nil
-	}
-	return sv
 }


### PR DESCRIPTION
The component test provider and the property log handler converted a
`property.Value` into its protobuf form through `resource.PropertyValue`. Both
now call `propertyrpc` directly.

`propertyrpc` has fixed semantics, which changes two things in the log handler.
A resource reference keeps its identity, where the handler wrote a raw URN or
ID before. A string that contains bytes which are not valid UTF-8 travels as a
byte string, where the handler dropped the attribute before. The
`resource.PropertyValue` and the `property.Value` form of an attribute now give
the same result.
