### PR TITLE
Protect resources retained by `pulumi state promote`

### DIFF
--- a/changelog/pending/cli-improvement-state-promote-protect.yaml
+++ b/changelog/pending/cli-improvement-state-promote-protect.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Protect resources retained by `pulumi state promote` so a subsequent update cannot delete them before the generated code is added to the program
+time: 2026-09-11T00:00:00Z

--- a/pkg/cmd/pulumi/state/state_promote.go
+++ b/pkg/cmd/pulumi/state/state_promote.go
@@ -59,7 +59,10 @@ func newStatePromoteCommand(ws pkgWorkspace.Context, lm cmdBackend.LoginManager)
 
 This command generates Pulumi program code for a stateful snippet, prints the
 generated files, then removes the snippet from the stack while leaving the
-resources it registered in state. The argument is the snippet's logical name.
+resources it registered in state. The retained resources are marked as
+protected so that a subsequent update cannot delete them before you have
+copied the generated code into your program. The argument is the
+snippet's logical name.
 
 This command must be run from a real Pulumi project so the generated code has
 a backing project runtime.`,
@@ -167,6 +170,7 @@ func promoteSnippetFromSnapshot(snap *deploy.Snapshot, expected resource.Snippet
 	for _, res := range snap.Resources {
 		if res != nil && res.SnippetID == expected.UUID {
 			res.SnippetID = ""
+			res.Protect = true
 			cleared++
 		}
 	}

--- a/pkg/cmd/pulumi/state/state_promote_test.go
+++ b/pkg/cmd/pulumi/state/state_promote_test.go
@@ -51,7 +51,42 @@ func TestPromoteSnippetFromSnapshot_RemovesSnippetAndClearsResourceOwnership(t *
 	require.Len(t, snap.Snippets, 1)
 	assert.Equal(t, "other-snippet", snap.Snippets[0].UUID)
 	assert.Empty(t, snap.Resources[0].SnippetID)
+	assert.True(t, snap.Resources[0].Protect,
+		"promoted resource should be protected so the user can safely copy the generated code")
 	assert.Equal(t, "other-snippet", snap.Resources[1].SnippetID)
+	assert.False(t, snap.Resources[1].Protect,
+		"resources belonging to other snippets should be untouched")
+}
+
+func TestPromoteSnippetFromSnapshot_ProtectsAllRangeResources(t *testing.T) {
+	t.Parallel()
+
+	// A snippet with `options { range = ... }` produces multiple resources that all share the
+	// same SnippetID. Promote must protect every one of them, not just the first match.
+	const snippetID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+	urnA := resource.URN("urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket-0")
+	urnB := resource.URN("urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket-1")
+	urnC := resource.URN("urn:pulumi:dev::proj::aws:s3/bucket:Bucket::bucket-2")
+	snap := &deploy.Snapshot{
+		Snippets: []resource.Snippet{
+			{UUID: snippetID, Name: "bucket", Type: string(urnA.Type())},
+		},
+		Resources: []*pkgresource.State{
+			{URN: urnA, Type: urnA.Type(), Custom: true, SnippetID: snippetID},
+			{URN: urnB, Type: urnB.Type(), Custom: true, SnippetID: snippetID},
+			{URN: urnC, Type: urnC.Type(), Custom: true, SnippetID: snippetID},
+		},
+	}
+
+	cleared, err := promoteSnippetFromSnapshot(snap, snap.Snippets[0])
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, cleared)
+	assert.Empty(t, snap.Snippets)
+	for i, res := range snap.Resources {
+		assert.Emptyf(t, res.SnippetID, "resource %d should have SnippetID cleared", i)
+		assert.Truef(t, res.Protect, "range resource %d should be protected", i)
+	}
 }
 
 func TestPromoteSnippetFromSnapshot_MissingSnippet(t *testing.T) {


### PR DESCRIPTION
`pulumi state promote` removes a snippet from the stack and keeps the resources it produced in state, printing generated program code the user is expected to paste into their Pulumi program. If the user forgets to copy that code before running `pulumi up`, the retained resources have no program registration and will be deleted.

Mirror the safety net that `pulumi import` already provides: set `Protect = true` on every retained resource.

The protect bit is applied inside the same loop that clears `SnippetID`, so snippets that produced multiple resources via `options { range }` are covered — a unit test locks that behavior in alongside the single-resource case.