### PR TITLE
Count an attached provider as an installed plugin

### DIFF
--- a/changelog/pending/cli-fix-20260904-attached-required-packages.yaml
+++ b/changelog/pending/cli-fix-20260904-attached-required-packages.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: fix
+body: Treat a resource provider attached through PULUMI_DEBUG_PROVIDERS as installed, so
+    package installation does not try to download it
+time: 2026-09-04T00:00:00Z

--- a/pkg/pluginstorage/pluginstorage.go
+++ b/pkg/pluginstorage/pluginstorage.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/blang/semver"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -38,7 +41,14 @@ type Context interface {
 
 type defaultContext struct{}
 
+// HasPlugin reports whether the plugin is installed. A resource provider attached
+// through PULUMI_DEBUG_PROVIDERS is already running, so it counts as installed.
 func (defaultContext) HasPlugin(_ context.Context, spec workspace.PluginDescriptor) bool {
+	if spec.Kind == apitype.ResourcePlugin {
+		if port, err := plugin.GetProviderAttachPort(tokens.Package(spec.Name)); err == nil && port != nil {
+			return true
+		}
+	}
 	return workspace.HasPlugin(spec)
 }
 

--- a/pkg/pluginstorage/pluginstorage_test.go
+++ b/pkg/pluginstorage/pluginstorage_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginstorage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// An attached resource provider counts as installed; the attachment applies to
+// resource plugins only, and to nothing else in the empty plugin cache.
+func TestHasPluginAttachedProvider(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	t.Setenv("PULUMI_DEBUG_PROVIDERS", "attached:12345")
+
+	has := func(name string, kind apitype.PluginKind) bool {
+		return Instance.HasPlugin(t.Context(), workspace.PluginDescriptor{Name: name, Kind: kind})
+	}
+	assert.Equal(t, map[string]bool{
+		"attached resource": true,
+		"attached language": false,
+		"other resource":    false,
+	}, map[string]bool{
+		"attached resource": has("attached", apitype.ResourcePlugin),
+		"attached language": has("attached", apitype.LanguagePlugin),
+		"other resource":    has("other", apitype.ResourcePlugin),
+	})
+}


### PR DESCRIPTION
PULUMI_DEBUG_PROVIDERS names a resource provider that already runs. The
engine attaches to it over its port and never reads it from the plugin
cache. HasPlugin did not know that, so package installation reported the
plugin as missing and tried to download it.

Report an attached resource provider as installed. The attachment applies
to resource plugins only, so every other kind still goes to the cache.