### PR TITLE
Root plugin.NewContext at the detected project directory

### DIFF
--- a/changelog/pending/cli-fix-20260909-context-root-from-project.yaml
+++ b/changelog/pending/cli-fix-20260909-context-root-from-project.yaml
@@ -1,0 +1,5 @@
+component: cli
+kind: fix
+body: Resolve a project's relative plugin and package paths against the project directory
+    when a plugin starts from a subdirectory of the project
+time: 2026-09-09T00:00:00Z

--- a/pkg/resource/plugin/context.go
+++ b/pkg/resource/plugin/context.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"context"
 	"io"
+	"path/filepath"
 	"sync"
 
 	"github.com/opentracing/opentracing-go"
@@ -194,7 +195,10 @@ func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSo
 	// TODO: really this ought to just take plugins *workspace.Plugins and packages map[string]workspace.PackageSpec
 	// as args, but yaml depends on this function so *sigh*. For now just see if there's a project we should be using,
 	// and use it if there is.
+	// The project's plugin and package paths are relative to the project
+	// directory, so that directory is the root when a project is found.
 	projPath, err := workspace.DetectProjectPath()
+	root := pwd
 	var plugins *workspace.Plugins
 	var packages map[string]workspace.PackageSpec
 	if err == nil && projPath != "" {
@@ -202,10 +206,11 @@ func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSo
 		if err == nil {
 			plugins = project.Plugins
 			packages = project.GetPackageSpecs()
+			root = filepath.Dir(projPath)
 		}
 	}
 
-	return NewContextWithRoot(ctx, d, statusD, host, pwd, pwd, runtimeOptions,
+	return NewContextWithRoot(ctx, d, statusD, host, pwd, root, runtimeOptions,
 		disableProviderPreview, parentSpan, plugins, packages, nil)
 }
 

--- a/pkg/resource/plugin/context_test.go
+++ b/pkg/resource/plugin/context_test.go
@@ -15,6 +15,8 @@
 package plugin
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -79,4 +81,34 @@ func TestWithoutProviderDebugging(t *testing.T) {
 	require.Equal(t, ctx.Host, view.Host)
 
 	require.Same(t, view, view.WithoutProviderDebugging())
+}
+
+// A project's package paths are relative to the project directory. A plugin
+// that starts in a subdirectory of the project must resolve them from there,
+// not from its own working directory.
+func TestNewContextRootsAtDetectedProject(t *testing.T) { //nolint:paralleltest // t.Chdir forbids t.Parallel
+	projectDir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	componentDir := filepath.Join(projectDir, "component")
+	require.NoError(t, os.Mkdir(componentDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "Pulumi.yaml"),
+		[]byte("name: project\nruntime: yaml\npackages:\n  component: ./component\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(componentDir, "PulumiPlugin.yaml"),
+		[]byte("name: component\nruntime: yaml\n"), 0o600))
+	t.Chdir(componentDir)
+
+	ctx, err := NewContext(
+		t.Context(),
+		diagtest.LogSink(t),
+		diagtest.LogSink(t),
+		&MockHost{},
+		nil,
+		componentDir,
+		nil,
+		false,
+		mocktracer.New().StartSpan("root"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, projectDir, ctx.Root)
+	require.Equal(t, componentDir, ctx.Pwd)
 }


### PR DESCRIPTION
`plugin.NewContext` detects the enclosing project and reads its `plugins` and `packages`, but it passes the working directory as the context root. Relative `packages:` paths are relative to the project directory, so a plugin process that starts inside a subdirectory of the project resolves them against its own working directory.

A user hits this with a YAML project that consumes a local HCL component:

```yaml
# Pulumi.yaml
name: demo
runtime: yaml
packages:
  wrapper: ./wrapper
```

The `pulumi-terraform-provider` plugin calls `plugin.NewContext` while it generates the bridged schema for `wrapper`, with `./wrapper` as its working directory. It fails with:

```
error: no folder at path '<project>/wrapper/wrapper'
```

With this change the root is the directory that holds the detected `Pulumi.yaml`, and the working directory stays `Pwd`.

The fix takes effect for plugins that link this package once they are rebuilt against a release that contains it.
