### PR TITLE
Fix stack tag validation on the local (diy) backend

### DIFF
--- a/changelog/pending/cli-fix-stack-tag-validation-diy.yaml
+++ b/changelog/pending/cli-fix-stack-tag-validation-diy.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Validate stack tags on the local (diy) backend, matching Pulumi Cloud behavior
+time: 2026-09-11T21:30:11Z

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/util/validation"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -145,6 +146,9 @@ func ImportStackDeployment(ctx context.Context, s Stack, deployment *apitype.Unt
 
 // UpdateStackTags updates the stacks's tags, replacing all existing tags.
 func UpdateStackTags(ctx context.Context, s Stack, tags map[apitype.StackTagName]string) error {
+	if err := validation.ValidateStackTags(tags); err != nil {
+		return fmt.Errorf("validating stack tags: %w", err)
+	}
 	return s.Backend().UpdateStackTags(ctx, s, tags)
 }
 

--- a/pkg/backend/stack_tags_test.go
+++ b/pkg/backend/stack_tags_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// TestUpdateStackTagsValidation ensures the shared UpdateStackTags entrypoint
+// validates tags for every backend, not just the Pulumi Cloud (httpstate)
+// client. See https://github.com/pulumi/pulumi/issues/24428.
+func TestUpdateStackTagsValidation(t *testing.T) {
+	t.Parallel()
+
+	// A mock backend that records whether it was reached, so we can assert
+	// that invalid tags never make it past validation.
+	called := false
+	be := &MockBackend{
+		UpdateStackTagsF: func(
+			ctx context.Context, stack Stack, tags map[apitype.StackTagName]string,
+		) error {
+			called = true
+			return nil
+		},
+	}
+	stack := &MockStack{
+		BackendF: func() Backend { return be },
+	}
+
+	t.Run("rejects an over-long tag name", func(t *testing.T) {
+		called = false
+		tags := map[apitype.StackTagName]string{
+			"this tag name is way over forty characters long!!!": "value",
+		}
+		err := UpdateStackTags(context.Background(), stack, tags)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too long")
+		assert.False(t, called, "backend must not be called for invalid tags")
+	})
+
+	t.Run("rejects an invalid tag name character set", func(t *testing.T) {
+		called = false
+		tags := map[apitype.StackTagName]string{
+			"not valid!": "value",
+		}
+		err := UpdateStackTags(context.Background(), stack, tags)
+		require.Error(t, err)
+		assert.False(t, called, "backend must not be called for invalid tags")
+	})
+
+	t.Run("passes valid tags through to the backend", func(t *testing.T) {
+		called = false
+		tags := map[apitype.StackTagName]string{
+			"environment": "development",
+		}
+		err := UpdateStackTags(context.Background(), stack, tags)
+		require.NoError(t, err)
+		assert.True(t, called, "backend must be called for valid tags")
+	})
+}


### PR DESCRIPTION
## What

Move stack tag validation into the shared `backend.UpdateStackTags` entrypoint so it applies to **every** backend, not just the Pulumi Cloud (httpstate) client.

## Why

`pulumi stack tag set` behaves inconsistently depending on the backend:

- Against Pulumi Cloud, invalid tags are rejected up front (name ≤40 chars, restricted charset, value ≤256 chars).
- Against a local/`diy` backend, the same invalid tags are written straight to disk with no validation.

This lets invalid tags be persisted in the `.pulumi-tags` file, which later surfaces as confusing errors far from where the bad data was introduced (e.g. migrating a local stack to Pulumi Cloud, or any code path that re-uploads tags).

Fixes #24428.

## How

`pkg/backend/stack.go`'s `UpdateStackTags` now calls `validation.ValidateStackTags(tags)` before delegating to the backend. The httpstate client already validates, so this is a no-op there; it fills the gap for the `diy` backend (and any other backend that doesn't self-validate).

Added `TestUpdateStackTagsValidation` covering over-long names, invalid charsets, and the valid-tag pass-through path.

## References

- #24428
