### PR TITLE
Expose ESC environment IDs in the evaluator's execution context

### DIFF
--- a/changelog/pending/sdk-feat-20260909-esc-environment-ids.yaml
+++ b/changelog/pending/sdk-feat-20260909-esc-environment-ids.yaml
@@ -1,0 +1,6 @@
+component: sdk/go
+kind: feat
+body: Expose ESC environment IDs as context.currentEnvironment.id and context.rootEnvironment.id,
+    supplied through eval.EvalOptions.RootEnvironmentID and the optional eval.EnvironmentLoaderWithID
+    loader extension
+time: 2026-09-09T09:00:00-07:00

--- a/sdk/go/common/esc/environment.go
+++ b/sdk/go/common/esc/environment.go
@@ -39,9 +39,8 @@ type EnvExecContext interface {
 	GetCurrentEnvironmentName() string
 }
 
-// EnvExecContextWithIDs is an optional extension of EnvExecContext implemented by execution contexts that know the
-// unique IDs of the environments being evaluated. Consumers should type-assert, and treat an empty ID as unknown:
-// IDs are only available when the caller (and, for imports, the environment loader) supplies them.
+// EnvExecContextWithIDs is an EnvExecContext that also knows the environments' IDs. Type-assert for it; an empty ID
+// means unknown.
 type EnvExecContextWithIDs interface {
 	EnvExecContext
 
@@ -67,10 +66,8 @@ func (ec *ExecContext) CopyForEnv(envName string) *ExecContext {
 	return ec.CopyForEnvWithID(envName, "")
 }
 
-// CopyForEnvWithID is like CopyForEnv, but also records the unique ID (e.g. the UUID assigned by the environment's
-// backend) of the environment being evaluated. When envID is non-empty it is exposed beside the name as
-// `context.currentEnvironment.id` (and as `context.rootEnvironment.id` when the environment is the root); an empty
-// envID produces a context identical to CopyForEnv's.
+// CopyForEnvWithID is CopyForEnv plus the environment's ID. A non-empty ID is exposed to interpolation as
+// context.currentEnvironment.id; an empty ID gives the same context as CopyForEnv.
 func (ec *ExecContext) CopyForEnvWithID(envName, envID string) *ExecContext {
 	values := copyContext(ec.values)
 	values["currentEnvironment"] = NewValue(environmentContextValue(envName, envID))

--- a/sdk/go/common/esc/environment.go
+++ b/sdk/go/common/esc/environment.go
@@ -61,6 +61,8 @@ type ExecContext struct {
 	values               map[string]Value
 }
 
+var _ EnvExecContextWithIDs = (*ExecContext)(nil)
+
 func (ec *ExecContext) CopyForEnv(envName string) *ExecContext {
 	return ec.CopyForEnvWithID(envName, "")
 }

--- a/sdk/go/common/esc/environment.go
+++ b/sdk/go/common/esc/environment.go
@@ -39,32 +39,66 @@ type EnvExecContext interface {
 	GetCurrentEnvironmentName() string
 }
 
+// EnvExecContextWithIDs is an optional extension of EnvExecContext implemented by execution contexts that know the
+// unique IDs of the environments being evaluated. Consumers should type-assert, and treat an empty ID as unknown:
+// IDs are only available when the caller (and, for imports, the environment loader) supplies them.
+type EnvExecContextWithIDs interface {
+	EnvExecContext
+
+	// Returns the unique ID of the root evaluated environment, or "" if unknown.
+	// For anonymous environments, it resolves to the "rootest" non anonymous environment.
+	GetRootEnvironmentID() string
+
+	// Returns the unique ID of the current environment being evaluated, or "" if unknown.
+	GetCurrentEnvironmentID() string
+}
+
 type ExecContext struct {
-	rootEnvironment    string
-	currentEnvironment string
-	values             map[string]Value
+	rootEnvironment      string
+	rootEnvironmentID    string
+	currentEnvironment   string
+	currentEnvironmentID string
+	values               map[string]Value
 }
 
 func (ec *ExecContext) CopyForEnv(envName string) *ExecContext {
-	values := copyContext(ec.values)
-	values["currentEnvironment"] = NewValue(map[string]Value{
-		"name": NewValue(envName),
-	})
+	return ec.CopyForEnvWithID(envName, "")
+}
 
-	root := ec.rootEnvironment
+// CopyForEnvWithID is like CopyForEnv, but also records the unique ID (e.g. the UUID assigned by the environment's
+// backend) of the environment being evaluated. When envID is non-empty it is exposed beside the name as
+// `context.currentEnvironment.id` (and as `context.rootEnvironment.id` when the environment is the root); an empty
+// envID produces a context identical to CopyForEnv's.
+func (ec *ExecContext) CopyForEnvWithID(envName, envID string) *ExecContext {
+	values := copyContext(ec.values)
+	values["currentEnvironment"] = NewValue(environmentContextValue(envName, envID))
+
+	root, rootID := ec.rootEnvironment, ec.rootEnvironmentID
 	if ec.rootEnvironment == AnonymousEnvironmentName || ec.rootEnvironment == "" {
-		root = envName
+		root, rootID = envName, envID
 	}
 
-	values["rootEnvironment"] = NewValue(map[string]Value{
-		"name": NewValue(root),
-	})
+	values["rootEnvironment"] = NewValue(environmentContextValue(root, rootID))
 
 	return &ExecContext{
-		values:             values,
-		rootEnvironment:    root,
-		currentEnvironment: envName,
+		values:               values,
+		rootEnvironment:      root,
+		rootEnvironmentID:    rootID,
+		currentEnvironment:   envName,
+		currentEnvironmentID: envID,
 	}
+}
+
+// environmentContextValue builds the value for `context.currentEnvironment` or `context.rootEnvironment`. The `id`
+// property is omitted when unknown so that contexts built by ID-unaware callers are unchanged.
+func environmentContextValue(name, id string) map[string]Value {
+	v := map[string]Value{
+		"name": NewValue(name),
+	}
+	if id != "" {
+		v["id"] = NewValue(id)
+	}
+	return v
 }
 
 func (ec *ExecContext) Values() map[string]Value {
@@ -75,8 +109,16 @@ func (ec *ExecContext) GetRootEnvironmentName() string {
 	return ec.rootEnvironment
 }
 
+func (ec *ExecContext) GetRootEnvironmentID() string {
+	return ec.rootEnvironmentID
+}
+
 func (ec *ExecContext) GetCurrentEnvironmentName() string {
 	return ec.currentEnvironment
+}
+
+func (ec *ExecContext) GetCurrentEnvironmentID() string {
+	return ec.currentEnvironmentID
 }
 
 type copier struct {

--- a/sdk/go/common/esc/environment_test.go
+++ b/sdk/go/common/esc/environment_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ EnvExecContextWithIDs = (*ExecContext)(nil)
-
 func TestCopyForEnvWithID(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/common/esc/environment_test.go
+++ b/sdk/go/common/esc/environment_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ EnvExecContextWithIDs = (*ExecContext)(nil)
+
+func TestCopyForEnvWithID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records the ID beside the name", func(t *testing.T) {
+		t.Parallel()
+
+		ec, err := NewExecContext(nil)
+		require.NoError(t, err)
+
+		copy := ec.CopyForEnvWithID("dev", "dev-uuid")
+		assert.Equal(t, "dev", copy.GetCurrentEnvironmentName())
+		assert.Equal(t, "dev-uuid", copy.GetCurrentEnvironmentID())
+		assert.Equal(t, "dev", copy.GetRootEnvironmentName())
+		assert.Equal(t, "dev-uuid", copy.GetRootEnvironmentID())
+
+		expected := map[string]Value{
+			"name": NewValue("dev"),
+			"id":   NewValue("dev-uuid"),
+		}
+		assert.Equal(t, NewValue(expected), copy.Values()["currentEnvironment"])
+		assert.Equal(t, NewValue(expected), copy.Values()["rootEnvironment"])
+	})
+
+	t.Run("keeps the root ID through nested copies", func(t *testing.T) {
+		t.Parallel()
+
+		ec, err := NewExecContext(nil)
+		require.NoError(t, err)
+
+		copy := ec.CopyForEnvWithID("root", "root-uuid").CopyForEnvWithID("child", "child-uuid")
+		assert.Equal(t, "child", copy.GetCurrentEnvironmentName())
+		assert.Equal(t, "child-uuid", copy.GetCurrentEnvironmentID())
+		assert.Equal(t, "root", copy.GetRootEnvironmentName())
+		assert.Equal(t, "root-uuid", copy.GetRootEnvironmentID())
+
+		assert.Equal(t, NewValue(map[string]Value{
+			"name": NewValue("child"),
+			"id":   NewValue("child-uuid"),
+		}), copy.Values()["currentEnvironment"])
+		assert.Equal(t, NewValue(map[string]Value{
+			"name": NewValue("root"),
+			"id":   NewValue("root-uuid"),
+		}), copy.Values()["rootEnvironment"])
+	})
+
+	t.Run("resolves an anonymous root to the first named environment", func(t *testing.T) {
+		t.Parallel()
+
+		ec, err := NewExecContext(nil)
+		require.NoError(t, err)
+
+		copy := ec.CopyForEnv(AnonymousEnvironmentName).CopyForEnvWithID("dev", "dev-uuid")
+		assert.Equal(t, "dev", copy.GetRootEnvironmentName())
+		assert.Equal(t, "dev-uuid", copy.GetRootEnvironmentID())
+	})
+
+	t.Run("an empty ID matches CopyForEnv", func(t *testing.T) {
+		t.Parallel()
+
+		ec, err := NewExecContext(nil)
+		require.NoError(t, err)
+
+		withID := ec.CopyForEnvWithID("dev", "")
+		plain := ec.CopyForEnv("dev")
+		assert.Equal(t, plain.Values(), withID.Values())
+		assert.Equal(t, "", withID.GetCurrentEnvironmentID())
+		assert.Equal(t, "", withID.GetRootEnvironmentID())
+
+		// In particular, no `id` property is exposed for interpolation.
+		current, ok := plain.Values()["currentEnvironment"].Value.(map[string]Value)
+		require.True(t, ok)
+		assert.NotContains(t, current, "id")
+	})
+}

--- a/sdk/go/common/esc/eval/eval.go
+++ b/sdk/go/common/esc/eval/eval.go
@@ -69,16 +69,12 @@ type LoadedEnvironment struct {
 	Decrypter Decrypter
 }
 
-// An EnvironmentLoaderWithID is an optional extension of EnvironmentLoader implemented by loaders that know the
-// unique ID (e.g. the UUID assigned by the environment's backend) of each environment they load. When the evaluator's
-// loader implements this interface, LoadEnvironmentWithID is called in place of LoadEnvironment and the returned ID is
-// threaded through the imported environment's execution context (see esc.EnvExecContextWithIDs).
+// An EnvironmentLoaderWithID is an EnvironmentLoader that also knows each environment's ID. The evaluator prefers it
+// when present, so imported environments get their IDs.
 type EnvironmentLoaderWithID interface {
 	EnvironmentLoader
 
-	// LoadEnvironmentWithID is like EnvironmentLoader.LoadEnvironment, but returns the loaded environment as a
-	// LoadedEnvironment that also carries its unique ID. An empty LoadedEnvironment.ID indicates that the ID is
-	// unknown.
+	// LoadEnvironmentWithID is LoadEnvironment plus the environment's ID; an empty ID means unknown.
 	LoadEnvironmentWithID(ctx context.Context, name string) (LoadedEnvironment, error)
 }
 

--- a/sdk/go/common/esc/eval/eval.go
+++ b/sdk/go/common/esc/eval/eval.go
@@ -923,7 +923,7 @@ func (e *evalContext) evaluateExprAccess(x *expr, accessors []*propertyAccessor,
 	// Check for context interpolation.
 	if ok && k == "context" {
 		accessors[0].value = e.myContext
-		return e.evaluateValueAccess(x.repr.syntax(), e.myContext, accessors[1:])
+		return e.evaluateContextAccess(x.repr.syntax(), accessors[1:])
 	}
 
 	// Check for inline reference
@@ -982,6 +982,25 @@ func (e *evalContext) evaluateExprAccess(x *expr, accessors []*propertyAccessor,
 	}
 
 	return e.evaluateExpr(receiver, schema.Always())
+}
+
+// evaluateContextAccess is evaluateValueAccess over the `context` object, with a diagnostic that explains why
+// `context.{current,root}Environment.id` is absent when no ID was supplied. The exec context's ID getters are the
+// source of truth: the `id` key is omitted from the context exactly when they are empty.
+func (e *evalContext) evaluateContextAccess(syntax ast.Expr, accessors []*propertyAccessor) *value {
+	if len(accessors) >= 2 {
+		env, _ := e.objectKey(syntax, accessors[0].accessor, false)
+		prop, _ := e.objectKey(syntax, accessors[1].accessor, false)
+		missing := prop == "id" &&
+			((env == "currentEnvironment" && e.execContext.GetCurrentEnvironmentID() == "") ||
+				(env == "rootEnvironment" && e.execContext.GetRootEnvironmentID() == ""))
+		if missing {
+			e.accessorErrorf(syntax, accessors[1].accessor, "context.%s.id is not available: no ID was supplied for "+
+				"this environment (unsaved and anonymous environments have none)", env)
+			return e.invalidPropertyAccess(syntax, accessors)
+		}
+	}
+	return e.evaluateValueAccess(syntax, e.myContext, accessors)
 }
 
 // evaluateEnvironmentReferenceAccess performs an inline import of an environment.

--- a/sdk/go/common/esc/eval/eval.go
+++ b/sdk/go/common/esc/eval/eval.go
@@ -55,6 +55,33 @@ type EnvironmentLoader interface {
 	AuthorizeImport(ctx context.Context, importer string, imported string, importerIsRoot bool) error
 }
 
+// A LoadedEnvironment is the result of EnvironmentLoaderWithID.LoadEnvironmentWithID: the loaded environment's
+// definition together with the metadata the evaluator needs to evaluate it.
+type LoadedEnvironment struct {
+	// YAML is the environment's definition.
+	YAML []byte
+	// ResolvedName is the name the loader resolved the requested name to (e.g. after following an override).
+	ResolvedName string
+	// ID is the unique ID (e.g. the UUID assigned by the environment's backend) of the environment, or "" when
+	// unknown.
+	ID string
+	// Decrypter decrypts the definition's static secrets.
+	Decrypter Decrypter
+}
+
+// An EnvironmentLoaderWithID is an optional extension of EnvironmentLoader implemented by loaders that know the
+// unique ID (e.g. the UUID assigned by the environment's backend) of each environment they load. When the evaluator's
+// loader implements this interface, LoadEnvironmentWithID is called in place of LoadEnvironment and the returned ID is
+// threaded through the imported environment's execution context (see esc.EnvExecContextWithIDs).
+type EnvironmentLoaderWithID interface {
+	EnvironmentLoader
+
+	// LoadEnvironmentWithID is like EnvironmentLoader.LoadEnvironment, but returns the loaded environment as a
+	// LoadedEnvironment that also carries its unique ID. An empty LoadedEnvironment.ID indicates that the ID is
+	// unknown.
+	LoadEnvironmentWithID(ctx context.Context, name string) (LoadedEnvironment, error)
+}
+
 // LoadYAML decodes a YAML template from an io.Reader.
 func LoadYAML(filename string, r io.Reader) (*ast.EnvironmentDecl, syntax.Diagnostics, error) {
 	bytes, err := io.ReadAll(r)
@@ -194,6 +221,7 @@ func evalEnvironment(
 		validating,
 		rotating,
 		name,
+		opts.RootEnvironmentID,
 		env,
 		true,
 		decrypter,
@@ -276,6 +304,7 @@ func newEvalContext(
 	validating bool,
 	rotating bool,
 	name string,
+	id string,
 	env *ast.EnvironmentDecl,
 	isRootEnv bool,
 	decrypter Decrypter,
@@ -299,7 +328,7 @@ func newEvalContext(
 		providers:      providers,
 		environments:   environments,
 		imports:        imports,
-		execContext:    execContext.CopyForEnv(name),
+		execContext:    execContext.CopyForEnvWithID(name, id),
 		rotateDocPaths: rotateDocPaths,
 	}
 }
@@ -598,6 +627,16 @@ func (e *evalContext) evaluateImports() {
 	e.myImports = val
 }
 
+// loadEnvironment loads the named environment via the environment loader, preferring LoadEnvironmentWithID when the
+// loader supports it so that the environment's ID is available to the execution context.
+func (e *evalContext) loadEnvironment(name string) (LoadedEnvironment, error) {
+	if loader, ok := e.environments.(EnvironmentLoaderWithID); ok {
+		return loader.LoadEnvironmentWithID(e.ctx, name)
+	}
+	def, resolvedName, dec, err := e.environments.LoadEnvironment(e.ctx, name)
+	return LoadedEnvironment{YAML: def, ResolvedName: resolvedName, Decrypter: dec}, err
+}
+
 // evaluateImport evaluates an imported environment.
 //
 // Each environment in the import closure is only evaluated once.
@@ -622,13 +661,13 @@ func (e *evalContext) evaluateImport(expr ast.Expr, name string) (*value, bool) 
 		}
 		val = imported.value
 	} else {
-		bytes, resolvedName, dec, err := e.environments.LoadEnvironment(e.ctx, name)
+		loaded, err := e.loadEnvironment(name)
 		if err != nil {
 			e.errorf(expr, "%s", err.Error())
 			return nil, false
 		}
 
-		env, diags, err := LoadYAMLBytes(resolvedName, bytes)
+		env, diags, err := LoadYAMLBytes(loaded.ResolvedName, loaded.YAML)
 		e.diags.Extend(diags...)
 		if err != nil {
 			e.errorf(expr, "%s", err.Error())
@@ -639,7 +678,10 @@ func (e *evalContext) evaluateImport(expr ast.Expr, name string) (*value, bool) 
 		}
 
 		// we only want to rotate the root environment, so set rotating flag to false when evaluating imports
-		imp := newEvalContext(e.ctx, e.validating, false, resolvedName, env, false, dec, e.providers, e.environments, e.imports, e.execContext, e.showSecrets, nil) //nolint:lll
+		imp := newEvalContext(
+			e.ctx, e.validating, false, loaded.ResolvedName, loaded.ID, env, false, loaded.Decrypter,
+			e.providers, e.environments, e.imports, e.execContext, e.showSecrets, nil,
+		)
 		imp.declaredName = name
 		imp.traceMode = e.traceMode
 		v, diags := imp.evaluate()

--- a/sdk/go/common/esc/eval/eval_options.go
+++ b/sdk/go/common/esc/eval/eval_options.go
@@ -38,11 +38,7 @@ type EvalOptions struct {
 	// export, so TraceModeNone never allocates the dropped Trace.
 	TraceMode TraceMode
 
-	// RootEnvironmentID is the unique ID (e.g. the UUID assigned by the
-	// environment's backend) of the root environment being evaluated, if known.
-	// It is exposed through the execution context beside the environment's name
-	// (see esc.EnvExecContextWithIDs); imported environments get their IDs from
-	// the environment loader instead (see EnvironmentLoaderWithID). When empty,
-	// no ID is recorded for the root environment.
+	// RootEnvironmentID is the ID of the root environment, if known. Imported
+	// environments get their IDs from an EnvironmentLoaderWithID instead.
 	RootEnvironmentID string
 }

--- a/sdk/go/common/esc/eval/eval_options.go
+++ b/sdk/go/common/esc/eval/eval_options.go
@@ -37,4 +37,12 @@ type EvalOptions struct {
 	// TraceMode selects how much of each value's Trace to retain. Applied during
 	// export, so TraceModeNone never allocates the dropped Trace.
 	TraceMode TraceMode
+
+	// RootEnvironmentID is the unique ID (e.g. the UUID assigned by the
+	// environment's backend) of the root environment being evaluated, if known.
+	// It is exposed through the execution context beside the environment's name
+	// (see esc.EnvExecContextWithIDs); imported environments get their IDs from
+	// the environment loader instead (see EnvironmentLoaderWithID). When empty,
+	// no ID is recorded for the root environment.
+	RootEnvironmentID string
 }

--- a/sdk/go/common/esc/eval/eval_test.go
+++ b/sdk/go/common/esc/eval/eval_test.go
@@ -157,6 +157,28 @@ func (testProvider) Open(
 	return esc.NewValue(inputs), nil
 }
 
+// contextProvider echoes the name and ID of the environment it is opened in.
+type contextProvider struct{}
+
+func (contextProvider) Schema() (*schema.Schema, *schema.Schema) {
+	return schema.Always(), schema.Always()
+}
+
+func (contextProvider) Open(
+	ctx context.Context,
+	inputs map[string]esc.Value,
+	context esc.EnvExecContext,
+) (esc.Value, error) {
+	id := ""
+	if withIDs, ok := context.(esc.EnvExecContextWithIDs); ok {
+		id = withIDs.GetCurrentEnvironmentID()
+	}
+	return esc.NewValue(map[string]esc.Value{
+		"name": esc.NewValue(context.GetCurrentEnvironmentName()),
+		"id":   esc.NewValue(id),
+	}), nil
+}
+
 type secretWrapperProvider struct{}
 
 func (secretWrapperProvider) Schema() (*schema.Schema, *schema.Schema) {
@@ -265,6 +287,8 @@ func (tp testProviders) LoadProvider(ctx context.Context, name string) (esc.Prov
 		return testSchemaProvider{}, nil
 	case "test":
 		return testProvider{}, nil
+	case "context":
+		return contextProvider{}, nil
 	case "secret-wrapper":
 		return secretWrapperProvider{}, nil
 	case "bench":
@@ -442,6 +466,136 @@ values:
 	require.NotNil(t, result)
 	assert.Equal(t, "prod", result.Properties["importedEnvironmentName"].Value)
 	assert.Contains(t, environments.authorizations, importAuthorization{importer: "prod", imported: "child"})
+}
+
+// idEnvironments is an EnvironmentLoaderWithID whose environments each carry a unique ID.
+type idEnvironments struct {
+	defs map[string]idEnvironmentDef
+}
+
+type idEnvironmentDef struct {
+	yaml string
+	id   string
+}
+
+func (e *idEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, string, Decrypter, error) {
+	loaded, err := e.LoadEnvironmentWithID(ctx, name)
+	return loaded.YAML, loaded.ResolvedName, loaded.Decrypter, err
+}
+
+func (e *idEnvironments) LoadEnvironmentWithID(_ context.Context, name string) (LoadedEnvironment, error) {
+	def, ok := e.defs[name]
+	if !ok {
+		return LoadedEnvironment{}, os.ErrNotExist
+	}
+	return LoadedEnvironment{YAML: []byte(def.yaml), ResolvedName: name, ID: def.id, Decrypter: rot128{}}, nil
+}
+
+func (e *idEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
+func TestEvalEnvironment(t *testing.T) {
+	t.Parallel()
+
+	openContext := func(t *testing.T, v esc.Value) map[string]esc.Value {
+		props, ok := v.Value.(map[string]esc.Value)
+		require.True(t, ok)
+		return props
+	}
+
+	t.Run("exposes the current environment's ID beside its name", func(t *testing.T) {
+		t.Parallel()
+
+		env, diags, err := LoadYAMLBytes("root", []byte(`values:
+  currentName: ${context.currentEnvironment.name}
+  currentID: ${context.currentEnvironment.id}
+  rootID: ${context.rootEnvironment.id}
+`))
+		require.NoError(t, err)
+		require.False(t, diags.HasErrors(), "%v", diags)
+
+		execContext, err := esc.NewExecContext(nil)
+		require.NoError(t, err)
+		result, diags := EvalEnvironment(
+			t.Context(), "root", env, rot128{}, testProviders{}, &idEnvironments{}, execContext,
+			EvalOptions{RootEnvironmentID: "root-uuid"},
+		)
+		require.False(t, diags.HasErrors(), "%v", diags)
+		require.NotNil(t, result)
+		assert.Equal(t, "root", result.Properties["currentName"].Value)
+		assert.Equal(t, "root-uuid", result.Properties["currentID"].Value)
+		assert.Equal(t, "root-uuid", result.Properties["rootID"].Value)
+
+		current := openContext(t, result.ExecutionContext.Properties["currentEnvironment"])
+		assert.Equal(t, "root-uuid", current["id"].Value)
+	})
+
+	t.Run("threads each import's ID through the import chain", func(t *testing.T) {
+		t.Parallel()
+
+		env, diags, err := LoadYAMLBytes("root", []byte(`imports:
+  - a
+values:
+  rootContext: {fn::open::context: {}}
+`))
+		require.NoError(t, err)
+		require.False(t, diags.HasErrors(), "%v", diags)
+
+		execContext, err := esc.NewExecContext(nil)
+		require.NoError(t, err)
+		environments := &idEnvironments{
+			defs: map[string]idEnvironmentDef{
+				"a": {yaml: "imports:\n  - b\nvalues:\n  aContext: {fn::open::context: {}}\n", id: "a-uuid"},
+				"b": {yaml: "values:\n  bContext: {fn::open::context: {}}\n", id: "b-uuid"},
+			},
+		}
+		result, diags := EvalEnvironment(
+			t.Context(), "root", env, rot128{}, testProviders{}, environments, execContext,
+			EvalOptions{RootEnvironmentID: "root-uuid"},
+		)
+		require.False(t, diags.HasErrors(), "%v", diags)
+		require.NotNil(t, result)
+
+		// Each provider sees the environment that holds it, not the root.
+		assert.Equal(t, "root-uuid", openContext(t, result.Properties["rootContext"])["id"].Value)
+		assert.Equal(t, "a-uuid", openContext(t, result.Properties["aContext"])["id"].Value)
+		assert.Equal(t, "a", openContext(t, result.Properties["aContext"])["name"].Value)
+		assert.Equal(t, "b-uuid", openContext(t, result.Properties["bContext"])["id"].Value)
+	})
+
+	t.Run("tolerates loaders that do not provide IDs", func(t *testing.T) {
+		t.Parallel()
+
+		env, diags, err := LoadYAMLBytes("root", []byte(`imports:
+  - a
+values:
+  currentName: ${context.currentEnvironment.name}
+`))
+		require.NoError(t, err)
+		require.False(t, diags.HasErrors(), "%v", diags)
+
+		execContext, err := esc.NewExecContext(nil)
+		require.NoError(t, err)
+		environments := &overrideEnvironments{
+			defs: map[string]string{
+				"a": "values:\n  aContext: {fn::open::context: {}}\n",
+			},
+		}
+		result, diags := EvalEnvironment(
+			t.Context(), "root", env, rot128{}, testProviders{}, environments, execContext, EvalOptions{},
+		)
+		require.False(t, diags.HasErrors(), "%v", diags)
+		require.NotNil(t, result)
+		assert.Equal(t, "root", result.Properties["currentName"].Value)
+		assert.Equal(t, "a", openContext(t, result.Properties["aContext"])["name"].Value)
+		assert.Equal(t, "", openContext(t, result.Properties["aContext"])["id"].Value)
+
+		// Without an ID, the execution context exposes no `id` property at all.
+		current := openContext(t, result.ExecutionContext.Properties["currentEnvironment"])
+		assert.Equal(t, "root", current["name"].Value)
+		assert.NotContains(t, current, "id")
+	})
 }
 
 func TestEval(t *testing.T) {

--- a/sdk/go/common/esc/eval/eval_test.go
+++ b/sdk/go/common/esc/eval/eval_test.go
@@ -498,7 +498,7 @@ func (e *idEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, 
 func TestEvalEnvironment(t *testing.T) {
 	t.Parallel()
 
-	openContext := func(t *testing.T, v esc.Value) map[string]esc.Value {
+	objectProperties := func(t *testing.T, v esc.Value) map[string]esc.Value {
 		props, ok := v.Value.(map[string]esc.Value)
 		require.True(t, ok)
 		return props
@@ -527,7 +527,7 @@ func TestEvalEnvironment(t *testing.T) {
 		assert.Equal(t, "root-uuid", result.Properties["currentID"].Value)
 		assert.Equal(t, "root-uuid", result.Properties["rootID"].Value)
 
-		current := openContext(t, result.ExecutionContext.Properties["currentEnvironment"])
+		current := objectProperties(t, result.ExecutionContext.Properties["currentEnvironment"])
 		assert.Equal(t, "root-uuid", current["id"].Value)
 	})
 
@@ -558,10 +558,10 @@ values:
 		require.NotNil(t, result)
 
 		// Each provider sees the environment that holds it, not the root.
-		assert.Equal(t, "root-uuid", openContext(t, result.Properties["rootContext"])["id"].Value)
-		assert.Equal(t, "a-uuid", openContext(t, result.Properties["aContext"])["id"].Value)
-		assert.Equal(t, "a", openContext(t, result.Properties["aContext"])["name"].Value)
-		assert.Equal(t, "b-uuid", openContext(t, result.Properties["bContext"])["id"].Value)
+		assert.Equal(t, "root-uuid", objectProperties(t, result.Properties["rootContext"])["id"].Value)
+		assert.Equal(t, "a-uuid", objectProperties(t, result.Properties["aContext"])["id"].Value)
+		assert.Equal(t, "a", objectProperties(t, result.Properties["aContext"])["name"].Value)
+		assert.Equal(t, "b-uuid", objectProperties(t, result.Properties["bContext"])["id"].Value)
 	})
 
 	t.Run("tolerates loaders that do not provide IDs", func(t *testing.T) {
@@ -588,13 +588,86 @@ values:
 		require.False(t, diags.HasErrors(), "%v", diags)
 		require.NotNil(t, result)
 		assert.Equal(t, "root", result.Properties["currentName"].Value)
-		assert.Equal(t, "a", openContext(t, result.Properties["aContext"])["name"].Value)
-		assert.Equal(t, "", openContext(t, result.Properties["aContext"])["id"].Value)
+		assert.Equal(t, "a", objectProperties(t, result.Properties["aContext"])["name"].Value)
+		assert.Equal(t, "", objectProperties(t, result.Properties["aContext"])["id"].Value)
 
 		// Without an ID, the execution context exposes no `id` property at all.
-		current := openContext(t, result.ExecutionContext.Properties["currentEnvironment"])
+		current := objectProperties(t, result.ExecutionContext.Properties["currentEnvironment"])
 		assert.Equal(t, "root", current["name"].Value)
 		assert.NotContains(t, current, "id")
+	})
+
+	t.Run("keeps the root ID across an import whose loader has none", func(t *testing.T) {
+		t.Parallel()
+
+		// The root is evaluated with an ID, but "a" comes from an ID-unaware loader.
+		evalImport := func(t *testing.T, aYAML string) (*esc.Environment, syntax.Diagnostics) {
+			env, diags, err := LoadYAMLBytes("root", []byte("imports:\n  - a\n"))
+			require.NoError(t, err)
+			require.False(t, diags.HasErrors(), "%v", diags)
+
+			execContext, err := esc.NewExecContext(nil)
+			require.NoError(t, err)
+			environments := &overrideEnvironments{defs: map[string]string{"a": aYAML}}
+			return EvalEnvironment(
+				t.Context(), "root", env, rot128{}, testProviders{}, environments, execContext,
+				EvalOptions{RootEnvironmentID: "root-uuid"},
+			)
+		}
+
+		t.Run("rootEnvironment.id resolves inside the import", func(t *testing.T) {
+			t.Parallel()
+
+			result, diags := evalImport(t, "values:\n  rootID: ${context.rootEnvironment.id}\n")
+			require.False(t, diags.HasErrors(), "%v", diags)
+			require.NotNil(t, result)
+			assert.Equal(t, "root-uuid", result.Properties["rootID"].Value)
+		})
+
+		t.Run("currentEnvironment.id inside the import explains the missing ID", func(t *testing.T) {
+			t.Parallel()
+
+			_, diags := evalImport(t, "values:\n  currentID: ${context.currentEnvironment.id}\n")
+			require.True(t, diags.HasErrors())
+
+			summaries := make([]string, len(diags))
+			for i, d := range diags {
+				summaries[i] = d.Summary
+			}
+			assert.Equal(t, []string{
+				"context.currentEnvironment.id is not available: no ID was supplied for this environment " +
+					"(unsaved and anonymous environments have none)",
+			}, summaries)
+		})
+	})
+
+	t.Run("explains a missing environment ID when it is interpolated", func(t *testing.T) {
+		t.Parallel()
+
+		env, diags, err := LoadYAMLBytes("root", []byte(`values:
+  currentID: ${context.currentEnvironment.id}
+  rootID: ${context.rootEnvironment.id}
+`))
+		require.NoError(t, err)
+		require.False(t, diags.HasErrors(), "%v", diags)
+
+		execContext, err := esc.NewExecContext(nil)
+		require.NoError(t, err)
+		_, diags = EvalEnvironment(
+			t.Context(), "root", env, rot128{}, testProviders{}, &overrideEnvironments{}, execContext, EvalOptions{},
+		)
+		require.True(t, diags.HasErrors())
+
+		summaries := make([]string, len(diags))
+		for i, d := range diags {
+			summaries[i] = d.Summary
+		}
+		assert.ElementsMatch(t, []string{
+			"context.currentEnvironment.id is not available: no ID was supplied for this environment " +
+				"(unsaved and anonymous environments have none)",
+			"context.rootEnvironment.id is not available: no ID was supplied for this environment " +
+				"(unsaved and anonymous environments have none)",
+		}, summaries)
 	})
 }
 


### PR DESCRIPTION
## Summary
Providers opened inside an imported ESC environment can now learn which environment (by ID, not just name) they are running in.

This helps us build OIDC subjects from environment UUIDs so trust policies survive renames.

### Changes
- [`CopyForEnvWithID` and the `EnvExecContextWithIDs` extension](https://github.com/pulumi/pulumi/blob/321526fc64e37eb67be76a79649591f3f447a7ba/sdk/go/common/esc/environment.go#L45-L74) record the current and root environment IDs beside their names and expose them for interpolation as `context.currentEnvironment.id` and `context.rootEnvironment.id`.
- The [`EnvironmentLoaderWithID` loader extension](https://github.com/pulumi/pulumi/blob/321526fc64e37eb67be76a79649591f3f447a7ba/sdk/go/common/esc/eval/eval.go#L60-L86) returns a `LoadedEnvironment` struct with the ID for each import; the root's ID arrives via `EvalOptions.RootEnvironmentID`, matching how the root's name and decrypter already arrive by parameter.
- When no ID is known (an ID-unaware loader, an unsaved or anonymous root) the `id` key is omitted on purpose, and interpolating it produces a [targeted diagnostic](https://github.com/pulumi/pulumi/blob/321526fc64e37eb67be76a79649591f3f447a7ba/sdk/go/common/esc/eval/eval.go#L990) instead of a generic unknown-property error.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

New tests: `TestCopyForEnvWithID` (ID beside name, root ID retention through nested copies, anonymous-root resolution, empty ID equals `CopyForEnv`) and `TestEvalEnvironment` subtests covering the import chain (each provider sees its own environment's ID), ID-unaware loaders, the root-known/import-unknown mix, and the missing-ID diagnostic. Existing golden outputs are unchanged because an empty ID adds no key.

## Validation
- [x] `cd sdk && go build ./...`: clean
- [x] `cd sdk && go test ./go/common/esc/...`: all pass (Relevant SDK tests pass)
- [x] `cd sdk && ../bin/custom-gcl run --config ../.golangci.yml ./go/common/esc/...`: 0 issues
- [x] `gofmt -l sdk/go/common/esc`: clean
- [x] No `go.mod` changes, so tidy is a no-op

## Changelog
- [x] Changelog entry added.

## Risk
Purely additive to public API, so risk is low. Behavior is unchanged for any caller that does not supply IDs.