### PR TITLE
[sdk/esc] Serialize boolean schemas as their equivalent object forms

### DIFF
--- a/changelog/pending/20260908--sdk--esc-schema-boolean-object-forms.yaml
+++ b/changelog/pending/20260908--sdk--esc-schema-boolean-object-forms.yaml
@@ -1,0 +1,7 @@
+component: sdk
+kind: fix
+body: Serialize ESC boolean schemas as their equivalent object forms (`{}` for
+  "always", `{"not": {}}` for "never") so schema-carrying payloads are valid
+  instances of the OpenAPI models that describe them. Both boolean encodings
+  are still accepted when reading.
+time: 2026-09-08T00:00:00+02:00

--- a/sdk/go/common/esc/schema/schema.go
+++ b/sdk/go/common/esc/schema/schema.go
@@ -97,7 +97,7 @@ type Schema struct {
 
 	// Validation vocabulary
 
-	Type              string              `json:"type"`
+	Type              string              `json:"type,omitempty"`
 	Const             any                 `json:"const,omitempty"`
 	Enum              []any               `json:"enum,omitempty"`
 	MultipleOf        json.Number         `json:"multipleOf,omitempty"`
@@ -157,18 +157,39 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err == nil {
+		if len(keys) == 0 {
+			s.Always = true
+			return nil
+		}
+		if not, ok := keys["not"]; ok && len(keys) == 1 && isAlwaysEncoding(not) {
+			s.Never = true
+			return nil
+		}
+	}
+
 	type rawSchema Schema
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	return dec.Decode((*rawSchema)(s))
 }
 
+func isAlwaysEncoding(data []byte) bool {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		return b
+	}
+	var keys map[string]json.RawMessage
+	return json.Unmarshal(data, &keys) == nil && len(keys) == 0
+}
+
 func (s *Schema) MarshalJSON() ([]byte, error) {
 	switch {
 	case s.Never:
-		return []byte("false"), nil
+		return []byte(`{"not":{}}`), nil
 	case s.Always:
-		return []byte("true"), nil
+		return []byte(`{}`), nil
 	default:
 		type rawSchema Schema
 		return json.Marshal((*rawSchema)(s))

--- a/sdk/go/common/esc/schema/schema_test.go
+++ b/sdk/go/common/esc/schema/schema_test.go
@@ -34,20 +34,24 @@ func TestUnmarshal(t *testing.T) {
 
 func TestUnmarshalNever(t *testing.T) {
 	t.Parallel()
-	var s Schema
-	err := json.Unmarshal([]byte("false"), &s)
-	require.NoError(t, err)
-	assert.True(t, s.Never)
-	assert.False(t, s.Always)
+	for _, encoding := range []string{"false", `{"not":{}}`, `{"not":true}`} {
+		var s Schema
+		err := json.Unmarshal([]byte(encoding), &s)
+		require.NoError(t, err, encoding)
+		assert.True(t, s.Never, encoding)
+		assert.False(t, s.Always, encoding)
+	}
 }
 
 func TestUnmarshalAlways(t *testing.T) {
 	t.Parallel()
-	var s Schema
-	err := json.Unmarshal([]byte("true"), &s)
-	require.NoError(t, err)
-	assert.True(t, s.Always)
-	assert.False(t, s.Never)
+	for _, encoding := range []string{"true", "{}"} {
+		var s Schema
+		err := json.Unmarshal([]byte(encoding), &s)
+		require.NoError(t, err, encoding)
+		assert.True(t, s.Always, encoding)
+		assert.False(t, s.Never, encoding)
+	}
 }
 
 func TestMarshal(t *testing.T) {
@@ -61,14 +65,22 @@ func TestMarshalNever(t *testing.T) {
 	t.Parallel()
 	bytes, err := json.Marshal(Never())
 	require.NoError(t, err)
-	assert.Equal(t, []byte("false"), bytes)
+	assert.Equal(t, []byte(`{"not":{}}`), bytes)
+
+	var s Schema
+	require.NoError(t, json.Unmarshal(bytes, &s))
+	assert.True(t, s.Never)
 }
 
 func TestMarshalAlways(t *testing.T) {
 	t.Parallel()
 	bytes, err := json.Marshal(Always())
 	require.NoError(t, err)
-	assert.Equal(t, []byte("true"), bytes)
+	assert.Equal(t, []byte(`{}`), bytes)
+
+	var s Schema
+	require.NoError(t, json.Unmarshal(bytes, &s))
+	assert.True(t, s.Always)
 }
 
 func TestItem(t *testing.T) {


### PR DESCRIPTION
## Problem

`schema.Always()` and `schema.Never()` marshal as the JSON Schema boolean forms `true`/`false`. Valid JSON Schema, but the OpenAPI model describing ESC payloads (`EscSchemaSchema`) can only express the object form, so every payload carrying one cannot be deserialized by clients generated from the spec, including the published `pulumi-cloud-sdk` Go client:

```
json: cannot unmarshal bool into Go struct field EscExpr.exprs.schema of type apitype.EscSchemaSchema
```

The evaluator emits these constantly: `Always` is the default schema for most expressions, and every array literal produces `"items": false` via `schema.Tuple`. Demonstrated by pulumi/pulumi-service#48220.

## Fix

JSON Schema defines `true` ≡ `{}` and `false` ≡ `{"not": {}}`. Marshal those object forms instead:

| | before | after |
|---|---|---|
| `Always` | `true` | `{}` |
| `Never` | `false` | `{"not": {}}` |

`Type` gains `omitempty` so the empty form is truly `{}` rather than `{"type": ""}`.

## Compatibility

- Reading accepts both encodings, and the object forms canonicalize back to `Always`/`Never`, so old payloads and this repo's golden fixtures round-trip unchanged (no fixture churn; they now double as legacy-decode coverage).
- Deployed readers degrade safely: `esc.Schema.UnmarshalJSON` ignores unknown keys, esc-sdk models schema fields as untyped, and the console does not validate. The worst case for an old reader is `{"not": {}}` decoding as an empty (permissive) schema.

## Why not `oneOf` in the spec instead

The spec pipeline cannot express `oneOf` for Java/C#. This change makes the wire match the spec that already exists, instead of changing the spec to match the wire.

## Follow-up (pulumi-service, separate PR)

`EscSchemaSchema` marks `type` required; with this change schemas can legitimately omit it, so `type` should become optional (and `not` can be declared). Not a prerequisite: generated clients do not enforce `required` on decode, so they stop crashing as soon as this deploys.

https://claude.ai/code/session_015uyMkwo97pWSMd7bHsmbu1
