### PR TITLE
Update provider ConfigureRequest to use `property.Map`

### DIFF
--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -1365,7 +1365,7 @@ func TestDoCmdFunctionInvokeWithConfiguration(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					configureCalled = true
-					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
+					assert.Equal(t, "val1", req.Inputs.Get("opt1").AsString())
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
@@ -2171,7 +2171,7 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFile(t *testing.T) {
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					configureCalled = true
 					// The converted PCL ("opt1 = \"val1\"") should be bound, evaluated, and reach Configure intact.
-					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
+					assert.Equal(t, "val1", req.Inputs.Get("opt1").AsString())
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
@@ -2487,8 +2487,8 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					configureCalled = true
 					// The converted PCL ("opt1 = \"val1\"") + optTwo=val2 should be bound, evaluated, and reach Configure intact.
-					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
-					assert.Equal(t, "val2", req.Inputs["optTwo"].StringValue())
+					assert.Equal(t, "val1", req.Inputs.Get("opt1").AsString())
+					assert.Equal(t, "val2", req.Inputs.Get("optTwo").AsString())
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
@@ -2615,8 +2615,8 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					configureCalled = true
 					// The converted PCL ("opt1 = \"val1\"") + optTwo=val2 should be bound, evaluated, and reach Configure intact.
-					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
-					assert.Equal(t, "val2", req.Inputs["optTwo"].StringValue())
+					assert.Equal(t, "val1", req.Inputs.Get("opt1").AsString())
+					assert.Equal(t, "val2", req.Inputs.Get("optTwo").AsString())
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -1212,7 +1212,7 @@ func TestDoCmdResourceProviderFlagMergesStackInputs(t *testing.T) {
 			spec: spec,
 			MockProvider: plugin.MockProvider{
 				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-					gotInputs = req.Inputs
+					gotInputs = resource.ToResourcePropertyMap(req.Inputs)
 					return plugin.ConfigureResponse{}, nil
 				},
 				ReadF: func(_ context.Context, _ plugin.ReadRequest) (plugin.ReadResponse, error) {

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -941,7 +941,7 @@ func (pc *packageCommand) configureProvider(cmd *cobra.Command, ctx context.Cont
 		Name:   &name,
 		Type:   &typ,
 		ID:     &id,
-		Inputs: config,
+		Inputs: resource.FromResourcePropertyMap(config),
 	})
 	if err != nil {
 		return fmt.Errorf("configure provider: %w", err)

--- a/pkg/engine/lifecycletest/components_test.go
+++ b/pkg/engine/lifecycletest/components_test.go
@@ -1703,8 +1703,8 @@ func TestCallSelfProvider(t *testing.T) {
 			var state string
 			return &deploytest.Provider{
 				ConfigureF: func(ctx context.Context, cr plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-					if in, ok := cr.Inputs["state"]; ok {
-						state = in.StringValue()
+					if in, ok := cr.Inputs.GetOk("state"); ok {
+						state = in.AsString()
 					}
 					return plugin.ConfigureResponse{}, nil
 				},

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -442,7 +442,7 @@ func TestProviderInheritanceGolangLifecycle(t *testing.T) {
 				},
 			}
 			v.InvokeF = func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-				assert.True(t, v.Config.DeepEquals(resource.ToResourcePropertyMap(req.Args)))
+				assert.True(t, v.Config.Equals(req.Args))
 				return plugin.InvokeResponse{}, nil
 			}
 			return v, nil
@@ -467,7 +467,7 @@ func TestProviderInheritanceGolangLifecycle(t *testing.T) {
 				},
 			}
 			v.InvokeF = func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
-				assert.True(t, v.Config.DeepEquals(resource.ToResourcePropertyMap(req.Args)))
+				assert.True(t, v.Config.Equals(req.Args))
 				return plugin.InvokeResponse{}, nil
 			}
 			return v, nil

--- a/pkg/engine/lifecycletest/invoke_test.go
+++ b/pkg/engine/lifecycletest/invoke_test.go
@@ -87,8 +87,8 @@ func TestInvokeParentResolvesComponentProviders(t *testing.T) {
 			instance := "default"
 			return &deploytest.Provider{
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-					if v, ok := req.Inputs["instance"]; ok && v.IsString() {
-						instance = v.StringValue()
+					if v, ok := req.Inputs.GetOk("instance"); ok && v.IsString() {
+						instance = v.AsString()
 					}
 					return plugin.ConfigureResponse{}, nil
 				},

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -414,7 +414,7 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 						})
 					}
 
-					if !req.Inputs.DeepEquals(expected) {
+					if !resource.ToResourcePropertyMap(req.Inputs).DeepEquals(expected) {
 						return plugin.ConfigureResponse{},
 							fmt.Errorf("expected provider configuration to be %v, got %v", expected, req.Inputs)
 					}

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -396,7 +396,7 @@ func (p *configurableProvider) configure(
 	_ context.Context,
 	req plugin.ConfigureRequest,
 ) (plugin.ConfigureResponse, error) {
-	p.id = req.Inputs["id"].StringValue()
+	p.id = req.Inputs.Get("id").AsString()
 	return plugin.ConfigureResponse{}, nil
 }
 
@@ -2250,7 +2250,7 @@ func TestProviderSameStep(t *testing.T) {
 				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					expected := resource.URN("urn:pulumi:test::test::pulumi:providers:pkg::provA")
 					assert.Equal(t, &expected, req.URN)
-					assert.Equal(t, "100", req.Inputs["value"].StringValue())
+					assert.Equal(t, "100", req.Inputs.Get("value").AsString())
 					return plugin.ConfigureResponse{}, nil
 				},
 			}, nil

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -2159,7 +2159,7 @@ func TestInternalFiltered(t *testing.T) {
 						t.Fatalf("unexpected URN %v", req.URN)
 					}
 					assert.NotEmpty(t, req.ID)
-					assert.NotContains(t, req.Inputs, internalKey)
+					assert.NotContains(t, req.Inputs.AsMap(), string(internalKey))
 					return plugin.ConfigureResponse{}, nil
 				},
 			}, nil
@@ -2184,7 +2184,7 @@ func TestInternalFiltered(t *testing.T) {
 						t.Fatalf("unexpected URN %v", req.URN)
 					}
 					assert.NotEmpty(t, req.ID)
-					assert.NotContains(t, req.Inputs, internalKey)
+					assert.NotContains(t, req.Inputs.AsMap(), string(internalKey))
 					return plugin.ConfigureResponse{}, nil
 				},
 			}, nil

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -1469,7 +1469,7 @@ func TestRefreshWithProgramUpdateExplicitProvider(t *testing.T) {
 			var currentAuth resource.PropertyValue
 			return &deploytest.Provider{
 				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-					currentAuth = req.Inputs["auth"]
+					currentAuth = resource.ToResourcePropertyValue(req.Inputs.Get("auth"))
 
 					return plugin.ConfigureResponse{}, nil
 				},
@@ -1607,7 +1607,7 @@ func TestRefreshWithProgramUpdateDefaultProvider(t *testing.T) {
 			var currentAuth resource.PropertyValue
 			return &deploytest.Provider{
 				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-					currentAuth = req.Inputs["auth"]
+					currentAuth = resource.ToResourcePropertyValue(req.Inputs.Get("auth"))
 
 					return plugin.ConfigureResponse{}, nil
 				},
@@ -1742,7 +1742,7 @@ func TestRefreshWithProgramUpdateDefaultProviderWithoutRegistration(t *testing.T
 			var currentAuth resource.PropertyValue
 			return &deploytest.Provider{
 				ConfigureF: func(_ context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
-					currentAuth = req.Inputs["auth"]
+					currentAuth = resource.ToResourcePropertyValue(req.Inputs.Get("auth"))
 
 					return plugin.ConfigureResponse{}, nil
 				},

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -35,7 +35,7 @@ type Provider struct {
 	Package tokens.Package
 	Version semver.Version
 
-	Config     resource.PropertyMap
+	Config     property.Map
 	configured bool
 
 	DialMonitorF func(ctx context.Context, endpoint string) (*ResourceMonitor, error)

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -858,12 +858,13 @@ func (r *Registry) Same(ctx context.Context, res *pkgresource.State, fromCheck b
 	name := urn.Name()
 	typ := urn.Type()
 
+	filteredInputs := FilterProviderConfig(res.Inputs)
 	if _, err := provider.Configure(context.Background(), plugin.ConfigureRequest{
 		URN:    &urn,
 		Name:   &name,
 		Type:   &typ,
 		ID:     &res.ID,
-		Inputs: FilterProviderConfig(res.Inputs),
+		Inputs: resource.FromResourcePropertyMap(filteredInputs),
 	}); err != nil {
 		contract.IgnoreClose(provider)
 		return fmt.Errorf("configure provider '%v': %w", urn, err)
@@ -964,7 +965,7 @@ func (r *Registry) Create(ctx context.Context, req plugin.CreateRequest) (plugin
 		Name:   &name,
 		Type:   &typ,
 		ID:     &id,
-		Inputs: filteredProperties,
+		Inputs: resource.FromResourcePropertyMap(filteredProperties),
 	}); err != nil {
 		return plugin.CreateResponse{Status: resource.StatusOK}, err
 	}
@@ -1000,7 +1001,7 @@ func (r *Registry) Update(ctx context.Context, req plugin.UpdateRequest) (plugin
 		Name:   &name,
 		Type:   &typ,
 		ID:     &req.ID,
-		Inputs: filteredProperties,
+		Inputs: resource.FromResourcePropertyMap(filteredProperties),
 	})
 	if err != nil {
 		return plugin.UpdateResponse{Status: resource.StatusUnknown}, err

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -58,7 +58,7 @@ type testProvider struct {
 	checkConfig func(resource.URN, property.Map,
 		property.Map, bool) (property.Map, []plugin.CheckFailure, error)
 	diffConfig func(resource.URN, resource.PropertyMap, resource.PropertyMap, bool, []string) (plugin.DiffResult, error)
-	config     func(resource.PropertyMap) error
+	config     func(property.Map) error
 }
 
 func (prov *testProvider) GetSchema(
@@ -163,9 +163,9 @@ func newLoader(t *testing.T, pkg, version string,
 	}
 }
 
-func newSimpleLoader(t *testing.T, pkg, version string, config func(resource.PropertyMap) error) *providerLoader {
+func newSimpleLoader(t *testing.T, pkg, version string, config func(property.Map) error) *providerLoader {
 	if config == nil {
-		config = func(resource.PropertyMap) error {
+		config = func(property.Map) error {
 			return nil
 		}
 	}
@@ -467,7 +467,7 @@ func TestCRUDPreview(t *testing.T) {
 					// Always reuquire replacement.
 					return plugin.DiffResult{ReplaceKeys: []resource.PropertyKey{"id"}}, nil
 				},
-				config: func(inputs resource.PropertyMap) error {
+				config: func(inputs property.Map) error {
 					return nil
 				},
 			}, nil
@@ -1140,7 +1140,7 @@ func TestEnvMappingsPassedToHost(t *testing.T) {
 				diffConfig: func(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
 					return plugin.DiffResult{}, nil
 				},
-				config: func(inputs resource.PropertyMap) error {
+				config: func(inputs property.Map) error {
 					return nil
 				},
 			}, nil
@@ -1223,7 +1223,7 @@ func TestSameUpdateRace_UpdateFirst(t *testing.T) {
 					) (plugin.DiffResult, error) {
 						return plugin.DiffResult{Changes: plugin.DiffSome}, nil
 					},
-					config: func(resource.PropertyMap) error { return nil },
+					config: func(property.Map) error { return nil },
 				},
 			}
 			providersMu.Lock()
@@ -1311,7 +1311,7 @@ func TestSameUpdateRace_SameFirst(t *testing.T) {
 					) (plugin.DiffResult, error) {
 						return plugin.DiffResult{Changes: plugin.DiffSome}, nil
 					},
-					config: func(resource.PropertyMap) error { return nil },
+					config: func(property.Map) error { return nil },
 				},
 			}
 			providersMu.Lock()
@@ -1410,7 +1410,7 @@ func TestSameUpdateRace_Concurrent(t *testing.T) {
 							) (plugin.DiffResult, error) {
 								return plugin.DiffResult{Changes: plugin.DiffSome}, nil
 							},
-							config: func(resource.PropertyMap) error { return nil },
+							config: func(property.Map) error { return nil },
 						},
 					}
 					providersMu.Lock()

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -224,7 +224,7 @@ type ConfigureRequest struct {
 	// Handshake.
 	ID *resource.ID
 	// A map of input properties for the provider.
-	Inputs resource.PropertyMap
+	Inputs property.Map
 }
 
 type ConfigureResponse struct{}

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -938,37 +938,33 @@ func annotateSecrets(outs, ins resource.PropertyMap) {
 	}
 }
 
-func removeSecrets(v resource.PropertyValue) any {
+func removeSecrets(v property.Value) any {
 	switch {
 	case v.IsNull():
 		return nil
 	case v.IsBool():
-		return v.BoolValue()
+		return v.AsBool()
 	case v.IsNumber():
-		return v.NumberValue()
+		return v.AsNumber()
 	case v.IsString():
-		return v.StringValue()
+		return v.AsString()
 	case v.IsArray():
 		arr := []any{}
-		for _, v := range v.ArrayValue() {
+		for _, v := range v.AsArray().All {
 			arr = append(arr, removeSecrets(v))
 		}
 		return arr
 	case v.IsAsset():
-		return v.AssetValue()
+		return v.AsAsset()
 	case v.IsArchive():
-		return v.ArchiveValue()
+		return v.AsArchive()
 	case v.IsComputed():
-		return v.Input()
-	case v.IsOutput():
-		return v.OutputValue()
-	case v.IsSecret():
-		return removeSecrets(v.SecretValue().Element)
+		return ""
 	default:
-		contract.Assertf(v.IsObject(), "v is not Object '%v' instead", v.TypeString())
+		contract.Assertf(v.IsMap(), "v is not Object '%v' instead", v)
 		obj := map[string]any{}
-		for k, v := range v.ObjectValue() {
-			obj[string(k)] = removeSecrets(v)
+		for k, v := range v.AsMap().All {
+			obj[k] = removeSecrets(v)
 		}
 		return obj
 	}
@@ -1058,7 +1054,7 @@ func restoreElidedAssetContents(original resource.PropertyMap, transformed resou
 // Configure configures the resource provider with "globals" that control its behavior.
 func (p *provider) Configure(ctx context.Context, req ConfigureRequest) (ConfigureResponse, error) {
 	label := p.label() + ".Configure()"
-	logging.V(7).Infof("%s executing (#vars=%d)", label, len(req.Inputs))
+	logging.V(7).Infof("%s executing (#vars=%d)", label, req.Inputs.Len())
 
 	// The deprecated `variables` field is keyed by `<pkg>:config:<key>` for providers that still read config
 	// under the old name. The plugin no longer knows its own package, so we take it from the provider type the
@@ -1069,12 +1065,12 @@ func (p *provider) Configure(ctx context.Context, req ConfigureRequest) (Configu
 	// Convert the inputs to a variables map. If any are unknown, do not configure the underlying plugin: instead, leave
 	// the cfgknown bit unset and carry on.
 	variables := make(map[string]string)
-	for k, v := range req.Inputs {
+	for k, v := range req.Inputs.All {
 		if k == "version" {
 			continue
 		}
 
-		if v.ContainsUnknowns() {
+		if v.HasComputed() {
 			if p.protocol == nil {
 				p.protocol = &pluginProtocol{}
 			}
@@ -1096,10 +1092,10 @@ func (p *provider) Configure(ctx context.Context, req ConfigureRequest) (Configu
 			mapped = string(marshalled)
 		}
 
-		variables[string(pkg)+":config:"+string(k)] = mapped.(string)
+		variables[string(pkg)+":config:"+k] = mapped.(string)
 	}
 
-	minputs, err := MarshalProperties(req.Inputs, MarshalOptions{
+	minputs, err := MarshalProperties(resource.ToResourcePropertyMap(req.Inputs), MarshalOptions{
 		Label:         label + ".inputs",
 		KeepUnknowns:  true,
 		KeepSecrets:   true,

--- a/pkg/resource/plugin/provider_plugin_test.go
+++ b/pkg/resource/plugin/provider_plugin_test.go
@@ -779,7 +779,7 @@ func TestProvider_ConfigureDeleteRace(t *testing.T) {
 	<-deleting
 	_, err := p.Configure(t.Context(), ConfigureRequest{
 		Type:   new(tokens.Type("pulumi:providers:test")),
-		Inputs: props,
+		Inputs: resource.FromResourcePropertyMap(props),
 	})
 	require.NoError(t, err)
 	<-done

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -418,7 +418,7 @@ func (p *providerServer) Configure(ctx context.Context,
 		Name:   req.Name,
 		Type:   typ,
 		ID:     id,
-		Inputs: inputs,
+		Inputs: resource.FromResourcePropertyMap(inputs),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/resource/plugin/provider_server_test.go
+++ b/pkg/resource/plugin/provider_server_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,15 +36,15 @@ func TestProviderServer_Configure_variables(t *testing.T) {
 	t.Parallel()
 
 	provider := stubProvider{
-		ConfigureFunc: func(pm resource.PropertyMap) error {
-			assert.Equal(t, map[string]any{
-				"foo": "bar",
-				"baz": 42.0,
-				"qux": map[string]any{
-					"a": "str",
-					"b": true,
-				},
-			}, pm.Mappable())
+		ConfigureFunc: func(pm property.Map) error {
+			assert.Equal(t, property.NewMap(map[string]property.Value{
+				"foo": property.New("bar"),
+				"baz": property.New(42.0),
+				"qux": property.New(map[string]property.Value{
+					"a": property.New("str"),
+					"b": property.New(true),
+				}),
+			}), pm)
 			return nil
 		},
 	}
@@ -70,7 +71,7 @@ type stubProvider struct {
 		inputs, state resource.PropertyMap,
 	) (ReadResult, resource.Status, error)
 
-	ConfigureFunc func(resource.PropertyMap) error
+	ConfigureFunc func(property.Map) error
 
 	ListFunc func(ListRequest) (*ListStream, error)
 }

--- a/pkg/testing/pulumi-test-language/providers/config_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_provider.go
@@ -48,8 +48,8 @@ func (p *ConfigProvider) Close() error {
 func (p *ConfigProvider) Configure(
 	_ context.Context, req plugin.ConfigureRequest,
 ) (plugin.ConfigureResponse, error) {
-	if name, ok := req.Inputs["name"]; ok && name.IsString() {
-		p.name = name.StringValue()
+	if name, ok := req.Inputs.GetOk("name"); ok && name.IsString() {
+		p.name = name.AsString()
 	}
 	return plugin.ConfigureResponse{}, nil
 }

--- a/pkg/testing/pulumi-test-language/providers/configurer_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/configurer_provider.go
@@ -236,8 +236,8 @@ func (p *ConfigurerProvider) DiffConfig(
 func (p *ConfigurerProvider) Configure(
 	_ context.Context, req plugin.ConfigureRequest,
 ) (plugin.ConfigureResponse, error) {
-	if cfg, ok := req.Inputs["config"]; ok && cfg.IsString() {
-		p.config = cfg.StringValue()
+	if cfg, ok := req.Inputs.GetOk("config"); ok && cfg.IsString() {
+		p.config = cfg.AsString()
 	}
 	return plugin.ConfigureResponse{}, nil
 }

--- a/pkg/testing/pulumi-test-language/providers/output_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/output_provider.go
@@ -45,18 +45,18 @@ func (p *OutputProvider) Close() error {
 func (p *OutputProvider) Configure(
 	_ context.Context, req plugin.ConfigureRequest,
 ) (plugin.ConfigureResponse, error) {
-	elide, has := req.Inputs["elideUnknowns"]
+	elide, has := req.Inputs.GetOk("elideUnknowns")
 	if has {
 		if elide.IsBool() {
-			p.elideUnknowns = elide.BoolValue()
+			p.elideUnknowns = elide.AsBool()
 		} else if elide.IsString() {
-			parsed, err := strconv.ParseBool(elide.StringValue())
+			parsed, err := strconv.ParseBool(elide.AsString())
 			if err != nil {
-				return plugin.ConfigureResponse{}, fmt.Errorf("invalid value for elideUnknowns: %v", elide.StringValue())
+				return plugin.ConfigureResponse{}, fmt.Errorf("invalid value for elideUnknowns: %v", elide.AsString())
 			}
 			p.elideUnknowns = parsed
 		} else {
-			return plugin.ConfigureResponse{}, fmt.Errorf("invalid type for elideUnknowns: %v", elide.TypeString())
+			return plugin.ConfigureResponse{}, fmt.Errorf("invalid type for elideUnknowns: %v", elide)
 		}
 	}
 


### PR DESCRIPTION
Continuing the property map migration, this switch `ConfigureRequest` to use it.