### PR TITLE
Run ubuntu unit & fuzz test jobs inside a prebaked toolchain image

### DIFF
--- a/.github/actions/install-toolchain/action.yml
+++ b/.github/actions/install-toolchain/action.yml
@@ -1,0 +1,126 @@
+name: Install test toolchain
+description: >-
+  Installs the test toolchain on the runner, for jobs that do not run in a
+  prebaked toolchain container. Keep in sync with .github/toolchain/Dockerfile,
+  which bakes the same tools into the image.
+inputs:
+  version-set:
+    description: JSON version set from scripts/get-job-matrix.py.
+    required: true
+outputs:
+  go-cache-hit:
+    description: Whether setup-go restored an exact Go cache match.
+    value: ${{ steps.setup-go.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    # Resolve every tool pin once via the shared tool-pin script. Later
+    # steps only consume the env vars. Use plain assignments, so a failed
+    # parse aborts under `set -e`.
+    - name: Resolve tool pins from their authorities
+      shell: bash
+      run: |
+        set -euo pipefail
+        pin=./.github/scripts/tool-pin
+        DLV_VERSION=$($pin go:github.com/go-delve/delve/cmd/dlv)
+        JAVA_PIN=$($pin java) # e.g. temurin-11
+        GRADLE_VERSION=$($pin gradle)
+        YARN_VERSION=$($pin npm:yarn)
+        PNPM_VERSION=$($pin npm:pnpm)
+        NPM_VERSION=$($pin npm)
+        GOTESTSUM_VERSION=$($pin go:gotest.tools/gotestsum)
+        GOTESTSTATS_VERSION=$($pin github:pulumi/goteststats)
+        {
+          echo "DLV_VERSION=${DLV_VERSION}"
+          echo "JAVA_DISTRIBUTION=${JAVA_PIN%%-*}"
+          echo "JAVA_VERSION=${JAVA_PIN#*-}"
+          echo "GRADLE_VERSION=${GRADLE_VERSION}"
+          echo "YARN_VERSION=${YARN_VERSION}"
+          echo "PNPM_VERSION=${PNPM_VERSION}"
+          echo "NPM_VERSION=${NPM_VERSION}"
+          echo "GOTESTSUM_TAG=v${GOTESTSUM_VERSION}"
+          echo "GOTESTSTATS_TAG=v${GOTESTSTATS_VERSION}"
+        } >> "$GITHUB_ENV"
+    - uses: actions/setup-go@v6
+      id: setup-go
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        go-version: ${{ fromJson(inputs.version-set).go }}
+        check-latest: true
+        cache: true
+        cache-dependency-path: |
+          pkg/go.sum
+          .gocache.tmp
+    - name: Install delve
+      shell: bash
+      run: go install "github.com/go-delve/delve/cmd/dlv@v${DLV_VERSION}"
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: sdk/python/uv.lock
+    - name: Set up Python ${{ fromJson(inputs.version-set).python }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ fromJson(inputs.version-set).python }}
+    - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
+      uses: ./.github/actions/retry
+      with:
+        action: actions/setup-dotnet@v5
+        with: |
+          dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
+          dotnet-quality: ga
+    - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ fromJson(inputs.version-set).nodejs }}
+        cache: npm
+        cache-dependency-path: sdk/nodejs/package-lock.json
+    - name: Set up JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+    - name: Setup Gradle
+      uses: ./.github/actions/retry
+      with:
+        action: gradle/actions/setup-gradle@v6
+        with: |
+          gradle-version: "${{ env.GRADLE_VERSION }}"
+    - name: Install npm, yarn and pnpm
+      shell: bash
+      # npm >= 11.17.0 so the dependency-cooldown action's first-party
+      # exceptions (min-release-age-exclude) work.
+      run: npm install -g "yarn@${YARN_VERSION}" "pnpm@${PNPM_VERSION}" "npm@${NPM_VERSION}"
+    - name: Install bun
+      uses: ./.github/actions/retry
+      with:
+        action: oven-sh/setup-bun@v2
+    - name: Install Python deps
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip requests wheel urllib3 chardet build
+    - name: Install Poetry
+      shell: bash
+      run: python -m pip install poetry
+    - name: Install gotestsum
+      uses: ./.github/actions/retry
+      with:
+        action: jaxxstorm/action-install-gh-release@v3.0.0
+        with: |
+          repo: gotestyourself/gotestsum
+          tag: ${{ env.GOTESTSUM_TAG }}
+          cache: enable
+        attempt_limit: 3
+        attempt_delay: 5000
+    - name: Install goteststats
+      uses: ./.github/actions/retry
+      with:
+        action: jaxxstorm/action-install-gh-release@v3.0.0
+        with: |
+          repo: pulumi/goteststats
+          tag: ${{ env.GOTESTSTATS_TAG }}
+          cache: enable
+        attempt_limit: 3
+        attempt_delay: 5000

--- a/.github/scripts/tool-pin
+++ b/.github/scripts/tool-pin
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2026, Pulumi Corporation.
+#
+# Prints a tool pin from .mise.toml. The main parser that every CI consumer
+# shares. Reads only the [tools] and [vars] sections, and fails hard when a
+# pin does not parse or matches more than once, so format drift breaks
+# loudly instead of installing the wrong thing.
+#
+# Usage:
+#   tool-pin <mise-key>   # a [tools] or [vars] pin from .mise.toml, e.g.:
+#                         #   tool-pin gradle
+#                         #   tool-pin npm:yarn
+#                         #   tool-pin go:gotest.tools/gotestsum
+#                         #   tool-pin npm            (the [vars] npm range)
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+KEY="${1:?usage: $0 <mise-key>}"
+# Restrict matching to [tools] and [vars]: other sections can reuse a key
+# name for something that is not a version pin (e.g. gradle in [plugins]).
+# Accepts both TOML quote styles. A `.` in keys matches any character,
+# which is harmless under the full-line anchors.
+v=$(awk '/^\[/ { insec = ($0 == "[tools]" || $0 == "[vars]"); next } insec' .mise.toml \
+  | sed -n \
+      -e "s|^\"\{0,1\}${KEY}\"\{0,1\} = \"\(.*\)\"\$|\1|p" \
+      -e "s|^\"\{0,1\}${KEY}\"\{0,1\} = '\(.*\)'\$|\1|p")
+case "$v" in
+  "")
+    echo "FATAL: no pin for '${KEY}' parsed from .mise.toml (format change?)" >&2
+    exit 1
+    ;;
+  *$'\n'*)
+    echo "FATAL: multiple pins for '${KEY}' in .mise.toml" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' "$v"

--- a/.github/scripts/toolchain-image-tag
+++ b/.github/scripts/toolchain-image-tag
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2026, Pulumi Corporation.
+#
+# Prints the content-addressed toolchain image reference for a version set:
+# a hash of the image's inputs plus the ISO week. The week stamp rolls the
+# tag weekly so floating pins (Go patch, base image, apt) re-resolve.
+#
+# Usage: toolchain-image-tag <version-set-name>
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+SET="${1:?usage: $0 <version-set-name>}"
+VERSION_SET=$(./scripts/get-job-matrix.py generate-version-set --version-set "$SET")
+WEEK=$(date -u +%G-W%V)
+HASH=$(
+  {
+    cat .github/toolchain/Dockerfile \
+        .mise.toml \
+        .github/workflows/ci-toolchain-image.yml \
+        .github/actions/dependency-cooldown/action.yml
+    printf '%s\n%s\n' "$VERSION_SET" "$WEEK"
+  } | shasum -a 256 | cut -c1-12
+)
+REPO=$(echo "${GITHUB_REPOSITORY:-pulumi/pulumi}" | tr '[:upper:]' '[:lower:]')
+echo "ghcr.io/${REPO}/ci-toolchain:${SET}-${HASH}"

--- a/.github/toolchain/Dockerfile
+++ b/.github/toolchain/Dockerfile
@@ -1,0 +1,128 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Prebaked toolchain image for the ubuntu test jobs in ci-run-test.yml.
+# Built by ci-toolchain-image.yml, tagged by content hash (see
+# .github/scripts/toolchain-image-tag). mise installs the tools from
+# .mise.toml (language versions overridden by build args) and they are
+# symlinked into /usr/local/bin, so nothing at job runtime depends on mise.
+#
+# Build from the repo root: docker build -f .github/toolchain/Dockerfile .
+
+FROM ubuntu:24.04
+
+# Recorded before any install layer: a rolled tag must bust the layer
+# cache so floating pins re-resolve.
+ARG TOOLCHAIN_TAG=dev
+RUN echo "${TOOLCHAIN_TAG}" > /etc/toolchain-tag
+
+# All tool versions arrive as required build args from their authorities
+# (get-job-matrix.py, .mise.toml). Only mise, used solely here, is pinned.
+# COOLDOWN_DAYS is the window for the image's own npm/pip installs; the
+# build sites pass the default of .github/actions/dependency-cooldown, so
+# the runtime authority stays the only one. It is exported per layer below,
+# so the published image carries no cooldown settings of its own.
+ARG GO_VERSION=
+ARG NODE_VERSION=
+ARG PYTHON_VERSION=
+ARG DOTNET_VERSION=
+ARG NPM_VERSION=
+ARG COOLDOWN_DAYS=
+RUN for v in GO_VERSION NODE_VERSION PYTHON_VERSION DOTNET_VERSION NPM_VERSION COOLDOWN_DAYS; do \
+        eval "val=\${$v}"; \
+        if [ -z "$val" ]; then \
+            echo "FATAL: build-arg $v not set; build via ci-toolchain-image.yml or .github/toolchain/validate-local" >&2; \
+            exit 1; \
+        fi; \
+    done
+# renovate: datasource=github-releases depName=jdx/mise
+ARG MISE_VERSION=v2026.4.11
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Fail the build on fetch errors in the curl | sh pipes below.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash build-essential ca-certificates curl git \
+        jq libicu74 make sudo tar tzdata unzip xz-utils zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Fixed paths: the Actions runner overrides $HOME in job containers.
+ENV MISE_DATA_DIR=/opt/mise \
+    MISE_CACHE_DIR=/opt/mise/cache \
+    MISE_GLOBAL_CONFIG_FILE=/opt/mise/config.toml
+RUN curl -fsSL https://mise.run \
+    | env MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+# Derive a minimal config from .mise.toml: only the tools the test jobs
+# need, with the language pins overridden by the build args.
+COPY .mise.toml /tmp/mise-repo.toml
+RUN set -eux; \
+    mkdir -p "${MISE_DATA_DIR}"; \
+    section() { awk -v s="[$1]" '$0==s{f=1;next} /^\[/{f=0} f' /tmp/mise-repo.toml; }; \
+    { \
+        echo '[tools]'; \
+        echo "go = \"${GO_VERSION%.x}\""; \
+        echo "node = \"${NODE_VERSION%.x}\""; \
+        echo "python = \"${PYTHON_VERSION%.x}\""; \
+        echo "dotnet = \"${DOTNET_VERSION}\""; \
+        section tools | grep -E '^(java|gradle|uv|bun) = '; \
+        section tools | grep -E '^"(npm:yarn|npm:pnpm|go:github\.com/go-delve/delve/cmd/dlv|go:gotest\.tools/gotestsum|github:pulumi/goteststats)" = '; \
+        echo '[plugins]'; \
+        section plugins | grep '^gradle = '; \
+    } > "${MISE_GLOBAL_CONFIG_FILE}"; \
+    cat "${MISE_GLOBAL_CONFIG_FILE}"
+
+# The optional token (a BuildKit secret, never stored in a layer) avoids
+# GitHub API rate limits. Caches are cleared within each layer, since later
+# layers cannot shrink earlier ones.
+RUN --mount=type=secret,id=github-token \
+    set -eux; \
+    if [ -f /run/secrets/github-token ]; then { set +x; } 2>/dev/null; export GITHUB_TOKEN="$(cat /run/secrets/github-token)"; set -x; fi; \
+    mise install go node python dotnet java gradle uv bun; \
+    mise cache clear
+
+# Upgrade npm first: test jobs apply the dependency cooldown through this
+# npm, which needs min-release-age-exclude (npm >= 11.17.0). Then install
+# the remaining config tools (yarn, pnpm, dlv, gotestsum, goteststats).
+# The bundled npm enforces the cooldown on the upgrade itself only if it is
+# new enough, the same bootstrap gap host runners have.
+RUN --mount=type=secret,id=github-token \
+    set -eux; \
+    if [ -f /run/secrets/github-token ]; then { set +x; } 2>/dev/null; export GITHUB_TOKEN="$(cat /run/secrets/github-token)"; set -x; fi; \
+    export npm_config_min_release_age="${COOLDOWN_DAYS}"; \
+    mise exec -- npm install -g "npm@${NPM_VERSION}"; \
+    mise install; \
+    mise cache clear; \
+    rm -rf /root/go /root/.cache/go-build
+
+# mise's python has no PEP 668 marker, so pip manages it directly, as on
+# host runners. pip upgrades on its own first, so a cooldown-capable pip
+# (>= 26.1, older versions ignore the window) installs the floating packages.
+RUN set -eux; \
+    export PIP_UPLOADED_PRIOR_TO="P${COOLDOWN_DAYS}D"; \
+    mise exec -- python -m ensurepip --upgrade; \
+    mise exec -- python -m pip install --no-cache-dir --upgrade pip; \
+    mise exec -- python -m pip install --no-cache-dir requests wheel urllib3 chardet build; \
+    mise exec -- python -m pip install --no-cache-dir poetry
+
+# Symlink the real binaries into /usr/local/bin; reshim first so executables
+# added since install (poetry) are indexed.
+RUN set -eux; \
+    mise reshim; \
+    for tool in go gofmt node npm npx python python3 pip pip3 dotnet \
+                java javac gradle uv uvx bun bunx yarn pnpm \
+                dlv gotestsum goteststats poetry; do \
+        real="$(mise which "$tool")"; \
+        ln -sfv "$real" "/usr/local/bin/$tool"; \
+    done; \
+    java_home="$(mise where java)"; \
+    dotnet_root="$(mise where dotnet)"; \
+    ln -sfnv "$java_home" /opt/java; \
+    ln -sfnv "$dotnet_root" /opt/dotnet
+ENV JAVA_HOME=/opt/java \
+    DOTNET_ROOT=/opt/dotnet \
+    DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+# The workspace mount is owned by a different uid; let git operate on it.
+RUN git config --system --add safe.directory '*'

--- a/.github/toolchain/validate-local
+++ b/.github/toolchain/validate-local
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Copyright 2026, Pulumi Corporation.
+#
+# Local end-to-end validation of the prebaked toolchain image. CI never
+# runs test jobs inside the image before the ghcr package is made public,
+# so container mode is validated here: build the image the way
+# ci-toolchain-image.yml does, run verify-tools, run the permission-
+# sensitive unit-test packages inside the container as root, and re-run
+# them on the host.
+#
+# Requires docker with BuildKit; on Apple Silicon enable amd64 emulation.
+# Optionally set GITHUB_TOKEN to avoid GitHub API rate limits.
+#
+# Usage: validate-local [--skip-build]
+#   --skip-build  Reuse the image from a previous run instead of rebuilding.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+SET=current
+SKIP_BUILD=false
+if [ "${1:-}" = "--skip-build" ]; then
+  SKIP_BUILD=true
+fi
+
+command -v docker >/dev/null || { echo "FATAL: docker is required" >&2; exit 1; }
+
+echo "== 1/5 Syntax-checking toolchain scripts =="
+bash -n .github/scripts/toolchain-image-tag
+bash -n .github/toolchain/verify-tools
+bash -n .github/toolchain/validate-local
+echo "ok"
+
+REF=$(./.github/scripts/toolchain-image-tag "$SET")
+VERSION_SET=$(./scripts/get-job-matrix.py generate-version-set --version-set "$SET")
+NPM_VERSION=$(./.github/scripts/tool-pin npm)
+# The cooldown default of the runtime action is the only authority.
+# Keep the parse in sync with ci-toolchain-image.yml.
+COOLDOWN_DAYS=$(awk '/^  days:/{f=1} f && $1=="default:"{gsub(/"/,"",$2); print $2; exit}' \
+  .github/actions/dependency-cooldown/action.yml)
+if [ -z "$COOLDOWN_DAYS" ]; then
+  echo "FATAL: no days default parsed from dependency-cooldown/action.yml (format change?)" >&2
+  exit 1
+fi
+read -r GO_VERSION NODE_VERSION PYTHON_VERSION DOTNET_VERSION < <(
+  printf '%s' "$VERSION_SET" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+print(d["go"], d["nodejs"], d["python"], d["dotnet"])
+')
+
+if $SKIP_BUILD; then
+  echo "== 2/5 Skipping build; reusing ${REF} =="
+  docker image inspect "$REF" >/dev/null 2>&1 \
+    || { echo "FATAL: ${REF} not found locally; run without --skip-build" >&2; exit 1; }
+else
+  echo "== 2/5 Building ${REF} =="
+  SECRET_ARGS=()
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    SECRET_ARGS=(--secret id=github-token,env=GITHUB_TOKEN)
+  else
+    echo "note: GITHUB_TOKEN not set; building without GitHub API auth"
+  fi
+  DOCKER_BUILDKIT=1 docker build \
+    --platform linux/amd64 \
+    -f .github/toolchain/Dockerfile \
+    --build-arg "GO_VERSION=${GO_VERSION}" \
+    --build-arg "NODE_VERSION=${NODE_VERSION}" \
+    --build-arg "PYTHON_VERSION=${PYTHON_VERSION}" \
+    --build-arg "DOTNET_VERSION=${DOTNET_VERSION}" \
+    --build-arg "NPM_VERSION=${NPM_VERSION}" \
+    --build-arg "COOLDOWN_DAYS=${COOLDOWN_DAYS}" \
+    --build-arg "TOOLCHAIN_TAG=${REF}" \
+    ${SECRET_ARGS[@]+"${SECRET_ARGS[@]}"} \
+    -t "$REF" .
+fi
+
+echo "== 3/5 Verifying the image's tools =="
+./.github/toolchain/verify-tools "$REF" "$SET"
+
+echo "== 4/5 Running environment-sensitive unit tests in the container (as root) =="
+docker run --rm --platform linux/amd64 \
+  -v "$PWD:/repo" \
+  -v pulumi-toolchain-validate-gopath:/root/go \
+  -v pulumi-toolchain-validate-gocache:/root/.cache/go-build \
+  -w /repo \
+  "$REF" bash -c '
+    set -euo pipefail
+    id
+    (cd sdk && go test -count=1 -v -run "TestBuildablePackage" ./python/toolchain/...)
+    (cd sdk && go test -count=1 ./python/toolchain/... ./go/common/workspace/...)
+    (cd pkg && go test -count=1 -tags all ./logging/... ./workspace/...)
+  '
+
+echo "== 5/5 Re-running the fixed package on the host (permission checks enforced) =="
+(cd sdk && go test -count=1 -run "TestBuildablePackage" ./python/toolchain/...)
+
+echo
+echo "Toolchain image validation PASSED for ${REF}"

--- a/.github/toolchain/verify-tools
+++ b/.github/toolchain/verify-tools
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Copyright 2026, Pulumi Corporation.
+#
+# Pre-push gate for ci-toolchain-image.yml: runs a built toolchain image
+# and asserts every tool is present at its expected version, and that tool
+# resolution ignores a mounted repo's .mise.toml. Also runnable locally.
+#
+# Usage: verify-tools <image-ref> <version-set-name>
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+IMAGE="${1:?usage: $0 <image-ref> <version-set-name>}"
+SET="${2:?usage: $0 <image-ref> <version-set-name>}"
+
+# Pins resolve through the shared tool-pin script. Use plain assignments so a
+# failed lookup aborts under `set -e`.
+PIN=./.github/scripts/tool-pin
+DLV_PIN=$($PIN go:github.com/go-delve/delve/cmd/dlv)
+UV_PIN=$($PIN uv)
+BUN_PIN=$($PIN bun)
+YARN_PIN=$($PIN npm:yarn)
+PNPM_PIN=$($PIN npm:pnpm)
+GRADLE_PIN=$($PIN gradle)
+GOTESTSUM_PIN=$($PIN go:gotest.tools/gotestsum)
+JAVA_PIN=$($PIN java)
+JAVA_MAJOR=${JAVA_PIN#*-} # e.g. temurin-11 -> 11
+
+# npm's pin is a range like ^11.17.0, and installing from that range already
+# guarantees the cooldown floor. Assert on the major so a Renovate major
+# bump can't silently diverge from this check.
+NPM_RANGE=$($PIN npm)
+NPM_MAJOR=${NPM_RANGE//[!0-9.]/}
+NPM_MAJOR=${NPM_MAJOR%%.*}
+if [ -z "$NPM_MAJOR" ]; then
+  echo "FATAL: could not derive the npm major from '${NPM_RANGE}'" >&2
+  exit 1
+fi
+
+# The same language-version authority the image build used.
+VERSION_SET=$(./scripts/get-job-matrix.py generate-version-set --version-set "$SET")
+read -r GO_MINOR NODE_MAJOR PY_MINOR DOTNET_CHANNEL < <(printf '%s' "$VERSION_SET" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+def s(v):
+    return v[:-2] if v.endswith(".x") else v
+print(s(d["go"]), s(d["nodejs"]), s(d["python"]), d["dotnet"])
+')
+
+echo "== Verifying tools in ${IMAGE} (${SET}) =="
+docker run --rm -i --platform linux/amd64 \
+  -e "GO_MINOR=$GO_MINOR" -e "NODE_MAJOR=$NODE_MAJOR" \
+  -e "PY_MINOR=$PY_MINOR" -e "DOTNET_CHANNEL=$DOTNET_CHANNEL" \
+  -e "DLV_PIN=$DLV_PIN" \
+  -e "UV_PIN=$UV_PIN" \
+  -e "BUN_PIN=$BUN_PIN" \
+  -e "YARN_PIN=$YARN_PIN" \
+  -e "PNPM_PIN=$PNPM_PIN" \
+  -e "GRADLE_PIN=$GRADLE_PIN" \
+  -e "GOTESTSUM_PIN=$GOTESTSUM_PIN" \
+  -e "NPM_MAJOR=$NPM_MAJOR" \
+  -e "JAVA_MAJOR=$JAVA_MAJOR" \
+  "$IMAGE" bash -s <<'EOF'
+set -uo pipefail
+fail=0
+expect() { # expect <label> <expected-substring> <actual>
+  if [[ "$3" == *"$2"* ]]; then
+    echo "ok:   $1: $3 (contains '$2')"
+  else
+    echo "FAIL: $1: '$3' does not contain '$2'"; fail=1
+  fi
+}
+present() { # tools with no version pin to assert
+  if command -v "$1" >/dev/null; then
+    echo "ok:   $1 present ($(command -v "$1"))"
+  else
+    echo "FAIL: $1 missing"; fail=1
+  fi
+}
+
+expect go     "go${GO_MINOR}."      "$(go version)"
+expect node   "v${NODE_MAJOR}."     "$(node --version)"
+expect python "Python ${PY_MINOR}." "$(python --version)"
+expect python3 "Python ${PY_MINOR}." "$(python3 --version)"
+expect dotnet "${DOTNET_CHANNEL}."  "$(dotnet --version)"
+expect java   "version \"${JAVA_MAJOR}" "$(java -version 2>&1 | head -1)"
+expect gradle "Gradle ${GRADLE_PIN}" "$(gradle --version | grep Gradle)"
+expect dlv    "${DLV_PIN}"          "$(dlv version | grep -i version)"
+expect uv     "${UV_PIN}"           "$(uv --version)"
+expect bun    "${BUN_PIN}"          "$(bun --version)"
+expect yarn   "${YARN_PIN}"         "$(yarn --version)"
+expect pnpm   "${PNPM_PIN}."        "$(pnpm --version)"
+expect npm    "${NPM_MAJOR}."       "$(npm --version)"
+expect gotestsum "${GOTESTSUM_PIN}" "$(gotestsum --version)"
+present goteststats
+expect pip    "pip"                 "$(python -m pip --version)"
+present pip
+expect poetry "Poetry"              "$(poetry --version)"
+for pkg in requests wheel urllib3 chardet build; do
+  python -c "import $pkg" 2>/dev/null && echo "ok:   python package $pkg importable" \
+    || { echo "FAIL: python package $pkg not importable"; fail=1; }
+done
+present git; present make; present gcc; present jq; present curl
+present tar; present unzip; present zip; present sudo
+expect "git safe.directory" "*" "$(git config --system --get-all safe.directory)"
+
+exit $fail
+EOF
+
+# A mounted repo's .mise.toml must not affect tool resolution:
+# /usr/local/bin holds real symlinks, not mise shims.
+docker run --rm --platform linux/amd64 -v "$PWD:/repo:ro" -w /repo \
+  -e "GO_MINOR=$GO_MINOR" -e "NODE_MAJOR=$NODE_MAJOR" -e "PY_MINOR=$PY_MINOR" \
+  "$IMAGE" bash -c '
+    set -euo pipefail
+    go version | grep -q "go${GO_MINOR}\." \
+      || { echo "FAIL: go swayed by repo config: $(go version)"; exit 1; }
+    node --version | grep -q "^v${NODE_MAJOR}\." \
+      || { echo "FAIL: node swayed by repo config: $(node --version)"; exit 1; }
+    python --version | grep -q "Python ${PY_MINOR}\." \
+      || { echo "FAIL: python swayed by repo config: $(python --version)"; exit 1; }
+    echo "ok:   tool resolution independent of the mounted repo .mise.toml"'
+
+echo "${IMAGE} tool verification PASSED"

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -65,6 +65,13 @@ on:
         required: false
         default: false
         type: boolean
+      toolchain-image:
+        description: >-
+          Prebaked toolchain image to run the job in; when empty, the job
+          installs its toolchain on the runner.
+        required: false
+        default: ""
+        type: string
 
 defaults:
   run:
@@ -108,6 +115,8 @@ jobs:
       GOCACHE: ${{ contains(inputs.platform, 'windows') && 'D:/go-build-cache' || '' }}
 
     runs-on: ${{ inputs.platform }}
+    # An empty image means no container: the job runs directly on the runner.
+    container: ${{ inputs.toolchain-image }}
 
     timeout-minutes: 70
     continue-on-error: ${{ inputs.continue-on-error }}
@@ -163,9 +172,15 @@ jobs:
       # Frees ~24GiB; test jobs run out of disk otherwise (#17470). The bulk of
       # the cleanup runs in the background, overlapping the setup steps below.
       # The "Wait for disk cleanup" step joins it before tests run.
-      - if: contains(inputs.platform, 'ubuntu')
+      # Container jobs skip it: it frees host disk they cannot reach or need.
+      - if: contains(inputs.platform, 'ubuntu') && inputs.toolchain-image == ''
         name: Free Disk Space (Ubuntu)
         run: ./.github/scripts/free-disk-space start
+      # Container jobs run without that cleanup. Log the headroom so disk
+      # exhaustion is easy to diagnose.
+      - if: inputs.toolchain-image != ''
+        name: Show disk space (container)
+        run: df -h /
       - name: Setup versioning env vars
         env:
           version: ${{ inputs.version }}
@@ -191,19 +206,43 @@ jobs:
         env:
           CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"
         run: echo "$CACHE_KEY" > .gocache.tmp
-      - uses: actions/setup-go@v6
-        id: setup-go
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      # Host jobs install the toolchain; container jobs have it baked in
+      # and only restore its caches.
+      - name: Install toolchain on the runner
+        if: ${{ inputs.toolchain-image == '' }}
+        id: host-toolchain
+        uses: ./.github/actions/install-toolchain
         with:
-          go-version: ${{ fromJson(inputs.version-set).go }}
-          check-latest: true
-          cache: true
-          cache-dependency-path: |
-            pkg/go.sum
-            .gocache.tmp
+          version-set: ${{ inputs.version-set }}
+      - name: Restore Go caches (container)
+        if: ${{ inputs.toolchain-image != '' }}
+        id: go-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-container-${{ hashFiles('.gocache.tmp') }}-${{ hashFiles('pkg/go.sum') }}
+          restore-keys: go-container-${{ hashFiles('.gocache.tmp') }}-
+      - name: Restore npm cache (container)
+        if: ${{ inputs.toolchain-image != '' }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.npm
+          key: npm-container-${{ hashFiles('sdk/nodejs/package-lock.json') }}
+          restore-keys: npm-container-
+      - name: Restore uv cache (container)
+        if: ${{ inputs.toolchain-image != '' }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/uv
+          key: uv-container-${{ hashFiles('sdk/python/uv.lock') }}
+          restore-keys: uv-container-
       - name: Prime Go cache
-        if: ${{ ! steps.setup-go.outputs.cache-hit }}
+        # The outputs are strings, so `!` would treat 'false' as truthy.
+        # The skipped cache step's empty output counts as a miss, so the
+        # step that ran decides.
+        if: ${{ steps.host-toolchain.outputs.go-cache-hit != 'true' && steps.go-cache.outputs.cache-hit != 'true' }}
         # Compile every test to ensure we populate a good cache entry. The
         # sdk is also built with -trimpath: the Go language host compiles
         # test programs with -trimpath (see compileProgram in
@@ -217,42 +256,6 @@ jobs:
           ( cd sdk && go test -run "_________" ./... )
           ( cd pkg && go test -run "_________" ./... )
           ( cd sdk && go build -trimpath ./... )
-      - name: Install delve
-        run: |
-          go install github.com/go-delve/delve/cmd/dlv@latest
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: sdk/python/uv.lock
-      - name: Set up Python ${{ fromJson(inputs.version-set).python }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ fromJson(inputs.version-set).python }}
-      - name: Set up DotNet ${{ fromJson(inputs.version-set).dotnet }}
-        uses: ./.github/actions/retry
-        with:
-          action: actions/setup-dotnet@v5
-          with: |
-            dotnet-version: ${{ fromJson(inputs.version-set).dotnet }}
-            dotnet-quality: ga
-      - name: Set up Node ${{ fromJson(inputs.version-set).nodejs }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ fromJson(inputs.version-set).nodejs }}
-          cache: npm
-          cache-dependency-path: sdk/nodejs/package-lock.json
-      - name: Set up JDK 11
-        uses: actions/setup-java@v5
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Setup Gradle
-        uses: ./.github/actions/retry
-        with:
-          action: gradle/actions/setup-gradle@v6
-          with: |
-            gradle-version: "7.6"
       - name: Uninstall pre-installed Pulumi (windows)
         if: inputs.platform == 'windows-latest'
         run: |
@@ -260,20 +263,6 @@ jobs:
             echo "Deleting pulumi"
             rm -rf "$(command -v pulumi.exe)/../pulumi*"
           fi
-      - name: Install npm, yarn and pnpm
-        run: |
-          # npm added min-release-age-exclude in 11.17.0. Use a compatible npm 11 version so the
-          # cooldown and first-party exceptions work across every Node.js version in the matrix.
-          npm install -g yarn pnpm@11 npm@^11.17.0
-      - name: Install bun
-        uses: ./.github/actions/retry
-        with:
-          action: oven-sh/setup-bun@v2
-      - name: Install Python deps
-        run: |
-          python -m pip install --upgrade pip requests wheel urllib3 chardet build
-      - name: Install Poetry
-        run: python -m pip install poetry
       - name: Setup git
         run: |
           git config --global user.email "you@example.com"
@@ -281,26 +270,6 @@ jobs:
       - name: Set Go Dep path
         run: |
           echo "PULUMI_GO_DEP_ROOT=$(dirname "$(pwd)")" | tee -a "${GITHUB_ENV}"
-      - name: Install gotestsum
-        uses: ./.github/actions/retry
-        with:
-          action: jaxxstorm/action-install-gh-release@v3.0.0
-          with: |
-            repo: gotestyourself/gotestsum
-            tag: v1.13.0
-            cache: enable
-          attempt_limit: 3
-          attempt_delay: 5000
-      - name: Install goteststats
-        uses: ./.github/actions/retry
-        with:
-          action: jaxxstorm/action-install-gh-release@v3.0.0
-          with: |
-            repo: pulumi/goteststats
-            tag: v0.0.7
-            cache: enable
-          attempt_limit: 3
-          attempt_delay: 5000
       - name: Generate artifact name
         if: ${{ inputs.is-integration-test || inputs.is-performance-test }}
         id: goenv
@@ -396,7 +365,7 @@ jobs:
       - name: Create GCP service account key file
         run: |
           echo -n '${{ secrets.GCP_SERVICE_ACCOUNT }}' > '${{ runner.temp }}/application_default_credentials.json'
-      - if: contains(inputs.platform, 'ubuntu')
+      - if: contains(inputs.platform, 'ubuntu') && inputs.toolchain-image == ''
         name: Wait for disk cleanup (Ubuntu)
         run: ./.github/scripts/free-disk-space wait
       - name: run tests "${{ inputs.test-command }}"

--- a/.github/workflows/ci-toolchain-image.yml
+++ b/.github/workflows/ci-toolchain-image.yml
@@ -1,0 +1,133 @@
+name: Toolchain Image
+
+# Builds and publishes the prebaked toolchain images for the ubuntu test
+# jobs, tagged by content hash (.github/scripts/toolchain-image-tag). ci.yml
+# falls back to host installs when a tag is missing, so publishing is the
+# rollout and deleting a tag is the rollback. The ghcr package must be made
+# public once after the first publish: jobs pull without credentials. PRs
+# touching the image inputs build and verify, but never push. A weekly cron
+# publishes right after the ISO-week tag roll, so Monday jobs do not fall
+# back to host installs while waiting for the week's first master push.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+  schedule:
+    # Shortly after the ISO-week tag roll at Monday 00:00 UTC.
+    - cron: "5 0 * * 1"
+  pull_request:
+    paths:
+      - ".github/toolchain/**"
+      - ".github/workflows/ci-toolchain-image.yml"
+      - ".github/scripts/tool-pin"
+      - ".github/scripts/toolchain-image-tag"
+      # The image build reads the cooldown default from the action.
+      - ".github/actions/dependency-cooldown/action.yml"
+      - ".mise.toml"
+      # The language-version authority: version bumps roll the tag.
+      - "scripts/get-job-matrix.py"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: ${{ matrix.version-set }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: toolchain-image-${{ matrix.version-set }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version-set: [current]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      # Login before the probe, so trusted builds see the still-private package.
+      - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute the content-addressed image reference
+        id: ref
+        run: |
+          set -euo pipefail
+          REF=$(./.github/scripts/toolchain-image-tag "${{ matrix.version-set }}")
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          # PRs always build — that is the validation.
+          if [ "${{ github.event_name }}" != "pull_request" ] \
+              && docker manifest inspect "$REF" >/dev/null 2>&1; then
+            echo "${REF} already published; nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Building ${REF}."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Resolve language versions
+        if: ${{ steps.ref.outputs.exists == 'false' }}
+        id: versions
+        run: |
+          set -euo pipefail
+          # The same authority the test matrix uses.
+          VERSION_SET=$(./scripts/get-job-matrix.py \
+            generate-version-set \
+            --version-set "${{ matrix.version-set }}")
+          echo "$VERSION_SET" | jq .
+          # Plain assignment so a tool-pin failure aborts the step.
+          NPM_VERSION=$(./.github/scripts/tool-pin npm)
+          # Keep the parse in sync with .github/toolchain/validate-local.
+          COOLDOWN_DAYS=$(awk '/^  days:/{f=1} f && $1=="default:"{gsub(/"/,"",$2); print $2; exit}' \
+            .github/actions/dependency-cooldown/action.yml)
+          if [ -z "$COOLDOWN_DAYS" ]; then
+            echo "FATAL: no days default parsed from dependency-cooldown/action.yml (format change?)" >&2
+            exit 1
+          fi
+          {
+            echo "go=$(echo "$VERSION_SET" | jq -r .go)"
+            echo "nodejs=$(echo "$VERSION_SET" | jq -r .nodejs)"
+            echo "python=$(echo "$VERSION_SET" | jq -r .python)"
+            echo "dotnet=$(echo "$VERSION_SET" | jq -r .dotnet)"
+            echo "npm=${NPM_VERSION}"
+            echo "cooldown-days=${COOLDOWN_DAYS}"
+          } >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        if: ${{ steps.ref.outputs.exists == 'false' }}
+      - name: Build the image
+        if: ${{ steps.ref.outputs.exists == 'false' }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: .github/toolchain/Dockerfile
+          # Load locally; the push happens only after verify-tools passes.
+          load: true
+          tags: ${{ steps.ref.outputs.ref }}
+          # TOOLCHAIN_TAG busts the layer cache when the tag rolls.
+          build-args: |
+            GO_VERSION=${{ steps.versions.outputs.go }}
+            NODE_VERSION=${{ steps.versions.outputs.nodejs }}
+            PYTHON_VERSION=${{ steps.versions.outputs.python }}
+            DOTNET_VERSION=${{ steps.versions.outputs.dotnet }}
+            NPM_VERSION=${{ steps.versions.outputs.npm }}
+            COOLDOWN_DAYS=${{ steps.versions.outputs.cooldown-days }}
+            TOOLCHAIN_TAG=${{ steps.ref.outputs.ref }}
+          # Avoids unauthenticated GitHub API rate limits; never stored in a layer.
+          secrets: |
+            github-token=${{ secrets.GITHUB_TOKEN }}
+      # Pre-push gate: consumers only probe for tag existence, so a broken
+      # image must never get a tag.
+      - name: Verify the image's tools
+        if: ${{ steps.ref.outputs.exists == 'false' }}
+        run: ./.github/toolchain/verify-tools "${{ steps.ref.outputs.ref }}" "${{ matrix.version-set }}"
+      - name: Push (trusted triggers only)
+        if: ${{ steps.ref.outputs.exists == 'false' && github.event_name != 'pull_request' }}
+        run: docker push "${{ steps.ref.outputs.ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,11 @@ jobs:
           printf '%s' "${BUILD_TARGETS}" | ./.github/scripts/set-output build-targets
 
           # Prebaked toolchain images by version-set name. A missing tag
-          # maps to "" and those jobs install on the runner instead.
+          # maps to "" and those jobs install on the runner instead. Keep
+          # the set list in sync with the matrix in ci-toolchain-image.yml.
+          TOOLCHAIN_SETS=(current)
           TOOLCHAIN_IMAGES='{}'
-          for set in current; do
+          for set in "${TOOLCHAIN_SETS[@]}"; do
             ref=$(./.github/scripts/toolchain-image-tag "$set")
             if docker manifest inspect "$ref" >/dev/null 2>&1; then
               echo "Toolchain image for ${set}: ${ref}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,26 @@ jobs:
               { "os": "darwin",  "arch": "arm64", "build-platform": "ubuntu-latest" }
           ]'
           printf '%s' "${BUILD_TARGETS}" | ./.github/scripts/set-output build-targets
+
+          # Prebaked toolchain images by version-set name. A missing tag
+          # maps to "" and those jobs install on the runner instead.
+          TOOLCHAIN_IMAGES='{}'
+          for set in current; do
+            ref=$(./.github/scripts/toolchain-image-tag "$set")
+            if docker manifest inspect "$ref" >/dev/null 2>&1; then
+              echo "Toolchain image for ${set}: ${ref}"
+            else
+              echo "Toolchain image ${ref} not published; ${set} jobs install on the runner."
+              ref=""
+            fi
+            TOOLCHAIN_IMAGES=$(echo "$TOOLCHAIN_IMAGES" \
+              | jq -c --arg k "$set" --arg v "$ref" '.[$k] = $v')
+          done
+          printf '%s' "$TOOLCHAIN_IMAGES" | ./.github/scripts/set-output toolchain-images
     outputs:
       version-set: "${{ fromJson(steps.setup.outputs.version-set) }}"
       build-targets: "${{ fromJson(steps.setup.outputs.build-targets) }}"
+      toolchain-images: "${{ fromJson(steps.setup.outputs.toolchain-images) }}"
 
   matrix:
     runs-on: ubuntu-latest
@@ -373,7 +390,7 @@ jobs:
     # To this:
     #   CI / Unit Test / sdk/dotnet dotnet_test on macos-11/current
     name: Unit Test${{ matrix.platform && '' }}
-    needs: [matrix]
+    needs: [setup, matrix]
     if: ${{ needs.matrix.outputs.unit-test-matrix != '{}' }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -389,6 +406,7 @@ jobs:
       is-integration-test: false
       enable-coverage: ${{ inputs.enable-coverage }}
       test-retries: ${{ inputs.test-retries }}
+      toolchain-image: ${{ contains(matrix.platform, 'ubuntu') && fromJson(needs.setup.outputs.toolchain-images)[matrix.version-set.name] || '' }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
       version-set: ${{ toJson(matrix.version-set) }}
@@ -487,6 +505,8 @@ jobs:
       is-integration-test: false
       enable-coverage: false
       test-retries: ${{ inputs.test-retries }}
+      # Keyed by the generated version set so it matches version-set below.
+      toolchain-image: ${{ fromJson(needs.setup.outputs.toolchain-images)[fromJson(needs.setup.outputs.version-set).name] }}
       version-set: ${{ needs.setup.outputs.version-set }}
       continue-on-error: ${{ inputs.fuzz-test-optional }}
     secrets: inherit

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,6 +10,14 @@ on:
       - 'master'
 
 jobs:
+  # Publishes any missing toolchain images; a no-op when the tags exist.
+  toolchain-images:
+    name: toolchain-images
+    uses: ./.github/workflows/ci-toolchain-image.yml
+    permissions:
+      contents: read
+      packages: write
+
   info:
     name: info
     uses: ./.github/workflows/ci-info.yml

--- a/.mise.toml
+++ b/.mise.toml
@@ -29,7 +29,16 @@ protoc = "29.5"
 dotnet = "8"
 java = "temurin-11"
 gradle = "7.6"
+# renovate: datasource=github-releases depName=pulumi/goteststats extractVersion=^v(?<version>.*)$
 "github:pulumi/goteststats" = "0.0.7"
+# renovate: datasource=github-releases depName=gotestyourself/gotestsum extractVersion=^v(?<version>.*)$
+"go:gotest.tools/gotestsum" = "1.13.0"
+
+[vars]
+# The npm version that CI test jobs install. The dependency-cooldown action
+# needs 11.17.0 or newer. Read by .github/scripts/tool-pin, not by mise.
+# renovate: datasource=npm depName=npm versioning=npm
+npm = "^11.17.0"
 
 [env]
 PULUMI_TEST_USE_NPM = "true"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,9 @@
 [tools]
 github-cli = "2.93.0"
-"go:github.com/go-delve/delve/cmd/dlv" = "1.26.3"
+# Delve's minor version must match the Go minor in CI (see get-job-matrix.py),
+# or debugger tests fail with "Version of Delve is too old".
+# renovate: datasource=github-releases depName=go-delve/delve extractVersion=^v(?<version>.*)$
+"go:github.com/go-delve/delve/cmd/dlv" = "1.27.2"
 "go:golang.org/x/tools/gopls" = "0.23.0"
 go = "1.27"
 changie = "1.24.2"

--- a/changelog/pending/20260909--ci--toolchain-container.yaml
+++ b/changelog/pending/20260909--ci--toolchain-container.yaml
@@ -1,0 +1,4 @@
+component: ci
+kind: improvement
+body: Run Linux unit and fuzz test jobs in a prebaked toolchain container instead of installing the toolchain per job
+time: 2026-09-09T00:00:00Z

--- a/pkg/logging/encrypted_test.go
+++ b/pkg/logging/encrypted_test.go
@@ -184,6 +184,9 @@ func failNextLogRename(t *testing.T, path string) (restore func()) {
 	}
 	// Elsewhere, an open handle doesn't block renames, so make the directory
 	// read-only instead.
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions, so the rename failure cannot be injected")
+	}
 	dir := filepath.Dir(path)
 	require.NoError(t, os.Chmod(dir, 0o500))
 	return func() { require.NoError(t, os.Chmod(dir, 0o700)) }

--- a/renovate.json5
+++ b/renovate.json5
@@ -47,6 +47,20 @@
         '// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+"[^"]+":\\s+semver\\.MustParse\\("(?<currentValue>[^"]+)"\\)',
       ],
     },
+    // Update the CI toolchain pins: each lives in one annotated place
+    // (.mise.toml, or the toolchain Dockerfile for mise itself), and all
+    // consumers parse it from there at run time.
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github/toolchain/Dockerfile$/',
+        '/^\\.mise\\.toml$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+ARG \\S+=(?<currentValue>\\S+)',
+        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+"?[^"\\s=]+"? = "(?<currentValue>[^"]+)"',
+      ],
+    },
   ],
   // The preset's ignorePaths has `sdk/**` in it, we don't want that
   // https://github.com/pulumi/renovate-config/blob/main/default.json5#L70

--- a/sdk/go/common/workspace/paths_test.go
+++ b/sdk/go/common/workspace/paths_test.go
@@ -164,6 +164,9 @@ func TestProjectStackPath(t *testing.T) {
 //nolint:paralleltest // Theses test use and change the current working directory
 func TestDetectProjectUnreadableParent(t *testing.T) {
 	// Regression test for https://github.com/pulumi/pulumi/issues/12481
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions, so the unreadable parent cannot be simulated")
+	}
 
 	tmpDir := mkTempDir(t)
 

--- a/sdk/python/toolchain/pyproject_test.go
+++ b/sdk/python/toolchain/pyproject_test.go
@@ -35,6 +35,8 @@ func TestBuildablePackage(t *testing.T) {
 		setupFunc          func(dir string) error
 		isBuildablePackage bool
 		errContains        string
+		// Skip under root (e.g. CI job containers), which bypasses file permissions.
+		needsPermissionEnforcement bool
 	}{
 		{
 			name: "valid buildable package",
@@ -90,14 +92,18 @@ func TestBuildablePackage(t *testing.T) {
 				// Make the file unreadable
 				return os.Chmod(filepath.Join(dir, "pyproject.toml"), 0o000) // gosec
 			},
-			isBuildablePackage: false,
-			errContains:        "permission denied",
+			isBuildablePackage:         false,
+			errContains:                "permission denied",
+			needsPermissionEnforcement: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			if tt.needsPermissionEnforcement && os.Geteuid() == 0 {
+				t.Skip("root bypasses file permissions, so the permission failure cannot be simulated")
+			}
 			dir := t.TempDir()
 			pyprojectToml := filepath.Join(dir, "pyproject.toml")
 


### PR DESCRIPTION
Every ubuntu test job spends time installing Go, Node, Python, .NET, Java, and a handful of smaller tools before it can run anything. This change brings those tools into a Docker image and runs the unit and fuzz jobs inside it, skipping the install steps entirely.

Jobs only use an image after a registry check finds it, and the check cannot succeed until a one-time manual step after merge (make the ghcr package public). Until then, every job continues installing tools on the runner exactly as before.

## Changes

- The image gets its tool versions from the same sources jobs already use (`.mise.toml` and the test matrix), and is tagged by a hash of its inputs plus the week number, so any version change or new week produces a fresh image.
- Master pushes and a weekly cron publish missing images. PRs that touch the image inputs will build and verify (but never push), and nothing is published unless a verification run confirms every tool works at its expected version.
- Jobs probe the registry first: if the image for their version set exists, they run in it; otherwise they install on the runner exactly as today. A missing image won't break CI.
- Currently, the ubuntu unit and fuzz tests use the image, since they have no Docker-dependent tests. Windows, macOS, and ubuntu integration jobs are unchanged.
- The host install steps move into one composite action, every tool pin is single-sourced in `.mise.toml`, and the image build applies the same dependency-cooldown window test jobs use at runtime.

## Rollout

- The first publish creates the ghcr package private, and a package admin makes it public once so jobs can pull without credentials (the image holds only publicly available tools). Until then, every job installs on the runner as before.
- Rollback is deleting a tag or flipping the package back to private. Either will return CI to host installs on the next run.

## Follow-up

- Extend the ubuntu integration and acceptance tests to also the image. That needs the tools only they use (Docker CLI, azure-cli), a second image for the `minimum` version set, and a container-mode disk cleanup.
- Add retention for old image tags in ghcr; nothing deletes them today.

## Related

- Helps with #23351.
- Addresses #23079 for the containerized jobs: mise installs pinned tools once at image build time, and jobs never run it. The binaries are instead symlinked onto the PATH.
- #22181 tried mise on the runners per job and was reverted as flaky in #22957. This takes the opposite approach: any install flakiness happens in the image build, off the critical path of test jobs, and a failed build just leaves jobs on host installs.
- Helps with #22736 for the CI toolchain, by resolving every tool pin from `.mise.toml` through one shared parser.
