### PR TITLE
Update CODEOWNERS for renamed GitHub teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-* @pulumi/platform
+* @pulumi/iac-core
 /changelog/pending/ # We don't need a code-owner for changelog changes
-/pkg/cmd/pulumi/neo/ @pulumi/ai
-/pkg/cloudsetup/ @pulumi/iac-cloud
-/pkg/cmd/esc/ @pulumi/iac-cloud
-/sdk/go/common/esc/ @pulumi/iac-cloud
+/pkg/cmd/pulumi/neo/ @pulumi/ai-platform
+/pkg/cloudsetup/ @pulumi/pulumi-platform
+/pkg/cmd/esc/ @pulumi/pulumi-platform
+/sdk/go/common/esc/ @pulumi/pulumi-platform


### PR DESCRIPTION
The three old team slugs return 404 from the GitHub teams API. GitHub cannot resolve them, so it does not request reviews from them. This change updates the file to the current team names:

- `@pulumi/platform` -> `@pulumi/iac-core`
- `@pulumi/ai` -> `@pulumi/ai-platform`
- `@pulumi/iac-cloud` -> `@pulumi/pulumi-platform`

The source of truth is the `teams.yaml` file in the `pulumi/team-management` repo, at commit 525c7378, "Realign teams to the Aug 17 reorg".