### PR TITLE
Allow component state migrations to split managed resources

### DIFF
--- a/changelog/pending/engine-fix-state-migration-split-inference.yaml
+++ b/changelog/pending/engine-fix-state-migration-split-inference.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Allow component state migrations to split managed state using compatible existing resource identities
+time: 2026-09-05T15:00:00+02:00

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -778,40 +778,162 @@ func TestStateMigrationSecrets(t *testing.T) {
 	assert.Equal(t, "shh", child.Inputs["secret"].SecretValue().Element.StringValue())
 }
 
-// TestStateMigrationRejectsSplit verifies that a one-to-many migration cannot fabricate managed state. A final custom
-// resource must have a custom predecessor whose provider-managed identity the engine can verify.
-func TestStateMigrationRejectsSplit(t *testing.T) {
+// TestStateMigrationSplit exercises this one-to-many migration:
+//
+//	resource (managed, inline settings) -> resource (managed, settings removed)
+//	                                   + settings (managed, same physical ID and provider)
+//
+// The original resource retains its URN, and the new settings resource depends on it. The migration adopts the
+// settings resource without a provider create, and a subsequent update leaves both resources unchanged.
+func TestStateMigrationSplit(t *testing.T) {
 	t.Parallel()
-
-	env := newStateMigrationEnv(t)
-	snap, err := runUpdate(t, env.plan, nil, nil)
-	require.NoError(t, err)
-
-	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
-		callback, err := callbacks.Allocate(
-			stateMigrationFunction(func(
-				urn resource.URN, resources []apitype.ResourceV3,
+	const (
+		componentType = "pkgA:m:Component"
+		resourceType  = "pkgA:m:Resource"
+		settingsType  = "pkgA:m:Settings"
+		resourceURN   = resource.URN("urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Resource::resource")
+		settingsURN   = resource.URN("urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Settings::settings")
+	)
+	upgrade := false
+	creates := 0
+	settings := map[string]any{"enabled": true}
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					creates++
+					return plugin.CreateResponse{ID: "resource-id", Properties: req.Properties, Status: resource.StatusOK}, nil
+				},
+			}, nil
+		}),
+	}
+	program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+		var migrations []*pulumirpc.Callback
+		if upgrade {
+			callback, err := callbacks.Allocate(stateMigrationFunction(func(
+				_ resource.URN, states []apitype.ResourceV3,
 			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
-				var child apitype.ResourceV3
-				for _, res := range resources {
-					if res.URN == childAURN {
-						child = res
+				for _, state := range states {
+					if state.URN == settingsURN {
+						return nil, nil, nil
 					}
 				}
-				split := child
-				split.URN = childBURN
-				split.Inputs = map[string]any{"foo": "bar"}
-				split.Outputs = map[string]any{"foo": "bar"}
-				return append(resources, split), nil, nil
+				for i := range states {
+					if states[i].URN != resourceURN {
+						continue
+					}
+					sidecar := states[i]
+					sidecar.URN, sidecar.Type = settingsURN, settingsType
+					sidecar.Inputs = map[string]any{"resourceId": "resource-id", "settings": settings}
+					sidecar.Outputs = sidecar.Inputs
+					sidecar.Dependencies = []resource.URN{resourceURN}
+					sidecar.PropertyDependencies = map[resource.PropertyKey][]resource.URN{"resourceId": {resourceURN}}
+					delete(states[i].Inputs, "settings")
+					delete(states[i].Outputs, "settings")
+					return append(states, sidecar), nil, nil
+				}
+				return nil, nil, errors.New("missing resource")
 			}))
+			require.NoError(t, err)
+			migrations = []*pulumirpc.Callback{callback}
+		}
+		component, err := monitor.RegisterResource(componentType, "component", false, deploytest.ResourceOptions{
+			StateMigrations: migrations,
+		})
+		if err != nil {
+			return err
+		}
+		inputs := map[string]any{"name": "resource"}
+		if !upgrade {
+			inputs["settings"] = settings
+		}
+		_, err = monitor.RegisterResource(resourceType, "resource", true, deploytest.ResourceOptions{
+			Parent: component.URN, Inputs: resource.NewPropertyMapFromMap(inputs),
+		})
+		if err != nil || !upgrade {
+			return err
+		}
+		_, err = monitor.RegisterResource(settingsType, "settings", true, deploytest.ResourceOptions{
+			Parent: component.URN,
+			Inputs: resource.NewPropertyMapFromMap(map[string]any{
+				"resourceId": "resource-id", "settings": settings,
+			}),
+			Dependencies: []resource.URN{resourceURN},
+			PropertyDeps: map[resource.PropertyKey][]resource.URN{"resourceId": {resourceURN}},
+		})
+		return err
+	})
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
+	plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, host)}
+	snap, err := runUpdate(t, plan, nil, nil)
+	require.NoError(t, err)
+	upgrade = true
+	for range 2 {
+		snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 4}))
 		require.NoError(t, err)
-		return []*pulumirpc.Callback{callback}
+		require.NoError(t, snap.VerifyIntegrity())
+		assert.Contains(t, snapURNs(snap), resourceURN)
+		assert.Contains(t, snapURNs(snap), settingsURN)
 	}
+	assert.Equal(t, 1, creates, "the sidecar must be adopted from migrated state, not created")
+}
 
-	_, err = runUpdate(t, env.plan, snap, nil)
-	require.ErrorContains(t, err, "without a managed custom predecessor")
-	assert.Contains(t, snapURNs(snap), childAURN)
-	assert.NotContains(t, snapURNs(snap), childBURN)
+// TestStateMigrationRejectsInvalidSplit verifies that splitting preserves managed identity, ownership,
+// and lifecycle flags.
+func TestStateMigrationRejectsInvalidSplit(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		change  func(*apitype.ResourceV3)
+		message string
+	}{
+		{"identity", func(s *apitype.ResourceV3) { s.ID = "unrelated-object" }, "without a managed custom predecessor"},
+		{"ownership", func(s *apitype.ResourceV3) { s.External = !s.External }, "changes ownership"},
+		{
+			"pending replacement",
+			func(s *apitype.ResourceV3) { s.PendingReplacement = !s.PendingReplacement },
+			"changes PendingReplacement",
+		},
+		{"taint", func(s *apitype.ResourceV3) { s.Taint = !s.Taint }, "changes Taint"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			env := newStateMigrationEnv(t)
+			snap, err := runUpdate(t, env.plan, nil, nil)
+			require.NoError(t, err)
+
+			env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+				callback, err := callbacks.Allocate(
+					stateMigrationFunction(func(
+						urn resource.URN, resources []apitype.ResourceV3,
+					) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+						var child apitype.ResourceV3
+						for _, res := range resources {
+							if res.URN == childAURN {
+								child = res
+							}
+						}
+						split := child
+						split.URN = childBURN
+						tt.change(&split)
+						split.Inputs = map[string]any{"foo": "bar"}
+						split.Outputs = map[string]any{"foo": "bar"}
+						return append(resources, split), nil, nil
+					}))
+				require.NoError(t, err)
+				return []*pulumirpc.Callback{callback}
+			}
+
+			_, err = runUpdate(t, env.plan, snap, nil)
+			require.ErrorContains(t, err, tt.message)
+			assert.Contains(t, snapURNs(snap), childAURN)
+			assert.NotContains(t, snapURNs(snap), childBURN)
+		})
+	}
 }
 
 // TestStateMigrationFold exercises this many-to-one migration:

--- a/pkg/resource/deploy/state_migration_validation.go
+++ b/pkg/resource/deploy/state_migration_validation.go
@@ -62,6 +62,8 @@ func validateStateMigrationContext(
 // lifecycle (External), and its PendingReplacement and Taint flags must therefore follow its successor. Protect and
 // RetainOnDelete are engine-owned safety metadata and must be inherited conservatively by any custom or component
 // successor: when multiple resources are folded together, the successor must carry either flag if any predecessor did.
+// Additional custom resources must match prior managed state by physical ID, provider, and extension identity. They
+// preserve ownership and lifecycle flags for the matched prior resources, and inherit Protect and RetainOnDelete.
 // The provider identity restrictions do not apply to components because they have no provider-managed physical
 // identity.
 func validateStateMigrationManagedIdentity(
@@ -149,11 +151,38 @@ func validateStateMigrationManagedIdentity(
 		inheritedByURN[targetURN] = inherited
 	}
 
-	// The checks above validate retained custom resources and their successors. Now reject custom states without a
-	// managed predecessor, and reject safety or lifecycle flags that were not inherited from their predecessors. This
-	// includes states newly introduced by the migration.
+	// New resources without a predecessor must match the ID, provider, and extension against prior managed state, and
+	// inherit Protect and RetainOnDelete.
 	for _, state := range final {
-		inherited := inheritedByURN[state.URN]
+		inherited, hasPredecessor := inheritedByURN[state.URN]
+		if state.Custom && !hasPredecessor && state.ID != "" {
+			for _, old := range original {
+				if !old.Custom || old.ID != state.ID || old.Provider != state.Provider ||
+					old.ExtensionRef != state.ExtensionRef {
+					continue
+				}
+				if old.External != state.External {
+					return fmt.Errorf("state migration for %s changes ownership of custom resource %s "+
+						"from external=%t to external=%t on inferred successor %s; migrations must preserve managed resource ownership",
+						urn, old.URN, old.External, state.External, state.URN)
+				}
+				if old.PendingReplacement != state.PendingReplacement {
+					return fmt.Errorf("state migration for %s changes PendingReplacement for custom resource %s "+
+						"from %t to %t on inferred successor %s; migrations must preserve provider lifecycle state",
+						urn, old.URN, old.PendingReplacement, state.PendingReplacement, state.URN)
+				}
+				if old.Taint != state.Taint {
+					return fmt.Errorf("state migration for %s changes Taint for custom resource %s "+
+						"from %t to %t on inferred successor %s; migrations must preserve provider lifecycle state",
+						urn, old.URN, old.Taint, state.Taint, state.URN)
+				}
+				inherited.hasCustomPredecessor = true
+				inherited.protect = inherited.protect || old.Protect
+				inherited.retainOnDelete = inherited.retainOnDelete || old.RetainOnDelete
+				inherited.pendingReplacement = old.PendingReplacement
+				inherited.taint = old.Taint
+			}
+		}
 		if state.PendingReplacement && (!state.Custom || !inherited.pendingReplacement) {
 			return fmt.Errorf("state migration for %s returns resource %s with PendingReplacement set "+
 				"without a pending-replacement custom predecessor", urn, state.URN)

--- a/pkg/resource/deploy/state_migration_validation_test.go
+++ b/pkg/resource/deploy/state_migration_validation_test.go
@@ -24,6 +24,99 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+func TestStateMigrationSplitValidation(t *testing.T) {
+	t.Parallel()
+	old := apitype.ResourceV3{
+		URN:    "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Resource::resource",
+		Custom: true, ID: "resource-id", Provider: "provider",
+	}
+	additional := old
+	additional.URN = "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Settings::settings"
+	for _, tt := range []struct {
+		name   string
+		change func(*apitype.ResourceV3)
+	}{
+		{"ID", func(s *apitype.ResourceV3) { s.ID = "different" }},
+		{"provider", func(s *apitype.ResourceV3) { s.Provider = "different" }},
+		{"extension", func(s *apitype.ResourceV3) { s.ExtensionRef = "different" }},
+		{"ownership", func(s *apitype.ResourceV3) { s.External = true }},
+		{"pending replacement", func(s *apitype.ResourceV3) { s.PendingReplacement = true }},
+		{"taint", func(s *apitype.ResourceV3) { s.Taint = true }},
+		{"protection", func(s *apitype.ResourceV3) { s.Protect = true }},
+		{"retention", func(s *apitype.ResourceV3) { s.RetainOnDelete = true }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			changed := additional
+			tt.change(&changed)
+			require.Error(t, validateStateMigrationManagedIdentity(old.URN,
+				[]apitype.ResourceV3{old}, []apitype.ResourceV3{old, changed}, nil))
+		})
+	}
+	t.Run("same identity", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateStateMigrationManagedIdentity(old.URN,
+			[]apitype.ResourceV3{old}, []apitype.ResourceV3{old, additional}, nil))
+	})
+	for _, tt := range []struct {
+		name   string
+		change func(*apitype.ResourceV3)
+	}{
+		{"ownership", func(s *apitype.ResourceV3) { s.External = true }},
+		{"PendingReplacement", func(s *apitype.ResourceV3) { s.PendingReplacement = true }},
+		{"Taint", func(s *apitype.ResourceV3) { s.Taint = true }},
+	} {
+		t.Run("conflicting matches/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			other := old
+			other.URN = "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:OtherSettings::other-settings"
+			other.Protect, other.RetainOnDelete = true, true
+			tt.change(&other)
+			for _, sources := range [][]apitype.ResourceV3{{old, other}, {other, old}} {
+				for _, useOtherFlags := range []bool{false, true} {
+					target := additional
+					if useOtherFlags {
+						tt.change(&target)
+						target.Protect, target.RetainOnDelete = true, true
+					}
+					require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN, sources,
+						[]apitype.ResourceV3{old, other, target}, nil), "changes "+tt.name)
+				}
+			}
+			// Matching non-default flags are valid when all candidates agree.
+			target := additional
+			tt.change(&target)
+			target.Protect, target.RetainOnDelete = true, true
+			require.NoError(t, validateStateMigrationManagedIdentity(old.URN,
+				[]apitype.ResourceV3{other}, []apitype.ResourceV3{other, target}, nil))
+		})
+	}
+	t.Run("empty identity", func(t *testing.T) {
+		t.Parallel()
+		source, target := old, additional
+		source.ID, target.ID = "", ""
+		require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN,
+			[]apitype.ResourceV3{source}, []apitype.ResourceV3{source, target}, nil), "without a managed custom predecessor")
+	})
+	t.Run("all matching sources contribute safety flags", func(t *testing.T) {
+		t.Parallel()
+		other := old
+		other.URN = "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:OtherSettings::other-settings"
+		other.Protect, other.RetainOnDelete = true, true
+		for _, sources := range [][]apitype.ResourceV3{{old, other}, {other, old}} {
+			require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN, sources,
+				[]apitype.ResourceV3{old, other, additional}, nil), "changes Protect")
+			target := additional
+			target.Protect = true
+			require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN, sources,
+				[]apitype.ResourceV3{old, other, target}, nil), "changes RetainOnDelete")
+			target.RetainOnDelete = true
+			require.NoError(t, validateStateMigrationManagedIdentity(old.URN, sources,
+				[]apitype.ResourceV3{old, other, target}, nil))
+		}
+	})
+}
+
 func TestValidateStateMigrationContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Allow splitting managed resources. The split resources must have the same physical ID and provider. This enables the AWS case where certain bucket settings can be represented in “sidecar” resources.

Inline:

```typescript
const bucket = new aws.s3.Bucket("storage", {
  versioning: {
    enabled: true,
  },
});
```

Sidecar:

```typescript
const bucket = new aws.s3.Bucket("storage");

const versioning = new aws.s3.BucketVersioning("storage-versioning", {
  bucket: bucket.id,
  versioningConfiguration: {
    status: "Enabled",
  },
});
```
