### PR TITLE
Serialise the resource diff when --diff and --output json are combined

### DIFF
--- a/changelog/pending/cli-display-feat-20260903-114029.yaml
+++ b/changelog/pending/cli-display-feat-20260903-114029.yaml
@@ -1,0 +1,4 @@
+component: cli/display
+kind: feat
+body: Include the resource property diff in `--output json` when `--diff` is also set
+time: 2026-09-03T11:40:29.656895+02:00

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -443,21 +443,8 @@ func renderDiff(
 	// An OpSame might have a diff due to metadata changes (e.g. protect) but we should never print a property diff,
 	// even if the properties appear to have changed. See https://github.com/pulumi/pulumi/issues/15944 for context.
 	if metadata.Op != deploy.OpSame {
-		if metadata.DetailedDiff != nil {
-			var buf bytes.Buffer
-			if diff, hidden := engine.TranslateDetailedDiff(&metadata, refresh); diff != nil {
-				PrintObjectDiff(&buf, *diff, nil /*include*/, planning, indent+1,
-					opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets, hidden)
-			} else {
-				PrintObject(
-					&buf, metadata.Old.Inputs, planning, indent+1, deploy.OpSame, true, /*prefix*/
-					opts.TruncateOutput, debug, opts.ShowSecrets)
-			}
-			details = buf.String()
-		} else {
-			details = getResourcePropertiesDetails(
-				metadata, indent, planning, opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets)
-		}
+		details = getResourcePropertiesDetails(
+			metadata, indent, planning, refresh, opts.SummaryDiff, opts.TruncateOutput, debug, opts.ShowSecrets)
 	}
 	fprintIgnoreError(out, opts.Color.Colorize(summary))
 	fprintIgnoreError(out, opts.Color.Colorize(details))

--- a/pkg/backend/display/diff_json.go
+++ b/pkg/backend/display/diff_json.go
@@ -31,8 +31,8 @@ import (
 // structure the `--diff` view renders as text, emitted when `--diff` and
 // `--output json` are combined.
 type ObjectDiffJSON struct {
-	// Adds holds the properties present only in the new value.
-	Adds map[string]any `json:"adds,omitempty"`
+	// Creates holds the properties present only in the new value.
+	Creates map[string]any `json:"creates,omitempty"`
 	// Deletes holds the properties present only in the old value.
 	Deletes map[string]any `json:"deletes,omitempty"`
 	// Sames holds the properties that did not change.
@@ -60,8 +60,8 @@ type ValueDiffJSON struct {
 // ArrayDiffJSON is the JSON projection of a resource.ArrayDiff. Its maps are
 // keyed by array index.
 type ArrayDiffJSON struct {
-	// Adds holds the elements present only in the new array.
-	Adds map[int]any `json:"adds,omitempty"`
+	// Creates holds the elements present only in the new array.
+	Creates map[int]any `json:"creates,omitempty"`
 	// Deletes holds the elements present only in the old array.
 	Deletes map[int]any `json:"deletes,omitempty"`
 	// Sames holds the elements that did not change.
@@ -115,7 +115,7 @@ func (e diffJSONEncoder) objectDiff(diff *resource.ObjectDiff) *ObjectDiffJSON {
 		return nil
 	}
 	out := &ObjectDiffJSON{
-		Adds:    e.values(diff.Adds),
+		Creates: e.values(diff.Adds),
 		Deletes: e.values(diff.Deletes),
 		Sames:   e.values(diff.Sames),
 	}
@@ -141,7 +141,7 @@ func (e diffJSONEncoder) valueDiff(diff resource.ValueDiff) ValueDiffJSON {
 
 func (e diffJSONEncoder) arrayDiff(diff *resource.ArrayDiff) *ArrayDiffJSON {
 	out := &ArrayDiffJSON{
-		Adds:    e.elements(diff.Adds),
+		Creates: e.elements(diff.Adds),
 		Deletes: e.elements(diff.Deletes),
 		Sames:   e.elements(diff.Sames),
 	}

--- a/pkg/backend/display/diff_json.go
+++ b/pkg/backend/display/diff_json.go
@@ -27,16 +27,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// ObjectDiffJSON is the JSON projection of a resource.ObjectDiff: the same
-// structure the `--diff` view renders as text, emitted when `--diff` and
-// `--output json` are combined.
+// ObjectDiffJSON is the JSON projection of a resource.ObjectDiff, emitted when
+// `--diff` and `--output json` are combined. It keeps the nesting the `--diff`
+// view renders as text, but reports only what changed: unchanged properties,
+// which that view prints as context, are omitted.
 type ObjectDiffJSON struct {
 	// Creates holds the properties present only in the new value.
 	Creates map[string]any `json:"creates,omitempty"`
 	// Deletes holds the properties present only in the old value.
 	Deletes map[string]any `json:"deletes,omitempty"`
-	// Sames holds the properties that did not change.
-	Sames map[string]any `json:"sames,omitempty"`
 	// Updates holds the properties that changed, keyed by property name.
 	Updates map[string]ValueDiffJSON `json:"updates,omitempty"`
 	// Hidden lists property paths whose diffs were withheld from this object.
@@ -64,8 +63,6 @@ type ArrayDiffJSON struct {
 	Creates map[int]any `json:"creates,omitempty"`
 	// Deletes holds the elements present only in the old array.
 	Deletes map[int]any `json:"deletes,omitempty"`
-	// Sames holds the elements that did not change.
-	Sames map[int]any `json:"sames,omitempty"`
 	// Updates holds the elements that changed.
 	Updates map[int]ValueDiffJSON `json:"updates,omitempty"`
 }
@@ -117,7 +114,6 @@ func (e diffJSONEncoder) objectDiff(diff *resource.ObjectDiff) *ObjectDiffJSON {
 	out := &ObjectDiffJSON{
 		Creates: e.values(diff.Adds),
 		Deletes: e.values(diff.Deletes),
-		Sames:   e.values(diff.Sames),
 	}
 	if len(diff.Updates) > 0 {
 		out.Updates = make(map[string]ValueDiffJSON, len(diff.Updates))
@@ -143,7 +139,6 @@ func (e diffJSONEncoder) arrayDiff(diff *resource.ArrayDiff) *ArrayDiffJSON {
 	out := &ArrayDiffJSON{
 		Creates: e.elements(diff.Adds),
 		Deletes: e.elements(diff.Deletes),
-		Sames:   e.elements(diff.Sames),
 	}
 	if len(diff.Updates) > 0 {
 		out.Updates = make(map[int]ValueDiffJSON, len(diff.Updates))

--- a/pkg/backend/display/diff_json.go
+++ b/pkg/backend/display/diff_json.go
@@ -1,0 +1,279 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// ObjectDiffJSON is the JSON projection of a resource.ObjectDiff: the same
+// structure the `--diff` view renders as text, emitted when `--diff` and
+// `--output json` are combined.
+type ObjectDiffJSON struct {
+	// Adds holds the properties present only in the new value.
+	Adds map[string]any `json:"adds,omitempty"`
+	// Deletes holds the properties present only in the old value.
+	Deletes map[string]any `json:"deletes,omitempty"`
+	// Sames holds the properties that did not change.
+	Sames map[string]any `json:"sames,omitempty"`
+	// Updates holds the properties that changed, keyed by property name.
+	Updates map[string]ValueDiffJSON `json:"updates,omitempty"`
+	// Hidden lists property paths whose diffs were withheld from this object.
+	Hidden []string `json:"hidden,omitempty"`
+}
+
+// ValueDiffJSON is the JSON projection of a resource.ValueDiff. Exactly one of
+// Array, Object, or the Old/New pair is populated, matching the shape of the
+// value that changed.
+type ValueDiffJSON struct {
+	// Old is the previous value, for a change between two non-composite values.
+	Old *any `json:"old,omitempty"`
+	// New is the replacement value, for a change between two non-composite values.
+	New *any `json:"new,omitempty"`
+	// Array is the element-wise diff, when both values are arrays.
+	Array *ArrayDiffJSON `json:"array,omitempty"`
+	// Object is the property-wise diff, when both values are objects.
+	Object *ObjectDiffJSON `json:"object,omitempty"`
+}
+
+// ArrayDiffJSON is the JSON projection of a resource.ArrayDiff. Its maps are
+// keyed by array index.
+type ArrayDiffJSON struct {
+	// Adds holds the elements present only in the new array.
+	Adds map[int]any `json:"adds,omitempty"`
+	// Deletes holds the elements present only in the old array.
+	Deletes map[int]any `json:"deletes,omitempty"`
+	// Sames holds the elements that did not change.
+	Sames map[int]any `json:"sames,omitempty"`
+	// Updates holds the elements that changed.
+	Updates map[int]ValueDiffJSON `json:"updates,omitempty"`
+}
+
+// diffJSONEncoder converts property values to their JSON representation, using
+// the same blinding encrypter the streaming `--json` event display uses so that
+// secrets do not leak into the output.
+type diffJSONEncoder struct {
+	ctx         context.Context
+	enc         config.Encrypter
+	showSecrets bool
+}
+
+func newDiffJSONEncoder(showSecrets bool) diffJSONEncoder {
+	return diffJSONEncoder{
+		ctx:         context.TODO(),
+		enc:         config.BlindingCrypter,
+		showSecrets: showSecrets,
+	}
+}
+
+func (e diffJSONEncoder) value(v resource.PropertyValue) *any {
+	out, err := stack.SerializePropertyValue(e.ctx, v, e.enc, e.showSecrets)
+	contract.IgnoreError(err)
+	return &out
+}
+
+func (e diffJSONEncoder) values(m resource.PropertyMap) map[string]any {
+	out, err := stack.SerializeProperties(e.ctx, m, e.enc, e.showSecrets)
+	contract.IgnoreError(err)
+	return out
+}
+
+func (e diffJSONEncoder) elements(m map[int]resource.PropertyValue) map[int]any {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[int]any, len(m))
+	for i, v := range m {
+		out[i] = *e.value(v)
+	}
+	return out
+}
+
+func (e diffJSONEncoder) objectDiff(diff *resource.ObjectDiff) *ObjectDiffJSON {
+	if diff == nil {
+		return nil
+	}
+	out := &ObjectDiffJSON{
+		Adds:    e.values(diff.Adds),
+		Deletes: e.values(diff.Deletes),
+		Sames:   e.values(diff.Sames),
+	}
+	if len(diff.Updates) > 0 {
+		out.Updates = make(map[string]ValueDiffJSON, len(diff.Updates))
+		for k, v := range diff.Updates {
+			out.Updates[string(k)] = e.valueDiff(v)
+		}
+	}
+	return out
+}
+
+func (e diffJSONEncoder) valueDiff(diff resource.ValueDiff) ValueDiffJSON {
+	switch {
+	case diff.Array != nil:
+		return ValueDiffJSON{Array: e.arrayDiff(diff.Array)}
+	case diff.Object != nil:
+		return ValueDiffJSON{Object: e.objectDiff(diff.Object)}
+	default:
+		return ValueDiffJSON{Old: e.value(diff.Old), New: e.value(diff.New)}
+	}
+}
+
+func (e diffJSONEncoder) arrayDiff(diff *resource.ArrayDiff) *ArrayDiffJSON {
+	out := &ArrayDiffJSON{
+		Adds:    e.elements(diff.Adds),
+		Deletes: e.elements(diff.Deletes),
+		Sames:   e.elements(diff.Sames),
+	}
+	if len(diff.Updates) > 0 {
+		out.Updates = make(map[int]ValueDiffJSON, len(diff.Updates))
+		for i, v := range diff.Updates {
+			out.Updates[i] = e.valueDiff(v)
+		}
+	}
+	return out
+}
+
+// stepObjectDiff computes the property diff a step displays, mirroring the
+// selection renderDiff makes: the provider's detailed diff when it supplied
+// one, and a structural diff of the step's old and new state otherwise. It also
+// returns the top-level keys the diff should be restricted to, if any, and the
+// property paths whose diffs are hidden.
+func stepObjectDiff(
+	step engine.StepEventMetadata,
+) (*resource.ObjectDiff, []resource.PropertyKey, []resource.PropertyPath) {
+	// An OpSame may carry a metadata change (e.g. protect) but never a property diff.
+	if step.Op == deploy.OpSame {
+		return nil, nil, nil
+	}
+
+	if step.DetailedDiff != nil && step.Old != nil && step.New != nil {
+		diff, hidden := engine.TranslateDetailedDiff(&step, false /* refresh */)
+		return diff, nil, hidden
+	}
+
+	var hidePaths []resource.PropertyPath
+	if step.New != nil {
+		hidePaths = step.New.HideDiffs
+	} else if step.Old != nil {
+		hidePaths = step.Old.HideDiffs
+	}
+
+	var hidden []resource.PropertyPath
+	opts := []resource.DiffOption{
+		resource.IgnoreKeyFunc(resource.IsInternalPropertyKey),
+		resource.IgnorePathFunc(func(path resource.PropertyPath) bool {
+			for _, v := range hidePaths {
+				if v.Contains(path) {
+					hidden = append(hidden, v)
+					return true
+				}
+			}
+			return false
+		}),
+	}
+
+	old, new := step.Old, step.New
+	switch {
+	case old == nil && new == nil:
+		return nil, nil, nil
+	case old == nil:
+		news := new.Inputs
+		if len(new.Outputs) > 0 {
+			news = new.Outputs
+		}
+		return resource.PropertyMap{}.DiffWithOptions(news, opts...), nil, hidden
+	case new == nil:
+		return old.Inputs.DiffWithOptions(nil, opts...), nil, hidden
+	case len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement:
+		return old.Outputs.DiffWithOptions(new.Outputs, opts...), nil, hidden
+	default:
+		return old.Inputs.DiffWithOptions(new.Inputs, opts...), step.Diffs, hidden
+	}
+}
+
+// filterObjectDiff restricts a diff to the given top-level keys, matching the
+// filtering printObjectDiff applies when a step reports its changed keys.
+func filterObjectDiff(diff *resource.ObjectDiff, include []resource.PropertyKey) *resource.ObjectDiff {
+	if diff == nil || include == nil {
+		return diff
+	}
+
+	keep := make(map[resource.PropertyKey]bool, len(include))
+	for _, k := range include {
+		keep[k] = true
+	}
+
+	filterMap := func(m resource.PropertyMap) resource.PropertyMap {
+		out := make(resource.PropertyMap, len(m))
+		for k, v := range m {
+			if keep[k] {
+				out[k] = v
+			}
+		}
+		return out
+	}
+
+	out := &resource.ObjectDiff{
+		Adds:    filterMap(diff.Adds),
+		Deletes: filterMap(diff.Deletes),
+		Sames:   filterMap(diff.Sames),
+		Updates: make(map[resource.PropertyKey]resource.ValueDiff, len(diff.Updates)),
+	}
+	for k, v := range diff.Updates {
+		if keep[k] {
+			out.Updates[k] = v
+		}
+	}
+	return out
+}
+
+// stepDiffJSON renders a step's property diff as JSON, or nil when the step has
+// no diff to show.
+func stepDiffJSON(step engine.StepEventMetadata, showSecrets bool) *ObjectDiffJSON {
+	diff, include, hidden := stepObjectDiff(step)
+	diff = filterObjectDiff(diff, include)
+	if diff == nil && len(hidden) == 0 {
+		return nil
+	}
+
+	out := newDiffJSONEncoder(showSecrets).objectDiff(diff)
+	if out == nil {
+		out = &ObjectDiffJSON{}
+	}
+	for _, p := range sortedUniquePaths(hidden) {
+		out.Hidden = append(out.Hidden, p.String())
+	}
+	return out
+}
+
+// sortedUniquePaths sorts property paths and removes duplicates, so that hidden
+// paths are reported deterministically.
+func sortedUniquePaths(paths []resource.PropertyPath) []resource.PropertyPath {
+	slices.SortFunc(paths, func(a, b resource.PropertyPath) int {
+		return cmp.Compare(a.String(), b.String())
+	})
+	return slices.CompactFunc(paths, func(a, b resource.PropertyPath) bool {
+		return a.String() == b.String()
+	})
+}

--- a/pkg/backend/display/diff_json.go
+++ b/pkg/backend/display/diff_json.go
@@ -20,7 +20,6 @@ import (
 	"slices"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -149,64 +148,6 @@ func (e diffJSONEncoder) arrayDiff(diff *resource.ArrayDiff) *ArrayDiffJSON {
 	return out
 }
 
-// stepObjectDiff computes the property diff a step displays, mirroring the
-// selection renderDiff makes: the provider's detailed diff when it supplied
-// one, and a structural diff of the step's old and new state otherwise. It also
-// returns the top-level keys the diff should be restricted to, if any, and the
-// property paths whose diffs are hidden.
-func stepObjectDiff(
-	step engine.StepEventMetadata,
-) (*resource.ObjectDiff, []resource.PropertyKey, []resource.PropertyPath) {
-	// An OpSame may carry a metadata change (e.g. protect) but never a property diff.
-	if step.Op == deploy.OpSame {
-		return nil, nil, nil
-	}
-
-	if step.DetailedDiff != nil && step.Old != nil && step.New != nil {
-		diff, hidden := engine.TranslateDetailedDiff(&step, false /* refresh */)
-		return diff, nil, hidden
-	}
-
-	var hidePaths []resource.PropertyPath
-	if step.New != nil {
-		hidePaths = step.New.HideDiffs
-	} else if step.Old != nil {
-		hidePaths = step.Old.HideDiffs
-	}
-
-	var hidden []resource.PropertyPath
-	opts := []resource.DiffOption{
-		resource.IgnoreKeyFunc(resource.IsInternalPropertyKey),
-		resource.IgnorePathFunc(func(path resource.PropertyPath) bool {
-			for _, v := range hidePaths {
-				if v.Contains(path) {
-					hidden = append(hidden, v)
-					return true
-				}
-			}
-			return false
-		}),
-	}
-
-	old, new := step.Old, step.New
-	switch {
-	case old == nil && new == nil:
-		return nil, nil, nil
-	case old == nil:
-		news := new.Inputs
-		if len(new.Outputs) > 0 {
-			news = new.Outputs
-		}
-		return resource.PropertyMap{}.DiffWithOptions(news, opts...), nil, hidden
-	case new == nil:
-		return old.Inputs.DiffWithOptions(nil, opts...), nil, hidden
-	case len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement:
-		return old.Outputs.DiffWithOptions(new.Outputs, opts...), nil, hidden
-	default:
-		return old.Inputs.DiffWithOptions(new.Inputs, opts...), step.Diffs, hidden
-	}
-}
-
 // filterObjectDiff restricts a diff to the given top-level keys, matching the
 // filtering printObjectDiff applies when a step reports its changed keys.
 func filterObjectDiff(diff *resource.ObjectDiff, include []resource.PropertyKey) *resource.ObjectDiff {
@@ -246,7 +187,8 @@ func filterObjectDiff(diff *resource.ObjectDiff, include []resource.PropertyKey)
 // stepDiffJSON renders a step's property diff as JSON, or nil when the step has
 // no diff to show.
 func stepDiffJSON(step engine.StepEventMetadata, showSecrets bool) *ObjectDiffJSON {
-	diff, include, hidden := stepObjectDiff(step)
+	olds, news, include := stepDiffOperands(step)
+	diff, hidden := stepObjectDiff(step, olds, news, false /* refresh */, stepHidePaths(step))
 	diff = filterObjectDiff(diff, include)
 	if diff == nil && len(hidden) == 0 {
 		return nil
@@ -256,7 +198,7 @@ func stepDiffJSON(step engine.StepEventMetadata, showSecrets bool) *ObjectDiffJS
 	if out == nil {
 		out = &ObjectDiffJSON{}
 	}
-	for _, p := range sortedUniquePaths(hidden) {
+	for _, p := range hidden {
 		out.Hidden = append(out.Hidden, p.String())
 	}
 	return out

--- a/pkg/backend/display/diff_json_test.go
+++ b/pkg/backend/display/diff_json_test.go
@@ -38,7 +38,7 @@ func TestStepDiffJSON_SameHasNoDiff(t *testing.T) {
 	assert.Nil(t, stepDiffJSON(step, false))
 }
 
-func TestStepDiffJSON_CreateIsAllAdds(t *testing.T) {
+func TestStepDiffJSON_CreateIsAllCreates(t *testing.T) {
 	t.Parallel()
 
 	step := engine.StepEventMetadata{
@@ -50,7 +50,7 @@ func TestStepDiffJSON_CreateIsAllAdds(t *testing.T) {
 
 	got := stepDiffJSON(step, false)
 	require.NotNil(t, got)
-	assert.Equal(t, map[string]any{"bucket": "mybucket"}, got.Adds)
+	assert.Equal(t, map[string]any{"bucket": "mybucket"}, got.Creates)
 	assert.Empty(t, got.Deletes)
 	assert.Empty(t, got.Updates)
 }
@@ -68,7 +68,7 @@ func TestStepDiffJSON_DeleteIsAllDeletes(t *testing.T) {
 	got := stepDiffJSON(step, false)
 	require.NotNil(t, got)
 	assert.Equal(t, map[string]any{"bucket": "mybucket"}, got.Deletes)
-	assert.Empty(t, got.Adds)
+	assert.Empty(t, got.Creates)
 }
 
 func TestStepDiffJSON_UpdateUsesDetailedDiff(t *testing.T) {
@@ -98,12 +98,12 @@ func TestStepDiffJSON_UpdateUsesDetailedDiff(t *testing.T) {
 	got := stepDiffJSON(step, false)
 	require.NotNil(t, got)
 
-	assert.Equal(t, map[string]any{"versioning": true}, got.Adds)
+	assert.Equal(t, map[string]any{"versioning": true}, got.Creates)
 
 	tags, ok := got.Updates["tags"]
 	require.True(t, ok, "expected a nested diff for tags")
 	require.NotNil(t, tags.Object)
-	assert.Equal(t, map[string]any{"env": "prod"}, tags.Object.Adds)
+	assert.Equal(t, map[string]any{"env": "prod"}, tags.Object.Creates)
 
 	owner, ok := tags.Object.Updates["owner"]
 	require.True(t, ok)

--- a/pkg/backend/display/diff_json_test.go
+++ b/pkg/backend/display/diff_json_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStepDiffJSON_SameHasNoDiff(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op:  deploy.OpSame,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"a": resource.NewProperty("1")}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"a": resource.NewProperty("2")}},
+	}
+
+	assert.Nil(t, stepDiffJSON(step, false))
+}
+
+func TestStepDiffJSON_CreateIsAllAdds(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op: deploy.OpCreate,
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"bucket": resource.NewProperty("mybucket"),
+		}},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]any{"bucket": "mybucket"}, got.Adds)
+	assert.Empty(t, got.Deletes)
+	assert.Empty(t, got.Updates)
+}
+
+func TestStepDiffJSON_DeleteIsAllDeletes(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op: deploy.OpDelete,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"bucket": resource.NewProperty("mybucket"),
+		}},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]any{"bucket": "mybucket"}, got.Deletes)
+	assert.Empty(t, got.Adds)
+}
+
+func TestStepDiffJSON_UpdateUsesDetailedDiff(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"owner": resource.NewProperty("tom"),
+			}),
+		}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"tags": resource.NewProperty(resource.PropertyMap{
+				"owner": resource.NewProperty("tim"),
+				"env":   resource.NewProperty("prod"),
+			}),
+			"versioning": resource.NewProperty(true),
+		}},
+		DetailedDiff: map[string]plugin.PropertyDiff{
+			"tags.owner": {Kind: plugin.DiffUpdate, InputDiff: true},
+			"tags.env":   {Kind: plugin.DiffAdd, InputDiff: true},
+			"versioning": {Kind: plugin.DiffAdd, InputDiff: true},
+		},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got)
+
+	assert.Equal(t, map[string]any{"versioning": true}, got.Adds)
+
+	tags, ok := got.Updates["tags"]
+	require.True(t, ok, "expected a nested diff for tags")
+	require.NotNil(t, tags.Object)
+	assert.Equal(t, map[string]any{"env": "prod"}, tags.Object.Adds)
+
+	owner, ok := tags.Object.Updates["owner"]
+	require.True(t, ok)
+	require.NotNil(t, owner.Old)
+	require.NotNil(t, owner.New)
+	assert.Equal(t, "tom", *owner.Old)
+	assert.Equal(t, "tim", *owner.New)
+}
+
+func TestStepDiffJSON_SecretsAreBlinded(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op: deploy.OpCreate,
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"password": resource.MakeSecret(resource.NewProperty("hunter2")),
+		}},
+	}
+
+	encoded, err := json.Marshal(stepDiffJSON(step, false /* showSecrets */))
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "hunter2")
+}
+
+func TestStepDiffJSON_HiddenPathsAreReportedNotLeaked(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"secretish": resource.NewProperty("before"),
+			"plain":     resource.NewProperty("a"),
+		}},
+		New: &engine.StepEventStateMetadata{
+			Inputs: resource.PropertyMap{
+				"secretish": resource.NewProperty("after"),
+				"plain":     resource.NewProperty("b"),
+			},
+			HideDiffs: []resource.PropertyPath{{"secretish"}},
+		},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"secretish"}, got.Hidden)
+	assert.NotContains(t, got.Updates, "secretish")
+	assert.Contains(t, got.Updates, "plain")
+}

--- a/pkg/backend/display/diff_json_test.go
+++ b/pkg/backend/display/diff_json_test.go
@@ -128,27 +128,119 @@ func TestStepDiffJSON_SecretsAreBlinded(t *testing.T) {
 	assert.NotContains(t, string(encoded), "hunter2")
 }
 
-func TestStepDiffJSON_HiddenPathsAreReportedNotLeaked(t *testing.T) {
+// HideDiffs is a resource option set by the program (e.g. Go's
+// pulumi.HideDiffs([]string{"password"})). It travels to the display as
+// StepEventStateMetadata.HideDiffs, and the text view prints `password (hidden)`
+// in place of the before/after values. These tests cover the JSON equivalent.
+
+func TestStepDiffJSON_HiddenPathIsReportedNotLeaked(t *testing.T) {
 	t.Parallel()
 
+	// A structural diff (no provider detailed diff) over two changed properties,
+	// one of which the program asked to hide.
 	step := engine.StepEventMetadata{
 		Op: deploy.OpUpdate,
 		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
-			"secretish": resource.NewProperty("before"),
-			"plain":     resource.NewProperty("a"),
+			"password": resource.NewProperty("before"),
+			"plain":    resource.NewProperty("a"),
 		}},
 		New: &engine.StepEventStateMetadata{
 			Inputs: resource.PropertyMap{
-				"secretish": resource.NewProperty("after"),
-				"plain":     resource.NewProperty("b"),
+				"password": resource.NewProperty("after"),
+				"plain":    resource.NewProperty("b"),
 			},
-			HideDiffs: []resource.PropertyPath{{"secretish"}},
+			HideDiffs: []resource.PropertyPath{{"password"}},
 		},
 	}
 
 	got := stepDiffJSON(step, false)
 	require.NotNil(t, got)
-	assert.Equal(t, []string{"secretish"}, got.Hidden)
-	assert.NotContains(t, got.Updates, "secretish")
+	assert.Equal(t, []string{"password"}, got.Hidden)
 	assert.Contains(t, got.Updates, "plain")
+	assert.NotContains(t, got.Updates, "password")
+
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "before")
+	assert.NotContains(t, string(encoded), "after")
+}
+
+func TestStepDiffJSON_HiddenPathIsReportedFromDetailedDiff(t *testing.T) {
+	t.Parallel()
+
+	// The same option, but on the path where the provider supplied a detailed
+	// diff: TranslateDetailedDiff drops the hidden path and reports it instead.
+	step := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"password": resource.NewProperty("before"),
+			"plain":    resource.NewProperty("a"),
+		}},
+		New: &engine.StepEventStateMetadata{
+			Inputs: resource.PropertyMap{
+				"password": resource.NewProperty("after"),
+				"plain":    resource.NewProperty("b"),
+			},
+			HideDiffs: []resource.PropertyPath{{"password"}},
+		},
+		DetailedDiff: map[string]plugin.PropertyDiff{
+			"password": {Kind: plugin.DiffUpdate, InputDiff: true},
+			"plain":    {Kind: plugin.DiffUpdate, InputDiff: true},
+		},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"password"}, got.Hidden)
+	assert.Contains(t, got.Updates, "plain")
+	assert.NotContains(t, got.Updates, "password")
+}
+
+func TestStepDiffJSON_HiddenPathIsReportedWhenItIsTheOnlyChange(t *testing.T) {
+	t.Parallel()
+
+	// Hiding the only changed property leaves no diff to report, but the step
+	// still changed. The entry says a diff was withheld rather than vanishing,
+	// which would otherwise read as "nothing changed".
+	step := engine.StepEventMetadata{
+		Op: deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{
+			"password": resource.NewProperty("before"),
+		}},
+		New: &engine.StepEventStateMetadata{
+			Inputs: resource.PropertyMap{
+				"password": resource.NewProperty("after"),
+			},
+			HideDiffs: []resource.PropertyPath{{"password"}},
+		},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got, "a withheld diff must still be reported")
+	assert.Equal(t, []string{"password"}, got.Hidden)
+	assert.Empty(t, got.Creates)
+	assert.Empty(t, got.Deletes)
+	assert.Empty(t, got.Updates)
+
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"hidden": ["password"]}`, string(encoded))
+}
+
+func TestStepDiffJSON_NoHiddenPathsMeansNoHiddenField(t *testing.T) {
+	t.Parallel()
+
+	step := engine.StepEventMetadata{
+		Op:  deploy.OpUpdate,
+		Old: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"plain": resource.NewProperty("a")}},
+		New: &engine.StepEventStateMetadata{Inputs: resource.PropertyMap{"plain": resource.NewProperty("b")}},
+	}
+
+	got := stepDiffJSON(step, false)
+	require.NotNil(t, got)
+	assert.Nil(t, got.Hidden)
+
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "hidden")
 }

--- a/pkg/backend/display/object_diff.go
+++ b/pkg/backend/display/object_diff.go
@@ -205,21 +205,86 @@ func getResourcePropertiesSummary(step engine.StepEventMetadata, indent int, sho
 	return b.String()
 }
 
+// stepDiffOperands picks the property maps a step's diff is computed over, and
+// the top-level keys the result should be restricted to. Outputs are preferred
+// once a step has them, since they reflect what the provider returned rather
+// than what the program asked for.
+func stepDiffOperands(
+	step engine.StepEventMetadata,
+) (olds, news resource.PropertyMap, include []resource.PropertyKey) {
+	old, new := step.Old, step.New
+	switch {
+	case old == nil && new == nil:
+		return nil, nil, nil
+	case old == nil:
+		if len(new.Outputs) > 0 {
+			return nil, new.Outputs, nil
+		}
+		return nil, new.Inputs, nil
+	case new == nil:
+		return old.Inputs, nil, nil
+	case len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement:
+		return old.Outputs, new.Outputs, nil
+	default:
+		return old.Inputs, new.Inputs, step.Diffs
+	}
+}
+
+// stepHidePaths returns the property paths whose diffs the program asked to
+// hide, via the HideDiffs resource option.
+func stepHidePaths(step engine.StepEventMetadata) []resource.PropertyPath {
+	if step.New != nil {
+		return step.New.HideDiffs
+	}
+	if step.Old != nil {
+		return step.Old.HideDiffs
+	}
+	return nil
+}
+
+// stepObjectDiff computes a step's property diff: the provider's detailed diff
+// when it supplied one, and a structural diff of olds against news otherwise.
+// Paths in hidePaths are excluded from the diff and returned separately, so
+// callers can report that a diff was withheld rather than silently dropping it.
+func stepObjectDiff(
+	step engine.StepEventMetadata, olds, news resource.PropertyMap,
+	refresh bool, hidePaths []resource.PropertyPath,
+) (*resource.ObjectDiff, []resource.PropertyPath) {
+	// An OpSame may carry a metadata change (e.g. protect) but never a property diff.
+	// See https://github.com/pulumi/pulumi/issues/15944 for context.
+	if step.Op == deploy.OpSame {
+		return nil, nil
+	}
+
+	if step.DetailedDiff != nil && step.Old != nil && step.New != nil {
+		diff, hidden := engine.TranslateDetailedDiff(&step, refresh)
+		return diff, sortedUniquePaths(hidden)
+	}
+
+	var hidden []resource.PropertyPath
+	diff := olds.DiffWithOptions(news,
+		resource.IgnoreKeyFunc(resource.IsInternalPropertyKey),
+		resource.IgnorePathFunc(func(path resource.PropertyPath) bool {
+			for _, v := range hidePaths {
+				if v.Contains(path) {
+					hidden = append(hidden, v)
+					return true
+				}
+			}
+			return false
+		}),
+	)
+	return diff, sortedUniquePaths(hidden)
+}
+
 func getResourcePropertiesDetails(
-	step engine.StepEventMetadata, indent int, planning bool, summary bool, truncateOutput bool,
+	step engine.StepEventMetadata, indent int, planning, refresh, summary, truncateOutput bool,
 	debug bool, showSecrets bool,
 ) string {
 	var b bytes.Buffer
 
 	// indent everything an additional level, like other properties.
 	indent++
-
-	var hideDiff []resource.PropertyPath
-	if step.New != nil {
-		hideDiff = step.New.HideDiffs
-	} else if step.Old != nil {
-		hideDiff = step.Old.HideDiffs
-	}
 
 	old, new := step.Old, step.New
 	if old == nil && new != nil {
@@ -228,21 +293,39 @@ func getResourcePropertiesDetails(
 		} else {
 			PrintObject(&b, new.Inputs, planning, indent, step.Op, false, truncateOutput, debug, showSecrets)
 		}
-	} else if new == nil && old != nil {
+		return b.String()
+	}
+	if new == nil && old != nil {
 		// in summary view, we don't have to print out the entire object that is getting deleted.
 		// note, the caller will have already printed out the type/name/id/urn of the resource,
 		// and that's sufficient for a summarized deletion view.
 		if !summary {
 			PrintObject(&b, old.Inputs, planning, indent, step.Op, false, truncateOutput, debug, showSecrets)
 		}
-	} else if len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement {
-		printOldNewDiffs(&b, old.Outputs, new.Outputs, nil, planning, indent, step.Op,
-			summary, truncateOutput, debug, showSecrets, hideDiff)
-	} else {
-		printOldNewDiffs(&b, old.Inputs, new.Inputs, step.Diffs, planning, indent, step.Op,
-			summary, truncateOutput, debug, showSecrets, hideDiff)
+		return b.String()
 	}
 
+	olds, news, include := stepDiffOperands(step)
+	diff, hidden := stepObjectDiff(step, olds, news, refresh, stepHidePaths(step))
+	if diff == nil && len(hidden) > 0 {
+		// We have hidden all the diffs, but there was a diff.
+		diff = &resource.ObjectDiff{}
+	}
+	if diff == nil {
+		// If there's no diff, report the op as Same - there's no diff to render so it should be
+		// rendered as if nothing changed. The detailed diff reports the old state; a structural
+		// diff has already established that the new state is equivalent.
+		props := new.Inputs
+		if step.DetailedDiff != nil {
+			props = old.Inputs
+		} else if len(new.Outputs) > 0 && step.Op != deploy.OpImport && step.Op != deploy.OpImportReplacement {
+			props = new.Outputs
+		}
+		PrintObject(&b, props, planning, indent, deploy.OpSame, true, truncateOutput, debug, showSecrets)
+		return b.String()
+	}
+
+	PrintObjectDiff(&b, *diff, include, planning, indent, summary, truncateOutput, debug, showSecrets, hidden)
 	return b.String()
 }
 
@@ -772,49 +855,6 @@ func shortHash(hash string) string {
 		return hash[:7]
 	}
 	return hash
-}
-
-func printOldNewDiffs(
-	b *bytes.Buffer, olds resource.PropertyMap, news resource.PropertyMap, include []resource.PropertyKey,
-	planning bool, indent int, op display.StepOp, summary bool, truncateOutput bool, debug bool, showSecrets bool,
-	hidePaths []resource.PropertyPath,
-) {
-	var hiddenDiffs []resource.PropertyPath
-
-	// Get the full diff structure between the two, and print it (recursively).
-	diff := olds.DiffWithOptions(news,
-		resource.IgnoreKeyFunc(resource.IsInternalPropertyKey),
-		resource.IgnorePathFunc(func(path resource.PropertyPath) bool {
-			for _, v := range hidePaths {
-				if v.Contains(path) {
-					hiddenDiffs = append(hiddenDiffs, v)
-					return true
-				}
-			}
-			return false
-		}),
-	)
-
-	// Ensure that our paths are unique and sorted
-	slices.SortFunc(hiddenDiffs, func(a, b resource.PropertyPath) int {
-		return cmp.Compare(a.String(), b.String())
-	})
-	hiddenDiffs = slices.CompactFunc(hiddenDiffs, func(a, b resource.PropertyPath) bool {
-		return a.String() == b.String()
-	})
-
-	// We have hidden all the diffs, but there was a diff.
-	if diff == nil && len(hiddenDiffs) > 0 {
-		diff = &resource.ObjectDiff{}
-	}
-
-	if diff != nil {
-		PrintObjectDiff(b, *diff, include, planning, indent, summary, truncateOutput, debug, showSecrets, hiddenDiffs)
-	} else {
-		// If there's no diff, report the op as Same - there's no diff to render
-		// so it should be rendered as if nothing changed.
-		PrintObject(b, news, planning, indent, deploy.OpSame, true, truncateOutput, debug, showSecrets)
-	}
 }
 
 func PrintObjectDiff(b *bytes.Buffer, diff resource.ObjectDiff, include []resource.PropertyKey,

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -470,11 +470,11 @@ func getDiffInfo(step engine.StepEventMetadata, action apitype.UpdateKind) strin
 		// An OpSame might have a diff due to metadata changes (e.g. protect) but we should never print a property diff,
 		// even if the properties appear to have changed. See https://github.com/pulumi/pulumi/issues/15944 for context.
 		if step.Op != deploy.OpSame {
-			if step.DetailedDiff != nil {
-				diff, _ = engine.TranslateDetailedDiff(&step, false)
-			} else if step.Old.Inputs != nil && step.New.Inputs != nil {
-				diff = step.Old.Inputs.DiffWithOptions(step.New.Inputs,
-					resource.IgnoreKeyFunc(resource.IsInternalPropertyKey))
+			// The progress row lists property names only, and deliberately diffs
+			// inputs rather than outputs: it reports what the program changed.
+			if step.DetailedDiff != nil || (step.Old.Inputs != nil && step.New.Inputs != nil) {
+				diff, _ = stepObjectDiff(step, step.Old.Inputs, step.New.Inputs,
+					false /* refresh */, nil /* hidePaths */)
 			}
 		}
 

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -49,8 +49,8 @@ type SummaryJSON struct {
 }
 
 // ResourceJSON is the per-resource entry that appears in SummaryJSON.Resources.
-// It is intentionally compact: callers that need full diffs / property values
-// should use `--json` (the streaming event format) instead.
+// It is intentionally compact unless `--diff` is also set, in which case each
+// entry carries the same property diff the `--diff` view renders as text.
 type ResourceJSON struct {
 	// URN is the canonical, globally-unique identifier of the resource.
 	URN string `json:"urn"`
@@ -62,6 +62,9 @@ type ResourceJSON struct {
 	Op apitype.OpType `json:"op"`
 	// Parent is the URN of this resource's parent, if any.
 	Parent string `json:"parent,omitempty"`
+	// Diff is the resource's property diff. It is only populated when `--diff`
+	// is set alongside `--output json`.
+	Diff *ObjectDiffJSON `json:"diff,omitempty"`
 }
 
 // summaryJSONFromEvent extracts the summary JSON shape from a SummaryEventPayload.
@@ -79,11 +82,11 @@ func summaryJSONFromEvent(p engine.SummaryEventPayload) SummaryJSON {
 // per-resource JSON shape. Returns nil when the event should be skipped:
 // internal events never surface to users, and `same` (unchanged) resources are
 // omitted unless the display is configured to show them.
-func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *ResourceJSON {
+func resourceJSONFromEvent(p engine.ResourcePreEventPayload, opts Options) *ResourceJSON {
 	if p.Internal {
 		return nil
 	}
-	if p.Metadata.Op == deploy.OpSame && !showSames {
+	if p.Metadata.Op == deploy.OpSame && !opts.ShowSameResources {
 		return nil
 	}
 
@@ -98,6 +101,9 @@ func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *Re
 	}
 
 	r := NewResourceJSON(p.Metadata.URN, apitype.OpType(p.Metadata.Op), parent)
+	if opts.Type == DisplayDiff {
+		r.Diff = stepDiffJSON(p.Metadata, opts.ShowSecrets)
+	}
 	return &r
 }
 
@@ -150,7 +156,7 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 			switch e.Type { //nolint:exhaustive // we only care about two event types here
 			case engine.ResourcePreEvent:
 				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
-					if r := resourceJSONFromEvent(payload, opts.ShowSameResources); r != nil {
+					if r := resourceJSONFromEvent(payload, opts); r != nil {
 						resources = append(resources, *r)
 					}
 				}

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -123,7 +123,7 @@ func TestResourceJSONFromEvent_SkipsInternal(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpCreate, urn, "parent-urn", "", true /* internal */)
 
-	got := resourceJSONFromEvent(payload, false)
+	got := resourceJSONFromEvent(payload, Options{})
 	assert.Nil(t, got, "internal events must not surface in the summary")
 }
 
@@ -133,7 +133,7 @@ func TestResourceJSONFromEvent_SkipsSameByDefault(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
 
-	got := resourceJSONFromEvent(payload, false /* showSames */)
+	got := resourceJSONFromEvent(payload, Options{})
 	assert.Nil(t, got, "same resources are filtered out unless --show-sames is set")
 }
 
@@ -143,7 +143,7 @@ func TestResourceJSONFromEvent_IncludesSameWhenShowSames(t *testing.T) {
 	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
 	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
 
-	got := resourceJSONFromEvent(payload, true /* showSames */)
+	got := resourceJSONFromEvent(payload, Options{ShowSameResources: true})
 	require.NotNil(t, got)
 	assert.Equal(t, apitype.OpType("same"), got.Op)
 }
@@ -155,7 +155,7 @@ func TestResourceJSONFromEvent_ExtractsTypeAndName(t *testing.T) {
 	parentURN := resource.NewURN("dev", "myapp", "", "pulumi:pulumi:Stack", "myapp-dev")
 	payload := makePreEvent(deploy.OpUpdate, urn, parentURN, "", false)
 
-	got := resourceJSONFromEvent(payload, false)
+	got := resourceJSONFromEvent(payload, Options{})
 	require.NotNil(t, got)
 	assert.Equal(t, string(urn), got.URN)
 	assert.Equal(t, "aws:s3/bucket:Bucket", got.Type)
@@ -180,7 +180,7 @@ func TestResourceJSONFromEvent_ParentFallsBackToOldOnDelete(t *testing.T) {
 		},
 	}
 
-	got := resourceJSONFromEvent(payload, false)
+	got := resourceJSONFromEvent(payload, Options{})
 	require.NotNil(t, got)
 	assert.Equal(t, string(parentURN), got.Parent)
 	assert.Equal(t, apitype.OpType("delete"), got.Op)


### PR DESCRIPTION
`--diff` and `--output json` don't play nicely together. This PR adds a JSON renderer for `--diff` so that we can consume diffs in a, uh, different structured format.

```json
"diff": {
  "updates": {
    "tags": {
      "object": {
        "creates": {
          "env": "prod"
        },
        "updates": {
          "owner": {
            "old": "tom",
            "new": "tim"
          }
        }
      }
    },
    "zones": {
      "array": {
        "updates": {
          "1": {
            "old": "b",
            "new": "c"
          }
        }
      }
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


