### PR TITLE
improve error messages for invalid default org

### DIFF
--- a/changelog/pending/backend-service-improvement-20260909-173051.yaml
+++ b/changelog/pending/backend-service-improvement-20260909-173051.yaml
@@ -1,0 +1,4 @@
+component: backend/service
+kind: improvement
+body: Improve error messages if default org is invalid
+time: 2026-09-09T17:30:51.172667125+02:00

--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -178,6 +178,20 @@ func (err NotFoundError) Is(other error) bool {
 	}
 }
 
+// DefaultOrgError indicates that an operation failed because the organization taken from
+// the default organization setting does not exist or cannot be accessed by the current user.
+type DefaultOrgError struct {
+	Org string
+	Err error
+}
+
+func (err DefaultOrgError) Error() string {
+	return fmt.Sprintf("the organization %q set as the default organization does not exist or you do not have "+
+		"access to it; use `pulumi org set-default` to change the default organization: %v", err.Org, err.Err)
+}
+
+func (err DefaultOrgError) Unwrap() error { return err.Err }
+
 type ForbiddenError struct{ Err error }
 
 func (err ForbiddenError) Unwrap() error {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1270,7 +1270,26 @@ func (b *cloudBackend) DoesProjectExist(ctx context.Context, orgName string, pro
 		return false, err
 	}
 
-	return b.client.DoesProjectExist(ctx, orgName, projectName)
+	exists, err := b.client.DoesProjectExist(ctx, orgName, projectName)
+	if err != nil {
+		return false, b.enrichDefaultOrgError(ctx, orgName, err)
+	}
+	return exists, nil
+}
+
+// enrichDefaultOrgError wraps forbidden and not-found errors for operations on the
+// organization that the default organization setting resolved to, so that users whose
+// default organization is misspelled or inaccessible learn how to correct it.
+func (b *cloudBackend) enrichDefaultOrgError(ctx context.Context, orgName string, err error) error {
+	errResp, isErrResp := errors.AsType[*apitype.ErrorResponse](err)
+	notFound := isErrResp && errResp.Code == http.StatusNotFound
+	if !notFound && !errors.Is(err, backenderr.ErrForbidden) {
+		return err
+	}
+	if defaultOrg, defaultOrgErr := b.defaultOrg.Result(ctx); defaultOrgErr != nil || defaultOrg != orgName {
+		return err
+	}
+	return backenderr.DefaultOrgError{Org: orgName, Err: err}
 }
 
 func (b *cloudBackend) GetStack(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
@@ -1335,7 +1354,7 @@ func (b *cloudBackend) CreateStack(
 				return nil, &backenderr.OverStackLimitError{Message: errResp.Message}
 			}
 		}
-		return nil, err
+		return nil, b.enrichDefaultOrgError(ctx, stackID.Owner, err)
 	}
 
 	// Display messages from the backend if present.

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -1535,6 +1535,67 @@ func TestDefaultOrganizationPriority(t *testing.T) {
 	}
 }
 
+func TestDoesProjectExistForbiddenDefaultOrg(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	defaultOrg := &promise.CompletionSource[string]{}
+	defaultOrg.MustFulfill("some-org")
+	b := &cloudBackend{
+		client:     client.NewClient(server.URL, "test-token", false, diagtest.LogSink(t)),
+		d:          diagtest.LogSink(t),
+		defaultOrg: defaultOrg.Promise(),
+	}
+
+	_, err := b.DoesProjectExist(t.Context(), "", "proj")
+	require.ErrorContains(t, err, `the organization "some-org" set as the default organization`)
+	require.ErrorContains(t, err, "`pulumi org set-default`")
+	require.ErrorIs(t, err, backenderr.ErrForbidden)
+
+	_, err = b.DoesProjectExist(t.Context(), "explicit-org", "proj")
+	require.ErrorIs(t, err, backenderr.ErrForbidden)
+	require.NotContains(t, err.Error(), "set-default")
+}
+
+func TestCreateStackInaccessibleDefaultOrg(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+		_, err := rw.Write([]byte(`{"code": 404, "message": "Not Found: Organization 'some-org' not found"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	defaultOrg := &promise.CompletionSource[string]{}
+	defaultOrg.MustFulfill("some-org")
+	b := &cloudBackend{
+		client:     client.NewClient(server.URL, "test-token", false, diagtest.LogSink(t)),
+		d:          diagtest.LogSink(t),
+		defaultOrg: defaultOrg.Promise(),
+	}
+
+	_, err := b.CreateStack(t.Context(), cloudBackendReference{
+		owner:   "some-org",
+		project: "proj",
+		name:    tokens.MustParseStackName("dev"),
+	}, t.TempDir(), nil, nil)
+	require.ErrorContains(t, err, `the organization "some-org" set as the default organization`)
+	require.ErrorContains(t, err, "`pulumi org set-default`")
+
+	_, err = b.CreateStack(t.Context(), cloudBackendReference{
+		owner:   "other-org",
+		project: "proj",
+		name:    tokens.MustParseStackName("dev"),
+	}, t.TempDir(), nil, nil)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "set-default")
+}
+
 func TestNewDefaultOrgResolution(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/cmd/pulumi/org/org.go
+++ b/pkg/cmd/pulumi/org/org.go
@@ -17,6 +17,7 @@ package org
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -127,6 +129,13 @@ func newOrgSetDefaultCmd() *cobra.Command {
 			if !currentBe.SupportsOrganizations() {
 				return fmt.Errorf("unable to set a default organization for backend type: %s",
 					currentBe.Name())
+			}
+
+			if user, orgs, _, userErr := currentBe.CurrentUser(); userErr == nil &&
+				orgName != user && !slices.Contains(orgs, orgName) {
+				cmdutil.Diag().Warningf(diag.Message("",
+					"you do not appear to be a member of organization %q; "+
+						"commands that use the default organization may fail"), orgName)
 			}
 
 			cloudURL, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -16,12 +16,14 @@ package newcmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -126,6 +128,9 @@ func createStackWithRetry(ctx context.Context, sink diag.Sink, w io.Writer, ws p
 			return s, formatted, nil
 		}
 		if yes {
+			return nil, "", err
+		}
+		if _, ok := errors.AsType[backenderr.DefaultOrgError](err); ok {
 			return nil, "", err
 		}
 		// Let the user know about the error and loop around to try again.

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -133,7 +133,8 @@ func PromptForValue(
 				continue
 			} else if validationError != nil {
 				// Authentication errors should not be treated as validation failures.
-				if errors.Is(validationError, backenderr.LoginRequiredError{}) {
+				if errors.Is(validationError, backenderr.LoginRequiredError{}) ||
+					errors.Is(validationError, backenderr.ErrForbidden) {
 					return "", validationError
 				}
 				// If validation failed, let the user know. If interactive, we will print the error and

--- a/pkg/cmd/pulumi/ui/survey_test.go
+++ b/pkg/cmd/pulumi/ui/survey_test.go
@@ -16,6 +16,8 @@ package ui
 
 import (
 	"bytes"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -67,6 +69,30 @@ func TestConfirmDeletion(t *testing.T) {
 		assert.True(t, result.IsBail(err), "declining must return a bail error")
 		assert.Contains(t, w.String(), "confirmation declined")
 	})
+}
+
+//nolint:paralleltest // replaces os.Stdin and os.Stdout
+func TestPromptForValueBailsOnForbiddenError(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = w.WriteString("some-project\n")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	oldStdin, oldStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = r, outW
+	t.Cleanup(func() {
+		os.Stdin, os.Stdout = oldStdin, oldStdout
+		require.NoError(t, outW.Close())
+		require.NoError(t, outR.Close())
+	})
+
+	forbidden := backenderr.ForbiddenError{Err: errors.New("access to org denied")}
+	_, err = PromptForValue(false /*yes*/, "Project name", "default-name", false, /*secret*/
+		func(value string) error { return forbidden },
+		display.Options{Color: colors.Never})
+	require.ErrorIs(t, err, backenderr.ErrForbidden)
 }
 
 // failingReader fails the test if anything tries to read from it


### PR DESCRIPTION
Warn on `org set-default` when the given org doesn't exist, and also improve the error messages when the user set the default org to an invalid one.

Fixes #22071