### PR TITLE
Fix Go SDK source position for registered resources

### DIFF
--- a/changelog/pending/sdk-go-fix-20260909-source-position.yaml
+++ b/changelog/pending/sdk-go-fix-20260909-source-position.yaml
@@ -1,0 +1,4 @@
+component: sdk/go
+kind: fix
+body: Record the correct source position for Go SDK resource registrations
+time: 2026-09-09T10:19:28Z

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1825,10 +1825,10 @@ func (ctx *Context) registerResource(
 	resState := ctx.makeResourceState(t, name, resource, providers, provider, protect,
 		options.Version, options.PluginDownloadURL, aliasURNs, transformations)
 
-	// Get the stack trace and source position for the resource registration. Note that this assumes that there are two
-	// intermediate frames between this function and user code.
-	stackTrace := ctx.getStackTrace(4)
-	sourcePosition := ctx.getSourcePosition(4)
+	// Get the stack trace and source position for the resource registration. Note that this assumes that there is an
+	// intermediate frame between this function and user code.
+	stackTrace := ctx.getStackTrace(3)
+	sourcePosition := ctx.getSourcePosition(3)
 
 	// Kick off the resource registration.  If we are actually performing a deployment, the resulting properties
 	// will be resolved asynchronously as the RPC operation completes.  If we're just planning, values won't resolve.

--- a/sdk/go/pulumi/context_source_position_test.go
+++ b/sdk/go/pulumi/context_source_position_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+// These helpers are defined in a file separate from TestSourcePosition so that the test
+// can assert the recorded source position points at the registration call site (in this
+// file) rather than one frame too high (the caller in context_test.go). Keeping them in a
+// different file makes an off-by-one frame error observable via the file name in the
+// source position URI, which a same-file closure would hide.
+
+func registerSourcePositionResource(ctx *Context) error {
+	var res testResource2
+	return ctx.RegisterResource("test:resource:type", "reg", &testResource2Inputs{}, &res)
+}
+
+func readSourcePositionResource(ctx *Context) error {
+	var res testResource2
+	return ctx.ReadResource("test:resource:type", "read", ID("myid"), &testResource2Inputs{}, &res)
+}

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -618,7 +618,7 @@ func TestSourcePosition(t *testing.T) {
 
 			require.NotNil(t, sourcePosition)
 			assert.True(t, strings.HasPrefix(sourcePosition.Uri, "file:///"))
-			assert.True(t, strings.HasSuffix(sourcePosition.Uri, "context_test.go"))
+			assert.True(t, strings.HasSuffix(sourcePosition.Uri, "context_source_position_test.go"))
 
 			require.NotNil(t, stackTrace)
 			require.True(t, len(stackTrace.Frames) > 1)
@@ -633,20 +633,10 @@ func TestSourcePosition(t *testing.T) {
 	}
 
 	err := RunErr(func(ctx *Context) error {
-		reg := func() error {
-			var res testResource2
-			return ctx.RegisterResource("test:resource:type", "reg", &testResource2Inputs{}, &res)
-		}
-
-		read := func() error {
-			var res testResource2
-			return ctx.ReadResource("test:resource:type", "read", ID("myid"), &testResource2Inputs{}, &res)
-		}
-
-		err := reg()
+		err := registerSourcePositionResource(ctx)
 		require.NoError(t, err)
 
-		err = read()
+		err = readSourcePositionResource(ctx)
 		require.NoError(t, err)
 
 		return nil


### PR DESCRIPTION
## Description

The Go SDK records the wrong `sourcePosition` (and first `stackTrace` frame) for resources created with `ctx.RegisterResource`, `ctx.RegisterComponentResource`, and their `Package`/`Remote` variants. The recorded position is one stack frame too high: it points at the caller of the user's function instead of the line that registered the resource.

For a plain program the position lands on the line inside `RunWithContext` that calls the user's body (`sdk/go/pulumi/run.go`), so every resource ends up with the same wrong line. `ctx.ReadResource` records the correct line.

The cause is an off-by-one in the number of frames skipped when capturing the stack. `registerResource` and `readPackageResource` have the same call depth (a single public wrapper between them and user code), but `registerResource` skipped one extra frame.

## Fix

Align the frame skip in `registerResource` with the one used by the read path.

## Test

`TestSourcePosition` previously only checked the file name suffix, and its closure was invoked from the same file, so the off-by-one went unnoticed. The registration/read calls now live in helper functions in a separate file (`context_source_position_test.go`), and the test asserts the recorded position is that file. With the old skip value the assertion fails because the position resolves to the caller in `context_test.go`.

Fixes #24601
