### PR TITLE
Skip the unconsumed release-binary rebuild on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ on:
         default: false
         description: "If true, fuzz test failures won't block the workflow"
         type: boolean
+      rebuild-release-binaries:
+        required: true
+        description: >-
+          Rebuild uninstrumented binaries after coverage builds. Pass true
+          from callers whose runs package release artifacts.
+        type: boolean
     secrets:
       PULUMI_PROD_ACCESS_TOKEN:
         required: false
@@ -552,10 +558,11 @@ jobs:
           version: v10.0.1
           token: ${{ secrets.CODECOV_TOKEN }}
   build-release-binaries:
-    # This overwrites the previously built testing binaries with versions without coverage.
+    # Rebuilds the six CLI targets without coverage instrumentation, uploaded
+    # under the unsuffixed artifacts-cli-* names.
     name: Rebuild binaries
     needs: [setup]
-    if: ${{ inputs.enable-coverage }}
+    if: ${{ inputs.enable-coverage && inputs.rebuild-release-binaries }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -42,6 +42,9 @@ jobs:
       # data on every merge to main, so getting it in the daily cro
       # job is not important.
       enable-coverage: false
+      # Nothing in this run packages release artifacts, and with coverage
+      # off there is nothing to rebuild.
+      rebuild-release-binaries: false
     secrets: inherit
 
   performance-gate:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -48,6 +48,7 @@ jobs:
       test-retries: 2
       acceptance-test-platforms: 'macos-latest'
       fuzz-test-optional: true
+      rebuild-release-binaries: true
     secrets: inherit
 
   performance-gate:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -65,6 +65,9 @@ jobs:
           || 'windows-latest'
         }}
       enable-coverage: true
+      # PR runs package no release artifacts, so the post-coverage
+      # uninstrumented rebuild of all six CLI targets is skipped.
+      rebuild-release-binaries: false
     secrets: inherit
 
   performance-gate:

--- a/.github/workflows/pr-test-acceptance-on-dispatch.yml
+++ b/.github/workflows/pr-test-acceptance-on-dispatch.yml
@@ -68,6 +68,9 @@ jobs:
       acceptance-test-platforms: 'windows-latest'
       # We'll only upload coverage artifacts with the periodic-coverage cron workflow.
       enable-coverage: false
+      # Nothing in this run packages release artifacts, and with coverage
+      # off there is nothing to rebuild.
+      rebuild-release-binaries: false
     secrets:
       # Scope secrets to the minimum required:
       PULUMI_PROD_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/changelog/pending/20260904--ci--skip-release-rebuild-on-prs.yaml
+++ b/changelog/pending/20260904--ci--skip-release-rebuild-on-prs.yaml
@@ -1,0 +1,4 @@
+component: ci
+kind: improvement
+body: Skip the unconsumed release-binary rebuild on pull requests
+time: 2026-09-04T00:00:00Z


### PR DESCRIPTION
Every PR run rebuilds all six CLI binaries a second time, without coverage instrumentation. Those binaries exist only for release packaging; the merge queue consumes them, while test jobs download the separately named test binaries and dev releases build their own. This change skips the rebuild on PRs, while leaving leaves the merge queue and releases untouched.

## Changes

- `ci.yml` gets a new `rebuild-release-binaries` input. It is required and has no default, so every caller states explicitly whether its run packages release artifacts.
- The merge queue passes `true`: its release-prepare step consumes the rebuilt binaries, exactly as before.
- PR runs, the daily cron, and dispatch-triggered fork acceptance runs pass `false`. None of them package releases (the cron and dispatch runs also disable coverage, so the rebuild never ran there anyway — now that is explicit instead of incidental).
