### PR TITLE
new: error out on ambiguous templates

### DIFF
--- a/changelog/pending/cli-new-fix-20260909-171431.yaml
+++ b/changelog/pending/cli-new-fix-20260909-171431.yaml
@@ -1,0 +1,4 @@
+component: cli/new
+kind: fix
+body: Error out on ambiguous template names instead of failing silently
+time: 2026-09-09T17:14:31.245335662+02:00

--- a/pkg/cmd/pulumi/project/newcmd/guided.go
+++ b/pkg/cmd/pulumi/project/newcmd/guided.go
@@ -143,7 +143,7 @@ func chooseGuidedFromSource(
 	if len(all) > 1 {
 		fmt.Fprintln(opts.Stdout, "Falling back to the full template list.")
 	}
-	return pickFromSet(all, false /*yes*/, opts, selector)
+	return pickFromSet(all, "" /*requested*/, false /*yes*/, opts, selector)
 }
 
 func (g *guided) choose() (cmdTemplates.Template, error) {

--- a/pkg/cmd/pulumi/project/newcmd/template.go
+++ b/pkg/cmd/pulumi/project/newcmd/template.go
@@ -94,22 +94,36 @@ func resolveTemplate(
 	if err != nil {
 		return nil, err
 	}
-	return declinedToChoose(pickFromSet(all, args.yes, opts, selector))
+	return declinedToChoose(pickFromSet(all, args.templateNameOrURL, args.yes, opts, selector))
 }
 
-// `--yes` never prompts, and takes no template rather than guessing among several.
+// `--yes` never prompts: a requested template matching several is an error, and no
+// requested template takes none rather than guessing among all of them.
 func pickFromSet(
-	templates []cmdTemplates.Template, yes bool, opts display.Options, selector selectFunc,
+	templates []cmdTemplates.Template, requested string, yes bool, opts display.Options, selector selectFunc,
 ) (cmdTemplates.Template, error) {
 	switch {
 	case len(templates) == 1:
 		return templates[0], nil
+	case yes && requested != "" && len(templates) > 1:
+		return nil, ambiguousTemplateError(requested, templates)
 	case yes:
 		return nil, nil
 	case len(templates) == 0:
 		return nil, errors.New("no templates")
 	}
 	return chooseTemplateFromList(sortedForDisplay(templates), opts, selector)
+}
+
+func ambiguousTemplateError(requested string, templates []cmdTemplates.Template) error {
+	names := make([]string, 0, len(templates))
+	for _, t := range sortedForDisplay(templates) {
+		names = append(names, t.DisplayName())
+	}
+	return fmt.Errorf("template %q is ambiguous, it matches: %s; "+
+		"rerun without --yes to choose one interactively, or use a more specific "+
+		"name such as <publisher>/%s",
+		requested, strings.Join(names, ", "), requested)
 }
 
 func templateLabeler(templates []cmdTemplates.Template) func(cmdTemplates.Template) string {

--- a/pkg/cmd/pulumi/project/newcmd/template_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/template_test.go
@@ -239,6 +239,25 @@ func TestResolveTemplateWithoutGuidedFlowUsesTheFullSetOnly(t *testing.T) {
 	assert.Nil(t, got, "--yes takes no template rather than guessing among several")
 }
 
+func TestResolveTemplateYesErrorsOnAmbiguousName(t *testing.T) {
+	t.Parallel()
+
+	src := unsplitSource{all: []cmdTemplates.Template{
+		fakeTemplate{name: "aws-typescript"},
+		fakeRegistryTemplate{fakeTemplate: fakeTemplate{name: "aws-typescript"}, publisher: "pequod"},
+	}}
+
+	noPrompt := func(string, []string, display.Options) (int, error) {
+		t.Error("--yes must never prompt")
+		return 0, nil
+	}
+	got, err := resolveTemplate(
+		src, newArgs{yes: true, templateNameOrURL: "aws-typescript"}, display.Options{}, noPrompt)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, `template "aws-typescript" is ambiguous`)
+	assert.ErrorContains(t, err, "rerun without --yes")
+}
+
 func TestSortedForDisplaySortsAndMarksBroken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Currently when a user runs `pulumi new <ambiguous-template-name>` because there's two templates with the same name, none ends up getting instantiated, which is confusing to the user.

Since we can't really disambiguate well, just error out, and make the user pick, either through picking the template interactively, or using the publisher name.

Fixes #24502