### PR TITLE
Correct `pulumi plugin rm` help about automatic re-installation

### DIFF
--- a/changelog/pending/20260909--cli-plugin--rm-help-auto-reinstall.yaml
+++ b/changelog/pending/20260909--cli-plugin--rm-help-auto-reinstall.yaml
@@ -1,0 +1,3 @@
+component: cli/plugin
+kind: improvement
+body: Correct `pulumi plugin rm` help text to note that the CLI re-downloads removed plugins automatically

--- a/pkg/cmd/pulumi/plugin/plugin_remove.go
+++ b/pkg/cmd/pulumi/plugin/plugin_remove.go
@@ -50,9 +50,10 @@ func newPluginRemoveCmd(pluginContext pluginstorage.Context) *cobra.Command {
 			"NAME are specified, but not VERSION, all versions of the plugin with the\n" +
 			"given KIND and NAME will be removed.  VERSION may be a range.\n" +
 			"\n" +
-			"This removal cannot be undone.  If a deleted plugin is subsequently required\n" +
-			"in order to execute a Pulumi program, it must be re-downloaded and installed\n" +
-			"using the plugin install command.",
+			"Valid values for KIND are: resource, language, analyzer, converter, or tool.\n" +
+			"\n" +
+			"If a deleted plugin is subsequently required to execute a Pulumi program,\n" +
+			"the Pulumi CLI will attempt to download and install it automatically.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			yes = yes || env.SkipConfirmations.Value()
 			opts := display.Options{


### PR DESCRIPTION
The `pulumi plugin rm` help text told users that a removed plugin "must be re-downloaded and installed using the plugin install command." That hasn't been true for a while — it sends users to a command they don't need and makes `plugin rm` sound more destructive than it is. It also referenced `KIND` without ever listing the valid values.

### Before / after

```diff
 given KIND and NAME will be removed.  VERSION may be a range.

-This removal cannot be undone.  If a deleted plugin is subsequently required
-in order to execute a Pulumi program, it must be re-downloaded and installed
-using the plugin install command.
+Valid values for KIND are: resource, language, analyzer, converter, or tool.

+If a deleted plugin is subsequently required to execute a Pulumi program,
+the Pulumi CLI will attempt to download and install it automatically.
```

That is the whole diff of `pulumi plugin rm --help` — everything from `Usage:` onward is byte-for-byte unchanged.

### Why "will attempt to"

Automatic acquisition happens in two layers: `EnsurePluginsAreInstalled` (`pkg/engine/plugins.go`) installs missing plugins up front during up/destroy/refresh, and the provider registry installs them lazily on `MissingError` (`pkg/resource/deploy/providers/registry.go`). But it is not unconditional — `PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION` suppresses it, and it still depends on the plugin being downloadable. So the text hedges deliberately rather than promising a download outright.

### Carried-over review feedback

This is a fresh take on the `plugin rm` portion of #20803, which was closed as stale with unlanded review comments. Both of @tgummerer's questions there are resolved here:

- *"What do you mean with 'cannot be undone'?"* — the sentence is dropped.
- *"What do you mean with 'often'?"* — "will often download it" became "will attempt to download and install it".

Fixes #24617. Part of epic #20777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvbU7evxsgz7GnmgHgJSme
