### PR TITLE
Drop the Python wheel build from test jobs

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -390,10 +390,6 @@ jobs:
         run: |
           cd sdk/python
           make ensure
-      - name: Install Python SDK
-        run: |
-          cd sdk/python
-          make build_package
       - name: Set PULUMI_ACCEPT if version-set is not current
         if: ${{ fromJson(inputs.version-set).name != 'current' }}
         run: echo "PULUMI_ACCEPT=TRUE" >> "${GITHUB_ENV}"

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -16,9 +16,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/python/toolchain"
@@ -317,20 +319,34 @@ build-backend = "poetry.core.masonry.api"
 	}
 }
 
-// pulumiWheel searches for the built pulumi wheel in the sdk/python/dist directory
-// and returns its path.
-func pulumiWheel(t *testing.T) string {
-	dir, err := filepath.Abs(filepath.Join("..", "..", "build"))
-	require.NoError(t, err)
-	files, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	for _, file := range files {
-		if filepath.Ext(file.Name()) == ".whl" {
-			return filepath.Join(dir, file.Name())
-		}
+var buildPulumiWheel = sync.OnceValues(func() (string, error) {
+	coreSDK, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		return "", err
 	}
-	t.Fatalf("could not find wheel in %s", dir)
-	return ""
+	dest, err := os.MkdirTemp("", "pulumi-core-sdk-")
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("uv", "build", coreSDK, "--wheel", "-o", dest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("uv build %s: %w\n%s", coreSDK, err, out)
+	}
+	wheels, err := filepath.Glob(filepath.Join(dest, "*.whl"))
+	if err != nil {
+		return "", err
+	}
+	if len(wheels) != 1 {
+		return "", fmt.Errorf("expected exactly one wheel in %s, found %v", dest, wheels)
+	}
+	return wheels[0], nil
+})
+
+func pulumiWheel(t *testing.T) string {
+	t.Helper()
+	wheel, err := buildPulumiWheel()
+	require.NoError(t, err)
+	return wheel
 }
 
 func TestListPulumiPackageInfos(t *testing.T) {


### PR DESCRIPTION
Every test job ran `make build_package` in `sdk/python`. That target builds a wheel into `sdk/python/build`. Only one test read that wheel, and it now builds the wheel itself:

- `TestListPulumiPackageInfos` in `sdk/python/cmd/pulumi-language-python` now runs `uv build` once per test binary, which copies what the Python acceptance tests already do: https://github.com/pulumi/pulumi/blob/ef4feb66c1bdcc44b1e15f774d5eed6e81c7957e/tests/integration/integration_python_acceptance_test.go#L776-L783
- Go fixtures install the SDK from source with `uv add` or `uv pip install` in `sdk/go/common/testing/install.go`.
- The conformance tests get the wheel from the language host's Pack RPC.
- The `sdk/python` test suites only need the venv that `make ensure` creates.

The step cost about 24 job-minutes per PR run (12s per ubuntu job and 27s per windows job, measured on run 33968791017).
