### PR TITLE
Update CheckRequest/Response to use property.Map

### DIFF
--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -605,10 +605,10 @@ func (pc *packageCommand) checkResourceInputs(
 	ctx context.Context, urn resource.URN, res *schema.Resource, olds, news resource.PropertyMap,
 ) (resource.PropertyMap, error) {
 	checked, err := pc.provider.Check(ctx, plugin.CheckRequest{
-		URN:  urn,
-		Type: tokens.Type(res.Token),
-		Olds: olds,
-		News: news,
+		URN:       urn,
+		Type:      tokens.Type(res.Token),
+		OldInputs: resource.FromResourcePropertyMap(olds),
+		NewInputs: resource.FromResourcePropertyMap(news),
 	})
 	if err != nil {
 		return nil, err
@@ -621,7 +621,7 @@ func (pc *packageCommand) checkResourceInputs(
 		}
 		return nil, fmt.Errorf("%s", b.String())
 	}
-	return checked.Properties, nil
+	return resource.ToResourcePropertyMap(checked.Properties), nil
 }
 
 func readNotFound(read plugin.ReadResponse) bool {

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -226,9 +226,9 @@ func TestDoCmdResourceCreate(t *testing.T) {
 			CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
 				calls = append(calls, "check")
 				assert.Equal(t, tokens.Type("azure:index:myResource"), req.Type)
-				assert.Equal(t, "example", req.News["name"].StringValue())
-				assert.Equal(t, 2.0, req.News["size"].NumberValue())
-				return plugin.CheckResponse{Properties: req.News}, nil
+				assert.Equal(t, "example", req.NewInputs.Get("name").AsString())
+				assert.Equal(t, 2.0, req.NewInputs.Get("size").AsNumber())
+				return plugin.CheckResponse{Properties: req.NewInputs}, nil
 			},
 			CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 				calls = append(calls, "create")
@@ -300,11 +300,11 @@ func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
 		spec: spec,
 		MockProvider: plugin.MockProvider{
 			CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
-				assert.Equal(t, "example", req.News["name"].StringValue())
-				assert.Equal(t, 42.0, req.News["intValue"].NumberValue())
-				assert.Equal(t, "kebab", req.News["already-kebab-case"].StringValue())
-				assert.Equal(t, true, req.News["snake_case"].BoolValue())
-				return plugin.CheckResponse{Properties: req.News}, nil
+				assert.Equal(t, "example", req.NewInputs.Get("name").AsString())
+				assert.Equal(t, 42.0, req.NewInputs.Get("intValue").AsNumber())
+				assert.Equal(t, "kebab", req.NewInputs.Get("already-kebab-case").AsString())
+				assert.Equal(t, true, req.NewInputs.Get("snake_case").AsBool())
+				return plugin.CheckResponse{Properties: req.NewInputs}, nil
 			},
 			CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 				return plugin.CreateResponse{
@@ -424,11 +424,11 @@ func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 				},
 				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
 					calls = append(calls, "check")
-					assert.Equal(t, "old", req.Olds["name"].StringValue())
-					assert.Equal(t, "new", req.News["name"].StringValue())
-					assert.Equal(t, 1.0, req.News["size"].NumberValue())
-					assert.Equal(t, true, req.News["enabled"].BoolValue())
-					return plugin.CheckResponse{Properties: req.News}, nil
+					assert.Equal(t, "old", req.OldInputs.Get("name").AsString())
+					assert.Equal(t, "new", req.NewInputs.Get("name").AsString())
+					assert.Equal(t, 1.0, req.NewInputs.Get("size").AsNumber())
+					assert.Equal(t, true, req.NewInputs.Get("enabled").AsBool())
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				DiffF: func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
 					calls = append(calls, "diff")
@@ -490,9 +490,9 @@ enabled = true
 					}, nil
 				},
 				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
-					assert.Equal(t, "existing", req.News["name"].StringValue())
-					assert.Equal(t, true, req.News["enabled"].BoolValue())
-					return plugin.CheckResponse{Properties: req.News}, nil
+					assert.Equal(t, "existing", req.NewInputs.Get("name").AsString())
+					assert.Equal(t, true, req.NewInputs.Get("enabled").AsBool())
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				DiffF: func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
 					return plugin.DiffResponse{Changes: plugin.DiffSome}, nil
@@ -826,7 +826,7 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 			spec: doResourceSpec(false),
 			MockProvider: plugin.MockProvider{
 				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 					return plugin.CreateResponse{ID: "res-1", Properties: req.Properties}, nil
@@ -858,7 +858,7 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 			spec: doResourceSpec(false),
 			MockProvider: plugin.MockProvider{
 				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 					return plugin.CreateResponse{}, errors.New("quota exceeded")
@@ -936,7 +936,7 @@ func TestDoCmdResourceConfirmationSummary(t *testing.T) {
 					}}, nil
 				},
 				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				DiffF: func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
 					return plugin.DiffResponse{

--- a/pkg/cmd/pulumi/do/do_resource_upsert_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_upsert_test.go
@@ -769,12 +769,12 @@ func TestDoCmdResourceUpsertStateless(t *testing.T) {
 				},
 				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
 					calls = append(calls, "check")
-					assert.Equal(t, "old", req.Olds["name"].StringValue())
-					assert.Equal(t, "new", req.News["name"].StringValue())
-					assert.Equal(t, 2.0, req.News["size"].NumberValue())
-					_, hasEnabled := req.News["enabled"]
+					assert.Equal(t, "old", req.OldInputs.Get("name").AsString())
+					assert.Equal(t, "new", req.NewInputs.Get("name").AsString())
+					assert.Equal(t, 2.0, req.NewInputs.Get("size").AsNumber())
+					_, hasEnabled := req.NewInputs.GetOk("enabled")
 					assert.False(t, hasEnabled, "inputs should be fully replaced, not merged")
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
 					calls = append(calls, "diff")
@@ -825,9 +825,9 @@ size = 2
 				},
 				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
 					calls = append(calls, "check")
-					assert.Empty(t, req.Olds)
-					assert.Equal(t, "new", req.News["name"].StringValue())
-					return plugin.CheckResponse{Properties: req.News}, nil
+					assert.Zero(t, req.OldInputs.Len())
+					assert.Equal(t, "new", req.NewInputs.Get("name").AsString())
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 					calls = append(calls, "create")
@@ -871,7 +871,7 @@ size = 2
 				},
 				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
 					calls = append(calls, "check")
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 					calls = append(calls, "create")

--- a/pkg/engine/lifecycletest/autonaming_test.go
+++ b/pkg/engine/lifecycletest/autonaming_test.go
@@ -43,7 +43,7 @@ func TestAutonaming(t *testing.T) {
 					// Capture the autonaming options
 					receivedAutonaming = req.Autonaming
 					return plugin.CheckResponse{
-						Properties: req.News,
+						Properties: req.NewInputs,
 					}, nil
 				},
 			}, nil

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -1354,15 +1354,15 @@ func TestImportPlanSpecificProperties(t *testing.T) {
 				) (plugin.CheckResponse, error) {
 					// Error unless "foo" and "frob" are in news
 
-					if _, has := req.News["foo"]; !has {
+					if _, has := req.NewInputs.GetOk("foo"); !has {
 						return plugin.CheckResponse{}, errors.New("Need foo")
 					}
 
-					if _, has := req.News["frob"]; !has {
+					if _, has := req.NewInputs.GetOk("frob"); !has {
 						return plugin.CheckResponse{}, errors.New("Need frob")
 					}
 
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 			}, nil
 		}),

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -3906,26 +3906,26 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 				) (plugin.CheckResponse, error) {
 					// Check that the old inputs are passed to CheckF
 					if firstUpdate {
-						assert.Nil(t, req.Olds)
-						assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+						assert.Equal(t, property.Map{}, req.OldInputs)
+						assert.Equal(t, resource.FromResourcePropertyMap(resource.NewPropertyMapFromMap(map[string]any{
 							"foo": "bar",
-						}), req.News)
+						})), req.NewInputs)
 					} else {
-						assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+						assert.Equal(t, resource.FromResourcePropertyMap(resource.NewPropertyMapFromMap(map[string]any{
 							"foo":     "bar",
 							"default": "default",
-						}), req.Olds)
-						assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+						})), req.OldInputs)
+						assert.Equal(t, resource.FromResourcePropertyMap(resource.NewPropertyMapFromMap(map[string]any{
 							"foo": "baz",
-						}), req.News)
+						})), req.NewInputs)
 					}
 
 					// Add a default property
 					results := resource.PropertyMap{}
-					maps.Copy(results, req.News)
+					maps.Copy(results, resource.ToResourcePropertyMap(req.NewInputs))
 					results["default"] = resource.NewProperty("default")
 
-					return plugin.CheckResponse{Properties: results}, nil
+					return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(results)}, nil
 				},
 				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
 					// Check that the old inputs and outputs are passed to DiffF

--- a/pkg/engine/lifecycletest/resource_hooks_test.go
+++ b/pkg/engine/lifecycletest/resource_hooks_test.go
@@ -125,10 +125,10 @@ func TestResourceHooksAfterCreate(t *testing.T) {
 			return &deploytest.Provider{
 				CheckF: func(context.Context, plugin.CheckRequest) (plugin.CheckResponse, error) {
 					return plugin.CheckResponse{
-						Properties: resource.NewPropertyMapFromMap(map[string]any{
+						Properties: resource.FromResourcePropertyMap(resource.NewPropertyMapFromMap(map[string]any{
 							"a": "A",
 							"c": "C",
-						}),
+						})),
 					}, nil
 				},
 				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -1966,8 +1966,9 @@ func TestEnsureUntargetedSame(t *testing.T) {
 					req plugin.CheckRequest,
 				) (plugin.CheckResponse, error) {
 					// Pulumi GCP provider alters inputs during Check.
-					req.News["__defaults"] = resource.NewProperty("exists")
-					return plugin.CheckResponse{Properties: req.News}, nil
+					newInputs := resource.ToResourcePropertyMap(req.NewInputs)
+					newInputs["__defaults"] = resource.NewProperty("exists")
+					return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(newInputs)}, nil
 				},
 			}, nil
 		}),

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -1389,21 +1389,21 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 					req plugin.CheckRequest,
 				) (plugin.CheckResponse, error) {
 					// If we have name use it, else use olds name, else make one up
-					if _, has := req.News["name"]; has {
-						return plugin.CheckResponse{Properties: req.News}, nil
+					if _, has := req.NewInputs.GetOk("name"); has {
+						return plugin.CheckResponse{Properties: req.NewInputs}, nil
 					}
-					if _, has := req.Olds["name"]; has {
-						result := req.News.Copy()
-						result["name"] = req.Olds["name"]
-						return plugin.CheckResponse{Properties: result}, nil
+					if name, has := req.OldInputs.GetOk("name"); has {
+						result := resource.ToResourcePropertyMap(req.NewInputs)
+						result["name"] = resource.ToResourcePropertyValue(name)
+						return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(result)}, nil
 					}
 
 					name, err := resource.NewUniqueHex(req.URN.Name(), 8, 512)
 					require.NoError(t, err)
 
-					result := req.News.Copy()
+					result := resource.ToResourcePropertyMap(req.NewInputs)
 					result["name"] = resource.NewProperty(name)
-					return plugin.CheckResponse{Properties: result}, nil
+					return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(result)}, nil
 				},
 			}, nil
 		}),
@@ -1490,7 +1490,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 					_ context.Context,
 					req plugin.CheckRequest,
 				) (plugin.CheckResponse, error) {
-					if req.News["foo"].StringValue() == "bad" {
+					if req.NewInputs.Get("foo").AsString() == "bad" {
 						return plugin.CheckResponse{
 							Failures: []plugin.CheckFailure{{
 								Property: resource.PropertyKey("foo"),
@@ -1498,7 +1498,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 							}},
 						}, nil
 					}
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 			}, nil
 		}),
@@ -1615,18 +1615,20 @@ func TestProviderDeterministicPreview(t *testing.T) {
 					req plugin.CheckRequest,
 				) (plugin.CheckResponse, error) {
 					// make a deterministic autoname
-					if _, has := req.News["name"]; !has {
-						if name, has := req.Olds["name"]; has {
-							req.News["name"] = name
+					if _, has := req.NewInputs.GetOk("name"); !has {
+						result := resource.ToResourcePropertyMap(req.NewInputs)
+						if name, has := req.OldInputs.GetOk("name"); has {
+							result["name"] = resource.ToResourcePropertyValue(name)
 						} else {
 							name, err := resource.NewUniqueName(req.RandomSeed, req.URN.Name(), -1, -1, nil)
 							require.NoError(t, err)
 							generatedName = resource.NewProperty(name)
-							req.News["name"] = generatedName
+							result["name"] = generatedName
 						}
+						return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(result)}, nil
 					}
 
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
 					if !req.OldOutputs["foo"].DeepEquals(req.NewInputs["foo"]) {
@@ -1720,7 +1722,7 @@ func TestPlannedUpdateWithDependentDelete(t *testing.T) {
 					_ context.Context,
 					req plugin.CheckRequest,
 				) (plugin.CheckResponse, error) {
-					return plugin.CheckResponse{Properties: req.News}, nil
+					return plugin.CheckResponse{Properties: req.NewInputs}, nil
 				},
 				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
 					if strings.Contains(string(req.URN), "resA") || strings.Contains(string(req.URN), "resB") {
@@ -1957,9 +1959,9 @@ func TestPlannedUpdateWithInternalKeys(t *testing.T) {
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
 				CheckF: func(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
-					news := req.News.Copy()
+					news := resource.ToResourcePropertyMap(req.NewInputs)
 					news["__defaults"] = defaultsValue
-					return plugin.CheckResponse{Properties: news}, nil
+					return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 				},
 				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
 					return plugin.CreateResponse{

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -127,15 +127,17 @@ func (p *builtinProvider) Check(_ context.Context, req plugin.CheckRequest) (plu
 			"Update your SDK or if already up to date raise an issue at https://github.com/pulumi/pulumi/issues."
 		p.diag.Warningf(diag.Message(req.URN, msg))
 
-		for k := range req.News {
+		for k := range req.NewInputs.All {
 			if k != "name" {
 				return plugin.CheckResponse{
-					Failures: []plugin.CheckFailure{{Property: k, Reason: fmt.Sprintf("unknown property \"%v\"", k)}},
+					Failures: []plugin.CheckFailure{
+						{Property: resource.PropertyKey(k), Reason: fmt.Sprintf("unknown property \"%v\"", k)},
+					},
 				}, nil
 			}
 		}
 
-		name, ok := req.News["name"]
+		name, ok := req.NewInputs.GetOk("name")
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: []plugin.CheckFailure{{Property: "name", Reason: `missing required property "name"`}},
@@ -146,24 +148,26 @@ func (p *builtinProvider) Check(_ context.Context, req plugin.CheckRequest) (plu
 				Failures: []plugin.CheckFailure{{Property: "name", Reason: `property "name" must be a string`}},
 			}, nil
 		}
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: req.NewInputs}, nil
 	case stashType:
-		for k := range req.News {
+		for k := range req.NewInputs.All {
 			if k != "input" {
 				return plugin.CheckResponse{
-					Failures: []plugin.CheckFailure{{Property: k, Reason: fmt.Sprintf("unknown property \"%v\"", k)}},
+					Failures: []plugin.CheckFailure{
+						{Property: resource.PropertyKey(k), Reason: fmt.Sprintf("unknown property \"%v\"", k)},
+					},
 				}, nil
 			}
 		}
 
-		_, ok := req.News["input"]
+		_, ok := req.NewInputs.GetOk("input")
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: []plugin.CheckFailure{{Property: "input", Reason: `missing required property "input"`}},
 			}, nil
 		}
 
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: req.NewInputs}, nil
 	default:
 		return plugin.CheckResponse{}, fmt.Errorf("unrecognized resource type '%v'", typ)
 	}

--- a/pkg/resource/deploy/builtins_test.go
+++ b/pkg/resource/deploy/builtins_test.go
@@ -66,8 +66,8 @@ func TestBuiltinProvider(t *testing.T) {
 			p := &builtinProvider{}
 			_, err := p.Check(t.Context(), plugin.CheckRequest{
 				URN:           resource.CreateURN("foo", "not-stack-reference-type", "", "proj", "stack"),
-				Olds:          resource.PropertyMap{},
-				News:          resource.PropertyMap{},
+				OldInputs:     property.Map{},
+				NewInputs:     property.Map{},
 				AllowUnknowns: true,
 			})
 			assert.ErrorContains(t, err, "unrecognized resource type")
@@ -79,8 +79,8 @@ func TestBuiltinProvider(t *testing.T) {
 			}
 			resp, err := p.Check(t.Context(), plugin.CheckRequest{
 				URN:           resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
-				Olds:          resource.PropertyMap{},
-				News:          resource.PropertyMap{},
+				OldInputs:     property.Map{},
+				NewInputs:     property.Map{},
 				AllowUnknowns: true,
 			})
 			assert.Equal(t, []plugin.CheckFailure{
@@ -97,11 +97,11 @@ func TestBuiltinProvider(t *testing.T) {
 				diag: &deploytest.NoopSink{},
 			}
 			resp, err := p.Check(t.Context(), plugin.CheckRequest{
-				URN:  resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
-				Olds: resource.PropertyMap{},
-				News: resource.PropertyMap{
-					"name": resource.NewProperty(10.0),
-				},
+				URN:       resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
+				OldInputs: property.Map{},
+				NewInputs: property.NewMap(map[string]property.Value{
+					"name": property.New(10.0),
+				}),
 				AllowUnknowns: true,
 			})
 			assert.Equal(t, []plugin.CheckFailure{
@@ -119,16 +119,16 @@ func TestBuiltinProvider(t *testing.T) {
 			}
 			resp, err := p.Check(t.Context(), plugin.CheckRequest{
 				URN: resource.CreateURN("foo", stackReferenceType, "", "proj", "stack"),
-				News: resource.PropertyMap{
-					"name": resource.NewProperty("res-name"),
-				},
+				NewInputs: property.NewMap(map[string]property.Value{
+					"name": property.New("res-name"),
+				}),
 				AllowUnknowns: true,
 			})
 			assert.Nil(t, resp.Failures)
 			require.NoError(t, err)
-			assert.Equal(t, resource.PropertyMap{
-				"name": resource.NewProperty("res-name"),
-			}, resp.Properties)
+			assert.Equal(t, property.NewMap(map[string]property.Value{
+				"name": property.New("res-name"),
+			}), resp.Properties)
 		})
 	})
 	t.Run("Update (always fails)", func(t *testing.T) {

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -136,7 +136,7 @@ func (prov *Provider) Configure(ctx context.Context, req plugin.ConfigureRequest
 func (prov *Provider) Check(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
 	contract.Requiref(req.RandomSeed != nil, "randomSeed", "must not be nil")
 	if prov.CheckF == nil {
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: req.NewInputs}, nil
 	}
 	return prov.CheckF(ctx, req)
 }

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -439,8 +439,8 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 			providers.SetProviderParameterization(inputs, parameterization)
 		}
 		resp, err := i.deployment.providers.Check(ctx, plugin.CheckRequest{
-			URN:  urn,
-			News: inputs,
+			URN:       urn,
+			NewInputs: resource.FromResourcePropertyMap(inputs),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to validate provider config: %w", err)
@@ -538,8 +538,8 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		}
 
 		resp, err := i.deployment.providers.Check(ctx, plugin.CheckRequest{
-			URN:  providerURN,
-			News: inputs,
+			URN:       providerURN,
+			NewInputs: resource.FromResourcePropertyMap(inputs),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to validate explicit provider config for %s: %w", providerURN, err)

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -623,36 +623,40 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 	contract.Requiref(providers.IsProviderType(req.URN.Type()), "urn", "must be a provider type, got %v", req.URN.Type())
 
 	label := fmt.Sprintf("%s.Check(%s)", r.label(), req.URN)
-	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(req.Olds), len(req.News))
+	logging.V(7).Infof("%s executing (#oldInputs=%d,#newInputs=%d)",
+		label, req.OldInputs.Len(), req.NewInputs.Len())
+
+	oldInputs := resource.ToResourcePropertyMap(req.OldInputs)
+	newInputs := resource.ToResourcePropertyMap(req.NewInputs)
 
 	// Parse the version from the provider properties and load the provider.
 	providerPkg := providers.GetProviderPackage(req.URN.Type())
-	name, err := GetProviderName(providerPkg, req.News)
+	name, err := GetProviderName(providerPkg, newInputs)
 	if err != nil {
 		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
 			Property: "name", Reason: err.Error(),
 		}}}, nil
 	}
-	version, err := GetProviderVersion(req.News)
+	version, err := GetProviderVersion(newInputs)
 	if err != nil {
 		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
 			Property: "version", Reason: err.Error(),
 		}}}, nil
 	}
-	downloadURL, err := GetProviderDownloadURL(req.News)
+	downloadURL, err := GetProviderDownloadURL(newInputs)
 	if err != nil {
 		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
 			Property: "pluginDownloadURL", Reason: err.Error(),
 		}}}, nil
 	}
-	parameter, err := GetProviderParameterization(providerPkg, req.News)
+	parameter, err := GetProviderParameterization(providerPkg, newInputs)
 	if err != nil {
 		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
 			Property: "parameter", Reason: err.Error(),
 		}}}, nil
 	}
 
-	envVarMappings, err := GetEnvironmentVariableMappings(req.News)
+	envVarMappings, err := GetEnvironmentVariableMappings(newInputs)
 	if err != nil {
 		return plugin.CheckResponse{Failures: []plugin.CheckFailure{{
 			Property: "envVarMappings", Reason: err.Error(),
@@ -672,8 +676,8 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 	// Check the provider's config. If the check fails, unload the provider.
 	resp, err := provider.CheckConfig(ctx, plugin.CheckConfigRequest{
 		URN:           req.URN,
-		Olds:          resource.FromResourcePropertyMap(FilterProviderConfig(req.Olds)),
-		News:          resource.FromResourcePropertyMap(FilterProviderConfig(req.News)),
+		Olds:          resource.FromResourcePropertyMap(FilterProviderConfig(oldInputs)),
+		News:          resource.FromResourcePropertyMap(FilterProviderConfig(newInputs)),
 		AllowUnknowns: true,
 	})
 	if len(resp.Failures) != 0 || err != nil {
@@ -689,13 +693,13 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 	// If the provider tries to drop the versions field reset it back to the original value.
 	if _, ok := properties[versionKey]; !ok {
 		// Only set it if we had it originally
-		if _, ok := req.News[versionKey]; ok {
-			properties[versionKey] = req.News[versionKey]
+		if _, ok := newInputs[versionKey]; ok {
+			properties[versionKey] = newInputs[versionKey]
 		}
 	}
 	// If the provider tries to change the version field return an error
 	if newV, ok := properties[versionKey]; ok {
-		if oldV, ok := req.News[versionKey]; ok {
+		if oldV, ok := newInputs[versionKey]; ok {
 			if !oldV.DeepEquals(newV) {
 				return plugin.CheckResponse{}, fmt.Errorf("provider %q attempted to change version from %q to %q",
 					req.URN, oldV.StringValue(), newV.StringValue())
@@ -705,15 +709,15 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 
 	// We stripped __internal off of "News" when we passed it to CheckConfig, we need to readd it the checked
 	// properties returned from the plugin. Only add __internal back if it was originally in the inputs.
-	if _, has := req.News[internalKey]; has {
+	if _, has := newInputs[internalKey]; has {
 		// Before we reset it warn the user that the providers data is being discarded
 		if _, has := properties[internalKey]; has {
 			r.pctx.Host.Log(diag.Warning, req.URN, "provider attempted to use __internal key that is reserved by the engine", 0)
 		}
-		properties[internalKey] = req.News[internalKey]
+		properties[internalKey] = newInputs[internalKey]
 	}
 
-	return plugin.CheckResponse{Properties: properties}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(properties)}, nil
 }
 
 // RegisterAliases informs the registry that the new provider object with the given URN is aliased to the given list

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -327,12 +327,12 @@ func TestCRUD(t *testing.T) {
 
 		// Check
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: olds,
-			News: news,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(olds),
+			NewInputs: resource.FromResourcePropertyMap(news),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, news, check.Properties)
+		assert.Equal(t, news, resource.ToResourcePropertyMap(check.Properties))
 		assert.Empty(t, check.Failures)
 
 		// Since this is not a preview, the provider should not yet be configured.
@@ -345,7 +345,7 @@ func TestCRUD(t *testing.T) {
 			URN:        urn,
 			Name:       urn.Name(),
 			Type:       urn.Type(),
-			Properties: check.Properties,
+			Properties: resource.ToResourcePropertyMap(check.Properties),
 			Timeout:    timeout,
 		})
 		require.NoError(t, err)
@@ -373,12 +373,12 @@ func TestCRUD(t *testing.T) {
 
 		// Check
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: olds,
-			News: news,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(olds),
+			NewInputs: resource.FromResourcePropertyMap(news),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, news, check.Properties)
+		assert.Equal(t, news, resource.ToResourcePropertyMap(check.Properties))
 		assert.Empty(t, check.Failures)
 
 		// Since this is not a preview, the provider should not yet be configured.
@@ -407,7 +407,7 @@ func TestCRUD(t *testing.T) {
 			URN:        urn,
 			ID:         id,
 			OldOutputs: olds,
-			NewInputs:  check.Properties,
+			NewInputs:  resource.ToResourcePropertyMap(check.Properties),
 			Timeout:    timeout,
 		})
 		require.NoError(t, err)
@@ -512,12 +512,12 @@ func TestCRUDPreview(t *testing.T) {
 
 		// Check
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: olds,
-			News: news,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(olds),
+			NewInputs: resource.FromResourcePropertyMap(news),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, news, check.Properties)
+		assert.Equal(t, news, resource.ToResourcePropertyMap(check.Properties))
 		assert.Empty(t, check.Failures)
 
 		// The provider should not be configured: configuration will occur during the previewed Create.
@@ -537,12 +537,12 @@ func TestCRUDPreview(t *testing.T) {
 
 		// Check
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: olds,
-			News: news,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(olds),
+			NewInputs: resource.FromResourcePropertyMap(news),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, news, check.Properties)
+		assert.Equal(t, news, resource.ToResourcePropertyMap(check.Properties))
 		assert.Empty(t, check.Failures)
 
 		// The provider should remain unconfigured.
@@ -579,12 +579,12 @@ func TestCRUDPreview(t *testing.T) {
 
 		// Check
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: olds,
-			News: news,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(olds),
+			NewInputs: resource.FromResourcePropertyMap(news),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, news, check.Properties)
+		assert.Equal(t, news, resource.ToResourcePropertyMap(check.Properties))
 		assert.Empty(t, check.Failures)
 
 		// The provider should remain unconfigured.
@@ -625,13 +625,13 @@ func TestCRUDNoProviders(t *testing.T) {
 
 	// Check
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: olds,
-		News: news,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(olds),
+		NewInputs: resource.FromResourcePropertyMap(news),
 	})
 	assert.Error(t, err)
 	assert.Empty(t, check.Failures)
-	assert.Nil(t, check.Properties)
+	assert.Equal(t, property.Map{}, check.Properties)
 }
 
 func TestCRUDWrongPackage(t *testing.T) {
@@ -651,13 +651,13 @@ func TestCRUDWrongPackage(t *testing.T) {
 
 	// Check
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: olds,
-		News: news,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(olds),
+		NewInputs: resource.FromResourcePropertyMap(news),
 	})
 	assert.Error(t, err)
 	assert.Empty(t, check.Failures)
-	assert.Nil(t, check.Properties)
+	assert.Equal(t, property.Map{}, check.Properties)
 }
 
 func TestCRUDWrongVersion(t *testing.T) {
@@ -677,13 +677,13 @@ func TestCRUDWrongVersion(t *testing.T) {
 
 	// Check
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: olds,
-		News: news,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(olds),
+		NewInputs: resource.FromResourcePropertyMap(news),
 	})
 	assert.Error(t, err)
 	assert.Empty(t, check.Failures)
-	assert.Nil(t, check.Properties)
+	assert.Equal(t, property.Map{}, check.Properties)
 }
 
 func TestCRUDBadVersionNotString(t *testing.T) {
@@ -703,14 +703,14 @@ func TestCRUDBadVersionNotString(t *testing.T) {
 
 	// Check
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: olds,
-		News: news,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(olds),
+		NewInputs: resource.FromResourcePropertyMap(news),
 	})
 	require.NoError(t, err)
 	require.Len(t, check.Failures, 1)
 	assert.Equal(t, "version", string(check.Failures[0].Property))
-	assert.Nil(t, check.Properties)
+	assert.Equal(t, property.Map{}, check.Properties)
 }
 
 func TestCRUDBadVersion(t *testing.T) {
@@ -730,14 +730,14 @@ func TestCRUDBadVersion(t *testing.T) {
 
 	// Check
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: olds,
-		News: news,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(olds),
+		NewInputs: resource.FromResourcePropertyMap(news),
 	})
 	require.NoError(t, err)
 	require.Len(t, check.Failures, 1)
 	assert.Equal(t, "version", string(check.Failures[0].Property))
-	assert.Nil(t, check.Properties)
+	assert.Equal(t, property.Map{}, check.Properties)
 }
 
 func TestLoadProvider_missingError(t *testing.T) {
@@ -822,14 +822,14 @@ func TestConcurrentRegistryUsage(t *testing.T) {
 
 			// Check
 			check, err := r.Check(t.Context(), plugin.CheckRequest{
-				URN:  providerURN,
-				Olds: olds,
-				News: news,
+				URN:       providerURN,
+				OldInputs: resource.FromResourcePropertyMap(olds),
+				NewInputs: resource.FromResourcePropertyMap(news),
 			})
 			require.NoError(t, err)
 			require.Len(t, check.Failures, 1)
 			assert.Equal(t, "version", string(check.Failures[0].Property))
-			assert.Nil(t, check.Properties)
+			assert.Equal(t, property.Map{}, check.Properties)
 		}(i)
 	}
 }
@@ -1065,15 +1065,15 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 
 		// Check should succeed and preserve the mappings
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: resource.PropertyMap{},
-			News: news,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(resource.PropertyMap{}),
+			NewInputs: resource.FromResourcePropertyMap(news),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, check.Failures)
 
 		// The returned properties should contain the mappings
-		retrieved, err := GetEnvironmentVariableMappings(check.Properties)
+		retrieved, err := GetEnvironmentVariableMappings(resource.ToResourcePropertyMap(check.Properties))
 		require.NoError(t, err)
 		assert.Equal(t, mappings, retrieved)
 	})
@@ -1099,9 +1099,9 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 
 		// Call Check first
 		check, err := r.Check(t.Context(), plugin.CheckRequest{
-			URN:  urn,
-			Olds: resource.PropertyMap{},
-			News: inputs,
+			URN:       urn,
+			OldInputs: resource.FromResourcePropertyMap(resource.PropertyMap{}),
+			NewInputs: resource.FromResourcePropertyMap(inputs),
 		})
 		require.NoError(t, err)
 
@@ -1109,7 +1109,7 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 			URN:        urn,
 			Name:       urn.Name(),
 			Type:       urn.Type(),
-			Properties: check.Properties,
+			Properties: resource.ToResourcePropertyMap(check.Properties),
 			Timeout:    120,
 		})
 		require.NoError(t, err)
@@ -1164,9 +1164,9 @@ func TestEnvMappingsPassedToHost(t *testing.T) {
 
 	// Load the provider and pass env to host
 	_, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: resource.PropertyMap{},
-		News: inputs,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(resource.PropertyMap{}),
+		NewInputs: resource.FromResourcePropertyMap(inputs),
 	})
 	require.NoError(t, err)
 
@@ -1249,9 +1249,9 @@ func TestSameUpdateRace_UpdateFirst(t *testing.T) {
 
 	// First, do the Check/Diff/Update flow to register the provider with new config.
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: oldInputs,
-		News: newInputs,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(oldInputs),
+		NewInputs: resource.FromResourcePropertyMap(newInputs),
 	})
 	require.NoError(t, err)
 
@@ -1267,7 +1267,7 @@ func TestSameUpdateRace_UpdateFirst(t *testing.T) {
 		URN:        urn,
 		ID:         id,
 		OldOutputs: oldInputs,
-		NewInputs:  check.Properties,
+		NewInputs:  resource.ToResourcePropertyMap(check.Properties),
 	})
 	require.NoError(t, err)
 
@@ -1349,9 +1349,9 @@ func TestSameUpdateRace_SameFirst(t *testing.T) {
 
 	// Now do the Check/Diff/Update flow.
 	check, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: oldInputs,
-		News: newInputs,
+		URN:       urn,
+		OldInputs: resource.FromResourcePropertyMap(oldInputs),
+		NewInputs: resource.FromResourcePropertyMap(newInputs),
 	})
 	require.NoError(t, err)
 
@@ -1373,7 +1373,7 @@ func TestSameUpdateRace_SameFirst(t *testing.T) {
 		URN:        urn,
 		ID:         id,
 		OldOutputs: oldInputs,
-		NewInputs:  check.Properties,
+		NewInputs:  resource.ToResourcePropertyMap(check.Properties),
 	})
 	require.NoError(t, err)
 
@@ -1436,9 +1436,9 @@ func TestSameUpdateRace_Concurrent(t *testing.T) {
 
 			// Do Check first (outside of goroutines) since Update depends on it.
 			check, err := r.Check(t.Context(), plugin.CheckRequest{
-				URN:  urn,
-				Olds: oldInputs,
-				News: newInputs,
+				URN:       urn,
+				OldInputs: resource.FromResourcePropertyMap(oldInputs),
+				NewInputs: resource.FromResourcePropertyMap(newInputs),
 			})
 			require.NoError(t, err)
 
@@ -1466,7 +1466,7 @@ func TestSameUpdateRace_Concurrent(t *testing.T) {
 					URN:        urn,
 					ID:         id,
 					OldOutputs: oldInputs,
-					NewInputs:  check.Properties,
+					NewInputs:  resource.ToResourcePropertyMap(check.Properties),
 				})
 			}()
 

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -2178,8 +2178,8 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 			URN:           s.new.URN,
 			Name:          s.URN().Name(),
 			Type:          s.URN().Type(),
-			Olds:          s.old.Inputs,
-			News:          s.new.Inputs,
+			OldInputs:     resource.FromResourcePropertyMap(s.old.Inputs),
+			NewInputs:     resource.FromResourcePropertyMap(s.new.Inputs),
 			AllowUnknowns: s.deployment.opts.DryRun,
 			RandomSeed:    s.randomSeed,
 		})

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1359,7 +1359,7 @@ func (sg *stepGenerator) continueStepsFromImport(
 		if !isTargeted {
 			// If not targeted, stub out the provider check and use the old inputs directly.
 			checkInputs = func(context.Context, plugin.CheckRequest) (plugin.CheckResponse, error) {
-				return plugin.CheckResponse{Properties: oldInputs}, nil
+				return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(oldInputs)}, nil
 			}
 		}
 
@@ -1370,7 +1370,7 @@ func (sg *stepGenerator) continueStepsFromImport(
 		if recreating || wasExternal || sg.isTargetedReplace(urn, old) || old == nil {
 			resp, err = checkInputs(context.TODO(), plugin.CheckRequest{
 				URN:           urn,
-				News:          resource.ToResourcePropertyMap(goal.Properties),
+				NewInputs:     goal.Properties,
 				AllowUnknowns: allowUnknowns,
 				RandomSeed:    randomSeed,
 				Autonaming:    autonaming,
@@ -1378,15 +1378,15 @@ func (sg *stepGenerator) continueStepsFromImport(
 		} else {
 			resp, err = checkInputs(context.TODO(), plugin.CheckRequest{
 				URN:           urn,
-				Olds:          oldInputs,
-				News:          inputs,
-				OldOutputs:    oldOutputs,
+				OldInputs:     resource.FromResourcePropertyMap(oldInputs),
+				NewInputs:     resource.FromResourcePropertyMap(inputs),
+				OldOutputs:    resource.FromResourcePropertyMap(oldOutputs),
 				AllowUnknowns: allowUnknowns,
 				RandomSeed:    randomSeed,
 				Autonaming:    autonaming,
 			})
 		}
-		inputs = resp.Properties
+		inputs = resource.ToResourcePropertyMap(resp.Properties)
 
 		if err != nil {
 			return nil, false, err
@@ -2049,13 +2049,13 @@ func (sg *stepGenerator) continueStepsFromDiff(diffEvent ContinueResourceDiffEve
 			if prov != nil && !sg.isTargetedReplace(urn, old) {
 				resp, err := prov.Check(context.TODO(), plugin.CheckRequest{
 					URN:           urn,
-					News:          resource.ToResourcePropertyMap(goal.Properties),
+					NewInputs:     goal.Properties,
 					AllowUnknowns: allowUnknowns,
 					RandomSeed:    randomSeed,
 					Autonaming:    autonaming,
 				})
 				failures := resp.Failures
-				inputs := resp.Properties
+				inputs := resource.ToResourcePropertyMap(resp.Properties)
 				if err != nil {
 					return nil, err
 				} else if issueCheckErrors(sg.deployment, new, urn, failures) {

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -258,17 +258,19 @@ type CheckRequest struct {
 	URN  resource.URN
 	Name string
 	Type tokens.Type
-	// TODO Change to (State, Input)
-	Olds, News resource.PropertyMap
-	// OldOutputs is the previously persisted outputs of the resource, if any.
-	OldOutputs    resource.PropertyMap
+	// NewInputs are the new inputs for the resource from the program.
+	NewInputs property.Map
+	// OldInputs are the previously persisted inputs of the resource, if any.
+	OldInputs property.Map
+	// OldOutputs are the previously persisted outputs of the resource, if any.
+	OldOutputs    property.Map
 	AllowUnknowns bool
 	RandomSeed    []byte
 	Autonaming    *AutonamingOptions
 }
 
 type CheckResponse struct {
-	Properties resource.PropertyMap
+	Properties property.Map
 	Failures   []CheckFailure
 }
 

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -1168,10 +1168,10 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 		"req.Name (%s) != req.URN.Name() (%s)", req.Name, req.URN.Name())
 	contract.Assertf(req.Type == "" || req.Type == req.URN.Type(),
 		"req.Type (%s) != req.URN.Type() (%s)", req.Type, req.URN.Type())
-	contract.Assertf(req.News != nil, "Check requires new properties")
 
 	label := fmt.Sprintf("%s.Check(%s)", p.label(), req.URN)
-	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(req.Olds), len(req.News))
+	logging.V(7).Infof("%s executing (#oldInputs=%d,#newInputs=%d)",
+		label, req.OldInputs.Len(), req.NewInputs.Len())
 
 	// Ensure that the plugin is configured.
 	client := p.clientRaw
@@ -1183,11 +1183,11 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 	// If the configuration for this provider was not fully known--e.g. if we are doing a preview and some input
 	// property was sourced from another resource's output properties--don't call into the underlying provider.
 	if !pcfg.known {
-		return CheckResponse{Properties: req.News}, nil
+		return CheckResponse{Properties: req.NewInputs}, nil
 	}
 
-	molds, err := MarshalProperties(req.Olds, MarshalOptions{
-		Label:          label + ".olds",
+	moldInputs, err := MarshalProperties(resource.ToResourcePropertyMap(req.OldInputs), MarshalOptions{
+		Label:          label + ".oldInputs",
 		KeepUnknowns:   req.AllowUnknowns,
 		KeepSecrets:    protocol.acceptSecrets,
 		KeepResources:  protocol.acceptResources,
@@ -1202,8 +1202,8 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 	if err != nil {
 		return CheckResponse{}, err
 	}
-	mnews, err := MarshalProperties(req.News, MarshalOptions{
-		Label:          label + ".news",
+	mNewInputs, err := MarshalProperties(resource.ToResourcePropertyMap(req.NewInputs), MarshalOptions{
+		Label:          label + ".newInputs",
 		KeepUnknowns:   req.AllowUnknowns,
 		KeepSecrets:    protocol.acceptSecrets,
 		KeepResources:  protocol.acceptResources,
@@ -1230,26 +1230,24 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 	}
 
 	var moldOutputs *structpb.Struct
-	if req.OldOutputs != nil {
-		moldOutputs, err = MarshalProperties(req.OldOutputs, MarshalOptions{
-			Label:          label + ".oldOutputs",
-			KeepUnknowns:   req.AllowUnknowns,
-			KeepSecrets:    protocol.acceptSecrets,
-			KeepResources:  protocol.acceptResources,
-			KeepByteString: protocol.acceptsByteString,
-			PropagateNil:   true,
-		})
-		if err != nil {
-			return CheckResponse{}, err
-		}
+	moldOutputs, err = MarshalProperties(resource.ToResourcePropertyMap(req.OldOutputs), MarshalOptions{
+		Label:          label + ".oldOutputs",
+		KeepUnknowns:   req.AllowUnknowns,
+		KeepSecrets:    protocol.acceptSecrets,
+		KeepResources:  protocol.acceptResources,
+		KeepByteString: protocol.acceptsByteString,
+		PropagateNil:   true,
+	})
+	if err != nil {
+		return CheckResponse{}, err
 	}
 
 	resp, err := client.Check(p.requestContext(), &pulumirpc.CheckRequest{
 		Urn:        string(req.URN),
 		Name:       req.URN.Name(),
 		Type:       req.URN.Type().String(),
-		Olds:       molds,
-		News:       mnews,
+		Olds:       moldInputs,
+		News:       mNewInputs,
 		OldOutputs: moldOutputs,
 		RandomSeed: req.RandomSeed,
 		Autonaming: autonaming,
@@ -1280,7 +1278,7 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 	// allows us to retain metadata about secrets in many cases, even for providers that do not understand secrets
 	// natively.
 	if !protocol.acceptSecrets {
-		annotateSecrets(inputs, req.News)
+		annotateSecrets(inputs, resource.ToResourcePropertyMap(req.NewInputs))
 	}
 
 	// And now any properties that failed verification.
@@ -1290,7 +1288,7 @@ func (p *provider) Check(ctx context.Context, req CheckRequest) (CheckResponse, 
 	}
 
 	logging.V(7).Infof("%s success: inputs=#%d failures=#%d", label, len(inputs), len(failures))
-	return CheckResponse{Properties: inputs, Failures: failures}, nil
+	return CheckResponse{Properties: resource.FromResourcePropertyMap(inputs), Failures: failures}, nil
 }
 
 // Diff checks what impacts a hypothetical update will have on the resource's properties.

--- a/pkg/resource/plugin/provider_server.go
+++ b/pkg/resource/plugin/provider_server.go
@@ -483,9 +483,9 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		URN:           urn,
 		Name:          req.Name,
 		Type:          tokens.Type(req.Type),
-		Olds:          state,
-		News:          inputs,
-		OldOutputs:    oldOutputs,
+		OldInputs:     resource.FromResourcePropertyMap(state),
+		NewInputs:     resource.FromResourcePropertyMap(inputs),
+		OldOutputs:    resource.FromResourcePropertyMap(oldOutputs),
 		AllowUnknowns: true,
 		RandomSeed:    req.RandomSeed,
 		Autonaming:    autonaming,
@@ -494,7 +494,7 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		return nil, err
 	}
 
-	rpcInputs, err := MarshalProperties(resp.Properties, p.marshalOptions("newInputs"))
+	rpcInputs, err := MarshalProperties(resource.ToResourcePropertyMap(resp.Properties), p.marshalOptions("newInputs"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testing/pulumi-test-language/providers/alpha_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/alpha_provider.go
@@ -110,6 +110,7 @@ func (p *AlphaProvider) CheckConfig(
 func (p *AlphaProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "alpha:index:Resource"
 	if req.URN.Type() != "alpha:index:Resource" {
 		return plugin.CheckResponse{
@@ -118,7 +119,7 @@ func (p *AlphaProvider) Check(
 	}
 
 	// Expect just the boolean value
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -129,13 +130,13 @@ func (p *AlphaProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a boolean"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *AlphaProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/any_handled_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/any_handled_provider.go
@@ -82,15 +82,16 @@ func (p *AnyHandledProvider) CheckConfig(
 func (p *AnyHandledProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "any-handled:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
-	if _, ok := req.News["value"]; !ok {
+	if _, ok := news["value"]; !ok {
 		return plugin.CheckResponse{Failures: makeCheckFailure("value", "missing value")}, nil
 	}
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *AnyHandledProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/asset_archive_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/asset_archive_provider.go
@@ -125,12 +125,13 @@ func (p *AssetArchiveProvider) CheckConfig(
 func (p *AssetArchiveProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	isAsset, err := p.checkType(req.URN)
 	if err != nil {
 		return plugin.CheckResponse{Failures: makeCheckFailure("", err.Error())}, nil
 	}
 
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{Failures: makeCheckFailure("value", "missing value")}, nil
 	}
@@ -144,11 +145,11 @@ func (p *AssetArchiveProvider) Check(
 		}
 	}
 
-	if len(req.News) != 1 {
-		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News))}, nil
+	if len(news) != 1 {
+		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news))}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *AssetArchiveProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/byte_sink_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/byte_sink_provider.go
@@ -122,6 +122,7 @@ func (p *ByteSinkProvider) CheckConfig(
 func (p *ByteSinkProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "bytesink:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -129,7 +130,7 @@ func (p *ByteSinkProvider) Check(
 	}
 
 	for _, key := range []resource.PropertyKey{"bytes", "expectBase64"} {
-		value, ok := req.News[key]
+		value, ok := news[key]
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure(key, fmt.Sprintf("missing %s", key)),
@@ -141,13 +142,13 @@ func (p *ByteSinkProvider) Check(
 			}, nil
 		}
 	}
-	if len(req.News) != 2 {
+	if len(news) != 2 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ByteSinkProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/byte_source_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/byte_source_provider.go
@@ -127,13 +127,14 @@ func (p *ByteSourceProvider) CheckConfig(
 func (p *ByteSourceProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "bytesource:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	value, ok := req.News["base64"]
+	value, ok := news["base64"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("base64", "missing base64"),
@@ -151,13 +152,13 @@ func (p *ByteSourceProvider) Check(
 			}, nil
 		}
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ByteSourceProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/call_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/call_provider.go
@@ -267,8 +267,9 @@ func (p *CallProvider) Check(
 	_ context.Context,
 	req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() == "call:index:Custom" {
-		value, ok := req.News["value"]
+		value, ok := news["value"]
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -281,13 +282,13 @@ func (p *CallProvider) Check(
 			}, nil
 		}
 
-		if len(req.News) != 1 {
+		if len(news) != 1 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 			}, nil
 		}
 
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	}
 
 	return plugin.CheckResponse{

--- a/pkg/testing/pulumi-test-language/providers/camel_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/camel_names_provider.go
@@ -124,6 +124,7 @@ func (p *CamelNamesProvider) CheckConfig(
 func (p *CamelNamesProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "camelNames:CoolModule:SomeResource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -131,7 +132,7 @@ func (p *CamelNamesProvider) Check(
 	}
 
 	// Expect theInput (required) and optionally resourceName
-	value, ok := req.News["theInput"]
+	value, ok := news["theInput"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("theInput", "missing theInput"),
@@ -143,21 +144,21 @@ func (p *CamelNamesProvider) Check(
 		}, nil
 	}
 	expectedCount := 1
-	if _, hasName := req.News["resourceName"]; hasName {
-		if !req.News["resourceName"].IsString() && !req.News["resourceName"].IsComputed() {
+	if _, hasName := news["resourceName"]; hasName {
+		if !news["resourceName"].IsString() && !news["resourceName"].IsComputed() {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("resourceName", "resourceName is not a string"),
 			}, nil
 		}
 		expectedCount = 2
 	}
-	if len(req.News) != expectedCount {
+	if len(news) != expectedCount {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *CamelNamesProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/component_property_deps_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_property_deps_provider.go
@@ -291,8 +291,9 @@ func (p *ComponentPropertyDepsProvider) Check(
 	_ context.Context,
 	req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() == "component-property-deps:index:Custom" {
-		value, ok := req.News["value"]
+		value, ok := news["value"]
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -305,13 +306,13 @@ func (p *ComponentPropertyDepsProvider) Check(
 			}, nil
 		}
 
-		if len(req.News) != 1 {
+		if len(news) != 1 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 			}, nil
 		}
 
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	}
 
 	return plugin.CheckResponse{

--- a/pkg/testing/pulumi-test-language/providers/component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_provider.go
@@ -356,8 +356,9 @@ func (p *ComponentProvider) Check(
 	_ context.Context,
 	req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() == "component:index:Custom" {
-		value, ok := req.News["value"]
+		value, ok := news["value"]
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("value", "missing value"),
@@ -370,13 +371,13 @@ func (p *ComponentProvider) Check(
 			}, nil
 		}
 
-		if len(req.News) != 1 {
+		if len(news) != 1 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 			}, nil
 		}
 
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	}
 
 	return plugin.CheckResponse{

--- a/pkg/testing/pulumi-test-language/providers/config_enum_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_enum_provider.go
@@ -117,12 +117,13 @@ func (p *ConfigEnumProvider) CheckConfig(
 func (p *ConfigEnumProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "config-enum:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ConfigEnumProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/config_grpc_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_grpc_provider.go
@@ -242,7 +242,8 @@ func (p *ConfigGrpcProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, 
 func (p *ConfigGrpcProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
-	return plugin.CheckResponse{Properties: req.News}, nil
+	news := resource.ToResourcePropertyMap(req.NewInputs)
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ConfigGrpcProvider) CheckConfig(

--- a/pkg/testing/pulumi-test-language/providers/config_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/config_provider.go
@@ -220,6 +220,7 @@ func (p *ConfigProvider) Invoke(
 func (p *ConfigProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "config:index:Resource"
 	if req.URN.Type() != "config:index:Resource" {
 		return plugin.CheckResponse{
@@ -228,7 +229,7 @@ func (p *ConfigProvider) Check(
 	}
 
 	// Expect just the text string value
-	value, ok := req.News["text"]
+	value, ok := news["text"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("text", "missing text"),
@@ -239,13 +240,13 @@ func (p *ConfigProvider) Check(
 			Failures: makeCheckFailure("text", "text is not a string"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ConfigProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/configurer_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/configurer_provider.go
@@ -245,16 +245,17 @@ func (p *ConfigurerProvider) Configure(
 func (p *ConfigurerProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "configurer:index:Custom" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok || !value.IsString() {
 		return plugin.CheckResponse{Failures: makeCheckFailure("value", "missing or non-string value")}, nil
 	}
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ConfigurerProvider) Diff(

--- a/pkg/testing/pulumi-test-language/providers/const_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/const_provider.go
@@ -101,6 +101,7 @@ func (p *ConstProvider) CheckConfig(
 func (p *ConstProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "constant:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -117,7 +118,7 @@ func (p *ConstProvider) Check(
 		{"ratio", resource.NewProperty(1.5)},
 	}
 	for _, c := range constants {
-		v, ok := req.News[c.name]
+		v, ok := news[c.name]
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure(c.name, "missing value"),
@@ -130,7 +131,7 @@ func (p *ConstProvider) Check(
 		}
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ConstProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_many_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_many_provider.go
@@ -207,13 +207,14 @@ func (p *DiscriminatedUnionManyProvider) isKnownType(t tokens.Type) bool {
 func (p *DiscriminatedUnionManyProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if !p.isKnownType(req.URN.Type()) {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *DiscriminatedUnionManyProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_marked_key_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_marked_key_provider.go
@@ -165,13 +165,14 @@ func (p *DiscriminatedUnionMarkedKeyProvider) DiffConfig(
 func (p *DiscriminatedUnionMarkedKeyProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if string(req.URN.Type()) != fmt.Sprintf("%s:index:Example", p.pkg()) {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *DiscriminatedUnionMarkedKeyProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_provider.go
@@ -169,13 +169,14 @@ func (p *DiscriminatedUnionProvider) DiffConfig(
 func (p *DiscriminatedUnionProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if string(req.URN.Type()) != fmt.Sprintf("%s:index:Example", p.pkg()) {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *DiscriminatedUnionProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/docs_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/docs_provider.go
@@ -211,6 +211,7 @@ func (p *DocsProvider) CheckConfig(
 func (p *DocsProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "docs:index:Resource"
 	if req.URN.Type() != "docs:index:Resource" {
 		return plugin.CheckResponse{
@@ -221,7 +222,7 @@ func (p *DocsProvider) Check(
 	assertField := func(key resource.PropertyKey, typ string,
 		assertType func(resource.PropertyValue) bool,
 	) *plugin.CheckResponse {
-		v, ok := req.News[key]
+		v, ok := news[key]
 		if !ok {
 			return &plugin.CheckResponse{
 				Failures: makeCheckFailure(key, "missing value"),
@@ -242,19 +243,19 @@ func (p *DocsProvider) Check(
 		return *check, nil
 	}
 
-	if v, ok := req.News["externalEnum"]; ok && !v.IsString() {
+	if v, ok := news["externalEnum"]; ok && !v.IsString() {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("externalEnum", "value is not a string"),
 		}, nil
 	}
 
-	if len(req.News) != 1 && len(req.News) != 2 {
+	if len(news) != 1 && len(news) != 2 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *DocsProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/enum_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/enum_provider.go
@@ -198,12 +198,13 @@ func (p *EnumProvider) DiffConfig(
 func (p *EnumProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	switch req.URN.Type().String() {
 	case fmt.Sprintf("%s:index:Res", p.pkg()),
 		fmt.Sprintf("%s:mod:Res", p.pkg()),
 		fmt.Sprintf("%s:mod/nested:Res", p.pkg()),
 		fmt.Sprintf("%s:index:Deluxe", p.pkg()):
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	default:
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),

--- a/pkg/testing/pulumi-test-language/providers/extension_parameterized_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/extension_parameterized_provider.go
@@ -175,6 +175,7 @@ func (p *ExtensionParameterizedProvider) CheckConfig(
 func (p *ExtensionParameterizedProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	extName, _, _ := p.snapshot()
 	greeting := extName + ":index:Greeting"
 	base := extensionBaseName + ":index:Base"
@@ -184,7 +185,7 @@ func (p *ExtensionParameterizedProvider) Check(
 				fmt.Sprintf("invalid URN type %s, expected %s or %s", t, greeting, base)),
 		}, nil
 	}
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ExtensionParameterizedProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/external_enum_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/external_enum_ref_provider.go
@@ -123,9 +123,10 @@ func (p *ExternalEnumRefProvider) DiffConfig(
 func (p *ExternalEnumRefProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	switch req.URN.Type().String() {
 	case fmt.Sprintf("%s:index:Sink", p.pkg()):
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	default:
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),

--- a/pkg/testing/pulumi-test-language/providers/fail_on_create_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/fail_on_create_provider.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 type FailOnCreateProvider struct {
@@ -101,6 +102,7 @@ func (p *FailOnCreateProvider) CheckConfig(
 func (p *FailOnCreateProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "fail_on_create:index:Resource"
 	if req.URN.Type() != "fail_on_create:index:Resource" {
 		return plugin.CheckResponse{
@@ -109,7 +111,7 @@ func (p *FailOnCreateProvider) Check(
 	}
 
 	// Expect just the boolean value
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -120,13 +122,13 @@ func (p *FailOnCreateProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a boolean"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *FailOnCreateProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/flaky_create_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/flaky_create_provider.go
@@ -95,19 +95,20 @@ func (p *FlakyCreateProvider) CheckConfig(
 func (p *FlakyCreateProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "flaky:index:FlakyCreate" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	if len(req.News) != 0 {
+	if len(news) != 0 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *FlakyCreateProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/index_mod_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/index_mod_provider.go
@@ -353,6 +353,7 @@ func (p *IndexModProvider) Call(
 func (p *IndexModProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	switch req.URN.Type().String() {
 	case "index-mod:indexMine:Resource", "index-mod:indexMine/nested:Resource":
 	default:
@@ -361,13 +362,13 @@ func (p *IndexModProvider) Check(
 		}, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", news)),
 		}, nil
 	}
 
-	text, ok := req.News["text"]
+	text, ok := news["text"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("text", "missing required property 'text'"),
@@ -380,7 +381,7 @@ func (p *IndexModProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *IndexModProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/kebab_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/kebab_names_provider.go
@@ -205,38 +205,39 @@ func (p *KebabNamesProvider) CheckConfig(
 func (p *KebabNamesProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	switch typ := req.URN.Type(); typ {
 	case "kebab-names:kebab-module:some-resource":
-		if _, ok := req.News["the-input"]; !ok {
+		if _, ok := news["the-input"]; !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("the-input", "missing the-input"),
 			}, nil
 		}
-		if _, ok := req.News["nested"]; !ok {
+		if _, ok := news["nested"]; !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("nested", "missing nested"),
 			}, nil
 		}
-		if len(req.News) != 2 {
+		if len(news) != 2 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 			}, nil
 		}
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	case "kebab-names:kebab-module:another-resource":
-		if _, ok := req.News["the-input"]; !ok {
+		if _, ok := news["the-input"]; !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("the-input", "missing the-input"),
 			}, nil
 		}
-		if len(req.News) != 1 {
+		if len(news) != 1 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 			}, nil
 		}
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	case tokens.RootStackType:
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	default:
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", typ)),

--- a/pkg/testing/pulumi-test-language/providers/keywords_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/keywords_provider.go
@@ -143,6 +143,7 @@ func (p *KeywordsProvider) isValidResourceType(t tokens.Type) bool {
 func (p *KeywordsProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if !p.isValidResourceType(req.URN.Type()) {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -151,7 +152,7 @@ func (p *KeywordsProvider) Check(
 
 	for _, prop := range p.properties() {
 		propKey := resource.PropertyKey(prop)
-		value, ok := req.News[propKey]
+		value, ok := news[propKey]
 		if !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure(propKey, fmt.Sprintf("missing %s", propKey)),
@@ -163,13 +164,13 @@ func (p *KeywordsProvider) Check(
 			}, nil
 		}
 	}
-	if len(req.News) != len(p.properties()) {
+	if len(news) != len(p.properties()) {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *KeywordsProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/large_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/large_provider.go
@@ -137,11 +137,12 @@ func (p *LargeProvider) CheckConfig(
 func (p *LargeProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "large:index:String" && req.URN.Type() != "large:index:Map" {
 		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type()))}, nil
 	}
 
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{Failures: makeCheckFailure("value", "missing value")}, nil
 	}
@@ -152,7 +153,7 @@ func (p *LargeProvider) Check(
 	expectedLen := 1
 	if req.URN.Type() == "large:index:Map" {
 		expectedLen = 2
-		depth, ok := req.News["depth"]
+		depth, ok := news["depth"]
 		if !ok {
 			return plugin.CheckResponse{Failures: makeCheckFailure("depth", "missing depth")}, nil
 		}
@@ -160,11 +161,11 @@ func (p *LargeProvider) Check(
 			return plugin.CheckResponse{Failures: makeCheckFailure("depth", "depth is not a number")}, nil
 		}
 	}
-	if len(req.News) != expectedLen {
-		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News))}, nil
+	if len(news) != expectedLen {
+		return plugin.CheckResponse{Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news))}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *LargeProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/module_format_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/module_format_provider.go
@@ -437,6 +437,7 @@ func (p *ModuleFormatProvider) Call(
 func (p *ModuleFormatProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	switch req.URN.Type().String() {
 	case "module-format:index_Resource:Resource", "module-format:mod_Resource:Resource", "module-format:mod/nested_Resource:Resource": //nolint:lll
 	default:
@@ -445,13 +446,13 @@ func (p *ModuleFormatProvider) Check(
 		}, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", news)),
 		}, nil
 	}
 
-	text, ok := req.News["text"]
+	text, ok := news["text"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("text", "missing required property 'text'"),
@@ -464,7 +465,7 @@ func (p *ModuleFormatProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ModuleFormatProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/multi_argument_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/multi_argument_invoke_provider.go
@@ -191,19 +191,20 @@ func (p *MultiArgumentInvokeProvider) Invoke(
 func (p *MultiArgumentInvokeProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "multi-argument-invoke:index:StringResource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *MultiArgumentInvokeProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/names_provider.go
@@ -130,6 +130,7 @@ func (p *NamesProvider) CheckConfig(
 func (p *NamesProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if !slices.Contains(p.Types(), req.URN.Type().String()) {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -137,7 +138,7 @@ func (p *NamesProvider) Check(
 	}
 
 	// Expect just the boolean value
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -148,13 +149,13 @@ func (p *NamesProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a boolean"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *NamesProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/namespaced_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/namespaced_provider.go
@@ -118,6 +118,7 @@ func (p *NamespacedProvider) CheckConfig(
 func (p *NamespacedProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "namespaced:index:Resource"
 	if req.URN.Type() != "namespaced:index:Resource" {
 		return plugin.CheckResponse{
@@ -126,7 +127,7 @@ func (p *NamespacedProvider) Check(
 	}
 
 	// Expect just the boolean value
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -137,13 +138,13 @@ func (p *NamespacedProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a boolean"),
 		}, nil
 	}
-	if len(req.News) > 2 {
+	if len(news) > 2 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *NamespacedProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/nested_collections_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/nested_collections_provider.go
@@ -123,7 +123,8 @@ func (p *NestedCollectionsProvider) CheckConfig(
 func (p *NestedCollectionsProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
-	return plugin.CheckResponse{Properties: req.News}, nil
+	news := resource.ToResourcePropertyMap(req.NewInputs)
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *NestedCollectionsProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
@@ -237,7 +237,8 @@ func (p *NestedObjectProvider) CheckConfig(
 func (p *NestedObjectProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
-	return plugin.CheckResponse{Properties: req.News}, nil
+	news := resource.ToResourcePropertyMap(req.NewInputs)
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *NestedObjectProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/optional_primitive_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/optional_primitive_provider.go
@@ -124,6 +124,7 @@ func (p *OptionalPrimitiveProvider) CheckConfig(
 func (p *OptionalPrimitiveProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "optionalprimitive:index:Resource"
 	if req.URN.Type() != "optionalprimitive:index:Resource" {
 		return plugin.CheckResponse{
@@ -165,7 +166,7 @@ func (p *OptionalPrimitiveProvider) Check(
 	}
 
 	result := resource.PropertyMap{}
-	for key, value := range req.News {
+	for key, value := range news {
 		switch key {
 		case "boolean":
 			check := validate("boolean", value, resource.PropertyValue.IsBool, "boolean")
@@ -236,7 +237,7 @@ func (p *OptionalPrimitiveProvider) Check(
 		}
 	}
 
-	return plugin.CheckResponse{Properties: result}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(result)}, nil
 }
 
 func (p *OptionalPrimitiveProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/optional_primitive_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/optional_primitive_ref_provider.go
@@ -154,26 +154,27 @@ func (p *OptionalPrimitiveRefProvider) CheckConfig(
 func (p *OptionalPrimitiveRefProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "optional-primitive-ref:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	data, ok := req.News["data"]
+	data, ok := news["data"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("data", "missing value"),
 		}, nil
 	}
-	if len(req.News) > 2 {
+	if len(news) > 2 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
-	if _, ok := req.News["optionalData"]; len(req.News) == 2 && !ok {
+	if _, ok := news["optionalData"]; len(news) == 2 && !ok {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 		}, nil
 	}
 
@@ -229,13 +230,13 @@ func (p *OptionalPrimitiveRefProvider) Check(
 	if failures := checkData("data", data); len(failures) != 0 {
 		return plugin.CheckResponse{Failures: failures}, nil
 	}
-	if optionalData, ok := req.News["optionalData"]; ok {
+	if optionalData, ok := news["optionalData"]; ok {
 		if failures := checkData("optionalData", optionalData); len(failures) != 0 {
 			return plugin.CheckResponse{Failures: failures}, nil
 		}
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *OptionalPrimitiveRefProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
@@ -324,19 +324,20 @@ func (p *OutputOnlyInvokeProvider) Invoke(
 func (p *OutputOnlyInvokeProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "output-only-invoke:index:StringResource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *OutputOnlyInvokeProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/output_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/output_provider.go
@@ -234,6 +234,7 @@ func (p *OutputProvider) CheckConfig(
 func (p *OutputProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "output:index:Resource" && req.URN.Type() != "output:index:ComplexResource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -241,7 +242,7 @@ func (p *OutputProvider) Check(
 	}
 
 	// Expect just the number value
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -252,13 +253,13 @@ func (p *OutputProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a number"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *OutputProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/parameterized_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/parameterized_provider.go
@@ -226,6 +226,7 @@ func (p *ParameterizedProvider) CheckConfig(
 func (p *ParameterizedProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "{sub-package}:index:{parameterized-resource}"
 	expectedToken := fmt.Sprintf("%s:index:%s", p.parameterPackage, string(p.parameterValue))
 	if string(req.URN.Type()) != expectedToken {
@@ -235,7 +236,7 @@ func (p *ParameterizedProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ParameterizedProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/plain_component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/plain_component_provider.go
@@ -191,13 +191,14 @@ func (p *PlainComponentProvider) Configure(
 func (p *PlainComponentProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "plaincomponent:index:Custom" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -208,12 +209,12 @@ func (p *PlainComponentProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a string"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *PlainComponentProvider) Diff(

--- a/pkg/testing/pulumi-test-language/providers/plain_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/plain_provider.go
@@ -201,6 +201,7 @@ func (p *PlainProvider) CheckConfig(
 func (p *PlainProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "plain:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -225,15 +226,15 @@ func (p *PlainProvider) Check(
 		return nil
 	}
 
-	check := assertField(req.News, "data", "object", resource.PropertyValue.IsObject)
+	check := assertField(news, "data", "object", resource.PropertyValue.IsObject)
 	if check != nil {
 		return *check, nil
 	}
 
 	// Should have one to three properties: data is required, nonPlainData and dataList are optional
-	if len(req.News) > 3 {
+	if len(news) > 3 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
@@ -308,7 +309,7 @@ func (p *PlainProvider) Check(
 	}
 
 	// Check data
-	data := req.News["data"].ObjectValue()
+	data := news["data"].ObjectValue()
 	check = checkData(data)
 	if check != nil {
 		return *check, nil
@@ -319,8 +320,8 @@ func (p *PlainProvider) Check(
 	}
 
 	// Check nonPlainData
-	if _, ok := req.News["nonPlainData"]; ok {
-		nonPlainData := req.News["nonPlainData"].ObjectValue()
+	if _, ok := news["nonPlainData"]; ok {
+		nonPlainData := news["nonPlainData"].ObjectValue()
 		check = checkData(nonPlainData)
 		if check != nil {
 			return *check, nil
@@ -332,7 +333,7 @@ func (p *PlainProvider) Check(
 	}
 
 	// Check dataList
-	if v, ok := req.News["dataList"]; ok {
+	if v, ok := news["dataList"]; ok {
 		if !v.IsArray() {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("dataList", "dataList is not an array"),
@@ -351,7 +352,7 @@ func (p *PlainProvider) Check(
 		}
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *PlainProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/primitive_defaults_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/primitive_defaults_provider.go
@@ -118,6 +118,7 @@ func (p *PrimitiveDefaultsProvider) CheckConfig(
 func (p *PrimitiveDefaultsProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "primitive-defaults:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -133,7 +134,7 @@ func (p *PrimitiveDefaultsProvider) Check(
 
 	// Start with user-provided values.
 	props := resource.PropertyMap{}
-	maps.Copy(props, req.News)
+	maps.Copy(props, news)
 
 	// For each optional property: assert it is present and validate its type.
 	assertPresentAndType := func(
@@ -170,7 +171,7 @@ func (p *PrimitiveDefaultsProvider) Check(
 		return *resp, nil
 	}
 
-	return plugin.CheckResponse{Properties: props}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(props)}, nil
 }
 
 func (p *PrimitiveDefaultsProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/primitive_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/primitive_provider.go
@@ -143,6 +143,7 @@ func (p *PrimitiveProvider) CheckConfig(
 func (p *PrimitiveProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "primitive:index:Resource"
 	if req.URN.Type() != "primitive:index:Resource" {
 		return plugin.CheckResponse{
@@ -168,7 +169,7 @@ func (p *PrimitiveProvider) Check(
 	assertField := func(key resource.PropertyKey, typ string,
 		assertType func(resource.PropertyValue) bool,
 	) *plugin.CheckResponse {
-		v, ok := req.News[key]
+		v, ok := news[key]
 		if !ok {
 			return &plugin.CheckResponse{
 				Failures: makeCheckFailure(key, "missing value"),
@@ -210,7 +211,7 @@ func (p *PrimitiveProvider) Check(
 		return *check, nil
 	}
 	// Check the array is numbers
-	numberArray := unsecret(req.News["numberArray"])
+	numberArray := unsecret(news["numberArray"])
 	for _, v := range numberArray.ArrayValue() {
 		v = unsecret(v)
 		if v.IsComputed() {
@@ -228,7 +229,7 @@ func (p *PrimitiveProvider) Check(
 		return *check, nil
 	}
 	// Check the map values are booleans
-	booleanMap := unsecret(req.News["booleanMap"])
+	booleanMap := unsecret(news["booleanMap"])
 	for _, v := range booleanMap.ObjectValue() {
 		v = unsecret(v)
 		if v.IsComputed() {
@@ -242,13 +243,13 @@ func (p *PrimitiveProvider) Check(
 		}
 	}
 
-	if len(req.News) != 6 {
+	if len(news) != 6 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *PrimitiveProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/primitive_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/primitive_ref_provider.go
@@ -153,6 +153,7 @@ func (p *PrimitiveRefProvider) CheckConfig(
 func (p *PrimitiveRefProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "primitive-ref:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -177,18 +178,18 @@ func (p *PrimitiveRefProvider) Check(
 		return nil
 	}
 
-	check := assertField(req.News, "data", "object", resource.PropertyValue.IsObject)
+	check := assertField(news, "data", "object", resource.PropertyValue.IsObject)
 	if check != nil {
 		return *check, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	data := req.News["data"].ObjectValue()
+	data := news["data"].ObjectValue()
 
 	// Expect all required properties
 	check = assertField(data, "boolean", "boolean", resource.PropertyValue.IsBool)
@@ -236,7 +237,7 @@ func (p *PrimitiveRefProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *PrimitiveRefProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/read_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/read_provider.go
@@ -78,10 +78,11 @@ func (p *ReadProvider) CheckConfig(context.Context, plugin.CheckConfigRequest) (
 }
 
 func (p *ReadProvider) Check(_ context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "read:index:Resource" {
 		return plugin.CheckResponse{}, fmt.Errorf("invalid URN type: %s", req.URN.Type())
 	}
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ReadProvider) Create(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {

--- a/pkg/testing/pulumi-test-language/providers/ref_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/ref_ref_provider.go
@@ -183,6 +183,7 @@ func (p *RefRefProvider) CheckConfig(
 func (p *RefRefProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "ref-ref:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -207,18 +208,18 @@ func (p *RefRefProvider) Check(
 		return nil
 	}
 
-	check := assertField(req.News, "data", "object", resource.PropertyValue.IsObject)
+	check := assertField(news, "data", "object", resource.PropertyValue.IsObject)
 	if check != nil {
 		return *check, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	data := req.News["data"].ObjectValue()
+	data := news["data"].ObjectValue()
 
 	checkData := func(data resource.PropertyMap) *plugin.CheckResponse {
 		// Expect all required properties
@@ -318,7 +319,7 @@ func (p *RefRefProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *RefRefProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/replace_on_changes_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/replace_on_changes_provider.go
@@ -136,6 +136,7 @@ func (p *ReplaceOnChangesProvider) CheckConfig(
 func (p *ReplaceOnChangesProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	urnType := req.URN.Type()
 	if urnType != "replaceonchanges:index:ResourceA" && urnType != "replaceonchanges:index:ResourceB" {
 		return plugin.CheckResponse{
@@ -143,7 +144,7 @@ func (p *ReplaceOnChangesProvider) Check(
 		}, nil
 	}
 
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -156,16 +157,16 @@ func (p *ReplaceOnChangesProvider) Check(
 	}
 
 	if urnType == "replaceonchanges:index:ResourceA" {
-		if len(req.News) < 1 || len(req.News) > 2 {
+		if len(news) < 1 || len(news) > 2 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("wrong number of properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("wrong number of properties: %v", news)),
 			}, nil
 		}
-		if len(req.News) == 2 {
-			replaceProp, ok := req.News["replaceProp"]
+		if len(news) == 2 {
+			replaceProp, ok := news["replaceProp"]
 			if !ok {
 				return plugin.CheckResponse{
-					Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+					Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 				}, nil
 			}
 			if !replaceProp.IsBool() && !replaceProp.IsComputed() {
@@ -175,14 +176,14 @@ func (p *ReplaceOnChangesProvider) Check(
 			}
 		}
 	} else {
-		if len(req.News) != 1 {
+		if len(news) != 1 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 			}, nil
 		}
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ReplaceOnChangesProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/reserved_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/reserved_names_provider.go
@@ -106,7 +106,8 @@ func (p *ReservedNamesProvider) CheckConfig(
 func (p *ReservedNamesProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
-	return plugin.CheckResponse{Properties: req.News}, nil
+	news := resource.ToResourcePropertyMap(req.NewInputs)
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *ReservedNamesProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/secret_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/secret_provider.go
@@ -202,6 +202,7 @@ func (p *SecretProvider) CheckConfig(
 func (p *SecretProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "secret:index:Resource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
@@ -268,25 +269,25 @@ func (p *SecretProvider) Check(
 			unsecret(data["public"]).IsString()
 	}
 
-	check := assertField(req.News, "privateData", "secret object", isSecretObject)
+	check := assertField(news, "privateData", "secret object", isSecretObject)
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "publicData", "object", resource.PropertyValue.IsObject)
+	check = assertField(news, "publicData", "object", resource.PropertyValue.IsObject)
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "private", "secret string", isSecretString)
+	check = assertField(news, "private", "secret string", isSecretString)
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "public", "string", func(v resource.PropertyValue) bool {
+	check = assertField(news, "public", "string", func(v resource.PropertyValue) bool {
 		return unsecret(v).IsString()
 	})
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "privateArray", "secret array of strings", func(v resource.PropertyValue) bool {
+	check = assertField(news, "privateArray", "secret array of strings", func(v resource.PropertyValue) bool {
 		if !isSecretArray(v) {
 			return false
 		}
@@ -300,7 +301,7 @@ func (p *SecretProvider) Check(
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "privateMap", "secret map of strings", func(v resource.PropertyValue) bool {
+	check = assertField(news, "privateMap", "secret map of strings", func(v resource.PropertyValue) bool {
 		if !isSecretObject(v) {
 			return false
 		}
@@ -314,7 +315,7 @@ func (p *SecretProvider) Check(
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "privateDataArray", "secret array of Data", func(v resource.PropertyValue) bool {
+	check = assertField(news, "privateDataArray", "secret array of Data", func(v resource.PropertyValue) bool {
 		if !isSecretArray(v) {
 			return false
 		}
@@ -328,7 +329,7 @@ func (p *SecretProvider) Check(
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "privateDataMap", "secret map of Data", func(v resource.PropertyValue) bool {
+	check = assertField(news, "privateDataMap", "secret map of Data", func(v resource.PropertyValue) bool {
 		if !isSecretObject(v) {
 			return false
 		}
@@ -343,13 +344,13 @@ func (p *SecretProvider) Check(
 		return *check, nil
 	}
 
-	if len(req.News) != 8 {
+	if len(news) != 8 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	publicData := req.News["publicData"].ObjectValue()
+	publicData := news["publicData"].ObjectValue()
 	check = assertField(publicData, "private", "string", func(v resource.PropertyValue) bool {
 		return unsecret(v).IsString()
 	})
@@ -368,7 +369,7 @@ func (p *SecretProvider) Check(
 		}, nil
 	}
 
-	privateData := unsecret(req.News["privateData"]).ObjectValue()
+	privateData := unsecret(news["privateData"]).ObjectValue()
 	check = assertField(privateData, "private", "string", func(v resource.PropertyValue) bool {
 		return unsecret(v).IsString()
 	})
@@ -387,7 +388,7 @@ func (p *SecretProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *SecretProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/secret_provider_test.go
+++ b/pkg/testing/pulumi-test-language/providers/secret_provider_test.go
@@ -239,8 +239,8 @@ func TestSecretProvider_Check(t *testing.T) {
 			tt.mutate(props)
 			p := &SecretProvider{}
 			resp, err := p.Check(t.Context(), plugin.CheckRequest{
-				URN:  resource.NewURN("test-stack", "test-project", "", "secret:index:Resource", "res"),
-				News: props,
+				URN:       resource.NewURN("test-stack", "test-project", "", "secret:index:Resource", "res"),
+				NewInputs: resource.FromResourcePropertyMap(props),
 			})
 			require.NoError(t, err)
 			if tt.wantFail {

--- a/pkg/testing/pulumi-test-language/providers/simple_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_invoke_provider.go
@@ -485,19 +485,20 @@ func (p *SimpleInvokeProvider) Invoke(
 func (p *SimpleInvokeProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "simple-invoke:index:StringResource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *SimpleInvokeProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_invoke_with_scalar_return_provider.go
@@ -174,19 +174,20 @@ func (p *SimpleInvokeWithScalarReturnProvider) Invoke(
 func (p *SimpleInvokeWithScalarReturnProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	if req.URN.Type() != "simple-invoke-with-scalar-return:index:StringResource" {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
 		}, nil
 	}
 
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("expected exactly one property: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *SimpleInvokeWithScalarReturnProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/simple_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_provider.go
@@ -129,6 +129,7 @@ func (p *SimpleProvider) CheckConfig(
 func (p *SimpleProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "simple:index:Resource"
 	if req.URN.Type() != "simple:index:Resource" {
 		return plugin.CheckResponse{
@@ -137,7 +138,7 @@ func (p *SimpleProvider) Check(
 	}
 
 	// Expect just the boolean value
-	value, ok := req.News["value"]
+	value, ok := news["value"]
 	if !ok {
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("value", "missing value"),
@@ -148,13 +149,13 @@ func (p *SimpleProvider) Check(
 			Failures: makeCheckFailure("value", "value is not a boolean"),
 		}, nil
 	}
-	if len(req.News) != 1 {
+	if len(news) != 1 {
 		return plugin.CheckResponse{
-			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", news)),
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *SimpleProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/snake_names_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/snake_names_provider.go
@@ -213,38 +213,39 @@ func (p *SnakeNamesProvider) CheckConfig(
 func (p *SnakeNamesProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	switch typ := req.URN.Type(); typ {
 	case "snake_names:cool_module:some_resource":
-		if _, ok := req.News["the_input"]; !ok {
+		if _, ok := news["the_input"]; !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("the_input", "missing the_input"),
 			}, nil
 		}
-		if _, ok := req.News["nested"]; !ok {
+		if _, ok := news["nested"]; !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("nested", "missing nested"),
 			}, nil
 		}
-		if len(req.News) != 2 {
+		if len(news) != 2 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 			}, nil
 		}
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	case "snake_names:cool_module:another_resource":
-		if _, ok := req.News["the_input"]; !ok {
+		if _, ok := news["the_input"]; !ok {
 			return plugin.CheckResponse{
 				Failures: makeCheckFailure("the_input", "missing the_input"),
 			}, nil
 		}
-		if len(req.News) != 1 {
+		if len(news) != 1 {
 			return plugin.CheckResponse{
-				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", req.News)),
+				Failures: makeCheckFailure("", fmt.Sprintf("unexpected properties: %v", news)),
 			}, nil
 		}
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	case tokens.RootStackType:
-		return plugin.CheckResponse{Properties: req.News}, nil
+		return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 	default:
 		return plugin.CheckResponse{
 			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", typ)),

--- a/pkg/testing/pulumi-test-language/providers/sync_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/sync_provider.go
@@ -78,6 +78,7 @@ func (p *SyncProvider) CheckConfig(
 func (p *SyncProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	// URN should be of the form "sync:index:Resource"
 	if req.URN.Type() != "sync:index:Block" {
 		return plugin.CheckResponse{
@@ -85,7 +86,7 @@ func (p *SyncProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *SyncProvider) Create(

--- a/pkg/testing/pulumi-test-language/providers/union_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/union_provider.go
@@ -197,6 +197,7 @@ func (p *UnionProvider) DiffConfig(
 func (p *UnionProvider) Check(
 	_ context.Context, req plugin.CheckRequest,
 ) (plugin.CheckResponse, error) {
+	news := resource.ToResourcePropertyMap(req.NewInputs)
 	urnType := string(req.URN.Type())
 	exampleType := fmt.Sprintf("%s:index:Example", p.pkg())
 	enumOutputType := fmt.Sprintf("%s:index:EnumOutput", p.pkg())
@@ -206,7 +207,7 @@ func (p *UnionProvider) Check(
 		}, nil
 	}
 
-	return plugin.CheckResponse{Properties: req.News}, nil
+	return plugin.CheckResponse{Properties: resource.FromResourcePropertyMap(news)}, nil
 }
 
 func (p *UnionProvider) Create(


### PR DESCRIPTION
Took the chance to rename some of the fields here as well, given the TODO.

```diff
- // TODO Change to (State, Input)
- Olds, News resource.PropertyMap
- // OldOutputs is the previously persisted outputs of the resource, if any.
- OldOutputs    resource.PropertyMap
+ // NewInputs are the new inputs for the resource from the program.
+ NewInputs property.Map
+ // OldInputs are the previously persisted inputs of the resource, if any.
+ OldInputs property.Map
+ // OldOutputs are the previously persisted outputs of the resource, if any.
+ OldOutputs    property.Map
```

Didn't go with the TODOs suggestion of State/Input, but instead with the terminology we're using elsewhere about explicit old/new inputs/outputs.