### PR TITLE
Replace parver with packaging in generated Python SDKs

### DIFF
--- a/changelog/pending/sdkgen-python-improvement-20260903-155223.yaml
+++ b/changelog/pending/sdkgen-python-improvement-20260903-155223.yaml
@@ -1,0 +1,4 @@
+component: sdkgen/python
+kind: improvement
+body: Replace parver with packaging in generated Python SDKs
+time: 2026-09-03T15:52:23+02:00

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3853,8 +3853,8 @@ func calculateDeps(parameterized bool, requires map[string]string) ([][2]string,
 	// or else we'd be writing nil to the file, but since we append
 	// them here, I'd expect them to show up twice in the output file.
 	deps := []string{
+		"packaging>=24.0",
 		"semver>=2.8.1",
-		"parver>=0.2.1",
 	}
 	for dep := range requires {
 		deps = append(deps, dep)

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -316,9 +316,9 @@ func TestCalculateDeps(t *testing.T) {
 		inputDeps: map[string]string{},
 		expected: [][2]string{
 			// We expect three alphabetized deps,
-			// with semver and parver formatted differently from Pulumi.
+			// with packaging and semver formatted differently from Pulumi.
 			// Pulumi should not have a version.
-			{"parver>=0.2.1", ""},
+			{"packaging>=24.0", ""},
 			{"pulumi", ">=3.231.0,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
@@ -330,7 +330,7 @@ func TestCalculateDeps(t *testing.T) {
 		},
 		expected: [][2]string{
 			{"foobar", "7.10.8"},
-			{"parver>=0.2.1", ""},
+			{"packaging>=24.0", ""},
 			{"pulumi", ">=3.231.0,<4.0.0"},
 			{"semver>=2.8.1"},
 		},
@@ -342,8 +342,8 @@ func TestCalculateDeps(t *testing.T) {
 		},
 		expected: [][2]string{
 			// We expect three alphabetized deps,
-			// with semver and parver formatted differently from Pulumi.
-			{"parver>=0.2.1", ""},
+			// with packaging and semver formatted differently from Pulumi.
+			{"packaging>=24.0", ""},
 			{"pulumi", ">=3.0.0,<3.50.0"},
 			{"semver>=2.8.1"},
 		},

--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -14,8 +14,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -70,15 +70,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_alpha',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-handled-42.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-handled-42.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_handled',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-type-function-15.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-type-function-15.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_type_function',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_byepackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_call',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/camelNames-19.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/camelNames-19.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_camelNames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component_property_deps',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-9.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-enum-41.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-enum-41.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-grpc-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-grpc-1.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_grpc',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configurer',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/constant-43.0.0/pulumi_constant/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/constant-43.0.0/pulumi_constant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/constant-43.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/constant-43.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_constant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-31.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-31.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-many-49.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_many',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-marked-key-53.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/discriminated-union-marked-key-53.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_marked_key',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/pulumi_docs/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/pulumi_docs/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_docs',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/enum-30.0.0/pulumi_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/enum-30.0.0/pulumi_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/enum-30.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/enum-30.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extbase-45.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extbase-45.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extbase',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extenumref-32.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/extenumref-32.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extenumref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/flaky-46.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/flaky-46.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_flaky',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_goodbye',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_hipackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/index-mod-35.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/index-mod-35.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_index_mod',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/kebab-names-52.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_kebab_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/keywords-20.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/keywords-20.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_keywords',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/module-format-29.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/module-format-29.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_module_format',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/multi-argument-invoke-44.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/multi-argument-invoke-44.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_multi_argument_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/pulumi_myext/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/myext-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myext',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/names-6.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/names-6.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/namespaced-16.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='a_namespace_namespaced',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_component>=13.3.7',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedcollections-50.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedcollections-50.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedcollections',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedobject-1.42.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedobject-1.42.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedobject',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optional-primitive-ref-40.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optional-primitive-ref-40.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optional_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optionalprimitive-34.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/optionalprimitive-34.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optionalprimitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-23.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-23.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-only-invoke-24.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-only-invoke-24.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output_only_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plain-13.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plain-13.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plain',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plaincomponent-36.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plaincomponent-36.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plaincomponent',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-7.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-defaults-8.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-defaults-8.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_defaults',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-ref-11.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/read-39.0.0/pulumi_read/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/read-39.0.0/pulumi_read/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/read-39.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/read-39.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_read',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_ref_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/replaceonchanges-25.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/replaceonchanges-25.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_replaceonchanges',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/reservednames-51.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/reservednames-51.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_reservednames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/scalar-returns-21.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/scalar-returns-21.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_scalar_returns',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/secret-14.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/secret-14.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_secret',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-26.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-26.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-27.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-27.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-10.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke_with_scalar_return',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/snake_names-33.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/snake_names-33.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_snake_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_subpackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_sync',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_alpha',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-handled-42.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-handled-42.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_handled',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-type-function-15.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-type-function-15.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_type_function',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_byepackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_call',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/camelNames-19.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/camelNames-19.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_camelNames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component_property_deps',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-9.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-enum-41.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-enum-41.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-grpc-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-grpc-1.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_grpc',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configurer',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/constant-43.0.0/pulumi_constant/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/constant-43.0.0/pulumi_constant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/constant-43.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/constant-43.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_constant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-31.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-31.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-many-49.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_many',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-marked-key-53.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/discriminated-union-marked-key-53.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_marked_key',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/pulumi_docs/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/pulumi_docs/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_docs',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/enum-30.0.0/pulumi_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/enum-30.0.0/pulumi_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/enum-30.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/enum-30.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extbase-45.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extbase-45.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extbase',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extenumref-32.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/extenumref-32.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extenumref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/flaky-46.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/flaky-46.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_flaky',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_goodbye',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_hipackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/index-mod-35.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/index-mod-35.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_index_mod',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/kebab-names-52.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_kebab_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/keywords-20.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/keywords-20.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_keywords',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/module-format-29.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/module-format-29.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_module_format',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/multi-argument-invoke-44.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/multi-argument-invoke-44.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_multi_argument_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/pulumi_myext/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/myext-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myext',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/names-6.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/names-6.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/namespaced-16.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='a_namespace_namespaced',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_component>=13.3.7',
           'semver>=2.8.1'

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedcollections-50.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedcollections-50.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedcollections',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedobject-1.42.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedobject-1.42.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedobject',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optional-primitive-ref-40.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optional-primitive-ref-40.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optional_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optionalprimitive-34.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/optionalprimitive-34.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optionalprimitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-23.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-23.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-only-invoke-24.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-only-invoke-24.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output_only_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plain-13.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plain-13.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plain',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plaincomponent-36.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plaincomponent-36.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plaincomponent',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-7.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-defaults-8.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-defaults-8.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_defaults',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-ref-11.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/read-39.0.0/pulumi_read/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/read-39.0.0/pulumi_read/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/read-39.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/read-39.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_read',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_ref_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/replaceonchanges-25.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/replaceonchanges-25.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_replaceonchanges',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/reservednames-51.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/reservednames-51.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_reservednames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/scalar-returns-21.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/scalar-returns-21.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_scalar_returns',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/secret-14.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/secret-14.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_secret',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-26.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-26.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-27.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-27.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-10.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke_with_scalar_return',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/snake_names-33.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/snake_names-33.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_snake_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_subpackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_sync',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_alpha',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-handled-42.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-handled-42.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_handled',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-type-function-15.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-type-function-15.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_type_function',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/builtin-info-component-37.0.0/pulumi_builtin_info_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/builtin-info-component-37.0.0/pulumi_builtin_info_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/builtin-info-component-37.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/builtin-info-component-37.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_builtin_info_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_byepackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_call',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/camelNames-19.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/camelNames-19.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_camelNames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component_property_deps',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-9.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-enum-41.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-enum-41.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-grpc-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-grpc-1.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_grpc',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configurer',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/conformance-component-22.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/conformance-component-22.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_conformance_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/constant-43.0.0/pulumi_constant/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/constant-43.0.0/pulumi_constant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/constant-43.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/constant-43.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_constant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-31.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-31.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-many-49.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_many',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-marked-key-53.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/discriminated-union-marked-key-53.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_marked_key',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/pulumi_docs/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/pulumi_docs/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_docs',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1',

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/enum-30.0.0/pulumi_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/enum-30.0.0/pulumi_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/enum-30.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/enum-30.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extbase-45.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extbase-45.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extbase',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extenumref-32.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/extenumref-32.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extenumref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1',

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/flaky-46.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/flaky-46.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_flaky',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_goodbye',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_hipackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/index-mod-35.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/index-mod-35.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_index_mod',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/kebab-names-52.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_kebab_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/keywords-20.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/keywords-20.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_keywords',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/module-format-29.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/module-format-29.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_module_format',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/multi-argument-invoke-44.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/multi-argument-invoke-44.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_multi_argument_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/pulumi_myext/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/myext-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myext',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/names-6.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/names-6.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/namespaced-16.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='a_namespace_namespaced',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_component>=13.3.7',
           'semver>=2.8.1',

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedcollections-50.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedcollections-50.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedcollections',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedobject-1.42.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedobject-1.42.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedobject',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optional-primitive-ref-40.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optional-primitive-ref-40.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optional_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optionalprimitive-34.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/optionalprimitive-34.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optionalprimitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-23.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-23.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-only-invoke-24.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-only-invoke-24.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output_only_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plain-13.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plain-13.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plain',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plaincomponent-36.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plaincomponent-36.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plaincomponent',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-7.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-defaults-8.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-defaults-8.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_defaults',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-ref-11.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/read-39.0.0/pulumi_read/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/read-39.0.0/pulumi_read/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/read-39.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/read-39.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_read',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_ref_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/replaceonchanges-25.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/replaceonchanges-25.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_replaceonchanges',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/reservednames-51.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/reservednames-51.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_reservednames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/scalar-returns-21.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/scalar-returns-21.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_scalar_returns',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/secret-14.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/secret-14.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_secret',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-26.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-26.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-27.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-27.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-10.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke_with_scalar_return',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/snake_names-33.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/snake_names-33.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_snake_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_subpackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_sync',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_alpha',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-handled-42.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-handled-42.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_handled',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-type-function-15.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-type-function-15.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_any_type_function',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/asset-archive-5.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/asset-archive-5.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_asset_archive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/builtin-info-component-37.0.0/pulumi_builtin_info_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/builtin-info-component-37.0.0/pulumi_builtin_info_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/builtin-info-component-37.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/builtin-info-component-37.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_builtin_info_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_byepackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_call',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/camelNames-19.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/camelNames-19.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_camelNames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_component_property_deps',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-9.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-9.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-enum-41.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-enum-41.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-grpc-1.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-grpc-1.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_config_grpc',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configurer',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/conformance-component-22.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/conformance-component-22.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_conformance_component',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/constant-43.0.0/pulumi_constant/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/constant-43.0.0/pulumi_constant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/constant-43.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/constant-43.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_constant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-31.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-31.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-many-49.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_many',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-marked-key-53.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/discriminated-union-marked-key-53.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_discriminated_union_marked_key',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/pulumi_docs/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/pulumi_docs/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_docs',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1',

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/enum-30.0.0/pulumi_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/enum-30.0.0/pulumi_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/enum-30.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/enum-30.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_enum',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extbase-45.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extbase-45.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extbase',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extenumref-32.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/extenumref-32.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_extenumref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_enum>=30.0.0',
           'semver>=2.8.1',

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/fail_on_create-4.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/fail_on_create-4.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_fail_on_create',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/flaky-46.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/flaky-46.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_flaky',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_goodbye',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_hipackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/index-mod-35.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/index-mod-35.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_index_mod',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/kebab-names-52.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_kebab_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/keywords-20.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/keywords-20.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_keywords',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/large-4.3.2/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/large-4.3.2/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_large',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/module-format-29.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/module-format-29.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_module_format',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/multi-argument-invoke-44.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/multi-argument-invoke-44.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_multi_argument_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/pulumi_myext/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/myext-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myext',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/names-6.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/names-6.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/namespaced-16.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/namespaced-16.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='a_namespace_namespaced',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'pulumi_component>=13.3.7',
           'semver>=2.8.1',

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedcollections-50.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedcollections-50.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedcollections',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedobject-1.42.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedobject-1.42.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_nestedobject',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optional-primitive-ref-40.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optional-primitive-ref-40.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optional_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optionalprimitive-34.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/optionalprimitive-34.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_optionalprimitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-23.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-23.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-only-invoke-24.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-only-invoke-24.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_output_only_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plain-13.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plain-13.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plain',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plaincomponent-36.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plaincomponent-36.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plaincomponent',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-7.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-7.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-defaults-8.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-defaults-8.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_defaults',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-ref-11.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-ref-11.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_primitive_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/read-39.0.0/pulumi_read/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/read-39.0.0/pulumi_read/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/read-39.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/read-39.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_read',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_ref_ref',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/replaceonchanges-25.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/replaceonchanges-25.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_replaceonchanges',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/reservednames-51.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/reservednames-51.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_reservednames',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/scalar-returns-21.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/scalar-returns-21.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_scalar_returns',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/secret-14.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/secret-14.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_secret',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-26.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-26.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-27.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-27.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-10.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-10.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-with-scalar-return-17.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_simple_invoke_with_scalar_return',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/snake_names-33.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/snake_names-33.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_snake_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_subpackage',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.247.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_sync',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_union',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_alpha"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "3.0.0a1+internal.exp.sha.12345678"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-handled-42.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-handled-42.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_any_handled"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "42.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-type-function-15.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-type-function-15.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_any_type_function"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/asset-archive-5.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/asset-archive-5.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_asset_archive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "5.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_byepackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_call"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.7.9"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/camelNames-19.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/camelNames-19.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_camelNames"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "19.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.3.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component_property_deps"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.33.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-9.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-9.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "9.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-enum-41.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-enum-41.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config_enum"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "41.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-grpc-1.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-grpc-1.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config_grpc"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_configurer"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "38.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/constant-43.0.0/pulumi_constant/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/constant-43.0.0/pulumi_constant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/constant-43.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/constant-43.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_constant"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "43.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-31.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-31.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_discriminated_union"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "31.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-many-49.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_discriminated_union_many"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "49.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-marked-key-53.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/discriminated-union-marked-key-53.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_discriminated_union_marked_key"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "53.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pulumi_docs/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pulumi_docs/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_docs"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "28.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/enum-30.0.0/pulumi_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/enum-30.0.0/pulumi_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/enum-30.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/enum-30.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_enum"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "30.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extbase-45.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extbase-45.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_extbase"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "45.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extenumref-32.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/extenumref-32.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_extenumref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "32.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/fail_on_create-4.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/fail_on_create-4.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_fail_on_create"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/flaky-46.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/flaky-46.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_flaky"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "46.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_goodbye"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_hipackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/index-mod-35.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/index-mod-35.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_index_mod"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "35.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/kebab-names-52.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_kebab_names"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "52.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/keywords-20.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/keywords-20.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_keywords"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "20.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/large-4.3.2/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/large-4.3.2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_large"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.3.2"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/module-format-29.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/module-format-29.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_module_format"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "29.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/multi-argument-invoke-44.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/multi-argument-invoke-44.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_multi_argument_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "44.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pulumi_myext/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/myext-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_myext"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/names-6.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/names-6.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_names"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "6.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/namespaced-16.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/namespaced-16.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "a_namespace_namespaced"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "16.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedcollections-50.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedcollections-50.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_nestedcollections"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "50.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedobject-1.42.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedobject-1.42.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_nestedobject"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.42.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optional-primitive-ref-40.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optional-primitive-ref-40.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_optional_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "40.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optionalprimitive-34.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/optionalprimitive-34.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_optionalprimitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "34.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-23.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-23.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_output"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "23.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-only-invoke-24.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-only-invoke-24.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_output_only_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "24.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plain-13.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plain-13.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_plain"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plaincomponent-36.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plaincomponent-36.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_plaincomponent"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "36.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-7.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-7.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "7.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-defaults-8.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-defaults-8.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_defaults"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "8.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-ref-11.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-ref-11.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "11.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/read-39.0.0/pulumi_read/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/read-39.0.0/pulumi_read/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/read-39.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/read-39.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_read"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "39.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_ref_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "12.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/replaceonchanges-25.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/replaceonchanges-25.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_replaceonchanges"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "25.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/reservednames-51.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/reservednames-51.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_reservednames"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "51.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/scalar-returns-21.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/scalar-returns-21.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_scalar_returns"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "21.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/secret-14.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/secret-14.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_secret"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "14.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-26.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-26.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "26.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-27.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-27.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "27.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-10.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-10.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "10.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-with-scalar-return-17.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-with-scalar-return-17.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke_with_scalar_return"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "17.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/snake_names-33.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/snake_names-33.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_snake_names"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "33.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_subpackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_sync"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "3.0.0a1+internal.exp.sha.2143768"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_union"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "18.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_alpha"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "3.0.0a1+internal.exp.sha.12345678"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-handled-42.0.0/pulumi_any_handled/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-handled-42.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-handled-42.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_any_handled"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "42.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-type-function-15.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-type-function-15.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_any_type_function"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/asset-archive-5.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/asset-archive-5.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_asset_archive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "5.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_byepackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_call"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "15.7.9"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/camelNames-19.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/camelNames-19.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_camelNames"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "19.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.3.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_component_property_deps"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.33.7"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-9.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-9.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "9.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-enum-41.0.0/pulumi_config_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-enum-41.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-enum-41.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config_enum"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "41.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-grpc-1.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-grpc-1.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_config_grpc"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_configurer"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "38.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/constant-43.0.0/pulumi_constant/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/constant-43.0.0/pulumi_constant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/constant-43.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/constant-43.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_constant"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "43.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-31.0.0/pulumi_discriminated_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-31.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-31.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_discriminated_union"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "31.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pulumi_discriminated_union_many/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-many-49.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_discriminated_union_many"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "49.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-marked-key-53.0.0/pulumi_discriminated_union_marked_key/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-marked-key-53.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/discriminated-union-marked-key-53.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_discriminated_union_marked_key"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "53.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pulumi_docs/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pulumi_docs/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_docs"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "28.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/enum-30.0.0/pulumi_enum/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/enum-30.0.0/pulumi_enum/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/enum-30.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/enum-30.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_enum"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "30.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extbase-45.0.0/pulumi_extbase/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extbase-45.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extbase-45.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_extbase"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "45.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extenumref-32.0.0/pulumi_extenumref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extenumref-32.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/extenumref-32.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_extenumref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "pulumi_enum>=30.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "32.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/fail_on_create-4.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/fail_on_create-4.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_fail_on_create"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/flaky-46.0.0/pulumi_flaky/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/flaky-46.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/flaky-46.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_flaky"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "46.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_goodbye"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_hipackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/index-mod-35.0.0/pulumi_index_mod/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/index-mod-35.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/index-mod-35.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_index_mod"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "35.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pulumi_kebab_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/kebab-names-52.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_kebab_names"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "52.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/keywords-20.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/keywords-20.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_keywords"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "20.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/large-4.3.2/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/large-4.3.2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_large"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.3.2"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/module-format-29.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/module-format-29.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_module_format"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "29.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/multi-argument-invoke-44.0.0/pulumi_multi_argument_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/multi-argument-invoke-44.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/multi-argument-invoke-44.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_multi_argument_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "44.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pulumi_myext/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/myext-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_myext"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/names-6.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/names-6.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_names"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "6.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/namespaced-16.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/namespaced-16.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "a_namespace_namespaced"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "pulumi_component>=13.3.7", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "16.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedcollections-50.0.0/pulumi_nestedcollections/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedcollections-50.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedcollections-50.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_nestedcollections"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "50.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedobject-1.42.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedobject-1.42.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_nestedobject"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "1.42.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optional-primitive-ref-40.0.0/pulumi_optional_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optional-primitive-ref-40.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optional-primitive-ref-40.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_optional_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "40.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optionalprimitive-34.0.0/pulumi_optionalprimitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optionalprimitive-34.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/optionalprimitive-34.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_optionalprimitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "34.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-23.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-23.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_output"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "23.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-only-invoke-24.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-only-invoke-24.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_output_only_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "24.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plain-13.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plain-13.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_plain"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "13.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plaincomponent-36.0.0/pulumi_plaincomponent/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plaincomponent-36.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plaincomponent-36.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_plaincomponent"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "36.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-7.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-7.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "7.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-defaults-8.0.0/pulumi_primitive_defaults/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-defaults-8.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-defaults-8.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_defaults"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "8.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-ref-11.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-ref-11.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_primitive_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "11.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/read-39.0.0/pulumi_read/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/read-39.0.0/pulumi_read/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/read-39.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/read-39.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_read"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "39.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_ref_ref"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "12.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/replaceonchanges-25.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/replaceonchanges-25.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_replaceonchanges"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "25.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/reservednames-51.0.0/pulumi_reservednames/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/reservednames-51.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/reservednames-51.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_reservednames"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "51.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/scalar-returns-21.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/scalar-returns-21.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_scalar_returns"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "21.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/secret-14.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/secret-14.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_secret"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "14.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-26.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-26.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "26.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-27.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-27.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "27.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-10.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-10.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "10.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-with-scalar-return-17.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-with-scalar-return-17.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_simple_invoke_with_scalar_return"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "17.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/snake_names-33.0.0/pulumi_snake_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/snake_names-33.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/snake_names-33.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_snake_names"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "33.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_subpackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.247.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_sync"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "3.0.0a1+internal.exp.sha.2143768"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_union"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "18.0.0"

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/assets-and-archives/python/setup.py
+++ b/tests/testdata/codegen/assets-and-archives/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/azure-native-nested-types/python/setup.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/setup.py
@@ -38,7 +38,7 @@ setup(name='pulumi_azure_native',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/cyclic-types/python/setup.py
+++ b/tests/testdata/codegen/cyclic-types/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/dash-named-schema/python/setup.py
+++ b/tests/testdata/codegen/dash-named-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo_bar',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/dashed-import-schema/python/setup.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/different-enum/python/setup.py
+++ b/tests/testdata/codegen/different-enum/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/embedded-crd-types/python/setup.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-tls>=4.0.0,<5.0.0',
           'semver>=2.8.1',

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/external-python-same-module-name/python/setup.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-goalias>=1.0.0,<2.0.0',
           'semver>=2.8.1',

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/external-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/external-resource-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/hyphen-url/python/setup.py
+++ b/tests/testdata/codegen/hyphen-url/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_registrygeoreplication',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'pulumi-using-dashes>=1.0.0,<2.0.0',
           'semver>=2.8.1',

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/hyphenated-symbols/python/setup.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_repro',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/kubernetes20/python/pyproject.toml
+++ b/tests/testdata/codegen/kubernetes20/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_kubernetes"
   description = "A Pulumi package for creating and managing Kubernetes resources."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.25.0,<4.0.0", "requests>=2.21,<3.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.25.0,<4.0.0", "requests>=2.21,<3.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   keywords = ["pulumi", "kubernetes", "category/cloud", "kind/native"]
   readme = "README.md"
   requires-python = ">=3.9"

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/legacy-names/python/setup.py
+++ b/tests/testdata/codegen/legacy-names/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_legacy_names',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_metaprovider',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/naming-collisions/python/setup.py
+++ b/tests/testdata/codegen/naming-collisions/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/nested-module-thirdparty/python/setup.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/setup.py
@@ -31,7 +31,7 @@ setup(name='foo_bar',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/nested-module/python/setup.py
+++ b/tests/testdata/codegen/nested-module/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_myedgeorder',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/output-funcs/python/setup.py
+++ b/tests/testdata/codegen/output-funcs/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mypkg',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/plain-and-default/python/setup.py
+++ b/tests/testdata/codegen/plain-and-default/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foobar',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/plain-object-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/provider-config-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-config-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_configstation',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/provider-type-schema/python/setup.py
+++ b/tests/testdata/codegen/provider-type-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_providerType',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/setup.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_typedDictDisabledExample',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1',
           'third-party>=0.1.0,<0.2.0'

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_typedDictExample"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "third-party>=0.1.0,<0.2.0", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "third-party>=0.1.0,<0.2.0", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "0.0.0"

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/setup.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_typedDictExample',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1',
           'third-party>=0.1.0,<0.2.0',

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-8403/python/setup.py
+++ b/tests/testdata/codegen/regress-8403/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_mongodbatlas',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-node-8110/python/setup.py
+++ b/tests/testdata/codegen/regress-node-8110/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_my8110',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-py-12546/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12546/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_plant',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-py-12980/python/setup.py
+++ b/tests/testdata/codegen/regress-py-12980/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_myPkg',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-py-14012/python/setup.py
+++ b/tests/testdata/codegen/regress-py-14012/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_foo',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-py-14539/python/pyproject.toml
+++ b/tests/testdata/codegen/regress-py-14539/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_gcp"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "0.0.0"

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-py-17219/python/pyproject.toml
+++ b/tests/testdata/codegen/regress-py-17219/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_cloudinit"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "0.0.1"

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/setup.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_aws',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.0.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/resource-args-python/python/setup.py
+++ b/tests/testdata/codegen/resource-args-python/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/resource-property-overlap/python/setup.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-methods-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -31,7 +31,7 @@ setup(name='custom_py_package',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-resource-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_example"
   description = "This is a test package for pyproject.toml"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["packaging>=24.0", "pulumi>=3.231.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   keywords = ["Testing", "Pulumipus"]
   readme = "README.md"
   requires-python = ">=3.9"

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/simple-yaml-schema/python/setup.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_example',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/urn-id-properties/python/setup.py
+++ b/tests/testdata/codegen/urn-id-properties/python/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_urnid',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
@@ -18,8 +18,8 @@ import pulumi
 import pulumi.runtime
 from pulumi.runtime.sync_await import _sync_await
 
+from packaging.version import Version as PEP440Version
 from semver import VersionInfo as SemverVersion
-from parver import Version as PEP440Version
 
 C = typing.TypeVar("C", bound=typing.Callable)
 
@@ -74,15 +74,17 @@ def _get_semver_version():
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
 
     pep440_version_string = importlib.metadata.version(root_package)
-    pep440_version = PEP440Version.parse(pep440_version_string)
+    pep440_version = PEP440Version(pep440_version_string)
     (major, minor, patch) = pep440_version.release
     prerelease = None
-    if pep440_version.pre_tag == 'a':
-        prerelease = f"alpha.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'b':
-        prerelease = f"beta.{pep440_version.pre}"
-    elif pep440_version.pre_tag == 'rc':
-        prerelease = f"rc.{pep440_version.pre}"
+    if pep440_version.pre is not None:
+        pre_tag, pre_number = pep440_version.pre
+        if pre_tag == 'a':
+            prerelease = f"alpha.{pre_number}"
+        elif pre_tag == 'b':
+            prerelease = f"beta.{pre_number}"
+        elif pre_tag == 'rc':
+            prerelease = f"rc.{pre_number}"
     elif pep440_version.dev is not None:
         # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other

--- a/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/setup.py
@@ -31,7 +31,7 @@ setup(name='pulumi_credentials',
           ]
       },
       install_requires=[
-          'parver>=0.2.1',
+          'packaging>=24.0',
           'pulumi>=3.231.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'


### PR DESCRIPTION
[packaging](https://pypi.org/project/packaging/) is the pretty much official way to deal with python version numbers. We already depend on this for the core SDK, let’s use it in the generated SDKs too.

Fixes https://github.com/pulumi/pulumi/issues/21630
