### PR TITLE
Add query filtering to pulumi api list

### DIFF
--- a/changelog/pending/20260908--cli--api-list-filter.yaml
+++ b/changelog/pending/20260908--cli--api-list-filter.yaml
@@ -1,0 +1,3 @@
+component: cli
+kind: improvement
+body: Add `--filter` to `pulumi api list` to filter endpoints by keyword

--- a/changelog/pending/20260908--cli--api-list-query.yaml
+++ b/changelog/pending/20260908--cli--api-list-query.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Add `--query` to `pulumi api list` to filter endpoints by keyword
+time: 2026-09-08T00:00:00Z

--- a/changelog/pending/20260908--cli--api-list-query.yaml
+++ b/changelog/pending/20260908--cli--api-list-query.yaml
@@ -1,4 +1,0 @@
-component: cli
-kind: improvement
-body: Add `--query` to `pulumi api list` to filter endpoints by keyword
-time: 2026-09-08T00:00:00Z

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -154,7 +154,7 @@ func NewAPICmd() *cobra.Command {
 		Example: "  # Verify an op's parameters and schemas with `describe` before calling it.\n" +
 			"  pulumi api describe AddStackTag\n\n" +
 			"  # Find endpoints by keyword.\n" +
-			"  pulumi api list -q graph\n\n" +
+			"  pulumi api list --filter graph\n\n" +
 			"  # Query the organization's resource graph (Context API): what exists, what\n" +
 			"  # depends on what, what a change would affect. Read the guide first, then\n" +
 			"  # post a JSON selector.\n" +

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -153,6 +153,13 @@ func NewAPICmd() *cobra.Command {
 			"255 internal.",
 		Example: "  # Verify an op's parameters and schemas with `describe` before calling it.\n" +
 			"  pulumi api describe AddStackTag\n\n" +
+			"  # Find endpoints by keyword.\n" +
+			"  pulumi api list -q graph\n\n" +
+			"  # Query the organization's resource graph (Context API): what exists, what\n" +
+			"  # depends on what, what a change would affect. Read the guide first, then\n" +
+			"  # post a JSON selector.\n" +
+			"  pulumi api GetGraphQuerySchema --output=markdown\n" +
+			"  pulumi api GraphQuery --input selector.json\n\n" +
 			"  # Inspect the currently authenticated user.\n" +
 			"  pulumi api /api/user\n\n" +
 			"  # Call by raw path with template variables filled from -F.\n" +

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -158,7 +158,7 @@ func NewAPICmd() *cobra.Command {
 			"  # Query the organization's resource graph (Context API): what exists, what\n" +
 			"  # depends on what, what a change would affect. Read the guide first, then\n" +
 			"  # post a JSON selector.\n" +
-			"  pulumi api GetGraphQuerySchema --output=markdown\n" +
+			"  pulumi api GetGraphQuerySchema\n" +
 			"  pulumi api GraphQuery --input selector.json\n\n" +
 			"  # Inspect the currently authenticated user.\n" +
 			"  pulumi api /api/user\n\n" +

--- a/pkg/cmd/pulumi/cloud/list.go
+++ b/pkg/cmd/pulumi/cloud/list.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -35,6 +36,7 @@ import (
 // parent command's persistent flags (--refresh-spec).
 func newListCmd(api *apiCommand) *cobra.Command {
 	var output string
+	var query string
 	includePreview := true
 	includeDeprecated := false
 
@@ -51,9 +53,14 @@ func newListCmd(api *apiCommand) *cobra.Command {
 			"--output=table to keep the table when redirecting.\n" +
 			"\n" +
 			"Preview endpoints are listed by default; deprecated endpoints are hidden. Use\n" +
-			"--include-preview=false or --include-deprecated to change that.",
+			"--include-preview=false or --include-deprecated to change that.\n" +
+			"\n" +
+			"--query/-q keeps only operations whose ID, path, tag, summary, or description\n" +
+			"contain the given text (case-insensitive).",
 		Example: "  # Print the table of stable endpoints.\n" +
 			"  pulumi api list\n\n" +
+			"  # Find endpoints by keyword (matches ID, path, tag, summary, description).\n" +
+			"  pulumi api list -q graph\n\n" +
 			"  # Grab every operation as JSON (the default when piped).\n" +
 			"  pulumi api list --output=json\n\n" +
 			"  # Count endpoints per tag with jq.\n" +
@@ -80,9 +87,11 @@ func newListCmd(api *apiCommand) *cobra.Command {
 		"Include endpoints marked as preview")
 	cmd.Flags().BoolVar(&includeDeprecated, "include-deprecated", false,
 		"Include endpoints marked as deprecated")
+	cmd.Flags().StringVarP(&query, "query", "q", "",
+		"Show only operations whose ID, path, tag, summary, or description contains this text (case-insensitive)")
 
 	cmd.RunE = runWithEnvelope(func(cmd *cobra.Command, args []string) error {
-		return runLs(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), output,
+		return runLs(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), output, query,
 			includePreview, includeDeprecated, api.refreshSpec)
 	})
 	return cmd
@@ -91,7 +100,7 @@ func newListCmd(api *apiCommand) *cobra.Command {
 func runLs(
 	ctx context.Context,
 	w, warnW io.Writer,
-	output string,
+	output, query string,
 	includePreview, includeDeprecated, refresh bool,
 ) error {
 	mode, err := resolveOutput(output)
@@ -123,6 +132,7 @@ func runLs(
 	}
 
 	view := filterListedOps(idx, includePreview, includeDeprecated)
+	view = filterByQuery(view, query)
 
 	if mode == outputJSON {
 		return emitLsJSON(w, view)
@@ -149,6 +159,33 @@ func filterListedOps(idx *Index, includePreview, includeDeprecated bool) *Index 
 		ByKey:       idx.ByKey,
 		SpecVersion: idx.SpecVersion,
 	}
+}
+
+func filterByQuery(idx *Index, query string) *Index {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return idx
+	}
+	filtered := make([]*Operation, 0, len(idx.Operations))
+	for _, op := range idx.Operations {
+		if matchesQuery(op, query) {
+			filtered = append(filtered, op)
+		}
+	}
+	return &Index{
+		Operations:  filtered,
+		ByKey:       idx.ByKey,
+		SpecVersion: idx.SpecVersion,
+	}
+}
+
+func matchesQuery(op *Operation, query string) bool {
+	for _, field := range []string{op.OperationID, op.Path, op.Tag, op.Summary, op.Description} {
+		if strings.Contains(strings.ToLower(field), query) {
+			return true
+		}
+	}
+	return false
 }
 
 func emitLsJSON(w io.Writer, idx *Index) error {

--- a/pkg/cmd/pulumi/cloud/list.go
+++ b/pkg/cmd/pulumi/cloud/list.go
@@ -36,7 +36,7 @@ import (
 // parent command's persistent flags (--refresh-spec).
 func newListCmd(api *apiCommand) *cobra.Command {
 	var output string
-	var query string
+	var filter string
 	includePreview := true
 	includeDeprecated := false
 
@@ -55,12 +55,12 @@ func newListCmd(api *apiCommand) *cobra.Command {
 			"Preview endpoints are listed by default; deprecated endpoints are hidden. Use\n" +
 			"--include-preview=false or --include-deprecated to change that.\n" +
 			"\n" +
-			"--query/-q keeps only operations whose ID, path, tag, summary, or description\n" +
+			"--filter keeps only operations whose ID, path, tag, summary, or description\n" +
 			"contain the given text (case-insensitive).",
 		Example: "  # Print the table of stable endpoints.\n" +
 			"  pulumi api list\n\n" +
 			"  # Find endpoints by keyword (matches ID, path, tag, summary, description).\n" +
-			"  pulumi api list -q graph\n\n" +
+			"  pulumi api list --filter graph\n\n" +
 			"  # Grab every operation as JSON (the default when piped).\n" +
 			"  pulumi api list --output=json\n\n" +
 			"  # Count endpoints per tag with jq.\n" +
@@ -87,11 +87,11 @@ func newListCmd(api *apiCommand) *cobra.Command {
 		"Include endpoints marked as preview")
 	cmd.Flags().BoolVar(&includeDeprecated, "include-deprecated", false,
 		"Include endpoints marked as deprecated")
-	cmd.Flags().StringVarP(&query, "query", "q", "",
+	cmd.Flags().StringVar(&filter, "filter", "",
 		"Show only operations whose ID, path, tag, summary, or description contains this text (case-insensitive)")
 
 	cmd.RunE = runWithEnvelope(func(cmd *cobra.Command, args []string) error {
-		return runLs(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), output, query,
+		return runLs(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), output, filter,
 			includePreview, includeDeprecated, api.refreshSpec)
 	})
 	return cmd
@@ -100,7 +100,7 @@ func newListCmd(api *apiCommand) *cobra.Command {
 func runLs(
 	ctx context.Context,
 	w, warnW io.Writer,
-	output, query string,
+	output, filter string,
 	includePreview, includeDeprecated, refresh bool,
 ) error {
 	mode, err := resolveOutput(output)
@@ -132,7 +132,7 @@ func runLs(
 	}
 
 	view := filterListedOps(idx, includePreview, includeDeprecated)
-	view = filterByQuery(view, query)
+	view = filterByText(view, filter)
 
 	if mode == outputJSON {
 		return emitLsJSON(w, view)
@@ -161,14 +161,14 @@ func filterListedOps(idx *Index, includePreview, includeDeprecated bool) *Index 
 	}
 }
 
-func filterByQuery(idx *Index, query string) *Index {
-	query = strings.ToLower(strings.TrimSpace(query))
-	if query == "" {
+func filterByText(idx *Index, filter string) *Index {
+	filter = strings.ToLower(strings.TrimSpace(filter))
+	if filter == "" {
 		return idx
 	}
 	filtered := make([]*Operation, 0, len(idx.Operations))
 	for _, op := range idx.Operations {
-		if matchesQuery(op, query) {
+		if matchesFilter(op, filter) {
 			filtered = append(filtered, op)
 		}
 	}
@@ -179,9 +179,9 @@ func filterByQuery(idx *Index, query string) *Index {
 	}
 }
 
-func matchesQuery(op *Operation, query string) bool {
+func matchesFilter(op *Operation, filter string) bool {
 	for _, field := range []string{op.OperationID, op.Path, op.Tag, op.Summary, op.Description} {
-		if strings.Contains(strings.ToLower(field), query) {
+		if strings.Contains(strings.ToLower(field), filter) {
 			return true
 		}
 	}

--- a/pkg/cmd/pulumi/cloud/list_test.go
+++ b/pkg/cmd/pulumi/cloud/list_test.go
@@ -69,31 +69,31 @@ func TestFilterListedOps(t *testing.T) {
 	})
 }
 
-func TestFilterByQuery(t *testing.T) {
+func TestFilterByText(t *testing.T) {
 	t.Parallel()
 	idx := loadTestIndex(t)
 
 	t.Run("matches operationId case-insensitively", func(t *testing.T) {
 		t.Parallel()
-		view := filterByQuery(idx, "aitemplate")
+		view := filterByText(idx, "aitemplate")
 		assert.ElementsMatch(t, []string{"AITemplate"}, opIDs(view.Operations))
 	})
 
 	t.Run("matches path substring", func(t *testing.T) {
 		t.Parallel()
-		view := filterByQuery(idx, "agent-pools")
+		view := filterByText(idx, "agent-pools")
 		assert.ElementsMatch(t, []string{"ListOrgAgentPool"}, opIDs(view.Operations))
 	})
 
 	t.Run("matches description text", func(t *testing.T) {
 		t.Parallel()
-		view := filterByQuery(idx, "immediately invalidated")
+		view := filterByText(idx, "immediately invalidated")
 		assert.ElementsMatch(t, []string{"DeletePersonalToken"}, opIDs(view.Operations))
 	})
 
 	t.Run("no match yields zero operations", func(t *testing.T) {
 		t.Parallel()
-		view := filterByQuery(idx, "no-such-keyword-zzz")
+		view := filterByText(idx, "no-such-keyword-zzz")
 		assert.Empty(t, view.Operations)
 
 		var buf bytes.Buffer
@@ -105,20 +105,20 @@ func TestFilterByQuery(t *testing.T) {
 		assert.Equal(t, 0, env.Count)
 	})
 
-	t.Run("empty or whitespace-only query is a no-op", func(t *testing.T) {
+	t.Run("empty or whitespace-only filter is a no-op", func(t *testing.T) {
 		t.Parallel()
 		for _, q := range []string{"", "   ", "\t\n"} {
-			view := filterByQuery(idx, q)
+			view := filterByText(idx, q)
 			assert.ElementsMatch(t, opIDs(idx.Operations), opIDs(view.Operations))
 		}
 	})
 
 	t.Run("composes with preview/deprecated filters", func(t *testing.T) {
 		t.Parallel()
-		defaultView := filterByQuery(filterListedOps(idx, true, false), "deprecated")
+		defaultView := filterByText(filterListedOps(idx, true, false), "deprecated")
 		assert.Empty(t, defaultView.Operations)
 
-		withDeprecated := filterByQuery(filterListedOps(idx, true, true), "deprecated")
+		withDeprecated := filterByText(filterListedOps(idx, true, true), "deprecated")
 		assert.ElementsMatch(t, []string{"ListPolicyViolationsV2"}, opIDs(withDeprecated.Operations))
 	})
 }

--- a/pkg/cmd/pulumi/cloud/list_test.go
+++ b/pkg/cmd/pulumi/cloud/list_test.go
@@ -69,6 +69,60 @@ func TestFilterListedOps(t *testing.T) {
 	})
 }
 
+func TestFilterByQuery(t *testing.T) {
+	t.Parallel()
+	idx := loadTestIndex(t)
+
+	t.Run("matches operationId case-insensitively", func(t *testing.T) {
+		t.Parallel()
+		view := filterByQuery(idx, "aitemplate")
+		assert.ElementsMatch(t, []string{"AITemplate"}, opIDs(view.Operations))
+	})
+
+	t.Run("matches path substring", func(t *testing.T) {
+		t.Parallel()
+		view := filterByQuery(idx, "agent-pools")
+		assert.ElementsMatch(t, []string{"ListOrgAgentPool"}, opIDs(view.Operations))
+	})
+
+	t.Run("matches description text", func(t *testing.T) {
+		t.Parallel()
+		view := filterByQuery(idx, "immediately invalidated")
+		assert.ElementsMatch(t, []string{"DeletePersonalToken"}, opIDs(view.Operations))
+	})
+
+	t.Run("no match yields zero operations", func(t *testing.T) {
+		t.Parallel()
+		view := filterByQuery(idx, "no-such-keyword-zzz")
+		assert.Empty(t, view.Operations)
+
+		var buf bytes.Buffer
+		require.NoError(t, emitLsJSON(&buf, view))
+		var env struct {
+			Count int `json:"count"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &env))
+		assert.Equal(t, 0, env.Count)
+	})
+
+	t.Run("empty or whitespace-only query is a no-op", func(t *testing.T) {
+		t.Parallel()
+		for _, q := range []string{"", "   ", "\t\n"} {
+			view := filterByQuery(idx, q)
+			assert.ElementsMatch(t, opIDs(idx.Operations), opIDs(view.Operations))
+		}
+	})
+
+	t.Run("composes with preview/deprecated filters", func(t *testing.T) {
+		t.Parallel()
+		defaultView := filterByQuery(filterListedOps(idx, true, false), "deprecated")
+		assert.Empty(t, defaultView.Operations)
+
+		withDeprecated := filterByQuery(filterListedOps(idx, true, true), "deprecated")
+		assert.ElementsMatch(t, []string{"ListPolicyViolationsV2"}, opIDs(withDeprecated.Operations))
+	})
+}
+
 func opIDs(ops []*Operation) []string {
 	out := make([]string, 0, len(ops))
 	for _, op := range ops {
@@ -94,7 +148,7 @@ func TestRunLs_RejectsRawAndMarkdown(t *testing.T) {
 	for _, out := range []string{"raw", "markdown", "md"} {
 		t.Run(out, func(t *testing.T) {
 			t.Parallel()
-			err := runLs(t.Context(), io.Discard, io.Discard, out, true, false, false)
+			err := runLs(t.Context(), io.Discard, io.Discard, out, "", true, false, false)
 			require.Error(t, err)
 			apiErr, ok := errors.AsType[*APIError](err)
 			require.True(t, ok)


### PR DESCRIPTION
## Problem
`pulumi api list` can show many endpoints at once, so finding the endpoint you need means scanning the full list or piping the output to another tool.

## Solution
Add a `--filter` flag to `pulumi api list` that keeps only endpoints whose operation ID, path, tag, summary, or description contains the search text. The match is case-insensitive, trims empty input, and composes with the existing preview and deprecated endpoint filters.

The command help and top-level `pulumi api` examples now show how to search for endpoints by keyword, including Context API examples.

Testing: Added unit tests for query matching by operation ID, path, and description; empty queries; no-match output; and composition with preview/deprecated filters.