### PR TITLE
Error in PCL if converts fail

### DIFF
--- a/changelog/pending/cli-do-fix-20260913-115127.yaml
+++ b/changelog/pending/cli-do-fix-20260913-115127.yaml
@@ -1,0 +1,4 @@
+component: cli/do
+kind: fix
+body: Error sooner if string values can't be cast to numeric/boolean inputs
+time: 2026-09-13T11:51:27.624563+01:00

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2899,3 +2899,90 @@ func TestDoCmdFunctionInvokeWithYAMLExpression(t *testing.T) {
 	assert.True(t, converterCalled, "ConvertSnippet should be called for expression flags even without --input-file")
 	assert.JSONEq(t, `{"output1": "world"}`, stdout.String())
 }
+
+// Repro: if a converter emits an expression-flag value whose type does not match the schema (e.g. a string
+// literal or secret(string) assigned to a Number input), `do` must reject it during PCL bind rather than
+// forwarding a mistyped value to the provider.
+func TestDoCmdFunctionInvokeExpressionFlagTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{
+		ReadProjectF: func(_ string) (*workspace.Project, string, error) {
+			return &workspace.Project{
+				Name:    tokens.PackageName("my-project"),
+				Runtime: workspace.NewProjectRuntimeInfo("yaml", nil),
+			}, t.TempDir(), nil
+		},
+	}
+	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
+	}
+	loadConverter := func(
+		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
+	) (plugin.Converter, error) {
+		return &plugin.MockConverter{
+			ConvertSnippetF: func(ctx context.Context, req *plugin.ConvertSnippetRequest) (
+				*plugin.ConvertSnippetResponse, error,
+			) {
+				// Simulate the YAML converter failing to evaluate "4 * 2" and passing it through as a
+				// string (wrapped as secret, matching the observed prod behaviour).
+				return &plugin.ConvertSnippetResponse{
+					Filename: "inputs.pp",
+					Attributes: map[string]string{
+						"number": `secret("4 * 2")`,
+					},
+				}, nil
+			},
+		}, nil
+	}
+	invokeCalled := false
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"number": {TypeSpec: schema.TypeSpec{Type: "number"}},
+						},
+						Required: []string{"number"},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					invokeCalled = true
+					return plugin.InvokeResponse{
+						Properties: property.NewMap(map[string]property.Value{"output1": property.New("world")}),
+					}, nil
+				},
+			},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, yamlHost, loadConverter, nil)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"azure:index:myFunction",
+		"--input", "yaml",
+		"--input:number+", "4 * 2",
+	})
+	err := cmd.Execute()
+	require.Error(t, err, "do should reject a string expression flag assigned to a number input")
+	assert.False(t, invokeCalled, "provider Invoke must not be called when the input type does not match the schema")
+}

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2934,7 +2934,7 @@ func TestDoCmdFunctionInvokeExpressionFlagTypeMismatch(t *testing.T) {
 				return &plugin.ConvertSnippetResponse{
 					Filename: "inputs.pp",
 					Attributes: map[string]string{
-						"number": `secret("4 * 2")`,
+						"number": `"4 * 2"`,
 					},
 				}, nil
 			},
@@ -2983,6 +2983,8 @@ func TestDoCmdFunctionInvokeExpressionFlagTypeMismatch(t *testing.T) {
 		"--input:number+", "4 * 2",
 	})
 	err := cmd.Execute()
-	require.Error(t, err, "do should reject a string expression flag assigned to a number input")
+	require.EqualError(t, err,
+		`parse input file: :0,0-16: apply schema inputs: property "number": `+
+			`cannot convert string "4 * 2" to number: strconv.ParseFloat: parsing "4 * 2": invalid syntax; `)
 	assert.False(t, invokeCalled, "provider Invoke must not be called when the input type does not match the schema")
 }

--- a/pkg/pcl/runtime/convert.go
+++ b/pkg/pcl/runtime/convert.go
@@ -559,7 +559,8 @@ func applySchemaInputConversion(
 		if value.IsString() {
 			converted, err := strconv.ParseBool(value.StringValue())
 			if err != nil {
-				return value, nil
+				return resource.PropertyValue{}, fmt.Errorf(
+					"cannot convert string %q to bool: %w", value.StringValue(), err)
 			}
 			return resource.NewProperty(converted), nil
 		}
@@ -570,7 +571,8 @@ func applySchemaInputConversion(
 		if value.IsString() {
 			converted, err := strconv.ParseFloat(value.StringValue(), 64)
 			if err != nil {
-				return value, nil
+				return resource.PropertyValue{}, fmt.Errorf(
+					"cannot convert string %q to number: %w", value.StringValue(), err)
 			}
 			return resource.NewProperty(converted), nil
 		}


### PR DESCRIPTION
I hit this when using `pulumi do` to try and set an expression to a numeric field. I still had the default yaml input selected and tried to do `4 * 3` which yaml (which doesn't have numerical operators) just treated as the string `"4 * 3"`. That made it all the way to the provider which error'd out with an odd error from getting the wrong type of input.

This changes PCL to error if conversions fails rather than passing the original string through. This gives a much clearer error like "cannot convert string 4 * 3 to number: ...".