### PR TITLE
Preserve provider transforms alongside caller transforms on remote components and their children

### DIFF
--- a/changelog/pending/engine-fix-remote-component-transforms.yaml
+++ b/changelog/pending/engine-fix-remote-component-transforms.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Preserve provider transforms alongside caller transforms on remote components and their children
+time: 2026-09-10T08:53:09Z

--- a/changelog/pending/engine-fix-state-migration-remote-callback-order.yaml
+++ b/changelog/pending/engine-fix-state-migration-remote-callback-order.yaml
@@ -1,0 +1,4 @@
+component: engine
+kind: fix
+body: Fix remote component provider state migrations being skipped when the caller also supplies migrations
+time: 2026-09-09T13:04:42Z

--- a/pkg/engine/lifecycletest/state_migration_test.go
+++ b/pkg/engine/lifecycletest/state_migration_test.go
@@ -293,25 +293,28 @@ func snapIndices(snap *deploy.Snapshot) map[resource.URN]int {
 
 // renameMigration returns a migration callback that renames the child resource and maps its old URN to the new one.
 func renameMigration(t *testing.T, callbacks *deploytest.CallbackServer, oldName, newName string) *pulumirpc.Callback {
-	callback, err := callbacks.Allocate(
-		stateMigrationFunction(func(
-			urn resource.URN, resources []apitype.ResourceV3,
-		) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
-			successors := make(map[resource.URN]resource.URN)
-			for _, res := range resources {
-				if strings.HasSuffix(string(res.URN), "::"+oldName) {
-					renamed := renameByName([]apitype.ResourceV3{res}, oldName, newName)
-					successors[res.URN] = renamed[0].URN
-				}
-			}
-			if len(successors) == 0 {
-				// Already migrated: return the state unchanged.
-				return nil, nil, nil
-			}
-			return renameByName(resources, oldName, newName), successors, nil
-		}))
+	callback, err := callbacks.Allocate(renameMigrationFunction(oldName, newName))
 	require.NoError(t, err)
 	return callback
+}
+
+func renameMigrationFunction(oldName, newName string) func([]byte) (proto.Message, error) {
+	return stateMigrationFunction(func(
+		urn resource.URN, resources []apitype.ResourceV3,
+	) ([]apitype.ResourceV3, map[resource.URN]resource.URN, error) {
+		successors := make(map[resource.URN]resource.URN)
+		for _, res := range resources {
+			if strings.HasSuffix(string(res.URN), "::"+oldName) {
+				renamed := renameByName([]apitype.ResourceV3{res}, oldName, newName)
+				successors[res.URN] = renamed[0].URN
+			}
+		}
+		if len(successors) == 0 {
+			// Already migrated: return the state unchanged.
+			return nil, nil, nil
+		}
+		return renameByName(resources, oldName, newName), successors, nil
+	})
 }
 
 // setRenameMigration attaches the common rename migration used by lifecycle tests.
@@ -1396,6 +1399,176 @@ func TestStateMigrationConstruct(t *testing.T) {
 	urns := snapURNs(snap)
 	assert.Contains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typD$pkgA:m:typA::resB"))
 	assert.NotContains(t, urns, resource.URN("urn:pulumi:test::test::pkgA:m:typC$pkgA:m:typA::resA"))
+}
+
+// TestStateMigrationConstructCallbackOrder tests that we run migrations attached to the local (in the program) and
+// remote (in the provider) parts of a component, with the remote callbacks running before the local ones.
+//
+// Scenarios:
+//
+//	caller no-op:     provider 1 -> provider 2 -> caller 1 (no-op) -> caller 2 (no-op) -> commit
+//	caller migration: provider 1 -> provider 2 -> caller 1         -> caller 2 (no-op) -> commit
+//	provider failure: provider 1 -> provider 2 (error)                                 -> no commit
+//	caller failure:   provider 1 -> provider 2 -> caller 1         -> caller 2 (error) -> no commit
+func TestStateMigrationConstructCallbackOrder(t *testing.T) {
+	t.Parallel()
+
+	type migrationStep struct {
+		name     string
+		from, to string // Empty for a no-op or failure.
+		fail     bool
+	}
+	for _, tt := range []struct {
+		name               string
+		providerMigrations []migrationStep
+		callerMigrations   []migrationStep
+		finalName          string
+		wantError          string
+		wantCalls          []string
+	}{
+		{
+			name: "caller no-op",
+			providerMigrations: []migrationStep{
+				{name: "provider 1", from: "old", to: "intermediate"},
+				{name: "provider 2", from: "intermediate", to: "internal"},
+			},
+			callerMigrations: []migrationStep{{name: "caller 1"}, {name: "caller 2"}},
+			finalName:        "internal",
+			wantCalls:        []string{"provider 1", "provider 2", "caller 1", "caller 2"},
+		},
+		{
+			name: "caller migration",
+			providerMigrations: []migrationStep{
+				{name: "provider 1", from: "old", to: "intermediate"},
+				{name: "provider 2", from: "intermediate", to: "internal"},
+			},
+			callerMigrations: []migrationStep{
+				{name: "caller 1", from: "internal", to: "custom"},
+				{name: "caller 2"},
+			},
+			finalName: "custom",
+			wantCalls: []string{"provider 1", "provider 2", "caller 1", "caller 2"},
+		},
+		{
+			name: "provider failure",
+			providerMigrations: []migrationStep{
+				{name: "provider 1", from: "old", to: "intermediate"},
+				{name: "provider 2", fail: true},
+			},
+			callerMigrations: []migrationStep{
+				{name: "caller 1", from: "internal", to: "custom"},
+				{name: "caller 2"},
+			},
+			finalName: "custom",
+			wantError: "migration failed: provider 2",
+			wantCalls: []string{"provider 1", "provider 2"},
+		},
+		{
+			name: "caller failure",
+			providerMigrations: []migrationStep{
+				{name: "provider 1", from: "old", to: "intermediate"},
+				{name: "provider 2", from: "intermediate", to: "internal"},
+			},
+			callerMigrations: []migrationStep{
+				{name: "caller 1", from: "internal", to: "custom"},
+				{name: "caller 2", fail: true},
+			},
+			finalName: "custom",
+			wantError: "migration failed: caller 2",
+			wantCalls: []string{"provider 1", "provider 2", "caller 1", "caller 2"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			callbacks, err := deploytest.NewCallbacksServer()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, callbacks.Close()) })
+
+			var calls []string
+			registerMigrations := func(steps []migrationStep) []*pulumirpc.Callback {
+				result := make([]*pulumirpc.Callback, 0, len(steps))
+				for _, step := range steps {
+					callback, err := callbacks.Allocate(func(request []byte) (proto.Message, error) {
+						calls = append(calls, step.name)
+						if step.fail {
+							return nil, errors.New("migration failed: " + step.name)
+						}
+						if step.from == "" {
+							return &pulumirpc.StateMigrationResponse{}, nil
+						}
+						return renameMigrationFunction(step.from, step.to)(request)
+					})
+					require.NoError(t, err)
+					result = append(result, callback)
+				}
+				return result
+			}
+			providerMigrations := registerMigrations(tt.providerMigrations)
+			callerMigrations := registerMigrations(tt.callerMigrations)
+			upgrade := false
+			loaders := []*deploytest.ProviderLoader{
+				deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+					return &deploytest.Provider{
+						ConstructF: func(
+							_ context.Context, req plugin.ConstructRequest, monitor *deploytest.ResourceMonitor,
+						) (plugin.ConstructResponse, error) {
+							resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{
+								StateMigrations: providerMigrations,
+							})
+							if err != nil {
+								return plugin.ConstructResponse{}, err
+							}
+							childName := "old"
+							if upgrade {
+								childName = tt.finalName
+							}
+							_, err = monitor.RegisterResource("pkgA:m:typA", childName, true, deploytest.ResourceOptions{
+								Parent: resp.URN,
+							})
+							return plugin.ConstructResponse{URN: resp.URN}, err
+						},
+					}, nil
+				}),
+			}
+			program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+				_, err := monitor.RegisterResource("pkgA:m:Component", "comp", false, deploytest.ResourceOptions{
+					Remote: true, StateMigrations: callerMigrations,
+				})
+				return err
+			})
+			host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
+			plan := &lt.TestPlan{Options: stateMigrationTestOptions(t, host)}
+			snap, err := runUpdate(t, plan, nil, nil)
+			require.NoError(t, err)
+			require.Empty(t, calls)
+			before := snapURNs(snap)
+			var childID resource.ID
+			for _, res := range snap.Resources {
+				if res.URN.Name() == "old" {
+					childID = res.ID
+				}
+			}
+			require.NotEmpty(t, childID)
+
+			upgrade = true
+			if tt.wantError != "" {
+				snap, err = runUpdate(t, plan, snap, nil)
+				require.ErrorContains(t, err, tt.wantError)
+				assert.Equal(t, before, snapURNs(snap))
+			} else {
+				snap, err = runUpdate(t, plan, snap, validateOps(t, map[display.StepOp]int{deploy.OpSame: 3}))
+				require.NoError(t, err)
+				assert.Contains(t, snapURNs(snap),
+					resource.URN("urn:pulumi:test::test::pkgA:m:Component$pkgA:m:typA::"+tt.finalName))
+				for _, res := range snap.Resources {
+					if res.URN.Name() == tt.finalName {
+						assert.Equal(t, childID, res.ID)
+					}
+				}
+			}
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
 }
 
 // TestStateMigrationAliasedRootRename exercises this component type change:

--- a/pkg/engine/lifecycletest/transformation_test.go
+++ b/pkg/engine/lifecycletest/transformation_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver"
@@ -743,6 +744,124 @@ func TestRemoteComponentTransforms(t *testing.T) {
 	assert.Equal(t, resource.PropertyMap{
 		"foo": resource.NewProperty(2.0),
 	}, res.Inputs)
+}
+
+// TestRemoteComponentTransformComposition combines provider and caller transforms on a remote component and
+// its children, including a child registered after Construct returns.
+//
+//	component
+//	├─ inside  (registered by the provider during Construct)
+//	└─ outside (registered by the program after Construct returns)
+//
+// Both children explicitly use the component as their parent and must inherit its combined transforms,
+// regardless of which process registers them or whether Construct has returned.
+//
+//	remote request:        caller transforms
+//	provider registration: provider transforms -> caller transforms
+//	children:              provider transforms -> caller transforms
+func TestRemoteComponentTransformComposition(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name           string
+		provider       []string
+		caller         []string
+		componentCalls []string
+		childCalls     []string
+	}{
+		{
+			name: "caller only", caller: []string{"C1", "C2"},
+			componentCalls: []string{"C1", "C2", "C1", "C2"}, childCalls: []string{"C1", "C2"},
+		},
+		{
+			name: "provider only", provider: []string{"P1", "P2"},
+			componentCalls: []string{"P1", "P2"}, childCalls: []string{"P1", "P2"},
+		},
+		{
+			name: "provider and caller", provider: []string{"P1", "P2"}, caller: []string{"C1", "C2"},
+			componentCalls: []string{"C1", "C2", "P1", "P2", "C1", "C2"},
+			childCalls:     []string{"P1", "P2", "C1", "C2"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			callbacks, err := deploytest.NewCallbacksServer()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, callbacks.Close()) })
+
+			calls := map[string][]string{}
+			transforms := func(labels []string) []*pulumirpc.Callback {
+				result := make([]*pulumirpc.Callback, 0, len(labels))
+				for _, label := range labels {
+					callback, err := callbacks.Allocate(TransformFunction(func(
+						name, typ string, custom bool, parent string,
+						props resource.PropertyMap, opts *pulumirpc.TransformResourceOptions,
+					) (resource.PropertyMap, *pulumirpc.TransformResourceOptions, error) {
+						calls[name] = append(calls[name], label)
+						props["trace"] = pvApply(props["trace"], func(v resource.PropertyValue) resource.PropertyValue {
+							return resource.NewProperty(v.StringValue() + label)
+						})
+						return props, opts, nil
+					}))
+					require.NoError(t, err)
+					result = append(result, callback)
+				}
+				return result
+			}
+			providerTransforms, callerTransforms := transforms(tt.provider), transforms(tt.caller)
+			inputs := resource.PropertyMap{"trace": resource.NewProperty("")}
+			loaders := []*deploytest.ProviderLoader{
+				deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+					return &deploytest.Provider{
+						ConstructF: func(
+							_ context.Context, req plugin.ConstructRequest, monitor *deploytest.ResourceMonitor,
+						) (plugin.ConstructResponse, error) {
+							resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{
+								Inputs: resource.ToResourcePropertyMap(req.Inputs), Transforms: providerTransforms,
+							})
+							if err != nil {
+								return plugin.ConstructResponse{}, err
+							}
+							_, err = monitor.RegisterResource("pkgA:m:Child", "inside", true, deploytest.ResourceOptions{
+								Parent: resp.URN, Inputs: inputs,
+							})
+							return plugin.ConstructResponse{URN: resp.URN}, err
+						},
+					}, nil
+				}),
+			}
+			program := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+				resp, err := monitor.RegisterResource("pkgA:m:Component", "component", false, deploytest.ResourceOptions{
+					Remote: true, Inputs: inputs, Transforms: callerTransforms,
+				})
+				if err != nil {
+					return err
+				}
+				_, err = monitor.RegisterResource("pkgA:m:Child", "outside", true, deploytest.ResourceOptions{
+					Parent: resp.URN, Inputs: inputs,
+				})
+				return err
+			})
+			host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
+			plan := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: host, SkipDisplayTests: true}}
+			snap, err := lt.TestOp(Update).Run(plan.GetProject(), plan.GetTarget(t, nil), plan.Options,
+				false, plan.BackendClient, nil)
+			require.NoError(t, err)
+			assert.Equal(t, map[string][]string{
+				"component": tt.componentCalls, "inside": tt.childCalls, "outside": tt.childCalls,
+			}, calls)
+			require.Len(t, snap.Resources, 4)
+			for _, res := range snap.Resources {
+				want := tt.childCalls
+				if res.URN.Name() == "component" {
+					want = tt.componentCalls
+				} else if res.URN.Name() != "inside" && res.URN.Name() != "outside" {
+					continue
+				}
+				assert.Equal(t, resource.NewProperty(strings.Join(want, "")), res.Inputs["trace"])
+			}
+		})
+	}
 }
 
 func TestTransformsProviderOpt(t *testing.T) {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -2462,9 +2462,9 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		Hooks:                   req.GetHooks(),
 	}
 
-	// This might be a resource registation for a resource that another process requested to be constructed.
-	// If so we'll have saved the pending transforms for this and we should use those rather than what is on
-	// the request. ourTransforms is the list of transforms declared on _this_ resource, we save it later to
+	// This might be a resource registration for a resource that another process requested to be constructed.
+	// If so, run the provider's transforms before the caller's pending transforms. ourTransforms is the list
+	// of transforms declared on _this_ resource, we save it later to
 	// the resourceTransforms map. transforms is a collected list of _all_ transforms that need to run on this
 	// resource, including those from parents and the stack.
 	var ourTransforms []TransformFunction
@@ -2474,14 +2474,14 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		rm.pendingTransformsLock.Lock()
 		defer rm.pendingTransformsLock.Unlock()
 
+		ourTransforms, err = slice.MapError(req.Transforms, rm.wrapTransformCallback)
+		if err != nil {
+			return err
+		}
 		if pending, ok := rm.pendingTransforms[pendingKey]; ok {
 			delete(rm.pendingTransforms, pendingKey) // Remove the pending transforms, we don't need them again.
-			ourTransforms = pending
+			ourTransforms = append(ourTransforms, pending...)
 		} else {
-			ourTransforms, err = slice.MapError(req.Transforms, rm.wrapTransformCallback)
-			if err != nil {
-				return err
-			}
 			// We only need to save this for remote calls
 			if remote && len(ourTransforms) > 0 {
 				// Make a copy of the slice here, otherwise later appends will modify what we save here.
@@ -3092,7 +3092,11 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		func() {
 			rm.resourceTransformsLock.Lock()
 			defer rm.resourceTransformsLock.Unlock()
-			rm.resourceTransforms[result.State.URN] = ourTransforms
+			// Construct's registration has already saved the combined provider and caller transforms.
+			// The outer remote registration must not overwrite them with only the caller's transforms.
+			if !remote {
+				rm.resourceTransforms[result.State.URN] = ourTransforms
+			}
 		}()
 		if !custom {
 			func() {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -2535,25 +2535,24 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		opts = newOpts
 	}
 
-	// Collect the state migrations registered for this resource. A registration for a constructed resource
-	// reuses the migrations saved by the remote registration that requested construction, mirroring the pending
-	// transform handoff above.
+	// Collect the state migrations registered for this resource. For constructed resources, we run the provider's
+	// migrations before the caller's so caller migrations see the provider's upgraded state.
 	var stateMigrations []StateMigrationFunction
 	err = func() error {
 		rm.pendingStateMigrationsLock.Lock()
 		defer rm.pendingStateMigrationsLock.Unlock()
 
+		stateMigrations, err = slice.MapError(req.StateMigrations, rm.wrapStateMigrationCallback)
+		if err != nil {
+			return err
+		}
 		if pending, ok := rm.pendingStateMigrations[pendingKey]; ok {
 			delete(rm.pendingStateMigrations, pendingKey)
-			stateMigrations = pending.functions
+			stateMigrations = append(stateMigrations, pending.functions...)
 			// The constructed registration may omit aliases from the original remote registration. Keep them so the
 			// migration can find the prior state.
 			opts.Aliases = append(slices.Clone(pending.aliases), opts.Aliases...)
 		} else {
-			stateMigrations, err = slice.MapError(req.StateMigrations, rm.wrapStateMigrationCallback)
-			if err != nil {
-				return err
-			}
 			// We only need to save this for remote calls
 			if remote && len(stateMigrations) > 0 {
 				rm.pendingStateMigrations[pendingKey] = pendingStateMigration{


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/24620, compose provider transforms with caller transforms when registering a constructed component, rather than letting the caller’s list suppress the provider’s.
