### PR TITLE
Normalize references between state migration callbacks

### DIFF
--- a/changelog/pending/engine-fix-state-migration-callback-references.yaml
+++ b/changelog/pending/engine-fix-state-migration-callback-references.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Normalize successor references between chained component state migration callbacks
+time: 2026-09-09T08:35:06Z

--- a/changelog/pending/engine-fix-state-migration-split-inference.yaml
+++ b/changelog/pending/engine-fix-state-migration-split-inference.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Allow component state migrations to split managed state using compatible existing resource identities
+time: 2026-09-05T15:00:00+02:00

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -676,6 +676,90 @@ func TestStateMigrationChained(t *testing.T) {
 	assert.NotContains(t, urns, childBURN)
 }
 
+// TestStateMigrationChainedReferences exercises a root rename across two migrations:
+//
+//	old -> intermediate -> final
+//
+// Each callback renames only the root and relies on successor rewriting for its child's references. Running both
+// callbacks together must expose the same references as applying the upgrades separately.
+func TestStateMigrationChainedReferences(t *testing.T) {
+	t.Parallel()
+	for _, sequential := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sequential=%t", sequential), func(t *testing.T) {
+			t.Parallel()
+			rootURN := func(name string) resource.URN {
+				return resource.URN("urn:pulumi:test::test::pkg:m:Component::" + name)
+			}
+			stage := 0
+			names := []string{"old", "intermediate", "final"}
+			program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+				callbacks, err := deploytest.NewCallbacksServer()
+				require.NoError(t, err)
+				defer func() { require.NoError(t, callbacks.Close()) }()
+				opts := deploytest.ResourceOptions{}
+				for migration := 0; migration < stage; migration++ {
+					from, to := rootURN(names[migration]), rootURN(names[migration+1])
+					callback, err := callbacks.Allocate(stateMigrationFunction(func(
+						_ resource.URN, states []apitype.ResourceV3,
+					) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+						if states[0].URN != from {
+							return nil, nil, nil
+						}
+						if len(states) != 2 {
+							return nil, nil, fmt.Errorf("expected two resources, got %d", len(states))
+						}
+						child := states[1]
+						assert.Equal(t, from, child.Parent)
+						assert.Equal(t, []resource.URN{from}, child.Dependencies)
+						assert.Equal(t, []resource.URN{from}, child.PropertyDependencies["ref"])
+						ref := child.Inputs["ref"].(map[string]any)
+						assert.Equal(t, string(from), ref["urn"])
+						assert.Equal(t, string(rootURN("old")), child.Inputs["plain"])
+						states[0].URN = to
+						return states, map[resource.URN]resource.URN{from: to}, nil
+					}))
+					require.NoError(t, err)
+					opts.StateMigrations = append(opts.StateMigrations, callback)
+					opts.Aliases = append(opts.Aliases, &pulumirpc.Alias{
+						Alias: &pulumirpc.Alias_Urn{Urn: string(from)},
+					})
+				}
+				root, err := monitor.RegisterResource("pkg:m:Component", names[stage], false, opts)
+				if err != nil {
+					return err
+				}
+				_, err = monitor.RegisterResource("pkg:m:Child", "child", false, deploytest.ResourceOptions{
+					Parent:       root.URN,
+					Dependencies: []resource.URN{root.URN},
+					PropertyDeps: map[resource.PropertyKey][]resource.URN{"ref": {root.URN}},
+					Inputs: resource.PropertyMap{
+						"ref":   resource.MakeComponentResourceReference(root.URN, ""),
+						"plain": resource.NewProperty(string(rootURN("old"))),
+					},
+				})
+				return err
+			})
+			host := deploytest.NewPluginHostF(nil, nil, program, nil, nil)
+			plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, host)}
+			snap, err := runUpdate(t, plan, nil, nil)
+			require.NoError(t, err)
+			if sequential {
+				stage = 1
+				snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 2}))
+				require.NoError(t, err)
+			}
+			stage = 2
+			for range 2 {
+				snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 2}))
+				require.NoError(t, err)
+				require.NoError(t, snap.VerifyIntegrity())
+				require.Equal(t, rootURN("final"), snap.Resources[0].URN)
+				require.Equal(t, rootURN("final"), snap.Resources[1].Parent)
+			}
+		})
+	}
+}
+
 // TestStateMigrationErrors tests that any callback error or validation failure fails the update and leaves the prior
 // state untouched.
 func TestStateMigrationErrors(t *testing.T) {

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -778,40 +778,162 @@ func TestStateMigrationSecrets(t *testing.T) {
 	assert.Equal(t, "shh", child.Inputs["secret"].SecretValue().Element.StringValue())
 }
 
-// TestStateMigrationRejectsSplit verifies that a one-to-many migration cannot fabricate managed state. A final custom
-// resource must have a custom predecessor whose provider-managed identity the engine can verify.
-func TestStateMigrationRejectsSplit(t *testing.T) {
+// TestStateMigrationSplit exercises this one-to-many migration:
+//
+//	resource (managed, inline settings) -> resource (managed, settings removed)
+//	                                   + settings (managed, same physical ID and provider)
+//
+// The original resource retains its URN, and the new settings resource depends on it. The migration adopts the
+// settings resource without a provider create, and a subsequent update leaves both resources unchanged.
+func TestStateMigrationSplit(t *testing.T) {
 	t.Parallel()
-
-	env := newStateMigrationEnv(t)
-	snap, err := runUpdate(t, env.plan, nil, nil)
-	require.NoError(t, err)
-
-	env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
-		callback, err := callbacks.Allocate(
-			stateMigrationFunction(func(
-				urn resource.URN, resources []apitype.ResourceV3,
+	const (
+		componentType = "pkgA:m:Component"
+		resourceType  = "pkgA:m:Resource"
+		settingsType  = "pkgA:m:Settings"
+		resourceURN   = resource.URN("urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Resource::resource")
+		settingsURN   = resource.URN("urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Settings::settings")
+	)
+	upgrade := false
+	creates := 0
+	settings := map[string]any{"enabled": true}
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					creates++
+					return plugin.CreateResponse{ID: "resource-id", Properties: req.Properties, Status: resource.StatusOK}, nil
+				},
+			}, nil
+		}),
+	}
+	program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+		var migrations []*pulumirpc.Callback
+		if upgrade {
+			callback, err := callbacks.Allocate(stateMigrationFunction(func(
+				_ resource.URN, states []apitype.ResourceV3,
 			) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
-				var child apitype.ResourceV3
-				for _, res := range resources {
-					if res.URN == childAURN {
-						child = res
+				for _, state := range states {
+					if state.URN == settingsURN {
+						return nil, nil, nil
 					}
 				}
-				split := child
-				split.URN = childBURN
-				split.Inputs = map[string]any{"foo": "bar"}
-				split.Outputs = map[string]any{"foo": "bar"}
-				return append(resources, split), nil, nil
+				for i := range states {
+					if states[i].URN != resourceURN {
+						continue
+					}
+					sidecar := states[i]
+					sidecar.URN, sidecar.Type = settingsURN, settingsType
+					sidecar.Inputs = map[string]any{"resourceId": "resource-id", "settings": settings}
+					sidecar.Outputs = sidecar.Inputs
+					sidecar.Dependencies = []resource.URN{resourceURN}
+					sidecar.PropertyDependencies = map[resource.PropertyKey][]resource.URN{"resourceId": {resourceURN}}
+					delete(states[i].Inputs, "settings")
+					delete(states[i].Outputs, "settings")
+					return append(states, sidecar), nil, nil
+				}
+				return nil, nil, errors.New("missing resource")
 			}))
+			require.NoError(t, err)
+			migrations = []*pulumirpc.Callback{callback}
+		}
+		component, err := monitor.RegisterResource(componentType, "component", false, deploytest.ResourceOptions{
+			StateMigrations: migrations,
+		})
+		if err != nil {
+			return err
+		}
+		inputs := map[string]any{"name": "resource"}
+		if !upgrade {
+			inputs["settings"] = settings
+		}
+		_, err = monitor.RegisterResource(resourceType, "resource", true, deploytest.ResourceOptions{
+			Parent: component.URN, Inputs: resource.NewPropertyMapFromMap(inputs),
+		})
+		if err != nil || !upgrade {
+			return err
+		}
+		_, err = monitor.RegisterResource(settingsType, "settings", true, deploytest.ResourceOptions{
+			Parent: component.URN,
+			Inputs: resource.NewPropertyMapFromMap(map[string]any{
+				"resourceId": "resource-id", "settings": settings,
+			}),
+			Dependencies: []resource.URN{resourceURN},
+			PropertyDeps: map[resource.PropertyKey][]resource.URN{"resourceId": {resourceURN}},
+		})
+		return err
+	})
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
+	plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, host)}
+	snap, err := runUpdate(t, plan, nil, nil)
+	require.NoError(t, err)
+	upgrade = true
+	for range 2 {
+		snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 4}))
 		require.NoError(t, err)
-		return []*pulumirpc.Callback{callback}
+		require.NoError(t, snap.VerifyIntegrity())
+		assert.Contains(t, snapURNs(snap), resourceURN)
+		assert.Contains(t, snapURNs(snap), settingsURN)
 	}
+	assert.Equal(t, 1, creates, "the sidecar must be adopted from migrated state, not created")
+}
 
-	_, err = runUpdate(t, env.plan, snap, nil)
-	require.ErrorContains(t, err, "without a managed custom predecessor")
-	assert.Contains(t, snapURNs(snap), childAURN)
-	assert.NotContains(t, snapURNs(snap), childBURN)
+// TestStateMigrationRejectsInvalidSplit verifies that splitting preserves managed identity, ownership,
+// and lifecycle flags.
+func TestStateMigrationRejectsInvalidSplit(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		change  func(*apitype.ResourceV3)
+		message string
+	}{
+		{"identity", func(s *apitype.ResourceV3) { s.ID = "unrelated-object" }, "without a managed custom predecessor"},
+		{"ownership", func(s *apitype.ResourceV3) { s.External = !s.External }, "changes ownership"},
+		{
+			"pending replacement",
+			func(s *apitype.ResourceV3) { s.PendingReplacement = !s.PendingReplacement },
+			"changes PendingReplacement",
+		},
+		{"taint", func(s *apitype.ResourceV3) { s.Taint = !s.Taint }, "changes Taint"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			env := newStateMigrationEnv(t)
+			snap, err := runUpdate(t, env.plan, nil, nil)
+			require.NoError(t, err)
+
+			env.migrations = func(t *testing.T, callbacks *deploytest.CallbackServer) []*pulumirpc.Callback {
+				callback, err := callbacks.Allocate(
+					stateMigrationFunction(func(
+						urn resource.URN, resources []apitype.ResourceV3,
+					) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+						var child apitype.ResourceV3
+						for _, res := range resources {
+							if res.URN == childAURN {
+								child = res
+							}
+						}
+						split := child
+						split.URN = childBURN
+						tt.change(&split)
+						split.Inputs = map[string]any{"foo": "bar"}
+						split.Outputs = map[string]any{"foo": "bar"}
+						return append(resources, split), nil, nil
+					}))
+				require.NoError(t, err)
+				return []*pulumirpc.Callback{callback}
+			}
+
+			_, err = runUpdate(t, env.plan, snap, nil)
+			require.ErrorContains(t, err, tt.message)
+			assert.Contains(t, snapURNs(snap), childAURN)
+			assert.NotContains(t, snapURNs(snap), childBURN)
+		})
+	}
 }
 
 // TestStateMigrationFold exercises this many-to-one migration:

--- a/pkg/resource/deploy/state_migration.go
+++ b/pkg/resource/deploy/state_migration.go
@@ -139,7 +139,7 @@ func (sg *stepGenerator) applyStateMigrations(
 		logStateMigrationResource(ctx, "state migration prior resource", urn, state)
 	}
 
-	callbackResult, err := runStateMigrationCallbacks(ctx, urn, migrations, serialized)
+	callbackResult, err := runStateMigrationCallbacks(ctx, urn, migrations, serialized, opts.StateMigrationSerializer)
 	if err != nil {
 		return err
 	}
@@ -183,25 +183,11 @@ func (sg *stepGenerator) applyStateMigrations(
 			urn, strings.Join(pendingURNs, ", "), urn)
 	}
 
-	resultSubtree := make([]*pkgresource.State, len(callbackResult.resultResources))
-	for i, res := range callbackResult.resultResources {
-		state, err := opts.StateMigrationSerializer.Deserialize(res)
-		if err != nil {
-			return fmt.Errorf("state migration for %s: deserializing returned state of %s: %w", urn, res.URN, err)
-		}
-		resultSubtree[i] = state
-	}
-
-	rewrittenResultSubtree, err := rewriteStateMigrationReferences(
-		resultSubtree, callbackResult.allToFinal, stateMigrationSuccessorIdentities(resultSubtree))
+	_, resultSubtree, err := deserializeStateMigrationResult(
+		urn, callbackResult.resultResources, callbackResult.allToFinal, opts.StateMigrationSerializer)
 	if err != nil {
-		return fmt.Errorf("state migration for %s: rewriting successor references: %w", urn, err)
+		return fmt.Errorf("state migration for %s: %w", urn, err)
 	}
-	if _, err := mapResourcesToPreparedRewrites(
-		urn, resultSubtree, rewrittenResultSubtree, "returned by the migration"); err != nil {
-		return err
-	}
-	resultSubtree = rewrittenResultSubtree
 	for _, state := range resultSubtree {
 		logStateMigrationResource(ctx, "state migration result resource", urn, state)
 	}

--- a/pkg/resource/deploy/state_migration_callback.go
+++ b/pkg/resource/deploy/state_migration_callback.go
@@ -47,6 +47,7 @@ func runStateMigrationCallbacks(
 	urn resource.URN,
 	migrations []StateMigrationFunction,
 	original []apitype.ResourceV3,
+	serializer StateMigrationResourceSerializer,
 ) (*stateMigrationCallbackResult, error) {
 	currentJSON, err := json.Marshal(original)
 	if err != nil {
@@ -92,6 +93,32 @@ func runStateMigrationCallbacks(
 			allSuccessors[oldURN] = successor
 		}
 
+		// Rewrite references in the returned subtree before passing it to the next callback.
+		if i+1 < len(migrations) && len(allSuccessors) > 0 {
+			_, resolved, err := finalStateMigrationSuccessors(original, newSet, allSuccessors)
+			if err != nil {
+				return nil, fmt.Errorf("state migration %d of %d for %s: %w", i+1, len(migrations), urn, err)
+			}
+			states, rewritten, err := deserializeStateMigrationResult(urn, newSet, resolved, serializer)
+			if err != nil {
+				return nil, fmt.Errorf("state migration %d of %d for %s: %w", i+1, len(migrations), urn, err)
+			}
+			for j, state := range rewritten {
+				if state == states[j] {
+					continue
+				}
+				res, err := serializer.Serialize(ctx, state)
+				if err != nil {
+					return nil, fmt.Errorf("state migration %d of %d for %s: serializing intermediate state of %s: %w",
+						i+1, len(migrations), urn, state.URN, err)
+				}
+				newSet[j] = res
+			}
+			newJSON, err = json.Marshal(newSet)
+			if err != nil {
+				return nil, fmt.Errorf("state migration for %s: marshaling intermediate state: %w", urn, err)
+			}
+		}
 		current, currentJSON, changed = newSet, newJSON, true
 	}
 
@@ -123,4 +150,26 @@ func runStateMigrationCallbacks(
 		originalToFinal: originalToFinal,
 		allToFinal:      allToFinal,
 	}, nil
+}
+
+func deserializeStateMigrationResult(
+	urn resource.URN, resources []apitype.ResourceV3,
+	successors map[resource.URN]resource.URN, serializer StateMigrationResourceSerializer,
+) ([]*pkgresource.State, []*pkgresource.State, error) {
+	states := make([]*pkgresource.State, len(resources))
+	for i, res := range resources {
+		state, err := serializer.Deserialize(res)
+		if err != nil {
+			return nil, nil, fmt.Errorf("deserializing returned state of %s: %w", res.URN, err)
+		}
+		states[i] = state
+	}
+	rewritten, err := rewriteStateMigrationReferences(states, successors, stateMigrationSuccessorIdentities(states))
+	if err != nil {
+		return nil, nil, fmt.Errorf("rewriting successor references: %w", err)
+	}
+	if _, err := mapResourcesToPreparedRewrites(urn, states, rewritten, "returned by the migration"); err != nil {
+		return nil, nil, err
+	}
+	return states, rewritten, nil
 }

--- a/pkg/resource/deploy/state_migration_callback_test.go
+++ b/pkg/resource/deploy/state_migration_callback_test.go
@@ -78,7 +78,7 @@ func TestRunStateMigrationCallbacksRejectsInvalidAccounting(t *testing.T) {
 				return state, tt.successors, err
 			}
 			_, err := runStateMigrationCallbacks(
-				t.Context(), rootURN, []StateMigrationFunction{callback}, original)
+				t.Context(), rootURN, []StateMigrationFunction{callback}, original, nil)
 			require.ErrorContains(t, err, tt.want)
 		})
 	}

--- a/pkg/resource/deploy/state_migration_validation.go
+++ b/pkg/resource/deploy/state_migration_validation.go
@@ -62,6 +62,8 @@ func validateStateMigrationContext(
 // lifecycle (External), and its PendingReplacement and Taint flags must therefore follow its successor. Protect and
 // RetainOnDelete are engine-owned safety metadata and must be inherited conservatively by any custom or component
 // successor: when multiple resources are folded together, the successor must carry either flag if any predecessor did.
+// Additional custom resources must match prior managed state by physical ID, provider, and extension identity. They
+// preserve ownership and lifecycle flags for the matched prior resources, and inherit Protect and RetainOnDelete.
 // The provider identity restrictions do not apply to components because they have no provider-managed physical
 // identity.
 func validateStateMigrationManagedIdentity(
@@ -149,11 +151,38 @@ func validateStateMigrationManagedIdentity(
 		inheritedByURN[targetURN] = inherited
 	}
 
-	// The checks above validate retained custom resources and their successors. Now reject custom states without a
-	// managed predecessor, and reject safety or lifecycle flags that were not inherited from their predecessors. This
-	// includes states newly introduced by the migration.
+	// New resources without a predecessor must match the ID, provider, and extension against prior managed state, and
+	// inherit Protect and RetainOnDelete.
 	for _, state := range final {
-		inherited := inheritedByURN[state.URN]
+		inherited, hasPredecessor := inheritedByURN[state.URN]
+		if state.Custom && !hasPredecessor && state.ID != "" {
+			for _, old := range original {
+				if !old.Custom || old.ID != state.ID || old.Provider != state.Provider ||
+					old.ExtensionRef != state.ExtensionRef {
+					continue
+				}
+				if old.External != state.External {
+					return fmt.Errorf("state migration for %s changes ownership of custom resource %s "+
+						"from external=%t to external=%t on inferred successor %s; migrations must preserve managed resource ownership",
+						urn, old.URN, old.External, state.External, state.URN)
+				}
+				if old.PendingReplacement != state.PendingReplacement {
+					return fmt.Errorf("state migration for %s changes PendingReplacement for custom resource %s "+
+						"from %t to %t on inferred successor %s; migrations must preserve provider lifecycle state",
+						urn, old.URN, old.PendingReplacement, state.PendingReplacement, state.URN)
+				}
+				if old.Taint != state.Taint {
+					return fmt.Errorf("state migration for %s changes Taint for custom resource %s "+
+						"from %t to %t on inferred successor %s; migrations must preserve provider lifecycle state",
+						urn, old.URN, old.Taint, state.Taint, state.URN)
+				}
+				inherited.hasCustomPredecessor = true
+				inherited.protect = inherited.protect || old.Protect
+				inherited.retainOnDelete = inherited.retainOnDelete || old.RetainOnDelete
+				inherited.pendingReplacement = old.PendingReplacement
+				inherited.taint = old.Taint
+			}
+		}
 		if state.PendingReplacement && (!state.Custom || !inherited.pendingReplacement) {
 			return fmt.Errorf("state migration for %s returns resource %s with PendingReplacement set "+
 				"without a pending-replacement custom predecessor", urn, state.URN)

--- a/pkg/resource/deploy/state_migration_validation_test.go
+++ b/pkg/resource/deploy/state_migration_validation_test.go
@@ -24,6 +24,99 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+func TestStateMigrationSplitValidation(t *testing.T) {
+	t.Parallel()
+	old := apitype.ResourceV3{
+		URN:    "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Resource::resource",
+		Custom: true, ID: "resource-id", Provider: "provider",
+	}
+	additional := old
+	additional.URN = "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:Settings::settings"
+	for _, tt := range []struct {
+		name   string
+		change func(*apitype.ResourceV3)
+	}{
+		{"ID", func(s *apitype.ResourceV3) { s.ID = "different" }},
+		{"provider", func(s *apitype.ResourceV3) { s.Provider = "different" }},
+		{"extension", func(s *apitype.ResourceV3) { s.ExtensionRef = "different" }},
+		{"ownership", func(s *apitype.ResourceV3) { s.External = true }},
+		{"pending replacement", func(s *apitype.ResourceV3) { s.PendingReplacement = true }},
+		{"taint", func(s *apitype.ResourceV3) { s.Taint = true }},
+		{"protection", func(s *apitype.ResourceV3) { s.Protect = true }},
+		{"retention", func(s *apitype.ResourceV3) { s.RetainOnDelete = true }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			changed := additional
+			tt.change(&changed)
+			require.Error(t, validateStateMigrationManagedIdentity(old.URN,
+				[]apitype.ResourceV3{old}, []apitype.ResourceV3{old, changed}, nil))
+		})
+	}
+	t.Run("same identity", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateStateMigrationManagedIdentity(old.URN,
+			[]apitype.ResourceV3{old}, []apitype.ResourceV3{old, additional}, nil))
+	})
+	for _, tt := range []struct {
+		name   string
+		change func(*apitype.ResourceV3)
+	}{
+		{"ownership", func(s *apitype.ResourceV3) { s.External = true }},
+		{"PendingReplacement", func(s *apitype.ResourceV3) { s.PendingReplacement = true }},
+		{"Taint", func(s *apitype.ResourceV3) { s.Taint = true }},
+	} {
+		t.Run("conflicting matches/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			other := old
+			other.URN = "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:OtherSettings::other-settings"
+			other.Protect, other.RetainOnDelete = true, true
+			tt.change(&other)
+			for _, sources := range [][]apitype.ResourceV3{{old, other}, {other, old}} {
+				for _, useOtherFlags := range []bool{false, true} {
+					target := additional
+					if useOtherFlags {
+						tt.change(&target)
+						target.Protect, target.RetainOnDelete = true, true
+					}
+					require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN, sources,
+						[]apitype.ResourceV3{old, other, target}, nil), "changes "+tt.name)
+				}
+			}
+			// Matching non-default flags are valid when all candidates agree.
+			target := additional
+			tt.change(&target)
+			target.Protect, target.RetainOnDelete = true, true
+			require.NoError(t, validateStateMigrationManagedIdentity(old.URN,
+				[]apitype.ResourceV3{other}, []apitype.ResourceV3{other, target}, nil))
+		})
+	}
+	t.Run("empty identity", func(t *testing.T) {
+		t.Parallel()
+		source, target := old, additional
+		source.ID, target.ID = "", ""
+		require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN,
+			[]apitype.ResourceV3{source}, []apitype.ResourceV3{source, target}, nil), "without a managed custom predecessor")
+	})
+	t.Run("all matching sources contribute safety flags", func(t *testing.T) {
+		t.Parallel()
+		other := old
+		other.URN = "urn:pulumi:test::test::pkgA:m:Component$pkgA:m:OtherSettings::other-settings"
+		other.Protect, other.RetainOnDelete = true, true
+		for _, sources := range [][]apitype.ResourceV3{{old, other}, {other, old}} {
+			require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN, sources,
+				[]apitype.ResourceV3{old, other, additional}, nil), "changes Protect")
+			target := additional
+			target.Protect = true
+			require.ErrorContains(t, validateStateMigrationManagedIdentity(old.URN, sources,
+				[]apitype.ResourceV3{old, other, target}, nil), "changes RetainOnDelete")
+			target.RetainOnDelete = true
+			require.NoError(t, validateStateMigrationManagedIdentity(old.URN, sources,
+				[]apitype.ResourceV3{old, other, target}, nil))
+		}
+	})
+}
+
 func TestValidateStateMigrationContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
If we have a component with multiple migrations added over time, an update that applies all the migrations at once needs to behave the same as a series of updates that run one migration at at time would.

To ensure this, after each migration runs, we rewrite successor references in the intermediate result before invoking the next callback.

[Developer docs](https://pulumi-developer-docs--24310.org.readthedocs.build/24310/docs/architecture/deployment-execution/state-migrations.html)

Ref https://github.com/pulumi/pulumi/issues/24045
