### PR TITLE
Do not hold the loader goroutine while a provider boots

### DIFF
--- a/changelog/pending/engine-fix-20260904-provider-boot-deadlock.yaml
+++ b/changelog/pending/engine-fix-20260904-provider-boot-deadlock.yaml
@@ -1,5 +1,5 @@
 component: engine
 kind: fix
-body: Do not deadlock when a resource provider asks the engine to load another plugin
+body: Avoid a deadlock when a resource provider asks the engine to load another plugin
     while it boots
 time: 2026-09-04T00:00:00Z

--- a/changelog/pending/engine-fix-20260904-provider-boot-deadlock.yaml
+++ b/changelog/pending/engine-fix-20260904-provider-boot-deadlock.yaml
@@ -1,0 +1,5 @@
+component: engine
+kind: fix
+body: Do not deadlock when a resource provider asks the engine to load another plugin
+    while it boots
+time: 2026-09-04T00:00:00Z

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -282,14 +282,34 @@ func (host *defaultHost) AttachDebugger(spec plugin.DebugSpec) bool {
 func (host *defaultHost) loadPlugin(
 	loadRequestChannel chan pluginLoadRequest, load func() (any, error),
 ) (any, error) {
-	var plugin any
+	release, err := host.beginLoad()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return host.runOnLoader(loadRequestChannel, load)
+}
 
-	locked := host.pluginLock.TryRLock()
-	if !locked {
+// beginLoad takes the read lock that holds off shutdown until the load completes, and returns the
+// function that releases it. Do not call it while the caller already holds the read lock: a waiting
+// writer blocks new readers, so a second read lock can deadlock against Close.
+func (host *defaultHost) beginLoad() (func(), error) {
+	if !host.pluginLock.TryRLock() {
 		// If we couldn't get a read lock that must be because we're shutting down, so just return an error.
 		return nil, errors.New("plugin host is shutting down")
 	}
-	defer host.pluginLock.RUnlock()
+	return host.pluginLock.RUnlock, nil
+}
+
+// runOnLoader runs load on the goroutine that drains loadRequestChannel, which serializes access to
+// the host's plugin maps. The caller must hold the read lock that beginLoad takes.
+//
+// Only work that touches the plugin maps belongs here. A plugin that talks back to the engine while
+// it boots deadlocks if its boot occupies the loader goroutine.
+func (host *defaultHost) runOnLoader(
+	loadRequestChannel chan pluginLoadRequest, load func() (any, error),
+) (any, error) {
+	var plugin any
 
 	result := make(chan error)
 	loadRequestChannel <- pluginLoadRequest{
@@ -346,76 +366,85 @@ func (host *defaultHost) PolicyAnalyzer(
 	return hostedPlugin.(plugin.Analyzer), nil
 }
 
+// Provider boots a resource provider for ctx. Resource providers are not memoized, so only the
+// bookkeeping runs on the loader goroutine; the boot itself runs here. A provider may ask the
+// engine to load another provider while it boots -- a component provider resolves the providers it
+// wraps before it reports its port -- and that nested load needs the loader goroutine to be free.
 func (host *defaultHost) Provider(
 	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
 ) (plugin.Provider, error) {
-	hostedPlugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
-		pkg := descriptor.Name
-		version := descriptor.Version
+	release, err := host.beginLoad()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
-		// Try to load and bind to a plugin.
+	pkg := descriptor.Name
+	version := descriptor.Version
 
-		result := make(map[string]string)
-		for k, v := range ctx.Config() {
-			if k.Namespace() != pkg {
-				continue
-			}
-			result[k.Name()] = v
+	// Try to load and bind to a plugin.
+
+	result := make(map[string]string)
+	for k, v := range ctx.Config() {
+		if k.Namespace() != pkg {
+			continue
 		}
-		jsonConfig, err := json.Marshal(result)
-		if err != nil {
-			return nil, fmt.Errorf("Could not marshal config to JSON: %w", err)
-		}
-		plug, err := plugin.NewProvider(
-			host, ctx, descriptor,
-			ctx.RuntimeOptions(), ctx.DisableProviderPreview(), string(jsonConfig), ctx.ProjectName(), e,
-		)
-		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo(ctx.Request())
-			if infoerr != nil {
-				contract.IgnoreClose(plug)
-				return nil, infoerr
-			}
+		result[k.Name()] = v
+	}
+	jsonConfig, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("Could not marshal config to JSON: %w", err)
+	}
+	plug, err := plugin.NewProvider(
+		host, ctx, descriptor,
+		ctx.RuntimeOptions(), ctx.DisableProviderPreview(), string(jsonConfig), ctx.ProjectName(), e,
+	)
+	if err != nil || plug == nil {
+		return nil, err
+	}
+	info, infoerr := plug.GetPluginInfo(ctx.Request())
+	if infoerr != nil {
+		contract.IgnoreClose(plug)
+		return nil, infoerr
+	}
 
-			// Warn if the plugin version was not what we expected
-			if version != nil && !env.Dev.Value() {
-				if info.Version == nil || !info.Version.GTE(*version) {
-					var v string
-					if info.Version != nil {
-						v = info.Version.String()
-					}
-					ctx.Diag.Warningf(
-						diag.Message("", /*urn*/
-							"resource plugin %s is expected to have version >=%s, but has %s; "+
-								"the wrong version may be on your path, or this may be a bug in the plugin"),
-						pkg, version.String(), v,
-					)
+	_, err = host.runOnLoader(host.loadRequests, func() (any, error) {
+		// Warn if the plugin version was not what we expected
+		if version != nil && !env.Dev.Value() {
+			if info.Version == nil || !info.Version.GTE(*version) {
+				var v string
+				if info.Version != nil {
+					v = info.Version.String()
 				}
-			}
-
-			// Record the result and add the plugin's info to our list of loaded plugins if it's the first copy of its
-			// kind.
-			key := pkg
-			if info.Version != nil {
-				key += info.Version.String()
-			}
-			_, alreadyReported := host.reportedResourcePlugins[key]
-			if !alreadyReported {
-				host.reportedResourcePlugins[key] = struct{}{}
-			}
-			host.resourcePlugins[plug] = &resourcePlugin{
-				Plugin: plug, Info: info, Name: pkg, ctx: ctx.LifetimeContext(),
+				ctx.Diag.Warningf(
+					diag.Message("", /*urn*/
+						"resource plugin %s is expected to have version >=%s, but has %s; "+
+							"the wrong version may be on your path, or this may be a bug in the plugin"),
+					pkg, version.String(), v,
+				)
 			}
 		}
 
-		return plug, err
+		// Record the result and add the plugin's info to our list of loaded plugins if it's the first copy of its
+		// kind.
+		key := pkg
+		if info.Version != nil {
+			key += info.Version.String()
+		}
+		_, alreadyReported := host.reportedResourcePlugins[key]
+		if !alreadyReported {
+			host.reportedResourcePlugins[key] = struct{}{}
+		}
+		host.resourcePlugins[plug] = &resourcePlugin{
+			Plugin: plug, Info: info, Name: pkg, ctx: ctx.LifetimeContext(),
+		}
+		return nil, nil
 	})
-	if hostedPlugin == nil || err != nil {
+	if err != nil {
 		return nil, err
 	}
 
-	provider := hostedPlugin.(plugin.Provider)
-	return hostManagedProvider{provider, host}, nil
+	return hostManagedProvider{plug, host}, nil
 }
 
 // hostManagedProvider wraps a Provider such that it can be closed by the host that created it.

--- a/pkg/host/provider_test.go
+++ b/pkg/host/provider_test.go
@@ -15,16 +15,27 @@
 package host
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
-	"github.com/stretchr/testify/require"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 func TestStartupFailure(t *testing.T) {
@@ -191,4 +202,85 @@ func TestPulumiVersionRangeYaml(t *testing.T) {
 	_, err = plugin.NewProviderFromPath(ctx.Host, ctx, filepath.Join("testdata", "test-plugin-cli-version"))
 	require.ErrorContains(t, err,
 		"test-plugin-cli-version: Pulumi CLI version 3.1.2 does not satisfy the version range \">=100.0.0\"")
+}
+
+// fakeProvider answers the RPCs that the PULUMI_DEBUG_PROVIDERS attach path calls. Handshake is
+// left unimplemented, which the attach path accepts as a legacy provider.
+type fakeProvider struct {
+	pulumirpc.UnimplementedResourceProviderServer
+
+	// onGetPluginInfo, if set, runs before GetPluginInfo answers. The engine calls GetPluginInfo
+	// while it boots the provider, so this is the hook that a provider uses to talk back to the
+	// engine during its own boot.
+	onGetPluginInfo func() error
+}
+
+func (f *fakeProvider) Attach(context.Context, *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeProvider) GetPluginInfo(context.Context, *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
+	if f.onGetPluginInfo != nil {
+		if err := f.onGetPluginInfo(); err != nil {
+			return nil, err
+		}
+	}
+	return &pulumirpc.PluginInfo{Version: "1.0.0"}, nil
+}
+
+// serveFakeProvider serves prov on an ephemeral port and returns that port.
+func serveFakeProvider(t *testing.T, prov *fakeProvider) int {
+	cancel := make(chan bool)
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterResourceProviderServer(srv, prov)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	// Do not wait for the shutdown to complete. If the test fails because a provider RPC is
+	// stuck, a graceful stop never returns and the wait would hang the whole package.
+	t.Cleanup(func() { close(cancel) })
+	return handle.Port
+}
+
+// TestProviderLoadDuringProviderBoot ensures that a provider can request another provider on boot without deadlocking.
+func TestProviderLoadDuringProviderBoot(t *testing.T) {
+	d := diagtest.LogSink(t)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	host, ok := h.(*defaultHost)
+	require.True(t, ok)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
+
+	inner := workspace.PluginDescriptor{Name: "inner", Kind: apitype.ResourcePlugin}
+	outer := workspace.PluginDescriptor{Name: "outer", Kind: apitype.ResourcePlugin}
+
+	innerPort := serveFakeProvider(t, &fakeProvider{})
+	var innerErr error
+	outerPort := serveFakeProvider(t, &fakeProvider{
+		onGetPluginInfo: func() error {
+			_, innerErr = h.Provider(ctx, inner, env.Global())
+			return innerErr
+		},
+	})
+	t.Setenv("PULUMI_DEBUG_PROVIDERS", fmt.Sprintf("outer:%d,inner:%d", outerPort, innerPort))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.Provider(ctx, outer, env.Global())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("loading the outer provider deadlocked: its boot blocked the nested load of the inner provider")
+	}
+	require.NoError(t, innerErr)
+	require.Len(t, host.resourcePlugins, 2)
+	require.NoError(t, h.Close())
 }


### PR DESCRIPTION
The plugin host serializes plugin loads on one goroutine that drains
loadRequests. Resource providers are not memoized, so the provider boot
does not need that serialization. Only the bookkeeping does.

A provider can ask the engine for another provider while it boots. A
component provider resolves the providers that it wraps before it reports
its port. If the boot occupies the loader goroutine, the nested load waits
for a goroutine that cannot advance, and the engine hangs.

Move the boot out of the loader goroutine. The host still runs the
version check and the map updates there.