### PR TITLE
fix `disableSSL` to only override when no explicit scheme is given

### DIFF
--- a/changelog/pending/backend-diy-fix-20260908-182357.yaml
+++ b/changelog/pending/backend-diy-fix-20260908-182357.yaml
@@ -1,0 +1,4 @@
+component: backend/diy
+kind: fix
+body: Make sure `disableSSL` doesn't override explicitly specified protocols
+time: 2026-09-08T18:23:57.785276311+02:00

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -689,7 +689,9 @@ func massageBlobPath(path string) (string, error) {
 // before the upgrade keep working:
 //
 //   - disableSSL becomes disable_https; gocloud.dev v0.46 rejects the v1 name as an unknown
-//     query parameter.
+//     query parameter. When the endpoint carries an explicit scheme, disableSSL is dropped
+//     instead: the v1 SDK only used it to pick a scheme for scheme-less endpoints, while
+//     disable_https unconditionally downgrades requests to HTTP.
 //   - a scheme-less endpoint (e.g. endpoint=minio:9000) gets an explicit http:// or https://
 //     scheme depending on disableSSL; the v1 SDK implied the scheme, while the v2 SDK
 //     requires one.
@@ -716,7 +718,9 @@ func translateLegacyS3Params(urlstr string) (string, error) {
 			return "", fmt.Errorf("invalid value for query parameter %q: %w", "disableSSL", err)
 		}
 		query.Del("disableSSL")
-		query.Set("disable_https", strconv.FormatBool(disableSSL))
+		if !strings.Contains(query.Get("endpoint"), "://") {
+			query.Set("disable_https", strconv.FormatBool(disableSSL))
+		}
 		changed = true
 	}
 

--- a/pkg/backend/diy/legacy_s3_params_test.go
+++ b/pkg/backend/diy/legacy_s3_params_test.go
@@ -55,12 +55,26 @@ func TestTranslateLegacyS3Params(t *testing.T) {
 			give: "s3://bucket?endpoint=https://example.com&request_checksum_calculation=when_supported",
 		},
 		{
-			name: "disableSSL translated",
+			name: "disableSSL dropped when endpoint has explicit https scheme",
 			give: "s3://bucket?endpoint=https://minio:9000&disableSSL=true",
 			wantQuery: url.Values{
 				"endpoint":                     {"https://minio:9000"},
-				"disable_https":                {"true"},
 				"request_checksum_calculation": {"when_required"},
+			},
+		},
+		{
+			name: "disableSSL dropped when endpoint has explicit http scheme",
+			give: "s3://bucket?endpoint=http://minio:9000&disableSSL=true",
+			wantQuery: url.Values{
+				"endpoint":                     {"http://minio:9000"},
+				"request_checksum_calculation": {"when_required"},
+			},
+		},
+		{
+			name: "disableSSL translated without endpoint",
+			give: "s3://bucket?disableSSL=true",
+			wantQuery: url.Values{
+				"disable_https": {"true"},
 			},
 		},
 		{


### PR DESCRIPTION
In aws-sdk v1, `disableSSL` only had an effect when the scheme wasn't explicitly specified in the URL. We should do the same in this compatibility layer, even though it seems weird at first glance to want https and have this parameter set.

Having it not backwards compatible is more wrong though, so let's restore the behaviour from before the gocloud update.

Fixes #24589 