### PR TITLE
Accept input-interface destinations when marshalling

### DIFF
--- a/changelog/pending/sdk-go-fix-20260908-105832.yaml
+++ b/changelog/pending/sdk-go-fix-20260908-105832.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: fix
+body: Allow outputs and prompt values to be marshalled into fields typed as input interfaces, such as pulumi.StringInput
+time: 2026-09-08T10:58:32.672333+02:00

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -891,7 +891,7 @@ func TestInvokePlainWithOutputArgument(t *testing.T) {
 		res := result{}
 		return ctx.Invoke("test:invoke:success", args, &res)
 	}, WithMocks("project", "stack", mocks))
-	require.ErrorContains(t, err, "cannot marshal an input of type")
+	require.ErrorContains(t, err, "cannot marshal Output value of type pulumi.StringOutput")
 }
 
 // This test ensures that ctx.RegisterResourceOutputs is a no-op on subsequent

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -267,6 +267,10 @@ func marshalInputOptionsImpl(v any,
 				if newOutput, ok := internal.CallToOutputMethod(context.TODO(), reflect.ValueOf(input), destType); ok {
 					// We were able to convert the input. Use the result as the new input value.
 					input, valueType = newOutput, destType
+				} else if destType.Kind() == reflect.Interface && reflect.TypeOf(input).Implements(destType) {
+					// The destination is an input interface (e.g. pulumi.StringInput) that the value already
+					// satisfies. Marshal it as its own element type.
+					destType = valueType
 				} else if !valueType.AssignableTo(destType) {
 					err := fmt.Errorf(
 						"cannot marshal an input of type %T with element type %v as a value of type %v",

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -2133,3 +2133,30 @@ func TestResourceReferenceDependencies(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/13226: a destination typed as an input
+// interface (e.g. StringInput) accepts any value that satisfies it, including outputs.
+func TestMarshalInputInterfaceDestination(t *testing.T) {
+	t.Parallel()
+
+	type componentOutputs struct {
+		Ref  StringInput      `pulumi:"ref"`
+		Refs []StringInput    `pulumi:"refs"`
+		All  StringArrayInput `pulumi:"all"`
+	}
+
+	v, _, err := marshalInput(componentOutputs{
+		Ref:  String("a").ToStringOutput(),
+		Refs: []StringInput{String("b").ToStringOutput(), String("c")},
+		All:  StringArray{String("d")}.ToStringArrayOutput(),
+	}, reflect.TypeFor[componentOutputs]())
+	require.NoError(t, err)
+	assert.Equal(t, resource.NewProperty(resource.PropertyMap{
+		"ref": resource.NewProperty("a"),
+		"refs": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("b"),
+			resource.NewProperty("c"),
+		}),
+		"all": resource.NewProperty([]resource.PropertyValue{resource.NewProperty("d")}),
+	}), v)
+}


### PR DESCRIPTION
Marshalling fails when checking types against interfaces. This PR adds another case to handle this.

Fixes #13226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)