### PR TITLE
Redact secrets in plan violation error messages

### DIFF
--- a/changelog/pending/engine-fix-20260904-plan-violation-secrets.yaml
+++ b/changelog/pending/engine-fix-20260904-plan-violation-secrets.yaml
@@ -1,4 +1,5 @@
 component: engine
 kind: fix
-body: Redact secret property values in `violates plan` error messages
+body: Redact secret property values in `violates plan` error messages unless `--show-secrets`
+    is passed
 time: 2026-09-04T00:00:00Z

--- a/changelog/pending/engine-fix-20260904-plan-violation-secrets.yaml
+++ b/changelog/pending/engine-fix-20260904-plan-violation-secrets.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Redact secret property values in `violates plan` error messages
+time: 2026-09-04T00:00:00Z

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -152,6 +152,82 @@ func TestPlannedUpdate(t *testing.T) {
 	assert.Equal(t, expected, snap.Resources[1].Outputs)
 }
 
+func TestPlanViolationSecrets(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					return plugin.CreateResponse{
+						ID:         "created-id",
+						Properties: req.Properties,
+						Status:     resource.StatusOK,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	violate := func(t *testing.T, showSecrets bool, expected string) {
+		ins := resource.PropertyMap{
+			"password": resource.MakeSecret(resource.NewProperty("planned-secret")),
+		}
+		expectError := false
+		programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+				Inputs: ins,
+			})
+			if expectError {
+				require.Fail(t, "RegisterResource should not return")
+			} else {
+				require.NoError(t, err)
+			}
+			return nil
+		})
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+
+		p := &lt.TestPlan{
+			Options: lt.TestUpdateOptions{
+				T:     t,
+				HostF: hostF,
+				UpdateOptions: UpdateOptions{
+					GeneratePlan: true,
+					Experimental: true,
+					ShowSecrets:  showSecrets,
+				},
+				SkipDisplayTests: true,
+			},
+		}
+		project := p.GetProject()
+
+		plan, err := lt.TestOp(Update).Plan(project, p.GetTarget(t, nil), p.Options, p.BackendClient, nil)
+		require.NoError(t, err)
+
+		expectError = true
+		ins = resource.PropertyMap{
+			"password": resource.MakeSecret(resource.NewProperty("actual-secret")),
+		}
+		p.Options.Plan = plan.Clone()
+		validate := ExpectDiagMessage(t, regexp.QuoteMeta(expected))
+		_, err = lt.TestOp(Update).RunStep(
+			project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, validate, "0")
+		require.NoError(t, err)
+	}
+
+	t.Run("redacted by default", func(t *testing.T) {
+		t.Parallel()
+		violate(t, false, "<{%reset%}>resource urn:pulumi:test::test::pkgA:m:typA::resA violates plan: "+
+			"properties changed: ++password[{[secret]}!={[secret]}]<{%reset%}>\n")
+	})
+
+	t.Run("shown with --show-secrets", func(t *testing.T) {
+		t.Parallel()
+		violate(t, true, "<{%reset%}>resource urn:pulumi:test::test::pkgA:m:typA::resA violates plan: "+
+			"properties changed: ++password[{&{{planned-secret}}}!={&{{actual-secret}}}]<{%reset%}>\n")
+	})
+}
+
 func TestUnplannedCreate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -116,13 +116,14 @@ func (planDiff *PlanDiff) MakeError(
 	} else {
 		expectedOperation = "="
 	}
+	// This message is persisted in the stack's update history, so secrets stay redacted even under --show-secrets.
 	diff := ""
 	if actualValue != nil && expectedValue != nil {
-		diff = "[" + expectedValue.String() + "!=" + actualValue.String() + "]"
+		diff = "[" + expectedValue.RedactSecrets() + "!=" + actualValue.RedactSecrets() + "]"
 	} else if actualValue != nil {
-		diff = "[" + actualValue.String() + "]"
+		diff = "[" + actualValue.RedactSecrets() + "]"
 	} else if expectedValue != nil {
-		diff = "[" + expectedValue.String() + "]"
+		diff = "[" + expectedValue.RedactSecrets() + "]"
 	}
 	return expectedOperation + actualOperation + string(key) + diff
 }

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -98,6 +98,7 @@ func (planDiff *PlanDiff) MakeError(
 	key resource.PropertyKey,
 	actualOperation string,
 	actualValue *resource.PropertyValue,
+	showSecrets bool,
 ) string {
 	// diff wants to do 'actualOperation' (one of '+', '~', '-', '=') but plan differs. This function looks up what
 	// key wanted to do to print a more useful error message
@@ -116,14 +117,17 @@ func (planDiff *PlanDiff) MakeError(
 	} else {
 		expectedOperation = "="
 	}
-	// This message is persisted in the stack's update history, so secrets stay redacted even under --show-secrets.
+	render := resource.PropertyValue.RedactSecrets
+	if showSecrets {
+		render = resource.PropertyValue.String
+	}
 	diff := ""
 	if actualValue != nil && expectedValue != nil {
-		diff = "[" + expectedValue.RedactSecrets() + "!=" + actualValue.RedactSecrets() + "]"
+		diff = "[" + render(*expectedValue) + "!=" + render(*actualValue) + "]"
 	} else if actualValue != nil {
-		diff = "[" + actualValue.RedactSecrets() + "]"
+		diff = "[" + render(*actualValue) + "]"
 	} else if expectedValue != nil {
-		diff = "[" + expectedValue.RedactSecrets() + "]"
+		diff = "[" + render(*expectedValue) + "]"
 	}
 	return expectedOperation + actualOperation + string(key) + diff
 }
@@ -359,6 +363,7 @@ func checkMissingPlan(
 	oldState *pkgresource.State,
 	newInputs resource.PropertyMap,
 	programGoal *pkgresource.Goal,
+	showSecrets bool,
 ) error {
 	// We new up a fake ResourcePlan that matches the old state and then simply call checkGoal on it.
 	goal := &GoalPlan{
@@ -381,10 +386,10 @@ func checkMissingPlan(
 	}
 
 	rp := ResourcePlan{Goal: goal}
-	return rp.checkGoal(oldState.Inputs, newInputs, programGoal)
+	return rp.checkGoal(oldState.Inputs, newInputs, programGoal, showSecrets)
 }
 
-func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
+func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff, showSecrets bool) error {
 	changes := []string{}
 	var diff *resource.ObjectDiff
 	if diff = olds.DiffIncludeUnknowns(news); diff != nil {
@@ -397,11 +402,11 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 			if expected, has := planDiff.Adds[k]; has {
 				if !expected.DeepEqualsIncludeUnknowns(actual) {
 					// diff wants to add this with value X but constraint wants to add with value Y
-					changes = append(changes, planDiff.MakeError(k, "+", &actual))
+					changes = append(changes, planDiff.MakeError(k, "+", &actual, showSecrets))
 				}
 			} else {
 				// diff wants to add this, but not listed as an add in the constraints
-				changes = append(changes, planDiff.MakeError(k, "+", &actual))
+				changes = append(changes, planDiff.MakeError(k, "+", &actual, showSecrets))
 			}
 		}
 
@@ -420,11 +425,11 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 						// a delete, this is not a plan violation
 					} else {
 						// diff wants to delete this, plan wants to update it
-						changes = append(changes, planDiff.MakeError(k, "-", nil))
+						changes = append(changes, planDiff.MakeError(k, "-", nil, showSecrets))
 					}
 				} else {
 					// diff wants to delete this, but not listed as a delete in the constraints
-					changes = append(changes, planDiff.MakeError(k, "-", nil))
+					changes = append(changes, planDiff.MakeError(k, "-", nil, showSecrets))
 				}
 			}
 		}
@@ -442,16 +447,16 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 			if expected, has := planDiff.Updates[k]; has {
 				if !expected.DeepEqualsIncludeUnknowns(actual) {
 					// diff wants to change this with value X but constraint wants to change with value Y
-					changes = append(changes, planDiff.MakeError(k, "~", &actual))
+					changes = append(changes, planDiff.MakeError(k, "~", &actual, showSecrets))
 				}
 			} else if expected, has := planDiff.Adds[k]; has {
 				if !expected.DeepEqualsIncludeUnknowns(actual) {
 					// diff wants to change this with value X but constraint wants to add with value Y
-					changes = append(changes, planDiff.MakeError(k, "~", &actual))
+					changes = append(changes, planDiff.MakeError(k, "~", &actual, showSecrets))
 				}
 			} else {
 				// diff wants to update this, but not listed as an update in the constraints
-				changes = append(changes, planDiff.MakeError(k, "~", &actual))
+				changes = append(changes, planDiff.MakeError(k, "~", &actual, showSecrets))
 			}
 		}
 	} else {
@@ -475,7 +480,7 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 			if actual, has := news[k]; has {
 				if !expected.DeepEqualsIncludeUnknowns(actual) {
 					// diff wants to same this with value X but constraint wants to add with value Y
-					changes = append(changes, planDiff.MakeError(k, "=", &actual))
+					changes = append(changes, planDiff.MakeError(k, "=", &actual, showSecrets))
 				}
 			} else {
 				// Not a same, update or an add but constraint wants to add it
@@ -483,7 +488,7 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 				// Check if this was <computed> origionally because that could of resolved to undefined
 				// and thus it's ok to be missing, else this is a real missing property
 				if !expected.IsComputed() {
-					changes = append(changes, planDiff.MakeError(k, "-", nil))
+					changes = append(changes, planDiff.MakeError(k, "-", nil, showSecrets))
 				}
 			}
 		}
@@ -500,12 +505,12 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 			// Check if this was in adds, it's not ok to have an update constraint but actually do an add
 			if actual, has := diff.Adds[k]; has {
 				// Constraint wants to update it, but diff wants to add it
-				changes = append(changes, planDiff.MakeError(k, "+", &actual))
+				changes = append(changes, planDiff.MakeError(k, "+", &actual, showSecrets))
 			} else if actual, has := news[k]; has {
 				// It wasn't in the diff as an add so check we have a same
 				if !expected.DeepEqualsIncludeUnknowns(actual) {
 					// diff wants to same this with value X but constraint wants to update with value Y
-					changes = append(changes, planDiff.MakeError(k, "=", &actual))
+					changes = append(changes, planDiff.MakeError(k, "=", &actual, showSecrets))
 				}
 			} else {
 				// Not a same or an update but constraint wants to update it
@@ -513,7 +518,7 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 				// Check if this was <computed> origionally because that could of resolved to undefined
 				// and thus it's ok to be missing, else this is a real missing property
 				if !expected.IsComputed() {
-					changes = append(changes, planDiff.MakeError(k, "-", nil))
+					changes = append(changes, planDiff.MakeError(k, "-", nil, showSecrets))
 				}
 			}
 		}
@@ -529,13 +534,13 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 			// See if this is an add, update, or same
 			if actual, has := diff.Adds[k]; has {
 				// Constraint wants to delete this but diff wants to add it
-				changes = append(changes, planDiff.MakeError(k, "+", &actual))
+				changes = append(changes, planDiff.MakeError(k, "+", &actual, showSecrets))
 			} else if actual, has := diff.Updates[k]; has {
 				// Constraint wants to delete this but diff wants to update it
-				changes = append(changes, planDiff.MakeError(k, "~", &actual.New))
+				changes = append(changes, planDiff.MakeError(k, "~", &actual.New, showSecrets))
 			} else if actual, has := diff.Sames[k]; has {
 				// Constraint wants to delete this but diff wants to leave it same
-				changes = append(changes, planDiff.MakeError(k, "=", &actual))
+				changes = append(changes, planDiff.MakeError(k, "=", &actual, showSecrets))
 			}
 		}
 	}
@@ -552,17 +557,19 @@ func checkDiff(olds, news resource.PropertyMap, planDiff PlanDiff) error {
 func (rp *ResourcePlan) checkOutputs(
 	oldOutputs resource.PropertyMap,
 	newOutputs resource.PropertyMap,
+	showSecrets bool,
 ) error {
 	contract.Assertf(rp.Goal != nil, "resource plan goal must be set")
 
 	// Check that the property diffs meet the constraints set in the plan.
-	return checkDiff(oldOutputs, newOutputs, rp.Goal.OutputDiff)
+	return checkDiff(oldOutputs, newOutputs, rp.Goal.OutputDiff, showSecrets)
 }
 
 func (rp *ResourcePlan) checkGoal(
 	oldInputs resource.PropertyMap,
 	newInputs resource.PropertyMap,
 	programGoal *pkgresource.Goal,
+	showSecrets bool,
 ) error {
 	contract.Requiref(programGoal != nil, "programGoal", "must not be nil")
 	// rp.Goal may be nil, but if it isn't Type and Name should match
@@ -674,7 +681,7 @@ func (rp *ResourcePlan) checkGoal(
 	}
 
 	// Check that the property diffs meet the constraints set in the plan
-	if err := checkDiff(oldInputs, newInputs, rp.Goal.InputDiff); err != nil {
+	if err := checkDiff(oldInputs, newInputs, rp.Goal.InputDiff, showSecrets); err != nil {
 		return err
 	}
 

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -65,6 +65,19 @@ func TestPlan(t *testing.T) {
 			errStr := p.MakeError(resource.PropertyKey("foo"), "", &val)
 			assert.True(t, strings.HasPrefix(errStr, "-"))
 		})
+		t.Run("redacts secrets", func(t *testing.T) {
+			t.Parallel()
+			p := &PlanDiff{
+				Updates: resource.PropertyMap{
+					"foo": resource.MakeSecret(resource.NewProperty("expected")),
+				},
+			}
+			val := resource.NewProperty(resource.PropertyMap{
+				"nested": resource.MakeSecret(resource.NewProperty("actual")),
+			})
+			errStr := p.MakeError(resource.PropertyKey("foo"), "~", &val)
+			assert.Equal(t, "~~foo[{[secret]}!={map[nested:{[secret]}]}]", errStr)
+		})
 	})
 }
 

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -62,7 +62,7 @@ func TestPlan(t *testing.T) {
 				},
 			}
 			val := resource.NewProperty("val")
-			errStr := p.MakeError(resource.PropertyKey("foo"), "", &val)
+			errStr := p.MakeError(resource.PropertyKey("foo"), "", &val, false)
 			assert.True(t, strings.HasPrefix(errStr, "-"))
 		})
 		t.Run("redacts secrets", func(t *testing.T) {
@@ -75,8 +75,20 @@ func TestPlan(t *testing.T) {
 			val := resource.NewProperty(resource.PropertyMap{
 				"nested": resource.MakeSecret(resource.NewProperty("actual")),
 			})
-			errStr := p.MakeError(resource.PropertyKey("foo"), "~", &val)
+			errStr := p.MakeError(resource.PropertyKey("foo"), "~", &val, false)
 			assert.Equal(t, "~~foo[{[secret]}!={map[nested:{[secret]}]}]", errStr)
+		})
+		t.Run("shows secrets", func(t *testing.T) {
+			t.Parallel()
+			p := &PlanDiff{
+				Updates: resource.PropertyMap{
+					"foo": resource.MakeSecret(resource.NewProperty("expected")),
+				},
+			}
+			val := resource.MakeSecret(resource.NewProperty("actual"))
+			errStr := p.MakeError(resource.PropertyKey("foo"), "~", &val, true)
+			assert.Contains(t, errStr, "expected")
+			assert.Contains(t, errStr, "actual")
 		})
 	})
 }
@@ -254,7 +266,7 @@ func TestResourcePlan(t *testing.T) {
 			err := rp.checkGoal(
 				resource.PropertyMap{},
 				resource.PropertyMap{},
-				&pkgresource.Goal{})
+				&pkgresource.Goal{}, false)
 			require.NoError(t, err)
 		})
 		t.Run("violations", func(t *testing.T) {
@@ -270,7 +282,7 @@ func TestResourcePlan(t *testing.T) {
 					resource.PropertyMap{},
 					&pkgresource.Goal{
 						Custom: false,
-					})
+					}, false)
 				assert.ErrorContains(t, err, "resource kind changed (expected custom)")
 			})
 			t.Run("invalid provider reference", func(t *testing.T) {
@@ -287,7 +299,7 @@ func TestResourcePlan(t *testing.T) {
 						resource.PropertyMap{},
 						&pkgresource.Goal{
 							Provider: "urn:pulumi:dev::random::pulumi:providers:random::default_4_13_2::provider-foo",
-						})
+						}, false)
 					assert.ErrorContains(t, err, "failed to parse provider reference")
 				})
 				t.Run("goal", func(t *testing.T) {
@@ -302,7 +314,7 @@ func TestResourcePlan(t *testing.T) {
 						resource.PropertyMap{},
 						&pkgresource.Goal{
 							Provider: "bad-provider",
-						})
+						}, false)
 					assert.ErrorContains(t, err, "failed to parse provider reference")
 				})
 			})
@@ -318,7 +330,7 @@ func TestResourcePlan(t *testing.T) {
 					resource.PropertyMap{},
 					&pkgresource.Goal{
 						Provider: "urn:pulumi:dev::random::pulumi:providers:random::default_4_13_2::provider-foo",
-					})
+					}, false)
 				assert.ErrorContains(t, err, "provider changed")
 			})
 			t.Run("parent mismatch", func(t *testing.T) {
@@ -333,7 +345,7 @@ func TestResourcePlan(t *testing.T) {
 					resource.PropertyMap{},
 					&pkgresource.Goal{
 						Parent: "bar",
-					})
+					}, false)
 				assert.ErrorContains(t, err, "parent changed")
 			})
 			t.Run("protect mismatch", func(t *testing.T) {
@@ -348,7 +360,7 @@ func TestResourcePlan(t *testing.T) {
 					resource.PropertyMap{},
 					&pkgresource.Goal{
 						Protect: nil,
-					})
+					}, false)
 				assert.ErrorContains(t, err, "protect changed")
 			})
 			t.Run("deleteBeforeReplace mismatch", func(t *testing.T) {
@@ -367,7 +379,7 @@ func TestResourcePlan(t *testing.T) {
 						resource.PropertyMap{},
 						&pkgresource.Goal{
 							DeleteBeforeReplace: &goalRef,
-						})
+						}, false)
 					assert.ErrorContains(t, err, "deleteBeforeReplace changed")
 				})
 				t.Run("plan non-nil", func(t *testing.T) {
@@ -381,7 +393,7 @@ func TestResourcePlan(t *testing.T) {
 					err := rp.checkGoal(
 						resource.PropertyMap{},
 						resource.PropertyMap{},
-						&pkgresource.Goal{})
+						&pkgresource.Goal{}, false)
 					assert.ErrorContains(t, err, "deleteBeforeReplace changed (expected false)")
 				})
 				t.Run("goal non-nil", func(t *testing.T) {
@@ -395,7 +407,7 @@ func TestResourcePlan(t *testing.T) {
 						resource.PropertyMap{},
 						&pkgresource.Goal{
 							DeleteBeforeReplace: &goalRef,
-						})
+						}, false)
 					assert.ErrorContains(t, err, "deleteBeforeReplace changed (expected no value)")
 				})
 			})
@@ -411,7 +423,7 @@ func TestResourcePlan(t *testing.T) {
 					resource.PropertyMap{},
 					&pkgresource.Goal{
 						ID: "bar",
-					})
+					}, false)
 				assert.ErrorContains(t, err, "importID changed")
 			})
 			t.Run("customTimeouts mismatch", func(t *testing.T) {
@@ -431,7 +443,7 @@ func TestResourcePlan(t *testing.T) {
 							CustomTimeouts: resource.CustomTimeouts{
 								Create: 5,
 							},
-						})
+						}, false)
 					assert.ErrorContains(t, err, "create timeout changed")
 				})
 				t.Run("update", func(t *testing.T) {
@@ -450,7 +462,7 @@ func TestResourcePlan(t *testing.T) {
 							CustomTimeouts: resource.CustomTimeouts{
 								Update: 5,
 							},
-						})
+						}, false)
 					assert.ErrorContains(t, err, "update timeout changed")
 				})
 				t.Run("delete", func(t *testing.T) {
@@ -469,7 +481,7 @@ func TestResourcePlan(t *testing.T) {
 							CustomTimeouts: resource.CustomTimeouts{
 								Delete: 5,
 							},
-						})
+						}, false)
 					assert.ErrorContains(t, err, "delete timeout changed")
 				})
 			})
@@ -489,7 +501,7 @@ func TestResourcePlan(t *testing.T) {
 						IgnoreChanges: []string{
 							"bar",
 						},
-					})
+					}, false)
 				assert.ErrorContains(t, err, "ignoreChanges changed")
 			})
 			t.Run("additionalSecretOutputs mismatch", func(t *testing.T) {
@@ -508,7 +520,7 @@ func TestResourcePlan(t *testing.T) {
 						AdditionalSecretOutputs: []resource.PropertyKey{
 							"bar",
 						},
-					})
+					}, false)
 				assert.ErrorContains(t, err, "additionalSecretOutputs changed")
 			})
 			t.Run("dependencies mismatch", func(t *testing.T) {
@@ -527,7 +539,7 @@ func TestResourcePlan(t *testing.T) {
 						Dependencies: []resource.URN{
 							"bar",
 						},
-					})
+					}, false)
 				assert.ErrorContains(t, err, "dependencies changed")
 			})
 			t.Run("aliases mismatch", func(t *testing.T) {
@@ -546,7 +558,7 @@ func TestResourcePlan(t *testing.T) {
 						Aliases: []resource.Alias{
 							{Name: "bar"},
 						},
-					})
+					}, false)
 				assert.ErrorContains(t, err, "aliases changed")
 			})
 		})
@@ -566,7 +578,7 @@ func TestCheckDiff(t *testing.T) {
 					Deletes: []resource.PropertyKey{
 						"should-be-here",
 					},
-				})
+				}, false)
 			require.NoError(t, err)
 		})
 		t.Run("diff violation", func(t *testing.T) {
@@ -582,7 +594,7 @@ func TestCheckDiff(t *testing.T) {
 						Deletes: []resource.PropertyKey{
 							"should-delete",
 						},
-					})
+					}, false)
 				assert.Error(t, err)
 			})
 			t.Run("update", func(t *testing.T) {
@@ -598,7 +610,7 @@ func TestCheckDiff(t *testing.T) {
 						Deletes: []resource.PropertyKey{
 							"should-delete",
 						},
-					})
+					}, false)
 				assert.Error(t, err)
 			})
 			t.Run("same", func(t *testing.T) {
@@ -620,7 +632,7 @@ func TestCheckDiff(t *testing.T) {
 					Adds: resource.PropertyMap{
 						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
-				})
+				}, false)
 			require.NoError(t, err)
 		})
 		t.Run("diff violation", func(t *testing.T) {
@@ -643,7 +655,7 @@ func TestCheckDiff(t *testing.T) {
 					Updates: resource.PropertyMap{
 						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
-				})
+				}, false)
 			require.NoError(t, err)
 		})
 		t.Run("ok same", func(t *testing.T) {
@@ -659,7 +671,7 @@ func TestCheckDiff(t *testing.T) {
 					Updates: resource.PropertyMap{
 						resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 					},
-				})
+				}, false)
 			require.NoError(t, err)
 		})
 		t.Run("diff violation", func(t *testing.T) {
@@ -675,7 +687,7 @@ func TestCheckDiff(t *testing.T) {
 						Updates: resource.PropertyMap{
 							resource.PropertyKey("should-update"): resource.NewProperty("new-test"),
 						},
-					})
+					}, false)
 				assert.ErrorContains(t, err,
 					"properties changed: ~+should-update[{new-test}!={new-test}], ~+should-update[{new-test}!={new-test}]")
 			})
@@ -692,7 +704,7 @@ func TestCheckDiff(t *testing.T) {
 						Updates: resource.PropertyMap{
 							resource.PropertyKey("should-update"): resource.NewProperty("new-new-test"),
 						},
-					})
+					}, false)
 				assert.ErrorContains(t, err, "properties changed: ~=should-update[{new-new-test}!={new-test}]")
 			})
 			t.Run("missing", func(t *testing.T) {
@@ -708,7 +720,7 @@ func TestCheckDiff(t *testing.T) {
 							Updates: resource.PropertyMap{
 								resource.PropertyKey("should-update"): resource.NewProperty("new-new-test"),
 							},
-						})
+						}, false)
 					assert.ErrorContains(t, err,
 						"properties changed: ~-should-update[{new-new-test}], ~-should-update[{new-new-test}]")
 				})
@@ -723,7 +735,7 @@ func TestCheckDiff(t *testing.T) {
 							Updates: resource.PropertyMap{
 								resource.PropertyKey("should-update"): resource.MakeComputed(resource.NewProperty("new-new-test")),
 							},
-						})
+						}, false)
 					require.NoError(t, err)
 				})
 			})

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -274,7 +274,7 @@ func (se *stepExecutor) executeRegisterResourceOutputs(
 			return fmt.Errorf("no plan for resource %v", urn)
 		}
 
-		if err := resourcePlan.checkOutputs(oldOuts, outs); err != nil {
+		if err := resourcePlan.checkOutputs(oldOuts, outs, se.deployment.opts.ShowSecrets); err != nil {
 			return fmt.Errorf("resource violates plan: %w", err)
 		}
 	}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1420,11 +1420,11 @@ func (sg *stepGenerator) continueStepsFromImport(
 		if !ok {
 			if old == nil {
 				// We could error here, but we'll trigger an error later on anyway that Create isn't valid here
-			} else if err := checkMissingPlan(old, inputs, goal); err != nil {
+			} else if err := checkMissingPlan(old, inputs, goal, sg.deployment.opts.ShowSecrets); err != nil {
 				return nil, false, fmt.Errorf("resource %s violates plan: %w", urn, err)
 			}
 		} else {
-			if err := resourcePlan.checkGoal(oldInputs, inputs, goal); err != nil {
+			if err := resourcePlan.checkGoal(oldInputs, inputs, goal, sg.deployment.opts.ShowSecrets); err != nil {
 				return nil, false, fmt.Errorf("resource %s violates plan: %w", urn, err)
 			}
 		}


### PR DESCRIPTION
`PlanDiff.MakeError` was spitting out secrets in log lines, because we used `PropertyValue.String()` for the errors. This PR swaps those `String` calls to `RedactSecrets` instead on all three branches (unless `--show-secrets` is on). 

Fixes IAC-3602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)