### PR TITLE
Pin mise to 2026.9.2 in CI

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
             cache_key_prefix: mise-npm-shell-out-v0
       - name: Install CLI

--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -65,6 +65,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
       - name: Backfill PR numbers in pending changelog entries
         run: |

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -101,6 +101,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
             cache_key_prefix: mise-npm-shell-out-v1
       - name: Check Protobufs
@@ -206,6 +208,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
       - run: make lint_changelog
       - name: Lint changelog message style (advisory)

--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
             cache_key_prefix: mise-npm-shell-out-v0
       - name: Build

--- a/.github/workflows/cron-minor-release.yml
+++ b/.github/workflows/cron-minor-release.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
       - name: Create PR
         id: pr

--- a/.github/workflows/on-pr-neo.yml
+++ b/.github/workflows/on-pr-neo.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
       - id: gen
         run: |

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
       - name: Create PR
         env:

--- a/.github/workflows/update-automation-api.yml
+++ b/.github/workflows/update-automation-api.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           action: jdx/mise-action@v2
           with: |
+            # Pin mise: the latest advertised version, 2026.9.3, has no release assets.
+            version: 2026.9.2
             experimental: true
       - name: Regenerate
         run: make generate-automation-apis


### PR DESCRIPTION
The `jdx/mise-action` step installs the latest mise release when no version is given. The endpoint <https://mise.jdx.dev/VERSION> advertises `2026.9.3`, but the `jdx/mise` repository has no release for that tag. The download of `mise-v2026.9.3-linux-x64.tar.zst` returns HTTP 404. Every job that sets up mise fails as a result.

Example failing job: <https://github.com/pulumi/pulumi/actions/runs/34207619433/job/102001542530>

This change pins all nine `jdx/mise-action` call sites to `2026.9.2`. That is the newest release with assets, published 2026-09-07 with 46 assets.

Remove the pin when mise publishes assets for a newer release.