### PR TITLE
Fix the source position of read resources in the Go SDK

### DIFF
--- a/changelog/pending/sdk-go-fix-20260909-read-source-position.yaml
+++ b/changelog/pending/sdk-go-fix-20260909-read-source-position.yaml
@@ -1,0 +1,5 @@
+component: sdk/go
+kind: fix
+body: Report the source position of the user code that calls a generated resource
+    getter instead of the getter body
+time: 2026-09-09T00:00:00Z

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -27,7 +27,7 @@ do
 done
 
 # Excluding tests that have their dependencies code-generated but under .gitignore.
-EXCLUDE="-e tests/integration/construct_component_configure_provider/go/go.mod -e tests/integration/package-add/namespace/go/go.mod -e tests/integration/go/stale-parameterized-packageref/go.mod -e sdk/go/pulumi-language-go/testdata -e tests/testdata -e tests/smoke/testdata -e sdk/go/tools/automation/tests/runtime/go.mod -e sdk/go/common/util/logging/testdata/glog-flag-conflict/go.mod"
+EXCLUDE="-e tests/integration/construct_component_configure_provider/go/go.mod -e tests/integration/package-add/namespace/go/go.mod -e tests/integration/go/stale-parameterized-packageref/go.mod -e tests/integration/go/source-position/go.mod -e sdk/go/pulumi-language-go/testdata -e tests/testdata -e tests/smoke/testdata -e sdk/go/tools/automation/tests/runtime/go.mod -e sdk/go/common/util/logging/testdata/glog-flag-conflict/go.mod"
 
 for f in $(git ls-files '**go.mod' | grep -v $EXCLUDE)
 do

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1448,10 +1448,10 @@ func (ctx *Context) readPackageResource(
 	res := ctx.makeResourceState(t, name, resource, providers, provider, protect,
 		options.Version, options.PluginDownloadURL, aliasURNs, transformations)
 
-	// Get the stack trace and source position for the resource registration. Note that this assumes that there is an
-	// intermediate frame between the this function and user code.
-	stackTrace := ctx.getStackTrace(3)
-	sourcePosition := ctx.getSourcePosition(3)
+	// Get the stack trace and source position for the resource read. Note that this assumes that there are two
+	// intermediate frames between this function and user code: the public entry point and the generated getter.
+	stackTrace := ctx.getStackTrace(4)
+	sourcePosition := ctx.getSourcePosition(4)
 
 	// Kick off the resource read operation.  This will happen asynchronously and resolve the above properties.
 	go func() {

--- a/tests/integration/go/source-position/Pulumi.yaml
+++ b/tests/integration/go/source-position/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: source-position
+description: Registers and reads a resource through a generated SDK
+runtime: go

--- a/tests/integration/go/source-position/go.mod
+++ b/tests/integration/go/source-position/go.mod
@@ -1,0 +1,3 @@
+module source-position
+
+go 1.23

--- a/tests/integration/go/source-position/main.go
+++ b/tests/integration/go/source-position/main.go
@@ -1,0 +1,22 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+package main
+
+import (
+	"example.com/pulumi-pkg/sdk/go/pkg"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// TestSourcePositionGo asserts the line numbers of the two calls below. Update the expected lines
+// in that test if you move them.
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := pkg.NewRandom(ctx, "reg", &pkg.RandomArgs{Length: pulumi.Int(8)})
+		if err != nil {
+			return err
+		}
+
+		_, err = pkg.GetRandom(ctx, "read", pulumi.ID("abcdefgh"), nil)
+		return err
+	})
+}

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1284,6 +1285,80 @@ func TestPackageAddGo(t *testing.T) {
 	// Currently package add does not work correctly for non parameterized
 	// packages, once they add the go.mod as expected we can parse it and check
 	// if it contains a rename as the parameterized version of this test does.
+}
+
+// TestSourcePositionGo checks the source position that the Go SDK reports for a resource created
+// through a generated SDK. The position must be the line of user code that calls the generated
+// constructor or getter, not the line inside the generated function that calls the SDK.
+//
+//nolint:paralleltest // mutates environment
+func TestSourcePositionGo(t *testing.T) {
+	// `go build -trimpath` records a program's files relative to its module. That path has no
+	// volume, so the engine rejects it as not absolute and records no position on windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("the engine records no source position for a Go program on windows")
+	}
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory(filepath.Join("go", "source-position"))
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "package", "add", testutil.TestProvider(t), "pkg")
+
+	// `package add` rewrites Pulumi.yaml, so point the engine at the prebuilt provider afterwards.
+	require.NoError(t, appendLines(filepath.Join(e.CWD, "Pulumi.yaml"), []string{
+		"plugins:",
+		"  providers:",
+		"    - name: testprovider",
+		"      path: " + testutil.TestProviderDir(t),
+	}))
+
+	localSDK, err := filepath.Abs(filepath.Join("..", "..", "sdk"))
+	require.NoError(t, err)
+	e.RunCommand("go", "mod", "edit", "-replace", "github.com/pulumi/pulumi/sdk/v3="+localSDK)
+	e.RunCommand("go", "mod", "tidy")
+
+	e.RunCommand("pulumi", "stack", "init", "test")
+	e.RunCommand("pulumi", "up", "--yes", "--skip-preview")
+
+	stdout, _ := e.RunCommand("pulumi", "stack", "export")
+	var untyped apitype.UntypedDeployment
+	require.NoError(t, json.Unmarshal([]byte(stdout), &untyped))
+	var deployment apitype.DeploymentV3
+	require.NoError(t, json.Unmarshal(untyped.Deployment, &deployment))
+
+	// A position is recorded as "project:///<path>#<line>". `go build -trimpath` makes the path
+	// relative to the program's module and the engine then makes it relative to the project
+	// directory, so only the file name and the line are stable across machines.
+	type position struct {
+		File string
+		Line string
+	}
+	parse := func(recorded string) position {
+		file, line, ok := strings.Cut(recorded, "#")
+		require.True(t, ok, "malformed source position %q", recorded)
+		return position{File: path.Base(file), Line: line}
+	}
+
+	positions, traceHeads := map[string]position{}, map[string]position{}
+	for _, r := range deployment.Resources {
+		name := r.URN.Name()
+		if name != "reg" && name != "read" {
+			continue
+		}
+		positions[name] = parse(r.SourcePosition)
+		require.NotEmpty(t, r.StackTrace, "no stack trace recorded for %q", name)
+		traceHeads[name] = parse(r.StackTrace[0].SourcePosition)
+	}
+
+	// These are the lines of the pkg.NewRandom and pkg.GetRandom calls in main.go.
+	expected := map[string]position{
+		"reg":  {File: "main.go", Line: "14"},
+		"read": {File: "main.go", Line: "19"},
+	}
+	assert.Equal(t, expected, positions)
+	assert.Equal(t, expected, traceHeads)
 }
 
 // getPluginVersion finds the highest version of a plugin by name


### PR DESCRIPTION
Fix how Go reports source positions for `<pkg>.Get<resource>` functions, matching our TypeScript & Python behavior.

This behavior is tested with a full integration test to ensure our solution matches the SDKs we actually generate. If we add another function call between `<pkg>.Get<resource>` calls and `ctx.ReadResource`, this test will fail and we will know to adjust our behavior.

Fixes #24601