### PR TITLE
Use `assertTemplateContains` in `pulumi new` tests

### DIFF
--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1078,7 +1078,7 @@ func TestPulumiNewWithOrgTemplates(t *testing.T) {
 Available Templates:
 `)
 	// Check that our org based templates are there
-	assert.Contains(t, stdout.String(), `
+	assertTemplateContains(t, stdout.String(), `
   template-1                         Describe 1
   template-2                         Describe 2
 `)
@@ -1140,9 +1140,12 @@ func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 	assert.Contains(t, stdout.String(), `
 Available Templates:
 `)
+
 	// Check that our registry based templates are there with the appropriate disambiguation prefix.
-	assert.Contains(t, stdout.String(), "template-1 [Some org]              Describe 1")
-	assert.Contains(t, stdout.String(), "template-2 [some-org/repo]         Describe 2")
+	assertTemplateContains(t, stdout.String(), `
+template-1 [Some org]              Describe 1
+template-2 [some-org/repo]         Describe 2
+`)
 
 	// Check that normal templates are there
 	assertTemplateContains(t, stdout.String(), `
@@ -1223,6 +1226,8 @@ func TestPulumiNewWithoutTemplateSupport(t *testing.T) {
 	// Check that normal templates are there
 	assert.Contains(t, stdout.String(), `
 Available Templates:
+`)
+	assertTemplateContains(t, stdout.String(), `
   aiven-go                           A minimal Aiven Go Pulumi program
 `)
 	assert.Equal(t, "", stderr.String())


### PR DESCRIPTION
The column spacing depends on the names of the templates, which can change underneath us. We must always use the `assertTemplateContains` to guard against this.
