### PR TITLE
Add external TypeScript loader integration coverage

### DIFF
--- a/changelog/pending/sdk-nodejs-improvement-20260905-193900.yaml
+++ b/changelog/pending/sdk-nodejs-improvement-20260905-193900.yaml
@@ -1,4 +1,4 @@
 component: sdk/nodejs
 kind: improvement
 body: Add external TypeScript loader integration coverage
-time: 2026-09-05T19:39:00-07:00
+time: 2026-09-05T12:42:18-07:00

--- a/changelog/pending/sdk-nodejs-improvement-20260905-193900.yaml
+++ b/changelog/pending/sdk-nodejs-improvement-20260905-193900.yaml
@@ -1,0 +1,4 @@
+component: sdk/nodejs
+kind: improvement
+body: Add external TypeScript loader integration coverage
+time: 2026-09-05T19:39:00-07:00

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1358,6 +1358,37 @@ func TestESMTSX(t *testing.T) {
 	e.RunCommand("pulumi", "destroy", "--skip-preview")
 }
 
+func TestExternalLoaderNub(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join("nodejs", "external-loader-nub")
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory(dir)
+	stackName := ptesting.RandomStackName()
+	e.InstallDependencies()
+	e.RunCommand("npm", "run", "check")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("pulumi", "stack", "select", stackName)
+	e.RunCommand("pulumi", "up", "--yes")
+	stdout, _ := e.RunCommand("pulumi", "stack", "export")
+	var stackExport map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &stackExport))
+	resources := stackExport["deployment"].(map[string]any)["resources"].([]any)
+	var outputs map[string]any
+	for _, resource := range resources {
+		resourceMap := resource.(map[string]any)
+		if resourceMap["type"] == "pulumi:pulumi:Stack" {
+			outputs = resourceMap["outputs"].(map[string]any)
+			break
+		}
+	}
+	require.NotNil(t, outputs)
+	require.Equal(t, "dynamic-value", outputs["dynamicId"])
+	require.Greater(t, outputs["serializedLength"].(float64), 0.0)
+	e.RunCommand("pulumi", "destroy", "--skip-preview")
+}
+
 func TestESMTSAuto(t *testing.T) {
 	t.Parallel()
 	dir := filepath.Join("nodejs", "esm-ts-auto")

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1385,6 +1385,7 @@ func TestExternalLoaderNub(t *testing.T) {
 	}
 	require.NotNil(t, outputs)
 	require.Equal(t, "dynamic-value", outputs["dynamicId"])
+	require.Equal(t, "value-from-ts", outputs["dynamicValue"])
 	require.Greater(t, outputs["serializedLength"].(float64), 0.0)
 	e.RunCommand("pulumi", "destroy", "--skip-preview")
 }

--- a/tests/integration/nodejs/external-loader-nub/Pulumi.yaml
+++ b/tests/integration/nodejs/external-loader-nub/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: external-loader-nub
+main: index.ts
+runtime:
+  name: nodejs
+  options:
+    typescript: false
+    nodeargs: "--require @nubjs/loader"
+description: Run an ESM TypeScript program through an external Node loader.

--- a/tests/integration/nodejs/external-loader-nub/README.md
+++ b/tests/integration/nodejs/external-loader-nub/README.md
@@ -1,0 +1,13 @@
+# External TypeScript loader fixture
+
+This project runs an ESM TypeScript Pulumi program through `@nubjs/loader` while retaining the Node.js language host.
+
+```yaml
+runtime:
+  name: nodejs
+  options:
+    typescript: false
+    nodeargs: "--require @nubjs/loader"
+```
+
+The `--require` preload requires Node 22.15.0 or later for this fixture. The package script runs `tsc --noEmit` before deployment because `typescript: false` disables Pulumi's built-in `ts-node` registration. The program, providers, package manager, and deployment model otherwise remain unchanged.

--- a/tests/integration/nodejs/external-loader-nub/index.ts
+++ b/tests/integration/nodejs/external-loader-nub/index.ts
@@ -1,0 +1,22 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import { suffix } from "./shared.js";
+
+const provider: pulumi.dynamic.ResourceProvider = {
+    async create(inputs) {
+        return { id: `dynamic-${inputs.value}`, outs: { value: `${inputs.value}${suffix}` } };
+    },
+};
+
+class DynamicResource extends pulumi.dynamic.Resource {
+    constructor(name: string, props: pulumi.Inputs) {
+        super(provider, name, props);
+    }
+}
+
+const resource = new DynamicResource("resource", { value: "value" });
+const serialized = pulumi.runtime.serializeFunction(() => suffix);
+
+export const dynamicId = resource.id;
+export const serializedLength = pulumi.output(serialized).apply(value => value.text.length);

--- a/tests/integration/nodejs/external-loader-nub/index.ts
+++ b/tests/integration/nodejs/external-loader-nub/index.ts
@@ -10,6 +10,8 @@ const provider: pulumi.dynamic.ResourceProvider = {
 };
 
 class DynamicResource extends pulumi.dynamic.Resource {
+    declare readonly value: pulumi.Output<string>;
+
     constructor(name: string, props: pulumi.Inputs) {
         super(provider, name, props);
     }
@@ -19,4 +21,5 @@ const resource = new DynamicResource("resource", { value: "value" });
 const serialized = pulumi.runtime.serializeFunction(() => suffix);
 
 export const dynamicId = resource.id;
+export const dynamicValue = resource.value;
 export const serializedLength = pulumi.output(serialized).apply(value => value.text.length);

--- a/tests/integration/nodejs/external-loader-nub/package.json
+++ b/tests/integration/nodejs/external-loader-nub/package.json
@@ -5,6 +5,9 @@
     "scripts": {
         "check": "tsc --noEmit"
     },
+    "engines": {
+        "node": ">=22.15.0"
+    },
     "dependencies": {
         "@nubjs/loader": "0.8.3",
         "@pulumi/pulumi": "latest",

--- a/tests/integration/nodejs/external-loader-nub/package.json
+++ b/tests/integration/nodejs/external-loader-nub/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "external-loader-nub",
+    "license": "Apache-2.0",
+    "type": "module",
+    "scripts": {
+        "check": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@nubjs/loader": "0.8.3",
+        "@pulumi/pulumi": "latest",
+        "typescript": "5.9.3"
+    },
+    "devDependencies": {
+        "@types/node": "20.19.26"
+    }
+}

--- a/tests/integration/nodejs/external-loader-nub/shared.ts
+++ b/tests/integration/nodejs/external-loader-nub/shared.ts
@@ -1,0 +1,3 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+export const suffix = "-from-ts";

--- a/tests/integration/nodejs/external-loader-nub/tsconfig.json
+++ b/tests/integration/nodejs/external-loader-nub/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "strict": true,
+        "target": "es2022"
+    },
+    "files": [
+        "index.ts",
+        "shared.ts"
+    ]
+}


### PR DESCRIPTION
Adds an ESM TypeScript fixture that retains the `nodejs` runtime and preloads `@nubjs/loader` with `--require`. It runs `tsc --noEmit` explicitly, then checks a local-backend dynamic provider and closure serialization.

Tested:
- Remote Ubuntu: Node 22.15.0, Pulumi CLI 3.261.0, `@nubjs/loader@0.8.3`; `npm run check`, `pulumi up --yes --skip-preview`, `pulumi stack output --json`, and `pulumi destroy --yes --skip-preview`.
- `gofmt -d tests/integration/integration_nodejs_test.go`